### PR TITLE
updated examples to 4.1

### DIFF
--- a/examples/feign-example-github/build.gradle
+++ b/examples/feign-example-github/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'java'
 
 dependencies {
-  compile  'com.netflix.feign:feign-core:4.0.0'
-  compile  'com.netflix.feign:feign-gson:4.0.0'
-  provided 'com.squareup.dagger:dagger-compiler:1.0.1'
+  compile  'com.netflix.feign:feign-core:4.1.0'
+  compile  'com.netflix.feign:feign-gson:4.1.0'
+  provided 'com.squareup.dagger:dagger-compiler:1.1.0'
 }
 
 // create a self-contained jar that is executable

--- a/examples/feign-example-wikipedia/build.gradle
+++ b/examples/feign-example-wikipedia/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'java'
 
 dependencies {
-  compile  'com.netflix.feign:feign-core:4.0.0'
-  compile  'com.netflix.feign:feign-gson:4.0.0'
-  provided 'com.squareup.dagger:dagger-compiler:1.0.1'
+  compile  'com.netflix.feign:feign-core:4.1.0'
+  compile  'com.netflix.feign:feign-gson:4.1.0'
+  provided 'com.squareup.dagger:dagger-compiler:1.1.0'
 }
 
 // create a self-contained jar that is executable


### PR DESCRIPTION
depedency update as dagger 1.1 is out.

Note that this is just to allow use of dagger 1.1, refactoring feign to take advantage of new features in 1.1 will come later.
