### PR TITLE
update example to use feign 2.0.0 syntax

### DIFF
--- a/examples/feign-example-cli/build.gradle
+++ b/examples/feign-example-cli/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 
 dependencies {
-  compile  'com.netflix.feign:feign-core:1.1.1'
+  compile  'com.netflix.feign:feign-core:2.0.0'
   compile  'com.google.code.gson:gson:2.2.4'
   provided 'com.squareup.dagger:dagger-compiler:1.0.1'
 }


### PR DESCRIPTION
results in a 336k jar (mostly gson) which returns a github contributor list in <1s clock time.

```
$ time examples/feign-example-cli/build/github
quidryan (43)
adriancole (20)
gorzell (1)
Randgalt (1)
stonse (1)

real    0m0.930s
user    0m1.125s
sys 0m0.095s
```
