### PR TITLE
Added builder methods for Response and deprecated factory methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Version 9.2
 * Supports context path when using Ribbon `LoadBalancingTarget`
+* Adds builder methods for the Response object
+* Deprecates Response factory methods
+* Adds nullable Request field to the Response object
 
 ### Version 9.1
 * Allows query parameters to match on a substring. Ex `q=body:{body}`

--- a/core/src/main/java/feign/Client.java
+++ b/core/src/main/java/feign/Client.java
@@ -71,7 +71,7 @@ public interface Client {
     @Override
     public Response execute(Request request, Options options) throws IOException {
       HttpURLConnection connection = convertAndSend(request, options);
-      return convertResponse(connection);
+      return convertResponse(connection).toBuilder().request(request).build();
     }
 
     HttpURLConnection convertAndSend(Request request, Options options) throws IOException {
@@ -175,7 +175,12 @@ public interface Client {
       } else {
         stream = connection.getInputStream();
       }
-      return Response.create(status, reason, headers, stream, length);
+      return Response.builder()
+              .status(status)
+              .reason(reason)
+              .headers(headers)
+              .body(stream, length)
+              .build();
     }
   }
 }

--- a/core/src/main/java/feign/Logger.java
+++ b/core/src/main/java/feign/Logger.java
@@ -99,7 +99,7 @@ public abstract class Logger {
           log(configKey, "%s", decodeOrDefault(bodyData, UTF_8, "Binary data"));
         }
         log(configKey, "<--- END HTTP (%s-byte body)", bodyLength);
-        return Response.create(response.status(), response.reason(), response.headers(), bodyData);
+        return response.toBuilder().body(bodyData).build();
       } else {
         log(configKey, "<--- END HTTP (%s-byte body)", bodyLength);
       }

--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -95,6 +95,8 @@ final class SynchronousMethodHandler implements MethodHandler {
     long start = System.nanoTime();
     try {
       response = client.execute(request, options);
+      // ensure the request is set. TODO: remove in Feign 10
+      response.toBuilder().request(request).build();
     } catch (IOException e) {
       if (logLevel != Logger.Level.NONE) {
         logger.logIOException(metadata.configKey(), logLevel, e, elapsedTime(start));
@@ -108,6 +110,8 @@ final class SynchronousMethodHandler implements MethodHandler {
       if (logLevel != Logger.Level.NONE) {
         response =
             logger.logAndRebufferResponse(metadata.configKey(), logLevel, response, elapsedTime);
+        // ensure the request is set. TODO: remove in Feign 10
+        response.toBuilder().request(request).build();
       }
       if (Response.class == metadata.returnType()) {
         if (response.body() == null) {
@@ -120,7 +124,7 @@ final class SynchronousMethodHandler implements MethodHandler {
         }
         // Ensure the response body is disconnected
         byte[] bodyData = Util.toByteArray(response.body().asInputStream());
-        return Response.create(response.status(), response.reason(), response.headers(), bodyData);
+        return response.toBuilder().body(bodyData).build();
       }
       if (response.status() >= 200 && response.status() < 300) {
         if (void.class == metadata.returnType()) {

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -492,7 +492,12 @@ public class FeignTest {
   public void whenReturnTypeIsResponseNoErrorHandling() {
     Map<String, Collection<String>> headers = new LinkedHashMap<String, Collection<String>>();
     headers.put("Location", Arrays.asList("http://bar.com"));
-    final Response response = Response.create(302, "Found", headers, new byte[0]);
+    final Response response = Response.builder()
+            .status(302)
+            .reason("Found")
+            .headers(headers)
+            .body(new byte[0])
+            .build();
 
     TestInterface api = Feign.builder()
         .client(new Client() { // fake client as Client.Default follows redirects.

--- a/core/src/test/java/feign/ResponseTest.java
+++ b/core/src/test/java/feign/ResponseTest.java
@@ -31,41 +31,41 @@ public class ResponseTest {
 
   @Test
   public void reasonPhraseIsOptional() {
-    Response response = Response.create(200, null /* reason phrase */, Collections.
-        <String, Collection<String>>emptyMap(), new byte[0]);
+    Response response = Response.builder()
+            .status(200)
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .body(new byte[0])
+            .build();
 
     assertThat(response.reason()).isNull();
     assertThat(response.toString()).isEqualTo("HTTP/1.1 200\n\n");
   }
 
   @Test
-  public void lowerCasesNamesOfHeaders() {
-    Response response = Response.create(200,
-                                        null,
-                                        Collections.singletonMap("Content-Type",
-                                                                 Collections.singletonList("application/json")),
-                                        new byte[0]);
-    assertThat(response.headers()).containsOnly(entry(("content-type"), Collections.singletonList("application/json")));
-  }
-
-  @Test
   public void canAccessHeadersCaseInsensitively() {
+    Map<String, Collection<String>> headersMap = new LinkedHashMap();
     List<String> valueList = Collections.singletonList("application/json");
-    Response response = Response.create(200,
-                                        null,
-                                        Collections.singletonMap("Content-Type", valueList),
-                                        new byte[0]);
+    headersMap.put("Content-Type", valueList);
+    Response response = Response.builder()
+            .status(200)
+            .headers(headersMap)
+            .body(new byte[0])
+            .build();
     assertThat(response.headers().get("content-type")).isEqualTo(valueList);
     assertThat(response.headers().get("Content-Type")).isEqualTo(valueList);
   }
 
   @Test
   public void headerValuesWithSameNameOnlyVaryingInCaseAreMerged() {
-    Map<String, Collection<String>> headersMap = new LinkedHashMap<>();
+    Map<String, Collection<String>> headersMap = new LinkedHashMap();
     headersMap.put("Set-Cookie", Arrays.asList("Cookie-A=Value", "Cookie-B=Value"));
     headersMap.put("set-cookie", Arrays.asList("Cookie-C=Value"));
 
-    Response response = Response.create(200, null, headersMap, new byte[0]);
+    Response response = Response.builder()
+            .status(200)
+            .headers(headersMap)
+            .body(new byte[0])
+            .build();
 
     List<String> expectedHeaderValue = Arrays.asList("Cookie-A=Value", "Cookie-B=Value", "Cookie-C=Value");
     assertThat(response.headers()).containsOnly(entry(("set-cookie"), expectedHeaderValue));

--- a/core/src/test/java/feign/codec/DefaultDecoderTest.java
+++ b/core/src/test/java/feign/codec/DefaultDecoderTest.java
@@ -74,11 +74,19 @@ public class DefaultDecoderTest {
     InputStream inputStream = new ByteArrayInputStream(content.getBytes(UTF_8));
     Map<String, Collection<String>> headers = new HashMap<String, Collection<String>>();
     headers.put("Content-Type", Collections.singleton("text/plain"));
-    return Response.create(200, "OK", headers, inputStream, content.length());
+    return Response.builder()
+            .status(200)
+            .reason("OK")
+            .headers(headers)
+            .body(inputStream, content.length())
+            .build();
   }
 
   private Response nullBodyResponse() {
-    return Response
-        .create(200, "OK", Collections.<String, Collection<String>>emptyMap(), (byte[]) null);
+    return Response.builder()
+            .status(200)
+            .reason("OK")
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .build();
   }
 }

--- a/core/src/test/java/feign/codec/DefaultErrorDecoderTest.java
+++ b/core/src/test/java/feign/codec/DefaultErrorDecoderTest.java
@@ -45,7 +45,11 @@ public class DefaultErrorDecoderTest {
     thrown.expect(FeignException.class);
     thrown.expectMessage("status 500 reading Service#foo()");
 
-    Response response = Response.create(500, "Internal server error", headers, (byte[]) null);
+    Response response = Response.builder()
+            .status(500)
+            .reason("Internal server error")
+            .headers(headers)
+            .build();
 
     throw errorDecoder.decode("Service#foo()", response);
   }
@@ -55,14 +59,23 @@ public class DefaultErrorDecoderTest {
     thrown.expect(FeignException.class);
     thrown.expectMessage("status 500 reading Service#foo(); content:\nhello world");
 
-    Response response = Response.create(500, "Internal server error", headers, "hello world", UTF_8);
+    Response response = Response.builder()
+            .status(500)
+            .reason("Internal server error")
+            .headers(headers)
+            .body("hello world", UTF_8)
+            .build();
 
     throw errorDecoder.decode("Service#foo()", response);
   }
 
   @Test
   public void testFeignExceptionIncludesStatus() throws Throwable {
-    Response response = Response.create(400, "Bad request", headers, (byte[]) null);
+    Response response = Response.builder()
+            .status(400)
+            .reason("Bad request")
+            .headers(headers)
+            .build();
 
     Exception exception = errorDecoder.decode("Service#foo()", response);
 
@@ -76,7 +89,11 @@ public class DefaultErrorDecoderTest {
     thrown.expectMessage("status 503 reading Service#foo()");
 
     headers.put(RETRY_AFTER, Arrays.asList("Sat, 1 Jan 2000 00:00:00 GMT"));
-    Response response = Response.create(503, "Service Unavailable", headers, (byte[]) null);
+    Response response = Response.builder()
+            .status(503)
+            .reason("Service Unavailable")
+            .headers(headers)
+            .build();
 
     throw errorDecoder.decode("Service#foo()", response);
   }

--- a/gson/src/test/java/feign/gson/GsonCodecTest.java
+++ b/gson/src/test/java/feign/gson/GsonCodecTest.java
@@ -60,9 +60,12 @@ public class GsonCodecTest {
     Map<String, Object> map = new LinkedHashMap<String, Object>();
     map.put("foo", 1);
 
-    Response response =
-        Response.create(200, "OK", Collections.<String, Collection<String>>emptyMap(),
-                        "{\"foo\": 1}", UTF_8);
+    Response response = Response.builder()
+            .status(200)
+            .reason("OK")
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .body("{\"foo\": 1}", UTF_8)
+            .build();
     assertEquals(new GsonDecoder().decode(response, new TypeToken<Map<String, Object>>() {
     }.getType()), map);
   }
@@ -115,26 +118,34 @@ public class GsonCodecTest {
     zones.add(new Zone("denominator.io."));
     zones.add(new Zone("denominator.io.", "ABCD"));
 
-    Response response =
-        Response.create(200, "OK", Collections.<String, Collection<String>>emptyMap(), zonesJson,
-                        UTF_8);
+    Response response = Response.builder()
+            .status(200)
+            .reason("OK")
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .body(zonesJson, UTF_8)
+            .build();
     assertEquals(zones, new GsonDecoder().decode(response, new TypeToken<List<Zone>>() {
     }.getType()));
   }
 
   @Test
   public void nullBodyDecodesToNull() throws Exception {
-    Response response = Response.create(204, "OK",
-                                        Collections.<String, Collection<String>>emptyMap(),
-                                        (byte[]) null);
+    Response response = Response.builder()
+            .status(204)
+            .reason("OK")
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .build();
     assertNull(new GsonDecoder().decode(response, String.class));
   }
 
   @Test
   public void emptyBodyDecodesToNull() throws Exception {
-    Response response = Response.create(204, "OK",
-                                        Collections.<String, Collection<String>>emptyMap(),
-                                        new byte[0]);
+    Response response = Response.builder()
+            .status(204)
+            .reason("OK")
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .body(new byte[0])
+            .build();
     assertNull(new GsonDecoder().decode(response, String.class));
   }
 
@@ -181,8 +192,12 @@ public class GsonCodecTest {
     zones.add(new Zone("DENOMINATOR.IO.", "ABCD"));
 
     Response response =
-        Response.create(200, "OK", Collections.<String, Collection<String>>emptyMap(), zonesJson,
-                        UTF_8);
+        Response.builder()
+                .status(200)
+                .reason("OK")
+                .headers(Collections.<String, Collection<String>>emptyMap())
+                .body(zonesJson, UTF_8)
+                .build();
     assertEquals(zones, decoder.decode(response, new TypeToken<List<Zone>>() {
     }.getType()));
   }
@@ -214,9 +229,11 @@ public class GsonCodecTest {
   /** Enabled via {@link feign.Feign.Builder#decode404()} */
   @Test
   public void notFoundDecodesToEmpty() throws Exception {
-    Response response = Response.create(404, "NOT FOUND",
-        Collections.<String, Collection<String>>emptyMap(),
-        (byte[]) null);
+    Response response = Response.builder()
+            .status(404)
+            .reason("NOT FOUND")
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .build();
     assertThat((byte[]) new GsonDecoder().decode(response, byte[].class)).isEmpty();
   }
 }

--- a/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
+++ b/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
@@ -85,7 +85,7 @@ public final class ApacheHttpClient implements Client {
       throw new IOException("URL '" + request.url() + "' couldn't be parsed into a URI", e);
     }
     HttpResponse httpResponse = client.execute(httpUriRequest);
-    return toFeignResponse(httpResponse);
+    return toFeignResponse(httpResponse).toBuilder().request(request).build();
   }
 
   HttpUriRequest toHttpUriRequest(Request request, Request.Options options) throws
@@ -182,7 +182,12 @@ public final class ApacheHttpClient implements Client {
       headerValues.add(value);
     }
 
-    return Response.create(statusCode, reason, headers, toFeignBody(httpResponse));
+    return Response.builder()
+            .status(statusCode)
+            .reason(reason)
+            .headers(headers)
+            .body(toFeignBody(httpResponse))
+            .build();
   }
 
   Response.Body toFeignBody(HttpResponse httpResponse) throws IOException {

--- a/jackson-jaxb/src/test/java/feign/jackson/jaxb/JacksonJaxbCodecTest.java
+++ b/jackson-jaxb/src/test/java/feign/jackson/jaxb/JacksonJaxbCodecTest.java
@@ -30,8 +30,12 @@ public class JacksonJaxbCodecTest {
 
   @Test
   public void decodeTest() throws Exception {
-    Response response =
-        Response.create(200, "OK", Collections.<String, Collection<String>>emptyMap(), "{\"value\":\"Test\"}", UTF_8);
+    Response response = Response.builder()
+            .status(200)
+            .reason("OK")
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .body("{\"value\":\"Test\"}", UTF_8)
+            .build();
     JacksonJaxbJsonDecoder decoder = new JacksonJaxbJsonDecoder();
 
     assertThat(decoder.decode(response, MockObject.class))
@@ -41,9 +45,11 @@ public class JacksonJaxbCodecTest {
   /** Enabled via {@link feign.Feign.Builder#decode404()} */
   @Test
   public void notFoundDecodesToEmpty() throws Exception {
-    Response response = Response.create(404, "NOT FOUND",
-        Collections.<String, Collection<String>>emptyMap(),
-        (byte[]) null);
+    Response response = Response.builder()
+            .status(404)
+            .reason("NOT FOUND")
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .build();
     assertThat((byte[]) new JacksonJaxbJsonDecoder().decode(response, byte[].class)).isEmpty();
   }
 

--- a/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
+++ b/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
@@ -80,27 +80,34 @@ public class JacksonCodecTest {
     zones.add(new Zone("denominator.io."));
     zones.add(new Zone("denominator.io.", "ABCD"));
 
-    Response response =
-        Response.create(200, "OK", Collections.<String, Collection<String>>emptyMap(), zonesJson,
-                        UTF_8);
+    Response response = Response.builder()
+                .status(200)
+                .reason("OK")
+                .headers(Collections.<String, Collection<String>>emptyMap())
+                .body(zonesJson, UTF_8)
+                .build();
     assertEquals(zones, new JacksonDecoder().decode(response, new TypeReference<List<Zone>>() {
     }.getType()));
   }
 
   @Test
   public void nullBodyDecodesToNull() throws Exception {
-    Response
-        response =
-        Response
-            .create(204, "OK", Collections.<String, Collection<String>>emptyMap(), (byte[]) null);
+    Response response = Response.builder()
+            .status(204)
+            .reason("OK")
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .build();
     assertNull(new JacksonDecoder().decode(response, String.class));
   }
 
   @Test
   public void emptyBodyDecodesToNull() throws Exception {
-    Response response = Response.create(204, "OK",
-                                        Collections.<String, Collection<String>>emptyMap(),
-                                        new byte[0]);
+    Response response = Response.builder()
+            .status(204)
+            .reason("OK")
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .body(new byte[0])
+            .build();
     assertNull(new JacksonDecoder().decode(response, String.class));
   }
 
@@ -114,9 +121,12 @@ public class JacksonCodecTest {
     zones.add(new Zone("DENOMINATOR.IO."));
     zones.add(new Zone("DENOMINATOR.IO.", "ABCD"));
 
-    Response response =
-        Response.create(200, "OK", Collections.<String, Collection<String>>emptyMap(), zonesJson,
-                        UTF_8);
+    Response response = Response.builder()
+            .status(200)
+            .reason("OK")
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .body(zonesJson, UTF_8)
+            .build();
     assertEquals(zones, decoder.decode(response, new TypeReference<List<Zone>>() {
     }.getType()));
   }
@@ -205,9 +215,11 @@ public class JacksonCodecTest {
   /** Enabled via {@link feign.Feign.Builder#decode404()} */
   @Test
   public void notFoundDecodesToEmpty() throws Exception {
-    Response response = Response.create(404, "NOT FOUND",
-        Collections.<String, Collection<String>>emptyMap(),
-        (byte[]) null);
+    Response response = Response.builder()
+            .status(404)
+            .reason("NOT FOUND")
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .build();
     assertThat((byte[]) new JacksonDecoder().decode(response, byte[].class)).isEmpty();
   }
 }

--- a/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
+++ b/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
@@ -168,10 +168,12 @@ public class JAXBCodecTest {
     String mockXml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><mockObject>"
                      + "<value>Test</value></mockObject>";
 
-    Response
-        response =
-        Response
-            .create(200, "OK", Collections.<String, Collection<String>>emptyMap(), mockXml, UTF_8);
+    Response response = Response.builder()
+            .status(200)
+            .reason("OK")
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .body(mockXml, UTF_8)
+            .build();
 
     JAXBDecoder decoder = new JAXBDecoder(new JAXBContextFactory.Builder().build());
 
@@ -190,10 +192,12 @@ public class JAXBCodecTest {
     }
     Type parameterized = ParameterizedHolder.class.getDeclaredField("field").getGenericType();
 
-    Response
-        response =
-        Response
-            .create(200, "OK", Collections.<String, Collection<String>>emptyMap(), "<foo/>", UTF_8);
+    Response response = Response.builder()
+            .status(200)
+            .reason("OK")
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .body("<foo/>", UTF_8)
+            .build();
 
     new JAXBDecoder(new JAXBContextFactory.Builder().build()).decode(response, parameterized);
   }
@@ -201,9 +205,11 @@ public class JAXBCodecTest {
   /** Enabled via {@link feign.Feign.Builder#decode404()} */
   @Test
   public void notFoundDecodesToEmpty() throws Exception {
-    Response response = Response.create(404, "NOT FOUND",
-        Collections.<String, Collection<String>>emptyMap(),
-        (byte[]) null);
+    Response response = Response.builder()
+            .status(404)
+            .reason("NOT FOUND")
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .build();
     assertThat((byte[]) new JAXBDecoder(new JAXBContextFactory.Builder().build())
         .decode(response, byte[].class)).isEmpty();
   }

--- a/okhttp/src/main/java/feign/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/feign/okhttp/OkHttpClient.java
@@ -92,8 +92,12 @@ public final class OkHttpClient implements Client {
   }
 
   private static feign.Response toFeignResponse(Response input) throws IOException {
-    return feign.Response
-        .create(input.code(), input.message(), toMap(input.headers()), toBody(input.body()));
+    return feign.Response.builder()
+            .status(input.code())
+            .reason(input.message())
+            .headers(toMap(input.headers()))
+            .body(toBody(input.body()))
+            .build();
   }
 
   private static Map<String, Collection<String>> toMap(Headers headers) {
@@ -151,6 +155,6 @@ public final class OkHttpClient implements Client {
     }
     Request request = toOkHttpRequest(input);
     Response response = requestScoped.newCall(request).execute();
-    return toFeignResponse(response);
+    return toFeignResponse(response).toBuilder().request(input).build();
   }
 }

--- a/sax/src/test/java/feign/sax/SAXDecoderTest.java
+++ b/sax/src/test/java/feign/sax/SAXDecoderTest.java
@@ -74,24 +74,32 @@ public class SAXDecoderTest {
   }
 
   private Response statusFailedResponse() {
-    return Response
-        .create(200, "OK", Collections.<String, Collection<String>>emptyMap(), statusFailed, UTF_8);
+    return Response.builder()
+            .status(200)
+            .reason("OK")
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .body(statusFailed, UTF_8)
+            .build();
   }
 
   @Test
   public void nullBodyDecodesToNull() throws Exception {
-    Response response =
-        Response
-            .create(204, "OK", Collections.<String, Collection<String>>emptyMap(), (byte[]) null);
+    Response response = Response.builder()
+            .status(204)
+            .reason("OK")
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .build();
     assertNull(decoder.decode(response, String.class));
   }
 
   /** Enabled via {@link feign.Feign.Builder#decode404()} */
   @Test
   public void notFoundDecodesToEmpty() throws Exception {
-    Response response = Response.create(404, "NOT FOUND",
-        Collections.<String, Collection<String>>emptyMap(),
-        (byte[]) null);
+    Response response = Response.builder()
+            .status(404)
+            .reason("NOT FOUND")
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .build();
     assertThat((byte[]) decoder.decode(response, byte[].class)).isEmpty();
   }
 

--- a/slf4j/src/test/java/feign/slf4j/Slf4jLoggerTest.java
+++ b/slf4j/src/test/java/feign/slf4j/Slf4jLoggerTest.java
@@ -34,7 +34,12 @@ public class Slf4jLoggerTest {
   private static final Request REQUEST =
       new RequestTemplate().method("GET").append("http://api.example.com").request();
   private static final Response RESPONSE =
-      Response.create(200, "OK", Collections.<String, Collection<String>>emptyMap(), new byte[0]);
+          Response.builder()
+                  .status(200)
+                  .reason("OK")
+                  .headers(Collections.<String, Collection<String>>emptyMap())
+                  .body(new byte[0])
+                  .build();
   @Rule
   public final RecordingSimpleLogger slf4j = new RecordingSimpleLogger();
   private Slf4jLogger logger;


### PR DESCRIPTION
Adds builder methods to the Response object similar to that found in:
https://github.com/openzipkin/zipkin/blob/b6da02686249ac2df81daf98315f80c572142e29/zipkin/src/main/java/zipkin/Annotation.java

Added a nullable Request field into the Response object

Created an overloaded private constructor for the Response object used by the new builder methods

Set Requests field on Response by default in packaged feign clients on execution finish