### PR TITLE
Update to Ribbon 0.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ project(':feign-ribbon') {
 
     dependencies {
         compile     project(':feign-core')
-        compile     'com.netflix.ribbon:ribbon-core:0.2.3'
+        compile     'com.netflix.ribbon:ribbon-core:0.3.1'
         testCompile 'org.testng:testng:6.8.5'
         testCompile 'com.google.mockwebserver:mockwebserver:20130706'
     }

--- a/ribbon/src/main/java/feign/ribbon/LBClient.java
+++ b/ribbon/src/main/java/feign/ribbon/LBClient.java
@@ -62,21 +62,17 @@ class LBClient extends AbstractLoadBalancerAwareClient<LBClient.RibbonRequest, L
     return new RibbonResponse(request.getUri(), response);
   }
 
-  @Override protected boolean isCircuitBreakerException(Exception e) {
+  @Override protected boolean isCircuitBreakerException(Throwable e) {
     return e instanceof IOException;
   }
 
-  @Override protected boolean isRetriableException(Exception e) {
+  @Override protected boolean isRetriableException(Throwable e) {
     return e instanceof RetryableException;
   }
 
   @Override
   protected Pair<String, Integer> deriveSchemeAndPortFromPartialUri(RibbonRequest task) {
     return new Pair<String, Integer>(URI.create(task.request.url()).getScheme(), task.getUri().getPort());
-  }
-
-  @Override protected int getDefaultPort() {
-    return 443;
   }
 
   static class RibbonRequest extends ClientRequest implements Cloneable {
@@ -133,6 +129,13 @@ class LBClient extends AbstractLoadBalancerAwareClient<LBClient.RibbonRequest, L
 
     Response toResponse() {
       return response;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (response.body() != null) {
+            response.body().close();
+        }
     }
   }
 


### PR DESCRIPTION
Ribbon 0.3.1 has a few API changes in AbstractLoadBalancerAwareClient. Feign needs to be updated and released so that users of both feign and ribbon will get binary compatible jars.
