### PR TITLE
Allows query parameters to match on a substring. Ex q=body:{body}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 9.1
+* Allows query parameters to match on a substring. Ex `q=body:{body}`
+
 ### Version 9.0
 * Migrates to maven from gradle
 * Changes maven groupId to `io.github.openfeign`

--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -258,7 +258,7 @@ public interface Contract {
           isHttpAnnotation = true;
           String varName = '{' + name + '}';
           if (data.template().url().indexOf(varName) == -1 &&
-              !searchMapValuesContainsExact(data.template().queries(), varName) &&
+              !searchMapValuesContainsSubstring(data.template().queries(), varName) &&
               !searchMapValuesContainsSubstring(data.template().headers(), varName)) {
             data.formParams().add(name);
           }
@@ -274,22 +274,6 @@ public interface Contract {
         }
       }
       return isHttpAnnotation;
-    }
-
-    private static <K, V> boolean searchMapValuesContainsExact(Map<K, Collection<V>> map,
-                                                               V search) {
-      Collection<Collection<V>> values = map.values();
-      if (values == null) {
-        return false;
-      }
-
-      for (Collection<V> entry : values) {
-        if (entry.contains(search)) {
-          return true;
-        }
-      }
-
-      return false;
     }
 
     private static <K, V> boolean searchMapValuesContainsSubstring(Map<K, Collection<String>> map,

--- a/core/src/test/java/feign/DefaultContractTest.java
+++ b/core/src/test/java/feign/DefaultContractTest.java
@@ -770,4 +770,19 @@ public class DefaultContractTest {
     MethodMetadata md = mds.get(0);
     assertThat(md.configKey()).isEqualTo("DefaultMethodOnInterface#get(String)");
   }
+
+  interface SubstringQuery {
+    @RequestLine("GET /_search?q=body:{body}")
+    String paramIsASubstringOfAQuery(@Param("body") String body);
+  }
+
+  @Test
+  public void paramIsASubstringOfAQuery() throws Exception {
+    List<MethodMetadata> mds = contract.parseAndValidatateMetadata(SubstringQuery.class);
+
+    assertThat(mds.get(0).template().queries()).containsExactly(
+        entry("q", asList("body:{body}"))
+    );
+    assertThat(mds.get(0).formParams()).isEmpty(); // Prevent issue 424
+  }
 }


### PR DESCRIPTION
This is to help develop apis like Elasticsearch which nest queries in
query parameters.

Fixes #424