### PR TITLE
provide encoder/decoder in a module that addsTo = Feign.Defaults.class

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 * Decoders/Encoders are now more flexible, having access to the Response/RequestTemplate respectively.
 * Added Feign.Builder to simplify client customizations without using Dagger.
 * Gson type adapters can be registered as Dagger set bindings.
-* New Defaults.WithoutCodec to avoid binding collisions.
+* `Feign.create(...)` now requires specifying an encoder and decoder.
 
 ### Version 4.4.1
 * Fix NullPointerException on calling equals and hashCode.

--- a/core/src/main/java/feign/Feign.java
+++ b/core/src/main/java/feign/Feign.java
@@ -16,7 +16,6 @@
 package feign;
 
 
-import dagger.Module;
 import dagger.ObjectGraph;
 import dagger.Provides;
 import feign.Logger.NoOpLogger;
@@ -86,61 +85,43 @@ public abstract class Feign {
   }
 
   @SuppressWarnings("rawtypes")
-  @dagger.Module(complete = false, injects = {Feign.class, Builder.class},
-      includes = {Defaults.WithoutCodec.class, Defaults.Codec.class}, library = true)
+  // incomplete as missing Encoder/Decoder
+  @dagger.Module(injects = {Feign.class, Builder.class}, complete = false, includes = ReflectiveFeign.Module.class)
   public static class Defaults {
-
-    @dagger.Module(includes = {Defaults.Client.class}, library = true)
-    public static class WithoutCodec {
-      @Provides Contract contract() {
-        return new Contract.Default();
-      }
-
-      @Provides Logger.Level logLevel() {
-        return Logger.Level.NONE;
-      }
-
-      @Provides Logger noOp() {
-        return new NoOpLogger();
-      }
-
-      @Provides Retryer retryer() {
-        return new Retryer.Default();
-      }
-
-      @Provides ErrorDecoder errorDecoder() {
-        return new ErrorDecoder.Default();
-      }
+    @Provides Contract contract() {
+      return new Contract.Default();
     }
 
-    @dagger.Module(library = true)
-    public static class Client {
-      @Provides SSLSocketFactory sslSocketFactory() {
-        return SSLSocketFactory.class.cast(SSLSocketFactory.getDefault());
-      }
-
-      @Provides HostnameVerifier hostnameVerifier() {
-        return HttpsURLConnection.getDefaultHostnameVerifier();
-      }
-
-      @Provides feign.Client httpClient(feign.Client.Default client) {
-        return client;
-      }
-
-      @Provides Options options() {
-        return new Options();
-      }
+    @Provides Logger.Level logLevel() {
+      return Logger.Level.NONE;
     }
 
-    @dagger.Module(library = true)
-    public static class Codec {
-      @Provides Encoder defaultEncoder() {
-        return new Encoder.Default();
-      }
+    @Provides Logger noOp() {
+      return new NoOpLogger();
+    }
 
-      @Provides Decoder defaultDecoder() {
-        return new Decoder.Default();
-      }
+    @Provides Retryer retryer() {
+      return new Retryer.Default();
+    }
+
+    @Provides ErrorDecoder errorDecoder() {
+      return new ErrorDecoder.Default();
+    }
+
+    @Provides Options options() {
+      return new Options();
+    }
+
+    @Provides SSLSocketFactory sslSocketFactory() {
+      return SSLSocketFactory.class.cast(SSLSocketFactory.getDefault());
+    }
+
+    @Provides HostnameVerifier hostnameVerifier() {
+      return HttpsURLConnection.getDefaultHostnameVerifier();
+    }
+
+    @Provides feign.Client httpClient(feign.Client.Default client) {
+      return client;
     }
   }
 
@@ -176,15 +157,15 @@ public abstract class Feign {
   }
 
   private static List<Object> modulesForGraph(Object... modules) {
-    List<Object> modulesForGraph = new ArrayList<Object>(3);
+    List<Object> modulesForGraph = new ArrayList<Object>(2);
     modulesForGraph.add(new Defaults());
-    modulesForGraph.add(new ReflectiveFeign.Module());
     if (modules != null)
       for (Object module : modules)
         modulesForGraph.add(module);
     return modulesForGraph;
   }
 
+  @dagger.Module(injects = Feign.class, includes = ReflectiveFeign.Module.class)
   public static class Builder {
     private final Set<RequestInterceptor> requestInterceptors = new LinkedHashSet<RequestInterceptor>();
     @Inject Logger.Level logLevel;
@@ -192,8 +173,8 @@ public abstract class Feign {
     @Inject Client client;
     @Inject Retryer retryer;
     @Inject Logger logger;
-    @Inject Encoder encoder;
-    @Inject Decoder decoder;
+    Encoder encoder = new Encoder.Default();
+    Decoder decoder = new Decoder.Default();
     @Inject ErrorDecoder errorDecoder;
     @Inject Options options;
 
@@ -270,35 +251,7 @@ public abstract class Feign {
     }
 
     public <T> T target(Target<T> target) {
-      BuilderModule module = new BuilderModule(this);
-      return create(module).newInstance(target);
-    }
-  }
-
-  @Module(library = true, overrides = true, addsTo = Defaults.class)
-  static class BuilderModule {
-    private final Logger.Level logLevel;
-    private final Contract contract;
-    private final Client client;
-    private final Retryer retryer;
-    private final Logger logger;
-    private final Encoder encoder;
-    private final Decoder decoder;
-    private final ErrorDecoder errorDecoder;
-    private final Options options;
-    private final Set<RequestInterceptor> requestInterceptors;
-
-    BuilderModule(Builder builder) {
-      this.logLevel = builder.logLevel;
-      this.contract = builder.contract;
-      this.client = builder.client;
-      this.retryer = builder.retryer;
-      this.logger = builder.logger;
-      this.encoder = builder.encoder;
-      this.decoder = builder.decoder;
-      this.errorDecoder = builder.errorDecoder;
-      this.options = builder.options;
-      this.requestInterceptors = builder.requestInterceptors;
+      return ObjectGraph.create(this).get(Feign.class).newInstance(target);
     }
 
     @Provides Logger.Level logLevel() {

--- a/core/src/test/java/feign/LoggerTest.java
+++ b/core/src/test/java/feign/LoggerTest.java
@@ -19,6 +19,7 @@ import com.google.common.base.Joiner;
 import com.google.mockwebserver.MockResponse;
 import com.google.mockwebserver.MockWebServer;
 import dagger.Provides;
+import feign.codec.Decoder;
 import feign.codec.Encoder;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -122,7 +123,7 @@ public class LoggerTest {
     }
   }
 
-  static @dagger.Module(overrides = true, library = true) class DefaultModule {
+  static @dagger.Module(injects = Feign.class, overrides = true, addsTo = Feign.Defaults.class) class DefaultModule {
     final Logger logger;
     final Logger.Level logLevel;
 
@@ -131,12 +132,12 @@ public class LoggerTest {
       this.logLevel = logLevel;
     }
 
+    @Provides Decoder defaultDecoder() {
+      return new Decoder.Default();
+    }
+
     @Provides Encoder defaultEncoder() {
-      return new Encoder() {
-        @Override public void encode(Object object, RequestTemplate template) {
-          template.body(object.toString());
-        }
-      };
+      return new Encoder.Default();
     }
 
     @Provides @Singleton Logger logger() {

--- a/gson/src/main/java/feign/gson/GsonModule.java
+++ b/gson/src/main/java/feign/gson/GsonModule.java
@@ -26,6 +26,7 @@ import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import dagger.Provides;
+import feign.Feign;
 import feign.RequestTemplate;
 import feign.Response;
 import feign.codec.Decoder;
@@ -79,7 +80,7 @@ import static feign.Util.resolveLastTypeParameter;
  * }
  * </pre>
  */
-@dagger.Module(library = true)
+@dagger.Module(injects = Feign.class, addsTo = Feign.Defaults.class)
 public final class GsonModule {
 
   @Provides Encoder encoder(GsonCodec codec) {

--- a/gson/src/test/java/feign/gson/GsonModuleTest.java
+++ b/gson/src/test/java/feign/gson/GsonModuleTest.java
@@ -42,7 +42,7 @@ import static org.testng.Assert.assertEquals;
 
 @Test
 public class GsonModuleTest {
-  @Module(includes = GsonModule.class, library = true, injects = EncoderAndDecoderBindings.class)
+  @Module(includes = GsonModule.class, injects = EncoderAndDecoderBindings.class)
   static class EncoderAndDecoderBindings {
     @Inject Encoder encoder;
     @Inject Decoder decoder;
@@ -56,7 +56,7 @@ public class GsonModuleTest {
     assertEquals(bindings.decoder.getClass(), GsonModule.GsonCodec.class);
   }
 
-  @Module(includes = GsonModule.class, library = true, injects = EncoderBindings.class)
+  @Module(includes = GsonModule.class, injects = EncoderBindings.class)
   static class EncoderBindings {
     @Inject Encoder encoder;
   }
@@ -115,7 +115,7 @@ public class GsonModuleTest {
     private static final long serialVersionUID = 1L;
   }
 
-  @Module(includes = GsonModule.class, library = true, injects = DecoderBindings.class)
+  @Module(includes = GsonModule.class, injects = DecoderBindings.class)
   static class DecoderBindings {
     @Inject Decoder decoder;
   }
@@ -144,7 +144,7 @@ public class GsonModuleTest {
       + "  }\n"//
       + "]\n";
 
-  @Module(includes = GsonModule.class, library = true, injects = CustomTypeAdapter.class)
+  @Module(includes = GsonModule.class, injects = CustomTypeAdapter.class)
   static class CustomTypeAdapter {
     @Provides(type = Provides.Type.SET) TypeAdapter upperZone() {
       return new TypeAdapter<Zone>() {

--- a/gson/src/test/java/feign/gson/examples/GitHubExample.java
+++ b/gson/src/test/java/feign/gson/examples/GitHubExample.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.gson.examples;
+
+import feign.Feign;
+import feign.RequestLine;
+import feign.gson.GsonModule;
+
+import javax.inject.Named;
+import java.util.List;
+
+/**
+ * adapted from {@code com.example.retrofit.GitHubClient}
+ */
+public class GitHubExample {
+
+  interface GitHub {
+    @RequestLine("GET /repos/{owner}/{repo}/contributors")
+    List<Contributor> contributors(@Named("owner") String owner, @Named("repo") String repo);
+  }
+
+  static class Contributor {
+    String login;
+    int contributions;
+  }
+
+  public static void main(String... args) throws InterruptedException {
+    GitHub github = Feign.create(GitHub.class, "https://api.github.com", new GsonModule());
+
+    System.out.println("Let's fetch and print a list of the contributors to this library.");
+    List<Contributor> contributors = github.contributors("netflix", "feign");
+    for (Contributor contributor : contributors) {
+      System.out.println(contributor.login + " (" + contributor.contributions + ")");
+    }
+  }
+}

--- a/ribbon/src/test/java/feign/ribbon/LoadBalancingTargetTest.java
+++ b/ribbon/src/test/java/feign/ribbon/LoadBalancingTargetTest.java
@@ -51,7 +51,7 @@ public class LoadBalancingTargetTest {
 
     try {
       LoadBalancingTarget<TestInterface> target = LoadBalancingTarget.create(TestInterface.class, "http://" + name);
-      TestInterface api = Feign.create(target);
+      TestInterface api = Feign.builder().target(target);
 
       api.post();
       api.post();

--- a/ribbon/src/test/java/feign/ribbon/RibbonClientTest.java
+++ b/ribbon/src/test/java/feign/ribbon/RibbonClientTest.java
@@ -17,14 +17,15 @@ package feign.ribbon;
 
 import com.google.mockwebserver.MockResponse;
 import com.google.mockwebserver.MockWebServer;
-
+import dagger.Provides;
+import feign.Feign;
+import feign.RequestLine;
+import feign.codec.Decoder;
+import feign.codec.Encoder;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.net.URL;
-
-import feign.Feign;
-import feign.RequestLine;
 
 import static com.netflix.config.ConfigurationManager.getConfigInstance;
 import static org.testng.Assert.assertEquals;
@@ -33,6 +34,17 @@ import static org.testng.Assert.assertEquals;
 public class RibbonClientTest {
   interface TestInterface {
     @RequestLine("POST /") void post();
+
+    @dagger.Module(injects = Feign.class, addsTo = Feign.Defaults.class)
+    static class Module {
+      @Provides Decoder defaultDecoder() {
+        return new Decoder.Default();
+      }
+
+      @Provides Encoder defaultEncoder() {
+        return new Encoder.Default();
+      }
+    }
   }
 
   @Test
@@ -51,7 +63,7 @@ public class RibbonClientTest {
 
     try {
 
-      TestInterface api = Feign.create(TestInterface.class, "http://" + client, new RibbonModule());
+      TestInterface api = Feign.create(TestInterface.class, "http://" + client, new TestInterface.Module(), new RibbonModule());
 
       api.post();
       api.post();


### PR DESCRIPTION
This clarifies that `Feign.Defaults` contains everything needed except an `Encoder` and a `Decoder`.

In order to complete the graph, you'll want to 
1. use `Feign.builder()` and specify `.decoder()` and `encoder()`
2. include or specify a codec module `Feign.create(GitHub.class, "https://api.github.com", new GsonModule())`.
3. create your own module and add `@Provides` methods for codec.

``` java
@dagger.Module(addsTo = Feign.Defaults.class)
static class Dependencies {
  @Provides Decoder defaultDecoder() {
    return // my custom
  }

  @Provides Encoder defaultEncoder() {
    return // my custom
  }
}
```
