### PR TITLE
Simplify Encoder/Decoder interfaces (was: add RequestEncoder/ResponseDecoder interfaces) (#53)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 * Remove support for Observable methods.
 * SaxDecoder now decodes multiple types.
 * Remove pattern decoders in favor of SaxDecoder.
+* Use single non-generic Decoder/Encoder instead of sets of type-specific Decoders/Encoders.
+* Decoders/Encoders are now more flexible, having access to the Response/RequestTemplate respectively.
 
 ### Version 4.4.1
 * Fix NullPointerException on calling equals and hashCode.

--- a/core/src/main/java/feign/Feign.java
+++ b/core/src/main/java/feign/Feign.java
@@ -21,6 +21,8 @@ import dagger.Provides;
 import feign.Logger.NoOpLogger;
 import feign.Request.Options;
 import feign.Target.HardCodedTarget;
+import feign.codec.Decoder;
+import feign.codec.Encoder;
 import feign.codec.ErrorDecoder;
 
 import javax.net.ssl.HostnameVerifier;
@@ -105,6 +107,16 @@ public abstract class Feign {
 
     @Provides Logger noOp() {
       return new NoOpLogger();
+    }
+
+    @Provides
+    Encoder defaultEncoder() {
+      return new Encoder.Default();
+    }
+
+    @Provides
+    Decoder defaultDecoder() {
+      return new Decoder.Default();
     }
 
     @Provides ErrorDecoder errorDecoder() {

--- a/core/src/main/java/feign/FeignException.java
+++ b/core/src/main/java/feign/FeignException.java
@@ -35,8 +35,8 @@ public class FeignException extends RuntimeException {
     String message = format("status %s reading %s", response.status(), methodKey);
     try {
       if (response.body() != null) {
-        String body = toString.decode(response.body().asReader(), String.class);
-        response = Response.create(response.status(), response.reason(), response.headers(), body.toString());
+        String body = toString.decode(response, String.class).toString();
+        response = Response.create(response.status(), response.reason(), response.headers(), body);
         message += "; content:\n" + body;
       }
     } catch (IOException ignored) { // NOPMD

--- a/core/src/main/java/feign/Logger.java
+++ b/core/src/main/java/feign/Logger.java
@@ -191,7 +191,7 @@ public abstract class Logger {
           log(configKey, "<--- END HTTP (%s-byte body)", bodyAsString.getBytes(UTF_8).length);
           return Response.create(response.status(), response.reason(), response.headers(), bodyAsString);
         } finally {
-          ensureClosed(response.body());
+          ensureClosed(body);
         }
       }
     }

--- a/core/src/main/java/feign/MethodHandler.java
+++ b/core/src/main/java/feign/MethodHandler.java
@@ -52,7 +52,7 @@ interface MethodHandler {
     }
 
     public MethodHandler create(Target<?> target, MethodMetadata md, BuildTemplateFromArgs buildTemplateFromArgs,
-                                Options options, Decoder.TextStream<?> decoder, ErrorDecoder errorDecoder) {
+                                Options options, Decoder decoder, ErrorDecoder errorDecoder) {
       return new SynchronousMethodHandler(target, client, retryer, requestInterceptors, logger, logLevel, md,
           buildTemplateFromArgs, options, decoder, errorDecoder);
     }
@@ -82,14 +82,14 @@ interface MethodHandler {
     private final Provider<Logger.Level> logLevel;
     private final BuildTemplateFromArgs buildTemplateFromArgs;
     private final Options options;
-    private final Decoder.TextStream<?> decoder;
+    private final Decoder decoder;
     private final ErrorDecoder errorDecoder;
 
     private SynchronousMethodHandler(Target<?> target, Client client, Provider<Retryer> retryer,
                                      Set<RequestInterceptor> requestInterceptors, Logger logger,
                                      Provider<Logger.Level> logLevel, MethodMetadata metadata,
                                      BuildTemplateFromArgs buildTemplateFromArgs, Options options,
-                                     Decoder.TextStream<?> decoder, ErrorDecoder errorDecoder) {
+                                     Decoder decoder, ErrorDecoder errorDecoder) {
       this.target = checkNotNull(target, "target");
       this.client = checkNotNull(client, "client for %s", target);
       this.retryer = checkNotNull(retryer, "retryer for %s", target);
@@ -169,13 +169,8 @@ interface MethodHandler {
     }
 
     Object decode(Response response) throws Throwable {
-      if (metadata.returnType().equals(Response.class)) {
-        return response;
-      } else if (metadata.returnType() == void.class || response.body() == null) {
-        return null;
-      }
       try {
-        return decoder.decode(response.body().asReader(), metadata.returnType());
+        return decoder.decode(response, metadata.returnType());
       } catch (FeignException e) {
         throw e;
       } catch (RuntimeException e) {

--- a/core/src/main/java/feign/Util.java
+++ b/core/src/main/java/feign/Util.java
@@ -15,6 +15,7 @@
  */
 package feign;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.lang.reflect.Array;
 import java.lang.reflect.ParameterizedType;
@@ -128,10 +129,10 @@ public class Util {
     return map.containsKey(key) ? map.get(key) : Collections.<T>emptyList();
   }
 
-  public static void ensureClosed(Response.Body body) {
-    if (body != null) {
+  public static void ensureClosed(Closeable closeable) {
+    if (closeable != null) {
       try {
-        body.close();
+        closeable.close();
       } catch (IOException ignored) { // NOPMD
       }
     }

--- a/core/src/main/java/feign/codec/StringDecoder.java
+++ b/core/src/main/java/feign/codec/StringDecoder.java
@@ -15,26 +15,39 @@
  */
 package feign.codec;
 
+import feign.Response;
+
 import java.io.IOException;
 import java.io.Reader;
 import java.lang.reflect.Type;
 import java.nio.CharBuffer;
 
+import static feign.Util.ensureClosed;
+
 /**
  * Adapted from {@code com.google.common.io.CharStreams.toString()}.
  */
-public class StringDecoder implements Decoder.TextStream<String> {
+public class StringDecoder implements Decoder {
   private static final int BUF_SIZE = 0x800; // 2K chars (4K bytes)
 
   @Override
-  public String decode(Reader from, Type type) throws IOException {
-    StringBuilder to = new StringBuilder();
-    CharBuffer buf = CharBuffer.allocate(BUF_SIZE);
-    while (from.read(buf) != -1) {
-      buf.flip();
-      to.append(buf);
-      buf.clear();
+  public Object decode(Response response, Type type) throws IOException {
+    Response.Body body = response.body();
+    if (body == null) {
+      return null;
     }
-    return to.toString();
+    Reader from = body.asReader();
+    try {
+      StringBuilder to = new StringBuilder();
+      CharBuffer buf = CharBuffer.allocate(BUF_SIZE);
+      while (from.read(buf) != -1) {
+        buf.flip();
+        to.append(buf);
+        buf.clear();
+      }
+      return to.toString();
+    } finally {
+      ensureClosed(from);
+    }
   }
 }

--- a/core/src/test/java/feign/LoggerTest.java
+++ b/core/src/test/java/feign/LoggerTest.java
@@ -32,7 +32,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import static dagger.Provides.Type.SET;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -132,10 +131,10 @@ public class LoggerTest {
       this.logLevel = logLevel;
     }
 
-    @Provides(type = SET) Encoder defaultEncoder() {
-      return new Encoder.Text<Object>() {
-        @Override public String encode(Object object) {
-          return object.toString();
+    @Provides Encoder defaultEncoder() {
+      return new Encoder() {
+        @Override public void encode(Object object, RequestTemplate template) {
+          template.body(object.toString());
         }
       };
     }

--- a/core/src/test/java/feign/UtilTest.java
+++ b/core/src/test/java/feign/UtilTest.java
@@ -16,7 +16,6 @@
 package feign;
 
 import feign.codec.Decoder;
-import feign.codec.StringDecoder;
 import org.testng.annotations.Test;
 
 import java.io.Reader;
@@ -31,42 +30,44 @@ public class UtilTest {
 
   interface LastTypeParameter {
     final List<String> LIST_STRING = null;
-    final Decoder.TextStream<List<String>> DECODER_LIST_STRING = null;
-    final Decoder.TextStream<? extends List<String>> DECODER_WILDCARD_LIST_STRING = null;
+    final Parameterized<List<String>> PARAMETERIZED_LIST_STRING = null;
+    final Parameterized<? extends List<String>> PARAMETERIZED_WILDCARD_LIST_STRING = null;
     final ParameterizedDecoder<List<String>> PARAMETERIZED_DECODER_LIST_STRING = null;
     final ParameterizedDecoder<?> PARAMETERIZED_DECODER_UNBOUND = null;
   }
 
-  interface ParameterizedDecoder<T extends List<String>> extends Decoder.TextStream<T> {
+  interface ParameterizedDecoder<T extends List<String>> extends Decoder {
+  }
+
+  interface Parameterized<T> {
+  }
+
+  class ParameterizedSubtype implements Parameterized<String> {
   }
 
   @Test public void resolveLastTypeParameterWhenNotSubtype() throws Exception {
-    Type context = LastTypeParameter.class.getDeclaredField("DECODER_LIST_STRING").getGenericType();
+    Type context = LastTypeParameter.class.getDeclaredField("PARAMETERIZED_LIST_STRING").getGenericType();
     Type listStringType = LastTypeParameter.class.getDeclaredField("LIST_STRING").getGenericType();
-    Type last = resolveLastTypeParameter(context, Decoder.class);
+    Type last = resolveLastTypeParameter(context, Parameterized.class);
     assertEquals(last, listStringType);
   }
 
   @Test public void lastTypeFromInstance() throws Exception {
-    Decoder.TextStream<?> decoder = new StringDecoder();
-    Type last = resolveLastTypeParameter(decoder.getClass(), Decoder.class);
+    Parameterized instance = new ParameterizedSubtype();
+    Type last = resolveLastTypeParameter(instance.getClass(), Parameterized.class);
     assertEquals(last, String.class);
   }
 
   @Test public void lastTypeFromAnonymous() throws Exception {
-    Decoder.TextStream<?> decoder = new Decoder.TextStream<Reader>() {
-      @Override public Reader decode(Reader reader, Type type) {
-        return null;
-      }
-    };
-    Type last = resolveLastTypeParameter(decoder.getClass(), Decoder.class);
+    Parameterized instance = new Parameterized<Reader>() {};
+    Type last = resolveLastTypeParameter(instance.getClass(), Parameterized.class);
     assertEquals(last, Reader.class);
   }
 
   @Test public void resolveLastTypeParameterWhenWildcard() throws Exception {
-    Type context = LastTypeParameter.class.getDeclaredField("DECODER_WILDCARD_LIST_STRING").getGenericType();
+    Type context = LastTypeParameter.class.getDeclaredField("PARAMETERIZED_WILDCARD_LIST_STRING").getGenericType();
     Type listStringType = LastTypeParameter.class.getDeclaredField("LIST_STRING").getGenericType();
-    Type last = resolveLastTypeParameter(context, Decoder.class);
+    Type last = resolveLastTypeParameter(context, Parameterized.class);
     assertEquals(last, listStringType);
   }
 

--- a/core/src/test/java/feign/codec/DefaultDecoderTest.java
+++ b/core/src/test/java/feign/codec/DefaultDecoderTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.codec;
+
+import feign.FeignException;
+import feign.Response;
+import org.testng.annotations.Test;
+import org.w3c.dom.Document;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class DefaultDecoderTest {
+  private final Decoder decoder = new Decoder.Default();
+
+  @Test public void testDecodesToVoid() throws Exception {
+    assertEquals(decoder.decode(knownResponse(), void.class), null);
+  }
+
+  @Test public void testDecodesToResponse() throws Exception {
+    Response response = knownResponse();
+    Object decodedObject = decoder.decode(response, Response.class);
+    assertEquals(decodedObject.getClass(), Response.class, "");
+    Response decodedResponse = (Response) decodedObject;
+    assertEquals(decodedResponse.status(), response.status());
+    assertEquals(decodedResponse.reason(), response.reason());
+    assertEquals(decodedResponse.headers(), response.headers());
+    assertEquals(decodedResponse.body().toString(), response.body().toString());
+  }
+
+  @Test public void testDecodesToString() throws Exception {
+    Response response = knownResponse();
+    Object decodedObject = decoder.decode(response, String.class);
+    assertEquals(decodedObject.getClass(), String.class);
+    assertEquals(decodedObject.toString(), response.body().toString());
+  }
+
+  @Test public void testDecodesNullBodyToNull() throws Exception {
+    assertNull(decoder.decode(nullBodyResponse(), Document.class));
+  }
+
+  @Test(expectedExceptions = DecodeException.class, expectedExceptionsMessageRegExp = ".* is not a type supported by this decoder.")
+  public void testRefusesToDecodeOtherTypes() throws Exception {
+    decoder.decode(knownResponse(), Document.class);
+  }
+
+  private Response knownResponse() {
+    Map<String, Collection<String>> headers = new HashMap<String, Collection<String>>();
+    headers.put("Content-Type", Collections.singleton("text/plain"));
+    return Response.create(200, "OK", headers, "response body");
+  }
+
+  private Response nullBodyResponse() {
+    return Response.create(200, "OK", Collections.<String, Collection<String>>emptyMap(), null);
+  }
+}

--- a/core/src/test/java/feign/codec/DefaultEncoderTest.java
+++ b/core/src/test/java/feign/codec/DefaultEncoderTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.codec;
+
+import feign.RequestTemplate;
+import org.testng.annotations.Test;
+
+import java.util.Date;
+
+import static org.testng.Assert.assertEquals;
+
+public class DefaultEncoderTest {
+  private final Encoder encoder = new Encoder.Default();
+
+  @Test public void testEncodesStrings() throws Exception {
+    String content = "This is my content";
+    RequestTemplate template = new RequestTemplate();
+    encoder.encode(content, template);
+    assertEquals(template.body(), content);
+  }
+
+  @Test(expectedExceptions = EncodeException.class, expectedExceptionsMessageRegExp = ".* is not a type supported by this encoder.")
+  public void testRefusesToEncodeOtherTypes() throws Exception {
+    encoder.encode(new Date(), new RequestTemplate());
+  }
+}

--- a/gson/src/test/java/feign/gson/GsonModuleTest.java
+++ b/gson/src/test/java/feign/gson/GsonModuleTest.java
@@ -18,52 +18,54 @@ package feign.gson;
 import com.google.gson.reflect.TypeToken;
 import dagger.Module;
 import dagger.ObjectGraph;
+import feign.RequestTemplate;
+import feign.Response;
 import feign.codec.Decoder;
 import feign.codec.Encoder;
 import org.testng.annotations.Test;
 
 import javax.inject.Inject;
-import java.io.StringReader;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.testng.Assert.assertEquals;
 
 @Test
 public class GsonModuleTest {
-  @Module(includes = GsonModule.class, library = true, injects = EncodersAndDecoders.class)
-  static class EncodersAndDecoders {
-    @Inject Set<Encoder> encoders;
-    @Inject Set<Decoder> decoders;
+  @Module(includes = GsonModule.class, library = true, injects = EncoderAndDecoderBindings.class)
+  static class EncoderAndDecoderBindings {
+    @Inject Encoder encoder;
+    @Inject Decoder decoder;
   }
 
-  @Test public void providesEncoderDecoderAndIncrementalDecoder() throws Exception {
-    EncodersAndDecoders bindings = new EncodersAndDecoders();
+  @Test public void providesEncoderDecoder() throws Exception {
+    EncoderAndDecoderBindings bindings = new EncoderAndDecoderBindings();
     ObjectGraph.create(bindings).inject(bindings);
 
-    assertEquals(bindings.encoders.size(), 1);
-    assertEquals(bindings.encoders.iterator().next().getClass(), GsonModule.GsonCodec.class);
-    assertEquals(bindings.decoders.size(), 1);
-    assertEquals(bindings.decoders.iterator().next().getClass(), GsonModule.GsonCodec.class);
+    assertEquals(bindings.encoder.getClass(), GsonModule.GsonCodec.class);
+    assertEquals(bindings.decoder.getClass(), GsonModule.GsonCodec.class);
   }
 
-  @Module(includes = GsonModule.class, library = true, injects = Encoders.class)
-  static class Encoders {
-    @Inject Set<Encoder> encoders;
+  @Module(includes = GsonModule.class, library = true, injects = EncoderBindings.class)
+  static class EncoderBindings {
+    @Inject Encoder encoder;
   }
 
   @Test public void encodesMapObjectNumericalValuesAsInteger() throws Exception {
-    Encoders bindings = new Encoders();
+    EncoderBindings bindings = new EncoderBindings();
     ObjectGraph.create(bindings).inject(bindings);
 
     Map<String, Object> map = new LinkedHashMap<String, Object>();
     map.put("foo", 1);
 
-    assertEquals(Encoder.Text.class.cast(bindings.encoders.iterator().next()).encode(map), ""//
+    RequestTemplate template = new RequestTemplate();
+    bindings.encoder.encode(map, template);
+    assertEquals(template.body(), ""//
         + "{\n" //
         + "  \"foo\": 1\n" //
         + "}");
@@ -71,14 +73,16 @@ public class GsonModuleTest {
 
   @Test public void encodesFormParams() throws Exception {
 
-    Encoders bindings = new Encoders();
+    EncoderBindings bindings = new EncoderBindings();
     ObjectGraph.create(bindings).inject(bindings);
 
     Map<String, Object> form = new LinkedHashMap<String, Object>();
     form.put("foo", 1);
     form.put("bar", Arrays.asList(2, 3));
 
-    assertEquals(Encoder.Text.class.cast(bindings.encoders.iterator().next()).encode(form), ""//
+    RequestTemplate template = new RequestTemplate();
+    bindings.encoder.encode(form, template);
+    assertEquals(template.body(), ""//
         + "{\n" //
         + "  \"foo\": 1,\n" //
         + "  \"bar\": [\n" //
@@ -106,22 +110,22 @@ public class GsonModuleTest {
     private static final long serialVersionUID = 1L;
   }
 
-  @Module(includes = GsonModule.class, library = true, injects = Decoders.class)
-  static class Decoders {
-    @Inject Set<Decoder> decoders;
+  @Module(includes = GsonModule.class, library = true, injects = DecoderBindings.class)
+  static class DecoderBindings {
+    @Inject Decoder decoder;
   }
 
   @Test public void decodes() throws Exception {
-    Decoders bindings = new Decoders();
+    DecoderBindings bindings = new DecoderBindings();
     ObjectGraph.create(bindings).inject(bindings);
 
     List<Zone> zones = new LinkedList<Zone>();
     zones.add(new Zone("denominator.io."));
     zones.add(new Zone("denominator.io.", "ABCD"));
 
-    assertEquals(Decoder.TextStream.class.cast(bindings.decoders.iterator().next())
-        .decode(new StringReader(zonesJson), new TypeToken<List<Zone>>() {
-        }.getType()), zones);
+    Response response = Response.create(200, "OK", Collections.<String, Collection<String>>emptyMap(), zonesJson);
+    assertEquals(bindings.decoder.decode(response, new TypeToken<List<Zone>>() {
+    }.getType()), zones);
   }
 
   private String zonesJson = ""//


### PR DESCRIPTION
This is intended as a step towards simplifying Feign, by allowing the
removal of the Encoder/Decoder interfaces in a future version.

This is a first attempt; all comments welcome.  I started out trying Adrian's suggestion of having a single Codec type, but ended up having two types instead.  I didn't like having to provide a no-op implementation of encode if I only care about decoding, or decode if I only cared about encoding.  It also would have somewhat complicated the implementation of backwards-compatibility adapter classes.

I haven't yet touched form encoders.  My guess is that they will want to remain as a separate thing, and perhaps cut their dependency on the Encoder.Text type.

In introducing the new interfaces, I was keeping in mind that at some point, we'll want to add support for binary bodies.  For ResponseDecoder, that means that the method now takes a Response as the parameter.  This allows access to the body as a reader right now, and it would be easy to add access to the body as an InputStream or something similar later.  It also has the potentially interesting side effect of allowing using headers as part of the decoding.  For RequestEncoder, I currently have the return value as byte[].  Since the rest of the library hasn't yet been retrofitted to support binary bodies, that means that there's currently a couple extra String encode/decodes that don't serve much value.  I'm not convinced that returning a byte[] is necessarily the right direction here.  Passing the RequestTemplate to allow filling in the body might be a better approach, and allow easy extension to supporting binary content when it's ready.
