### PR TITLE
Makes request info available to logResponseAndRebuffer method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 9.2
+* Adds support for logging HTTP request only on error response
+
 ### Version 9.1
 * Allows query parameters to match on a substring. Ex `q=body:{body}`
 

--- a/core/src/main/java/feign/Logger.java
+++ b/core/src/main/java/feign/Logger.java
@@ -75,8 +75,8 @@ public abstract class Logger {
     log(configKey, "---> RETRYING");
   }
 
-  protected Response logAndRebufferResponse(String configKey, Level logLevel, Response response,
-                                            long elapsedTime) throws IOException {
+  protected Response logAndRebufferResponse(String configKey, Level logLevel, Request request,
+                                            Response response, long elapsedTime) throws IOException {
     String reason = response.reason() != null && logLevel.compareTo(Level.NONE) > 0 ?
         " " + response.reason() : "";
     log(configKey, "<--- HTTP/1.1 %s%s (%sms)", response.status(), reason, elapsedTime);
@@ -168,10 +168,10 @@ public abstract class Logger {
     }
 
     @Override
-    protected Response logAndRebufferResponse(String configKey, Level logLevel, Response response,
-                                              long elapsedTime) throws IOException {
+    protected Response logAndRebufferResponse(String configKey, Level logLevel, Request request,
+                                              Response response, long elapsedTime) throws IOException {
       if (logger.isLoggable(java.util.logging.Level.FINE)) {
-        return super.logAndRebufferResponse(configKey, logLevel, response, elapsedTime);
+        return super.logAndRebufferResponse(configKey, logLevel, request, response, elapsedTime);
       }
       return response;
     }
@@ -210,8 +210,8 @@ public abstract class Logger {
     }
 
     @Override
-    protected Response logAndRebufferResponse(String configKey, Level logLevel, Response response,
-                                              long elapsedTime) throws IOException {
+    protected Response logAndRebufferResponse(String configKey, Level logLevel, Request request,
+                                              Response response, long elapsedTime) throws IOException {
       return response;
     }
 

--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -107,7 +107,7 @@ final class SynchronousMethodHandler implements MethodHandler {
     try {
       if (logLevel != Logger.Level.NONE) {
         response =
-            logger.logAndRebufferResponse(metadata.configKey(), logLevel, response, elapsedTime);
+            logger.logAndRebufferResponse(metadata.configKey(), logLevel, request, response, elapsedTime);
       }
       if (Response.class == metadata.returnType()) {
         if (response.body() == null) {

--- a/slf4j/src/main/java/feign/slf4j/Slf4jLogger.java
+++ b/slf4j/src/main/java/feign/slf4j/Slf4jLogger.java
@@ -56,10 +56,10 @@ public class Slf4jLogger extends feign.Logger {
   }
 
   @Override
-  protected Response logAndRebufferResponse(String configKey, Level logLevel, Response response,
-                                            long elapsedTime) throws IOException {
+  protected Response logAndRebufferResponse(String configKey, Level logLevel, Request request,
+                                            Response response, long elapsedTime) throws IOException {
     if (logger.isDebugEnabled()) {
-      return super.logAndRebufferResponse(configKey, logLevel, response, elapsedTime);
+      return super.logAndRebufferResponse(configKey, logLevel, request, response, elapsedTime);
     }
     return response;
   }

--- a/slf4j/src/test/java/feign/slf4j/Slf4jLoggerTest.java
+++ b/slf4j/src/test/java/feign/slf4j/Slf4jLoggerTest.java
@@ -15,6 +15,7 @@
  */
 package feign.slf4j;
 
+import com.sun.org.apache.regexp.internal.RE;
 import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
@@ -82,7 +83,7 @@ public class Slf4jLoggerTest {
     logger = new Slf4jLogger();
     logger.log(CONFIG_KEY, "A message with %d formatting %s.", 2, "tokens");
     logger.logRequest(CONFIG_KEY, Logger.Level.BASIC, REQUEST);
-    logger.logAndRebufferResponse(CONFIG_KEY, Logger.Level.BASIC, RESPONSE, 273);
+    logger.logAndRebufferResponse(CONFIG_KEY, Logger.Level.BASIC, REQUEST, RESPONSE, 273);
   }
 
   @Test
@@ -96,6 +97,6 @@ public class Slf4jLoggerTest {
     logger = new Slf4jLogger();
     logger.log(CONFIG_KEY, "A message with %d formatting %s.", 2, "tokens");
     logger.logRequest(CONFIG_KEY, Logger.Level.BASIC, REQUEST);
-    logger.logAndRebufferResponse(CONFIG_KEY, Logger.Level.BASIC, RESPONSE, 273);
+    logger.logAndRebufferResponse(CONFIG_KEY, Logger.Level.BASIC, REQUEST, RESPONSE, 273);
   }
 }


### PR DESCRIPTION
Added the 'Request request' parameter to the abstract logResponseAndRebuffer method.
* Allows developer to check response code before logging HTTP requests