### PR TITLE
default client: add support for gzip-encoded request bodies (#52)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### Version 4.4
+* Support overriding default HostnameVerifier
+* Support GZIP content encoding for request bodies
+
 ### Version 4.3
 * Add ability to configure zero or more RequestInterceptors.
 * Remove `overrides = true` on codec modules.

--- a/core/src/main/java/feign/Util.java
+++ b/core/src/main/java/feign/Util.java
@@ -40,9 +40,17 @@ public class Util {
    */
   public static final String CONTENT_LENGTH = "Content-Length";
   /**
+   * The HTTP Content-Encoding header field name.
+   */
+  public static final String CONTENT_ENCODING = "Content-Encoding";
+  /**
    * The HTTP Retry-After header field name.
    */
   public static final String RETRY_AFTER = "Retry-After";
+  /**
+   * Value for the Content-Encoding header that indicates that GZIP encoding is in use.
+   */
+  public static final String ENCODING_GZIP = "gzip";
 
   // com.google.common.base.Charsets
   /**

--- a/core/src/test/java/feign/GZIPStreams.java
+++ b/core/src/test/java/feign/GZIPStreams.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign;
+
+import com.google.common.io.InputSupplier;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.GZIPInputStream;
+
+class GZIPStreams {
+  static InputSupplier<GZIPInputStream> newInputStreamSupplier(InputSupplier<? extends InputStream> supplier) {
+    return new GZIPInputStreamSupplier(supplier);
+  }
+
+  private static class GZIPInputStreamSupplier implements InputSupplier<GZIPInputStream> {
+    private final InputSupplier<? extends InputStream> supplier;
+
+    GZIPInputStreamSupplier(InputSupplier<? extends InputStream> supplier) {
+      this.supplier = supplier;
+    }
+
+    @Override
+    public GZIPInputStream getInput() throws IOException {
+      return new GZIPInputStream(supplier.getInput());
+    }
+  }
+}


### PR DESCRIPTION
Enhances the default client to GZIP-encode request bodies when the appropriate
content-encoding header is set in the interface's method definition.

https://github.com/Netflix/feign/issues/52
