### PR TITLE
Reduce logging overhead

### DIFF
--- a/core/src/main/java/feign/Logger.java
+++ b/core/src/main/java/feign/Logger.java
@@ -178,7 +178,9 @@ public abstract class Logger {
 
     @Override
     protected void log(String configKey, String format, Object... args) {
-      logger.fine(String.format(methodTag(configKey) + format, args));
+      if (logger.isLoggable(java.util.logging.Level.FINE)) {
+        logger.fine(String.format(methodTag(configKey) + format, args));
+      }
     }
 
     /**

--- a/slf4j/src/main/java/feign/slf4j/Slf4jLogger.java
+++ b/slf4j/src/main/java/feign/slf4j/Slf4jLogger.java
@@ -68,6 +68,8 @@ public class Slf4jLogger extends feign.Logger {
   protected void log(String configKey, String format, Object... args) {
     // Not using SLF4J's support for parameterized messages (even though it would be more efficient) because it would
     // require the incoming message formats to be SLF4J-specific.
-    logger.debug(String.format(methodTag(configKey) + format, args));
+    if (logger.isDebugEnabled()) {
+      logger.debug(String.format(methodTag(configKey) + format, args));
+    }
   }
 }


### PR DESCRIPTION
* Avoid overhead when logging is disabled.
* Reuse a single StringBuilder when constructing method tag.