### PR TITLE
Gson type adapters can be registered as Dagger set bindings.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 * Use single non-generic Decoder/Encoder instead of sets of type-specific Decoders/Encoders.
 * Decoders/Encoders are now more flexible, having access to the Response/RequestTemplate respectively.
 * Added Feign.Builder to simplify client customizations without using Dagger.
+* Gson type adapters can be registered as Dagger set bindings.
 
 ### Version 4.4.1
 * Fix NullPointerException on calling equals and hashCode.

--- a/gson/src/main/java/feign/gson/GsonModule.java
+++ b/gson/src/main/java/feign/gson/GsonModule.java
@@ -38,9 +38,47 @@ import java.io.Reader;
 import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 import static feign.Util.ensureClosed;
+import static feign.Util.resolveLastTypeParameter;
 
+/**
+ * <h3>Custom type adapters</h3>
+ * <br>
+ * In order to specify custom json parsing,
+ * {@code Gson} supports {@link TypeAdapter type adapters}. This module adds one
+ * to read numbers in a {@code Map<String, Object>} as Integers. You can
+ * customize further by adding additional set bindings to the raw type
+ * {@code TypeAdapter}.
+ *
+ * <br>
+ * Here's an example of adding a custom json type adapter.
+ * 
+ * <pre>
+ * &#064;Provides(type = Provides.Type.SET)
+ * TypeAdapter upperZone() {
+ *     return new TypeAdapter&lt;Zone&gt;() {
+ * 
+ *         &#064;Override
+ *         public void write(JsonWriter out, Zone value) throws IOException {
+ *             throw new IllegalArgumentException();
+ *         }
+ * 
+ *         &#064;Override
+ *         public Zone read(JsonReader in) throws IOException {
+ *             in.beginObject();
+ *             Zone zone = new Zone();
+ *             while (in.hasNext()) {
+ *                 zone.put(in.nextName(), in.nextString().toUpperCase());
+ *             }
+ *             in.endObject();
+ *             return zone;
+ *         }
+ *     };
+ * }
+ * </pre>
+ */
 @dagger.Module(library = true)
 public final class GsonModule {
 
@@ -87,8 +125,17 @@ public final class GsonModule {
     }
   }
 
+  @Provides @Singleton Gson gson(Set<TypeAdapter> adapters) {
+    GsonBuilder builder = new GsonBuilder().setPrettyPrinting();
+    for (TypeAdapter<?> adapter : adapters) {
+      Type type = resolveLastTypeParameter(adapter.getClass(), TypeAdapter.class);
+      builder.registerTypeAdapter(type, adapter);
+    }
+    return builder.create();
+  }
+
   // deals with scenario where gson Object type treats all numbers as doubles.
-  @Provides TypeAdapter<Map<String, Object>> doubleToInt() {
+  @Provides(type = Provides.Type.SET) TypeAdapter doubleToInt() {
     return new TypeAdapter<Map<String, Object>>() {
       TypeAdapter<Map<String, Object>> delegate = new MapTypeAdapterFactory(new ConstructorConstructor(
           Collections.<Type, InstanceCreator<?>>emptyMap()), false).create(new Gson(), token);
@@ -111,10 +158,6 @@ public final class GsonModule {
     }.nullSafe();
   }
 
-  @Provides @Singleton Gson gson(TypeAdapter<Map<String, Object>> doubleToInt) {
-    return new GsonBuilder().registerTypeAdapter(token.getType(), doubleToInt).setPrettyPrinting().create();
-  }
-
-  protected final static TypeToken<Map<String, Object>> token = new TypeToken<Map<String, Object>>() {
+  private final static TypeToken<Map<String, Object>> token = new TypeToken<Map<String, Object>>() {
   };
 }


### PR DESCRIPTION
Now you can register more custom gson types by adding to the set binding for `TypeAdapter`.

ex.

``` java
@Provides(type = Provides.Type.SET) TypeAdapter upperZone() {
  return new TypeAdapter<Zone>() {

    @Override public void write(JsonWriter out, Zone value) throws IOException {
      throw new IllegalArgumentException();
    }

    @Override public Zone read(JsonReader in) throws IOException {
      in.beginObject();
      Zone zone = new Zone();
      while (in.hasNext()) {
        zone.put(in.nextName(), in.nextString().toUpperCase());
      }
      in.endObject();
      return zone;
    }
  };
}
```
