### PR TITLE
Simplify Decoder.Default by extending StringDecoder

### DIFF
--- a/core/src/main/java/feign/Util.java
+++ b/core/src/main/java/feign/Util.java
@@ -168,6 +168,9 @@ public class Util {
 
   private static final int BUF_SIZE = 0x800; // 2K chars (4K bytes)
 
+  /**
+   * Adapted from {@code com.google.common.io.CharStreams.toString()}.
+   */
   public static String toString(Reader reader) throws IOException {
     if (reader == null) {
       return null;

--- a/core/src/main/java/feign/codec/Decoder.java
+++ b/core/src/main/java/feign/codec/Decoder.java
@@ -17,12 +17,9 @@ package feign.codec;
 
 import feign.FeignException;
 import feign.Response;
-import feign.Util;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
-
-import static java.lang.String.format;
 
 /**
  * Decodes an HTTP response into a single object of the given {@code type}. Invoked when
@@ -76,17 +73,8 @@ public interface Decoder {
   Object decode(Response response, Type type) throws IOException, DecodeException, FeignException;
 
   /**
-   * Default implementation of {@code Decoder} that supports {@code String} signatures.
+   * Default implementation of {@code Decoder}.
    */
-  public class Default implements Decoder {
-    @Override
-    public Object decode(Response response, Type type) throws IOException {
-      if (response.body() == null) {
-        return null;
-      } else if (String.class.equals(type)) {
-        return Util.toString(response.body().asReader());
-      }
-      throw new DecodeException(format("%s is not a type supported by this decoder.", type));
-    }
+  public class Default extends StringDecoder {
   }
 }

--- a/core/src/main/java/feign/codec/StringDecoder.java
+++ b/core/src/main/java/feign/codec/StringDecoder.java
@@ -21,9 +21,8 @@ import feign.Util;
 import java.io.IOException;
 import java.lang.reflect.Type;
 
-/**
- * Adapted from {@code com.google.common.io.CharStreams.toString()}.
- */
+import static java.lang.String.format;
+
 public class StringDecoder implements Decoder {
   @Override
   public Object decode(Response response, Type type) throws IOException {
@@ -31,6 +30,9 @@ public class StringDecoder implements Decoder {
     if (body == null) {
       return null;
     }
-    return Util.toString(body.asReader());
+    if (String.class.equals(type)) {
+      return Util.toString(body.asReader());
+    }
+    throw new DecodeException(format("%s is not a type supported by this decoder.", type));
   }
 }

--- a/core/src/test/java/feign/codec/DefaultDecoderTest.java
+++ b/core/src/test/java/feign/codec/DefaultDecoderTest.java
@@ -16,7 +16,6 @@
 package feign.codec;
 
 import feign.Response;
-import feign.Util;
 import org.testng.annotations.Test;
 import org.w3c.dom.Document;
 


### PR DESCRIPTION
Previously, the default decoder had logic relating to responses that made it distinct from StringDecoder.
Now that that's handled elsewhere, the body of the decode methods had less meaningful differences.
I opted to maintain Decoder.Default for consistency with other default implementations.  StringDecoder
is maintained as a separate class for backwards compatibility, and because it may be useful in the
future for clients to use a plain String decoder even if the default decoder starts having additional
capabilities.
