### PR TITLE
support Feign.builder() w/ SAX decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,15 @@ GitHub github = Feign.create(GitHub.class, "https://api.github.com", new GsonMod
 ### Sax
 [SaxDecoder](https://github.com/Netflix/feign/tree/master/sax) allows you to decode XML in a way that is compatible with normal JVM and also Android environments.
 
+Here's an example of how to configure Sax response parsing:
+```java
+api = Feign.builder()
+           .decoder(SAXDecoder.builder()
+                              .registerContentHandler(UserIdHandler.class)
+                              .build())
+           .target(Api.class, "https://apihost");
+```
+
 ### JAX-RS
 [JAXRSModule](https://github.com/Netflix/feign/tree/master/jaxrs) overrides annotation processing to instead use standard ones supplied by the JAX-RS specification.  This is currently targeted at the 1.1 spec.
 

--- a/sax/README.md
+++ b/sax/README.md
@@ -6,19 +6,9 @@ This module adds support for decoding xml via SAX.
 Add this to your object graph like so:
 
 ```java
-IAM iam = Feign.create(IAM.class, "https://iam.amazonaws.com", new DecodeWithSax());
-
---snip--
-@Module(addsTo = Feign.Defaults.class)
-static class DecodeWithSax {
-  @Provides Decoder saxDecoder(Provider<UserIdHandler> userIdHandler) {
-    return SAXDecoder.builder() //
-        .addContentHandler(userIdHandler) //
-        .build();
-  }
-
-  @Provides Encoder defaultEncoder() {
-    return new Encoder.Default();
-  }
-}
+api = Feign.builder()
+           .decoder(SAXDecoder.builder()
+                              .registerContentHandler(UserIdHandler.class)
+                              .build())
+           .target(Api.class, "https://apihost");
 ```

--- a/sax/src/test/java/feign/sax/SAXDecoderTest.java
+++ b/sax/src/test/java/feign/sax/SAXDecoderTest.java
@@ -17,9 +17,8 @@ package feign.sax;
 
 import dagger.ObjectGraph;
 import dagger.Provides;
-import feign.codec.Decoder;
-import feign.codec.DecodeException;
 import feign.Response;
+import feign.codec.Decoder;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.xml.sax.helpers.DefaultHandler;
@@ -39,11 +38,10 @@ public class SAXDecoderTest {
 
   @dagger.Module(injects = SAXDecoderTest.class)
   static class Module {
-    @Provides Decoder saxDecoder(Provider<NetworkStatusHandler> networkStatus, //
-                                 Provider<NetworkStatusStringHandler> networkStatusAsString) {
+    @Provides Decoder saxDecoder(Provider<NetworkStatusHandler> networkStatus) {
       return SAXDecoder.builder() //
-          .addContentHandler(networkStatus) //
-          .addContentHandler(networkStatusAsString) //
+          .registerContentHandler(NetworkStatus.class, networkStatus) //
+          .registerContentHandler(NetworkStatusStringHandler.class) //
           .build();
     }
   }

--- a/sax/src/test/java/feign/sax/examples/IAMExample.java
+++ b/sax/src/test/java/feign/sax/examples/IAMExample.java
@@ -15,20 +15,13 @@
  */
 package feign.sax.examples;
 
-import dagger.Module;
-import dagger.Provides;
 import feign.Feign;
 import feign.Request;
 import feign.RequestLine;
 import feign.RequestTemplate;
 import feign.Target;
-import feign.codec.Decoder;
-import feign.codec.Encoder;
 import feign.sax.SAXDecoder;
 import org.xml.sax.helpers.DefaultHandler;
-
-import javax.inject.Inject;
-import javax.inject.Provider;
 
 public class IAMExample {
 
@@ -37,7 +30,9 @@ public class IAMExample {
   }
 
   public static void main(String... args) {
-    IAM iam = Feign.create(new IAMTarget(args[0], args[1]), new DecodeWithSax());
+    IAM iam = Feign.builder()//
+        .decoder(SAXDecoder.builder().registerContentHandler(UserIdHandler.class).build())//
+        .target(new IAMTarget(args[0], args[1]));
     System.out.println(iam.userId());
   }
 
@@ -65,23 +60,7 @@ public class IAMExample {
     }
   }
 
-  @Module(addsTo = Feign.Defaults.class)
-  static class DecodeWithSax {
-    @Provides Decoder saxDecoder(Provider<UserIdHandler> userIdHandler) {
-      return SAXDecoder.builder() //
-          .addContentHandler(userIdHandler) //
-          .build();
-    }
-
-    @Provides Encoder defaultEncoder() {
-      return new Encoder.Default();
-    }
-  }
-
-  static class UserIdHandler extends DefaultHandler implements
-      SAXDecoder.ContentHandlerWithResult<Long> {
-    @Inject UserIdHandler() {
-    }
+  static class UserIdHandler extends DefaultHandler implements SAXDecoder.ContentHandlerWithResult<Long> {
 
     private StringBuilder currentText = new StringBuilder();
 


### PR DESCRIPTION
simplified based on feedback from @davidmc24 yesterday.  Notably supports `Feign.builder()` now.

Ex.

``` java
api = Feign.builder()
           .decoder(SAXDecoder.builder()
                              .registerContentHandler(UserIdHandler.class)
                              .build())
           .target(Api.class, "https://apihost");
```
