### PR TITLE
Integrate with latest ribbon release (ribbon-loadbalancer)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ project(':feign-ribbon') {
 
     dependencies {
         compile     project(':feign-core')
-        compile     'com.netflix.ribbon:ribbon-core:0.2.4'
+        compile     'com.netflix.ribbon:ribbon-loadbalancer:2.0-RC5'
         testCompile 'org.testng:testng:6.8.5'
         testCompile 'com.google.mockwebserver:mockwebserver:20130706'
     }


### PR DESCRIPTION
latest ribbon-release (2.0-RC5) is not compatible with feign api. This PR addresses the issue.
