### PR TITLE
Disables fallback when there's no fallback class configured

### DIFF
--- a/hystrix/src/main/java/feign/hystrix/HystrixInvocationHandler.java
+++ b/hystrix/src/main/java/feign/hystrix/HystrixInvocationHandler.java
@@ -90,7 +90,9 @@ final class HystrixInvocationHandler implements InvocationHandler {
     String commandKey = method.getName();
     HystrixCommand.Setter setter = HystrixCommand.Setter
         .withGroupKey(HystrixCommandGroupKey.Factory.asKey(groupKey))
-        .andCommandKey(HystrixCommandKey.Factory.asKey(commandKey));
+        .andCommandKey(HystrixCommandKey.Factory.asKey(commandKey))
+        .andCommandPropertiesDefaults(
+            HystrixCommandProperties.Setter().withFallbackEnabled(fallback != null));
 
     HystrixCommand<Object> hystrixCommand = new HystrixCommand<Object>(setter) {
       @Override

--- a/hystrix/src/test/java/feign/hystrix/HystrixBuilderTest.java
+++ b/hystrix/src/test/java/feign/hystrix/HystrixBuilderTest.java
@@ -301,7 +301,7 @@ public class HystrixBuilderTest {
     assertThat(testSubscriber.getOnNextEvents()).isEmpty();
     assertThat(testSubscriber.getOnErrorEvents().get(0))
         .isInstanceOf(HystrixRuntimeException.class)
-        .hasMessage("listObservable failed and no fallback available.");
+        .hasMessage("listObservable failed and fallback disabled.");
   }
 
   @Test


### PR DESCRIPTION
I'm not sure if this will solve the below issue, but it seems like we
should disable fallbacks when we know we don't have one.

See https://github.com/spring-cloud/spring-cloud-netflix/issues/1204