### PR TITLE
Support urls which have query parameters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
 ### Version 4.4
-* Support overriding default HostnameVerifier
-* Support GZIP content encoding for request bodies
-* Support Iterable args for query parameters
+* Support overriding default HostnameVerifier.
+* Support GZIP content encoding for request bodies.
+* Support Iterable args for query parameters.
+* Support urls which have query parameters.
 
 ### Version 4.3
 * Add ability to configure zero or more RequestInterceptors.

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -203,8 +203,7 @@ public final class RequestTemplate implements Serializable {
 
   /* @see #url() */
   public RequestTemplate insert(int pos, CharSequence value) {
-    url.insert(pos, value);
-    url = pullAnyQueriesOutOfUrl(url);
+    url.insert(pos, pullAnyQueriesOutOfUrl(new StringBuilder(value)));
     return this;
   }
 

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -122,6 +122,28 @@ public class RequestTemplateTest {
         + "/domains/1001/records?name=denominator.io&type=CNAME HTTP/1.1\n");
   }
 
+  @Test public void insertHasQueryParams() throws Exception {
+    RequestTemplate template = new RequestTemplate().method("GET")//
+        .append("/domains/{domainId}/records")//
+        .query("name", "{name}")//
+        .query("type", "{type}");
+
+    template = template.resolve(ImmutableMap.<String, Object>builder()//
+        .put("domainId", 1001)//
+        .put("name", "denominator.io")//
+        .put("type", "CNAME")//
+        .build()
+    );
+
+    assertEquals(template.toString(), ""//
+        + "GET /domains/1001/records?name=denominator.io&type=CNAME HTTP/1.1\n");
+
+    template.insert(0, "https://host/v1.0/1234?provider=foo");
+
+    assertEquals(template.request().toString(), ""//
+        + "GET https://host/v1.0/1234/domains/1001/records?provider=foo&name=denominator.io&type=CNAME HTTP/1.1\n");
+  }
+
   @Test public void resolveTemplateWithBodyTemplateSetsBodyAndContentLength() {
     RequestTemplate template = new RequestTemplate().method("POST")
         .bodyTemplate("%7B\"customer_name\": \"{customer_name}\", \"user_name\": \"{user_name}\", " +


### PR DESCRIPTION
For example, `https://host/api?provider=route53`
