### PR TITLE
Handle JAXRS Path annotation processes without slashes

### DIFF
--- a/jaxrs/src/main/java/feign/jaxrs/JAXRSModule.java
+++ b/jaxrs/src/main/java/feign/jaxrs/JAXRSModule.java
@@ -57,6 +57,9 @@ public final class JAXRSModule {
       if (path != null) {
         String pathValue = emptyToNull(path.value());
         checkState(pathValue != null, "Path.value() was empty on type %s", method.getDeclaringClass().getName());
+        if (!pathValue.startsWith("/")) {
+            pathValue = "/" + pathValue;
+        }
         md.template().insert(0, pathValue);
       }
       return md;
@@ -74,7 +77,11 @@ public final class JAXRSModule {
       } else if (annotationType == Path.class) {
         String pathValue = emptyToNull(Path.class.cast(methodAnnotation).value());
         checkState(pathValue != null, "Path.value() was empty on method %s", method.getName());
-        data.template().append(Path.class.cast(methodAnnotation).value());
+        String methodAnnotationValue = Path.class.cast(methodAnnotation).value();
+        if (!methodAnnotationValue.startsWith("/") && !data.template().toString().endsWith("/")) {
+          methodAnnotationValue = "/" + methodAnnotationValue;
+        }
+        data.template().append(methodAnnotationValue);
       } else if (annotationType == Produces.class) {
         String[] serverProduces = ((Produces) methodAnnotation).value();
         String clientAccepts = serverProduces.length == 0 ? null: emptyToNull(serverProduces[0]);

--- a/jaxrs/src/test/java/feign/jaxrs/JAXRSContractTest.java
+++ b/jaxrs/src/test/java/feign/jaxrs/JAXRSContractTest.java
@@ -342,4 +342,34 @@ public class JAXRSContractTest {
   public void emptyHeaderParam() throws Exception {
     contract.parseAndValidatateMetadata(HeaderParams.class.getDeclaredMethod("emptyHeaderParam", String.class));
   }
+
+  @Path("base")
+  interface PathsWithoutAnySlashes {
+    @GET @Path("specific") Response get();
+  }
+
+  @Test public void pathsWithoutSlashesParseCorrectly() throws Exception {
+    MethodMetadata md = contract.parseAndValidatateMetadata(PathsWithoutAnySlashes.class.getDeclaredMethod("get"));
+    assertEquals(md.template().url(), "/base/specific");
+  }
+
+  @Path("/base")
+  interface PathsWithSomeSlashes {
+    @GET @Path("specific") Response get();
+  }
+
+  @Test public void pathsWithSomeSlashesParseCorrectly() throws Exception {
+    MethodMetadata md = contract.parseAndValidatateMetadata(PathsWithSomeSlashes.class.getDeclaredMethod("get"));
+    assertEquals(md.template().url(), "/base/specific");
+  }
+
+  @Path("base")
+  interface PathsWithSomeOtherSlashes {
+    @GET @Path("/specific") Response get();
+  }
+
+  @Test public void pathsWithSomeOtherSlashesParseCorrectly() throws Exception {
+    MethodMetadata md = contract.parseAndValidatateMetadata(PathsWithSomeOtherSlashes.class.getDeclaredMethod("get"));
+    assertEquals(md.template().url(), "/base/specific");
+  }
 }


### PR DESCRIPTION
Path annotations without the leading or trailing slashes are supported by JAXRS, this small change will make sure that the module will work as well. Otherwise, the @Path values are just concatenated together.
