### PR TITLE
add RequestInterceptor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+### Version 4.3
+* Add ability to configure zero or more RequestInterceptors.
+
 ### Version 4.2/3.3
 * Document and enforce JAX-RS annotation processing from server POV
 * Skip query template parameters when corresponding java arg is null

--- a/README.md
+++ b/README.md
@@ -37,6 +37,25 @@ public static void main(String... args) {
 
 Feign includes a fully functional json codec in the `feign-gson` extension.  See the `Decoder` section for how to write your own.
 
+### Request Interceptors
+When you need to change all requests, regardless of their target, you'll want to configure a `RequestInterceptor`.
+For example, if you are acting as an intermediary, you might want to propagate the `X-Forwarded-For` header.
+
+```
+@Module(library = true)
+static class ForwardedForInterceptor implements RequestInterceptor {
+  @Provides(type = SET) RequestInterceptor provideThis() {
+    return this;
+  }
+
+  @Override public void apply(RequestTemplate template) {
+    template.header("X-Forwarded-For", "origin.host.com");
+  }
+}
+...
+GitHub github = Feign.create(GitHub.class, "https://api.github.com", new GsonModule(), new ForwardedForInterceptor());
+```
+
 ### Observable Methods
 If specified as the last return type of a method `Observable<T>` will invoke a new http request for each call to `subscribe()`.  This is the async equivalent to an `Iterable`.
 Here's how one looks:

--- a/core/src/main/java/feign/ReflectiveFeign.java
+++ b/core/src/main/java/feign/ReflectiveFeign.java
@@ -35,6 +35,7 @@ import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -105,17 +106,15 @@ public class ReflectiveFeign extends Feign {
     }
   }
 
-  @dagger.Module(complete = false, injects = Feign.class, library = true)
+  @dagger.Module(complete = false, injects = {Feign.class, MethodHandler.Factory.class}, library = true)
   public static class Module {
+    @Provides(type = Provides.Type.SET_VALUES) Set<RequestInterceptor> noRequestInterceptors() {
+      return new LinkedHashSet<RequestInterceptor>();
+    }
 
     @Provides Feign provideFeign(ReflectiveFeign in) {
       return in;
     }
-  }
-
-  private static IllegalStateException noConfig(String configKey, Class<?> type) {
-    return new IllegalStateException(format("no configuration for %s present for %s!", configKey,
-        type.getSimpleName()));
   }
 
   static final class ParseHandlersByName {

--- a/core/src/main/java/feign/RequestInterceptor.java
+++ b/core/src/main/java/feign/RequestInterceptor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign;
+
+/**
+ * Zero or more {@code RequestInterceptors} may be configured for purposes
+ * such as adding headers to all requests.  No guarantees are give with regards
+ * to the order that interceptors are applied.  Once interceptors are applied,
+ * {@link Target#apply(RequestTemplate)} is called to create the immutable http
+ * request sent via {@link Client#execute(Request, feign.Request.Options)}.
+ * <br>
+ * <br>
+ * For example:
+ * <br>
+ * <pre>
+ * public void apply(RequestTemplate input) {
+ *     input.replaceHeader(&quot;X-Auth&quot;, currentToken);
+ * }
+ * </pre>
+ * <br>
+ * <br><b>Configuration</b><br>
+ * <br>
+ * {@code RequestInterceptors} are configured via Dagger
+ * {@link dagger.Provides.Type#SET set} or
+ * {@link dagger.Provides.Type#SET_VALUES set values}
+ * {@link dagger.Provides provider} methods.
+ * <br>
+ * <br>
+ * For example:
+ * <br>
+ * <pre>
+ * {@literal @}Provides(Type = SET) RequestInterceptor addTimestamp(TimestampInterceptor in) {
+ * return in;
+ * }
+ * </pre>
+ * <br>
+ * <br><b>Implementation notes</b><br>
+ * <br>
+ * Do not add parameters, such as {@code /path/{foo}/bar }
+ * in your implementation of {@link #apply(RequestTemplate)}.
+ * <br>
+ * Interceptors are applied after the template's parameters are
+ * {@link RequestTemplate#resolve(java.util.Map) resolved}.  This is to ensure
+ * that you can implement signatures are interceptors.
+ * <br>
+ * <br><br><b>Relationship to Retrofit 1.x</b><br>
+ * <br>
+ * This class is similar to {@code RequestInterceptor.intercept()},
+ * except that the implementation can read, remove, or otherwise mutate any
+ * part of the request template.
+ */
+public interface RequestInterceptor {
+  /**
+   * Called for every request. Add data using methods on the supplied {@link RequestTemplate}.
+   */
+  void apply(RequestTemplate template);
+}

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -73,19 +73,8 @@ public final class RequestTemplate implements Serializable {
   }
 
   /**
-   * Targets a template to this target, adding the {@link #url() base url} and
-   * any authentication headers.
-   * <br>
-   * <br>
-   * For example:
-   * <br>
-   * <pre>
-   * public Request apply(RequestTemplate input) {
-   *     input.insert(0, url());
-   *     input.replaceHeader(&quot;X-Auth&quot;, currentToken);
-   *     return input.asRequest();
-   * }
-   * </pre>
+   * Resolves any templated variables in the requests path, query, or headers
+   * against the supplied unencoded arguments.
    * <br>
    * <br><br><b>relationship to JAXRS 2.0</b><br>
    * <br>

--- a/core/src/main/java/feign/Target.java
+++ b/core/src/main/java/feign/Target.java
@@ -40,7 +40,7 @@ public interface Target<T> {
 
   /**
    * Targets a template to this target, adding the {@link #url() base url} and
-   * any authentication headers.
+   * any target-specific headers or query parameters.
    * <br>
    * <br>
    * For example:


### PR DESCRIPTION
When you need to change all requests, regardless of their target, you'll want to configure a `RequestInterceptor`.
For example, if you are acting as an intermediary, you might want to propagate the `X-Forwarded-For` header.

```
@Module(library = true)
static class ForwardedForInterceptor implements RequestInterceptor {
  @Provides(type = SET) RequestInterceptor provideThis() {
    return this;
  }

  @Override public void apply(RequestTemplate template) {
    template.header("X-Forwarded-For", "origin.host.com");
  }
}
...
GitHub github = Feign.create(GitHub.class, "https://api.github.com", new GsonModule(), new ForwardedForInterceptor());
```
