### PR TITLE
fix changelog for 6.0.1 (#95)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-### Version 6.0.2
+### Version 6.0.1
 * Fix for BasicAuthRequestInterceptor when username and/or password are long.
 
 ### Version 6.0


### PR DESCRIPTION
It looks like the changes for 6.0.1 accidentally got marked as 6.0.2 in the changelog.
