### PR TITLE
slf4j: add slf4j integration module (#94)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+### Version 6.1.0
+* Add [SLF4J](http://www.slf4j.org/) integration
+
 ### Version 6.0.1
 * Fix for BasicAuthRequestInterceptor when username and/or password are long.
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,17 @@ Integration requires you to pass your ribbon client name as the host part of the
 MyService api = Feign.create(MyService.class, "https://myAppProd", new RibbonModule());
 ```
 
+### SLF4J
+[SLF4JModule](https://github.com/Netflix/feign/tree/master/slf4j) allows directing Feign's logging to [SLF4J](http://www.slf4j.org/), allowing you to easily use a logging backend of your choice (Logback, Log4J, etc.)
+
+To use SLF4J with Feign, add both the SLF4J module and an SLF4J binding of your choice to your classpath.  Then, configure Feign to use the Slf4jLogger:
+
+```java
+GitHub github = Feign.builder()
+                     .logger(new Slf4jLogger())
+                     .target(GitHub.class, "https://api.github.com");
+```
+
 ### Decoders
 `Feign.builder()` allows you to specify additional configuration such as how to decode a response.
 
@@ -198,3 +209,5 @@ GitHub github = Feign.builder()
                      .logLevel(Logger.Level.FULL)
                      .target(GitHub.class, "https://api.github.com");
 ```
+
+The SLF4JModule (see above) may also be of interest.

--- a/build.gradle
+++ b/build.gradle
@@ -118,3 +118,18 @@ project(':feign-ribbon') {
         testCompile 'com.google.mockwebserver:mockwebserver:20130706'
     }
 }
+
+project(':feign-slf4j') {
+    apply plugin: 'java'
+
+    test {
+        useTestNG()
+    }
+
+    dependencies {
+        compile     project(':feign-core')
+        compile     'org.slf4j:slf4j-api:1.7.5'
+        testCompile 'org.testng:testng:6.8.5'
+        testCompile 'org.slf4j:slf4j-simple:1.7.5'
+    }
+}

--- a/core/src/main/java/feign/Logger.java
+++ b/core/src/main/java/feign/Logger.java
@@ -70,14 +70,13 @@ public abstract class Logger {
   public static class JavaLogger extends Logger {
     final java.util.logging.Logger logger = java.util.logging.Logger.getLogger(Logger.class.getName());
 
-    @Override void logRequest(String configKey, Level logLevel, Request request) {
+    @Override protected void logRequest(String configKey, Level logLevel, Request request) {
       if (logger.isLoggable(java.util.logging.Level.FINE)) {
         super.logRequest(configKey, logLevel, request);
       }
     }
 
-    @Override
-    Response logAndRebufferResponse(String configKey, Level logLevel, Response response, long elapsedTime) throws IOException {
+    @Override protected Response logAndRebufferResponse(String configKey, Level logLevel, Response response, long elapsedTime) throws IOException {
       if (logger.isLoggable(java.util.logging.Level.FINE)) {
         return super.logAndRebufferResponse(configKey, logLevel, response, elapsedTime);
       }
@@ -110,16 +109,14 @@ public abstract class Logger {
   }
 
   public static class NoOpLogger extends Logger {
-    @Override void logRequest(String configKey, Level logLevel, Request request) {
+    @Override protected void logRequest(String configKey, Level logLevel, Request request) {
     }
 
-    @Override
-    Response logAndRebufferResponse(String configKey, Level logLevel, Response response, long elapsedTime) throws IOException {
+    @Override protected Response logAndRebufferResponse(String configKey, Level logLevel, Response response, long elapsedTime) throws IOException {
       return response;
     }
 
-    @Override
-    protected void log(String configKey, String format, Object... args) {
+    @Override protected void log(String configKey, String format, Object... args) {
     }
   }
 
@@ -133,7 +130,7 @@ public abstract class Logger {
    */
   protected abstract void log(String configKey, String format, Object... args);
 
-  void logRequest(String configKey, Level logLevel, Request request) {
+  protected void logRequest(String configKey, Level logLevel, Request request) {
     log(configKey, "---> %s %s HTTP/1.1", request.method(), request.url());
     if (logLevel.ordinal() >= Level.HEADERS.ordinal()) {
 
@@ -160,7 +157,7 @@ public abstract class Logger {
     log(configKey, "---> RETRYING");
   }
 
-  Response logAndRebufferResponse(String configKey, Level logLevel, Response response, long elapsedTime) throws IOException {
+  protected  Response logAndRebufferResponse(String configKey, Level logLevel, Response response, long elapsedTime) throws IOException {
     log(configKey, "<--- HTTP/1.1 %s %s (%sms)", response.status(), response.reason(), elapsedTime);
     if (logLevel.ordinal() >= Level.HEADERS.ordinal()) {
 
@@ -200,7 +197,7 @@ public abstract class Logger {
     return ioe;
   }
 
-  static String methodTag(String configKey) {
+  protected static String methodTag(String configKey) {
     return new StringBuilder().append('[').append(configKey.substring(0, configKey.indexOf('('))).append("] ").toString();
   }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 rootProject.name='feign'
-include 'core', 'sax', 'gson', 'jackson', 'jaxrs', 'ribbon', 'example-github', 'example-wikipedia'
+include 'core', 'sax', 'gson', 'jackson', 'jaxrs', 'ribbon', 'slf4j', 'example-github', 'example-wikipedia'
 
 rootProject.children.each { childProject ->
     childProject.name = 'feign-' + childProject.name

--- a/slf4j/README.md
+++ b/slf4j/README.md
@@ -1,0 +1,12 @@
+SLF4J
+===================
+
+This module allows directing Feign's logging to [SLF4J](http://www.slf4j.org/), allowing you to easily use a logging backend of your choice (Logback, Log4J, etc.)
+
+To use SLF4J with Feign, add both the SLF4J module and an SLF4J binding of your choice to your classpath.  Then, configure Feign to use the Slf4jLogger:
+
+```java
+GitHub github = Feign.builder()
+                     .logger(new Slf4jLogger())
+                     .target(GitHub.class, "https://api.github.com");
+```

--- a/slf4j/src/main/java/feign/slf4j/Slf4jLogger.java
+++ b/slf4j/src/main/java/feign/slf4j/Slf4jLogger.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.slf4j;
+
+import feign.Request;
+import feign.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Logs to SLF4J at the debug level, if the underlying logger has debug logging enabled.  The underlying logger can
+ * be specified at construction-time, defaulting to the logger for {@link feign.Logger}.
+ */
+public class Slf4jLogger extends feign.Logger {
+  private final Logger logger;
+
+  public Slf4jLogger() {
+    this(feign.Logger.class);
+  }
+
+  public Slf4jLogger(Class<?> clazz) {
+    this(LoggerFactory.getLogger(clazz));
+  }
+
+  public Slf4jLogger(String name) {
+    this(LoggerFactory.getLogger(name));
+  }
+
+  Slf4jLogger(Logger logger) {
+    this.logger = logger;
+  }
+
+  @Override protected void logRequest(String configKey, Level logLevel, Request request) {
+    if (logger.isDebugEnabled()) {
+      super.logRequest(configKey, logLevel, request);
+    }
+  }
+
+  @Override protected Response logAndRebufferResponse(String configKey, Level logLevel, Response response, long elapsedTime) throws IOException {
+    if (logger.isDebugEnabled()) {
+      return super.logAndRebufferResponse(configKey, logLevel, response, elapsedTime);
+    }
+    return response;
+  }
+
+  @Override protected void log(String configKey, String format, Object... args) {
+    // Not using SLF4J's support for parameterized messages (even though it would be more efficient) because it would
+    // require the incoming message formats to be SLF4J-specific.
+    logger.debug(String.format(methodTag(configKey) + format, args));
+  }
+}

--- a/slf4j/src/test/java/feign/slf4j/ReflectionUtil.java
+++ b/slf4j/src/test/java/feign/slf4j/ReflectionUtil.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.slf4j;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+/**
+ * Lightweight approach to using reflection to bypass access restrictions for testing.  If this class grows, it may be
+ * better to use a testing library instead, such as Powermock.
+ */
+class ReflectionUtil {
+  static void setStaticField(Class<?> declaringClass, String fieldName, Object fieldValue) throws Exception {
+    Field field = declaringClass.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(null, fieldValue);
+  }
+
+  static void invokeVoidNoArgMethod(Class<?> declaringClass, String methodName, Object instance) throws Exception {
+    Method method = declaringClass.getDeclaredMethod(methodName);
+    method.setAccessible(true);
+    method.invoke(instance);
+  }
+}

--- a/slf4j/src/test/java/feign/slf4j/SimpleLoggerUtil.java
+++ b/slf4j/src/test/java/feign/slf4j/SimpleLoggerUtil.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.slf4j;
+
+import org.slf4j.LoggerFactory;
+import org.slf4j.impl.SimpleLogger;
+import org.slf4j.impl.SimpleLoggerFactory;
+
+import java.io.File;
+
+/**
+ * A testing utility to allow control over {@link SimpleLogger}.  In some cases, reflection is used to bypass access
+ * restrictions.
+ */
+class SimpleLoggerUtil {
+  static void initialize(File file, String logLevel) throws Exception {
+    System.setProperty(SimpleLogger.SHOW_THREAD_NAME_KEY, "false");
+    System.setProperty(SimpleLogger.LOG_FILE_KEY, file.getAbsolutePath());
+    System.setProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY, logLevel);
+    resetSlf4j();
+  }
+
+  static void resetToDefaults() throws Exception {
+    System.clearProperty(SimpleLogger.SHOW_THREAD_NAME_KEY);
+    System.clearProperty(SimpleLogger.LOG_FILE_KEY);
+    System.clearProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY);
+    resetSlf4j();
+  }
+
+  private static void resetSlf4j() throws Exception {
+    ReflectionUtil.setStaticField(SimpleLogger.class, "INITIALIZED", false);
+    ReflectionUtil.invokeVoidNoArgMethod(SimpleLoggerFactory.class, "reset", LoggerFactory.getILoggerFactory());
+  }
+}

--- a/slf4j/src/test/java/feign/slf4j/Slf4jLoggerTest.java
+++ b/slf4j/src/test/java/feign/slf4j/Slf4jLoggerTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.slf4j;
+
+import feign.Feign;
+import feign.Logger;
+import feign.Request;
+import feign.RequestTemplate;
+import feign.Response;
+import feign.Util;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.FileReader;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.testng.Assert.assertEquals;
+
+public class Slf4jLoggerTest {
+  private static final String CONFIG_KEY = "someMethod()";
+  private static final Request REQUEST =
+      new RequestTemplate().method("GET").append("http://api.example.com").request();
+  private static final Response RESPONSE =
+      Response.create(200, "OK", Collections.<String, Collection<String>>emptyMap(), new byte[0]);
+
+  private File logFile;
+  private Slf4jLogger logger;
+
+  @AfterMethod
+  void tearDown() throws Exception {
+    SimpleLoggerUtil.resetToDefaults();
+    logFile.delete();
+  }
+
+  @Test public void useFeignLoggerByDefault() throws Exception {
+    initializeSimpleLogger("debug");
+    logger = new Slf4jLogger();
+    logger.log(CONFIG_KEY, "This is my message");
+    assertLoggedMessages("DEBUG feign.Logger - [someMethod] This is my message\n");
+  }
+
+  @Test public void useLoggerByNameIfRequested() throws Exception {
+    initializeSimpleLogger("debug");
+    logger = new Slf4jLogger("named.logger");
+    logger.log(CONFIG_KEY, "This is my message");
+    assertLoggedMessages("DEBUG named.logger - [someMethod] This is my message\n");
+  }
+
+  @Test public void useLoggerByClassIfRequested() throws Exception {
+    initializeSimpleLogger("debug");
+    logger = new Slf4jLogger(Feign.class);
+    logger.log(CONFIG_KEY, "This is my message");
+    assertLoggedMessages("DEBUG feign.Feign - [someMethod] This is my message\n");
+  }
+
+  @Test public void useSpecifiedLoggerIfRequested() throws Exception {
+    initializeSimpleLogger("debug");
+    logger = new Slf4jLogger(LoggerFactory.getLogger("specified.logger"));
+    logger.log(CONFIG_KEY, "This is my message");
+    assertLoggedMessages("DEBUG specified.logger - [someMethod] This is my message\n");
+  }
+
+  @Test public void logOnlyIfDebugEnabled() throws Exception {
+    initializeSimpleLogger("info");
+    logger = new Slf4jLogger();
+    logger.log(CONFIG_KEY, "A message with %d formatting %s.", 2, "tokens");
+    logger.logRequest(CONFIG_KEY, Logger.Level.BASIC, REQUEST);
+    logger.logAndRebufferResponse(CONFIG_KEY, Logger.Level.BASIC, RESPONSE, 273);
+    assertLoggedMessages("");
+  }
+
+  @Test public void logRequestsAndResponses() throws Exception {
+    initializeSimpleLogger("debug");
+    logger = new Slf4jLogger();
+    logger.log(CONFIG_KEY, "A message with %d formatting %s.", 2, "tokens");
+    logger.logRequest(CONFIG_KEY, Logger.Level.BASIC, REQUEST);
+    logger.logAndRebufferResponse(CONFIG_KEY, Logger.Level.BASIC, RESPONSE, 273);
+    assertLoggedMessages(
+        "DEBUG feign.Logger - [someMethod] A message with 2 formatting tokens.\n" +
+        "DEBUG feign.Logger - [someMethod] ---> GET http://api.example.com HTTP/1.1\n" +
+        "DEBUG feign.Logger - [someMethod] <--- HTTP/1.1 200 OK (273ms)\n"
+    );
+  }
+
+  private void initializeSimpleLogger(String logLevel) throws Exception {
+    logFile = File.createTempFile(getClass().getName(), ".log");
+    SimpleLoggerUtil.initialize(logFile, logLevel);
+  }
+
+  private void assertLoggedMessages(String expectedMessages) throws Exception {
+    assertEquals(Util.toString(new FileReader(logFile)), expectedMessages);
+  }
+}


### PR DESCRIPTION
Adds a new "slf4j" module.  A few methods in Logger are now protected rather
than package protected to allow access by Logger subclasses that aren't
inner classes of Logger.
