### PR TITLE
Pump up versions of feign libraries used by examples.

### DIFF
--- a/example-github/build.gradle
+++ b/example-github/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'java'
 
 dependencies {
-  compile  'com.netflix.feign:feign-core:6.0.1'
-  compile  'com.netflix.feign:feign-gson:6.0.1'
+  compile  'com.netflix.feign:feign-core:6.1.1'
+  compile  'com.netflix.feign:feign-gson:6.1.1'
   provided 'com.squareup.dagger:dagger-compiler:1.1.0'
 }
 

--- a/example-wikipedia/build.gradle
+++ b/example-wikipedia/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'java'
 
 dependencies {
-  compile  'com.netflix.feign:feign-core:6.0.1'
-  compile  'com.netflix.feign:feign-gson:6.0.1'
+  compile  'com.netflix.feign:feign-core:6.1.1'
+  compile  'com.netflix.feign:feign-gson:6.1.1'
   provided 'com.squareup.dagger:dagger-compiler:1.1.0'
 }
 


### PR DESCRIPTION
These are some problems accessing 6.0.1 artifacts from the build job when releasing 6.1.2. So I am pumping up the versions.
