### PR TITLE
Defaults.WithoutCodec to avoid binding collisions.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 * Decoders/Encoders are now more flexible, having access to the Response/RequestTemplate respectively.
 * Added Feign.Builder to simplify client customizations without using Dagger.
 * Gson type adapters can be registered as Dagger set bindings.
+* New Defaults.WithoutCodec to avoid binding collisions.
 
 ### Version 4.4.1
 * Fix NullPointerException on calling equals and hashCode.

--- a/core/src/main/java/feign/Feign.java
+++ b/core/src/main/java/feign/Feign.java
@@ -86,53 +86,61 @@ public abstract class Feign {
   }
 
   @SuppressWarnings("rawtypes")
-  @dagger.Module(complete = false, injects = {Feign.class, Builder.class}, library = true)
+  @dagger.Module(complete = false, injects = {Feign.class, Builder.class},
+      includes = {Defaults.WithoutCodec.class, Defaults.Codec.class}, library = true)
   public static class Defaults {
 
-    @Provides Logger.Level logLevel() {
-      return Logger.Level.NONE;
+    @dagger.Module(includes = {Defaults.Client.class}, library = true)
+    public static class WithoutCodec {
+      @Provides Contract contract() {
+        return new Contract.Default();
+      }
+
+      @Provides Logger.Level logLevel() {
+        return Logger.Level.NONE;
+      }
+
+      @Provides Logger noOp() {
+        return new NoOpLogger();
+      }
+
+      @Provides Retryer retryer() {
+        return new Retryer.Default();
+      }
+
+      @Provides ErrorDecoder errorDecoder() {
+        return new ErrorDecoder.Default();
+      }
     }
 
-    @Provides Contract contract() {
-      return new Contract.Default();
+    @dagger.Module(library = true)
+    public static class Client {
+      @Provides SSLSocketFactory sslSocketFactory() {
+        return SSLSocketFactory.class.cast(SSLSocketFactory.getDefault());
+      }
+
+      @Provides HostnameVerifier hostnameVerifier() {
+        return HttpsURLConnection.getDefaultHostnameVerifier();
+      }
+
+      @Provides feign.Client httpClient(feign.Client.Default client) {
+        return client;
+      }
+
+      @Provides Options options() {
+        return new Options();
+      }
     }
 
-    @Provides SSLSocketFactory sslSocketFactory() {
-      return SSLSocketFactory.class.cast(SSLSocketFactory.getDefault());
-    }
+    @dagger.Module(library = true)
+    public static class Codec {
+      @Provides Encoder defaultEncoder() {
+        return new Encoder.Default();
+      }
 
-    @Provides HostnameVerifier hostnameVerifier() {
-      return HttpsURLConnection.getDefaultHostnameVerifier();
-    }
-
-    @Provides Client httpClient(Client.Default client) {
-      return client;
-    }
-
-    @Provides Retryer retryer() {
-      return new Retryer.Default();
-    }
-
-    @Provides Logger noOp() {
-      return new NoOpLogger();
-    }
-
-    @Provides
-    Encoder defaultEncoder() {
-      return new Encoder.Default();
-    }
-
-    @Provides
-    Decoder defaultDecoder() {
-      return new Decoder.Default();
-    }
-
-    @Provides ErrorDecoder errorDecoder() {
-      return new ErrorDecoder.Default();
-    }
-
-    @Provides Options options() {
-      return new Options();
+      @Provides Decoder defaultDecoder() {
+        return new Decoder.Default();
+      }
     }
   }
 
@@ -313,13 +321,11 @@ public abstract class Feign {
       return logger;
     }
 
-    @Provides
-    Encoder encoder() {
+    @Provides Encoder encoder() {
       return encoder;
     }
 
-    @Provides
-    Decoder decoder() {
+    @Provides Decoder decoder() {
       return decoder;
     }
 


### PR DESCRIPTION
When constructing pure Dagger apps, it is hard to compose a tree that includes Defaults and GsonModule.  This is because there's a clash in Encoder/Decoder that is particularly hard to work around.  This introduces Defaults.WithoutCodec, which avoids this collision for the common case of pure-dagger use as exists in Denominator.

ex.

``` java
    @dagger.Module(includes = { ReflectiveFeign.Module.class, Defaults.WithoutCodec.class, GsonModule.class, ... })
    public static final class FeignModule {
```
