### PR TITLE
support iterable query params

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ### Version 4.4
 * Support overriding default HostnameVerifier
 * Support GZIP content encoding for request bodies
+* Support Iterable args for query parameters
 
 ### Version 4.3
 * Add ability to configure zero or more RequestInterceptors.

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -20,6 +20,8 @@ import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
+
 import static feign.RequestTemplate.expand;
 import static org.testng.Assert.assertEquals;
 
@@ -81,6 +83,20 @@ public class RequestTemplateTest {
 
     assertEquals(template.request().toString(), ""//
         + "GET https://iam.amazonaws.com/?Action=DescribeRegions&RegionName.1=eu-west-1 HTTP/1.1\n");
+  }
+
+  @Test public void resolveTemplateWithBaseAndParameterizedIterableQuery() {
+    RequestTemplate template = new RequestTemplate().method("GET")
+        .append("/?Query=one").query("Queries", "{queries}");
+
+    template.resolve(ImmutableMap.of("queries", Arrays.asList("us-east-1", "eu-west-1")));
+    assertEquals(template.queries(),
+        ImmutableListMultimap.<String, String> builder()
+                             .put("Query", "one")
+                             .putAll("Queries", "us-east-1", "eu-west-1")
+                             .build().asMap());
+
+    assertEquals(template.toString(), "GET /?Query=one&Queries=us-east-1&Queries=eu-west-1 HTTP/1.1\n");
   }
 
   @Test public void resolveTemplateWithMixedRequestLineParams() throws Exception {


### PR DESCRIPTION
issue #55 

ex.

``` java
@RequestLine("GET /?1={1}&2={2}") // or jaxrs equiv if using feign-jaxrs
Response queryParams(@Named("1") String one, @Named("2") Iterable<String> twos);
```

called with

``` java
api.queryParams("user", Arrays.asList("apple", "pear"));
```

would send

```
GET /?1=user&2=apple&2=pear HTTP/1.1
```
