### PR TITLE
Adds FallbackFactory, allowing access to the cause of a Hystrix fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 9.3
+* Adds `FallbackFactory`, allowing access to the cause of a Hystrix fallback
+
 ### Version 9.2
 * Adds Hystrix `SetterFactory` to customize group and command keys
 * Supports context path when using Ribbon `LoadBalancingTarget`

--- a/hystrix/README.md
+++ b/hystrix/README.md
@@ -106,3 +106,26 @@ GitHub github = HystrixFeign.builder()
                             ...
                             .target(GitHub.class, "https://api.github.com", fallback);
 ```
+
+#### Considering the cause
+
+The cause of the fallback is logged by default to FINE level. You can programmatically inspect
+the cause by making your own `FallbackFactory`. In many cases, the cause will be a `FeignException`,
+which includes the http status.
+
+Here's an example of using `FallbackFactory`:
+
+```java
+// This instance will be invoked if there are errors of any kind.
+FallbackFactory<GitHub> fallbackFactory = cause -> (owner, repo) -> {
+  if (cause instanceof FeignException && ((FeignException) cause).status() == 403) {
+    return Collections.emptyList();
+  } else {
+    return Arrays.asList("yogi");
+  }
+};
+
+GitHub github = HystrixFeign.builder()
+                            ...
+                            .target(GitHub.class, "https://api.github.com", fallbackFactory);
+```

--- a/hystrix/src/main/java/feign/hystrix/FallbackFactory.java
+++ b/hystrix/src/main/java/feign/hystrix/FallbackFactory.java
@@ -1,0 +1,69 @@
+package feign.hystrix;
+
+import feign.FeignException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static feign.Util.checkNotNull;
+
+/**
+ * Used to control the fallback given its cause.
+ *
+ * Ex.
+ * <pre>{@code
+ * // This instance will be invoked if there are errors of any kind.
+ * FallbackFactory<GitHub> fallbackFactory = cause -> (owner, repo) -> {
+ *   if (cause instanceof FeignException && ((FeignException) cause).status() == 403) {
+ *     return Collections.emptyList();
+ *   } else {
+ *     return Arrays.asList("yogi");
+ *   }
+ * };
+ *
+ * GitHub github = HystrixFeign.builder()
+ *                             ...
+ *                             .target(GitHub.class, "https://api.github.com", fallbackFactory);
+ * }
+ * </pre>
+ *
+ * @param <T> the feign interface type
+ */
+public interface FallbackFactory<T> {
+
+  /**
+   * Returns an instance of the fallback appropriate for the given cause
+   *
+   * @param cause corresponds to {@link com.netflix.hystrix.AbstractCommand#getFailedExecutionException()}
+   * often, but not always an instance of {@link FeignException}.
+   */
+  T create(Throwable cause);
+
+  /** Returns a constant fallback after logging the cause to FINE level. */
+  final class Default<T> implements FallbackFactory<T> {
+    // jul to not add a dependency
+    final Logger logger;
+    final T constant;
+
+    public Default(T constant) {
+      this(constant, Logger.getLogger(Default.class.getName()));
+    }
+
+    Default(T constant, Logger logger) {
+      this.constant = checkNotNull(constant, "fallback");
+      this.logger = checkNotNull(logger, "logger");
+    }
+
+    @Override
+    public T create(Throwable cause) {
+      if (logger.isLoggable(Level.FINE)) {
+        logger.log(Level.FINE, "fallback due to: " + cause.getMessage(), cause);
+      }
+      return constant;
+    }
+
+    @Override
+    public String toString() {
+      return constant.toString();
+    }
+  }
+}

--- a/hystrix/src/test/java/feign/hystrix/FallbackFactoryTest.java
+++ b/hystrix/src/test/java/feign/hystrix/FallbackFactoryTest.java
@@ -1,0 +1,157 @@
+package feign.hystrix;
+
+import feign.FeignException;
+import feign.RequestLine;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static feign.assertj.MockWebServerAssertions.assertThat;
+
+public class FallbackFactoryTest {
+
+  interface TestInterface {
+    @RequestLine("POST /") String invoke();
+  }
+
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+  @Rule
+  public final MockWebServer server = new MockWebServer();
+
+  @Test
+  public void fallbackFactory_example_lambda() {
+    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse().setResponseCode(404));
+
+    TestInterface api = target(cause -> () -> {
+      assertThat(cause).isInstanceOf(FeignException.class);
+      return ((FeignException) cause).status() == 500 ? "foo" : "bar";
+    });
+
+    assertThat(api.invoke()).isEqualTo("foo");
+    assertThat(api.invoke()).isEqualTo("bar");
+  }
+
+  static class FallbackApiWithCtor implements TestInterface {
+    final Throwable cause;
+
+    FallbackApiWithCtor(Throwable cause) {
+      this.cause = cause;
+    }
+
+    @Override public String invoke() {
+      return "foo";
+    }
+  }
+
+  @Test
+  public void fallbackFactory_example_ctor() {
+    server.enqueue(new MockResponse().setResponseCode(500));
+
+    // method reference
+    TestInterface api = target(FallbackApiWithCtor::new);
+
+    assertThat(api.invoke()).isEqualTo("foo");
+
+    server.enqueue(new MockResponse().setResponseCode(500));
+
+    // lambda factory
+    api = target(throwable -> new FallbackApiWithCtor(throwable));
+
+    server.enqueue(new MockResponse().setResponseCode(500));
+
+    // old school
+    api = target(new FallbackFactory<TestInterface>() {
+      @Override public TestInterface create(Throwable cause) {
+        return new FallbackApiWithCtor(cause);
+      }
+    });
+
+    assertThat(api.invoke()).isEqualTo("foo");
+  }
+
+  // retrofit so people don't have to track 2 classes
+  static class FallbackApiRetro implements TestInterface, FallbackFactory<FallbackApiRetro> {
+
+    @Override public FallbackApiRetro create(Throwable cause) {
+      return new FallbackApiRetro(cause);
+    }
+
+    final Throwable cause; // nullable
+
+    public FallbackApiRetro() {
+      this(null);
+    }
+
+    FallbackApiRetro(Throwable cause) {
+      this.cause = cause;
+    }
+
+    @Override public String invoke() {
+      return cause != null ? cause.getMessage() : "foo";
+    }
+  }
+
+  @Test
+  public void fallbackFactory_example_retro() {
+    server.enqueue(new MockResponse().setResponseCode(500));
+
+    // method reference
+    TestInterface api = target(new FallbackApiRetro());
+
+    assertThat(api.invoke()).isEqualTo("status 500 reading TestInterface#invoke()");
+  }
+
+  @Test
+  public void defaultFallbackFactory_delegates() {
+    server.enqueue(new MockResponse().setResponseCode(500));
+
+    TestInterface api = target(new FallbackFactory.Default<>(() -> "foo"));
+
+    assertThat(api.invoke())
+        .isEqualTo("foo");
+  }
+
+  @Test
+  public void defaultFallbackFactory_doesntLogByDefault() {
+    server.enqueue(new MockResponse().setResponseCode(500));
+
+    Logger logger = new Logger("", null) {
+      @Override public void log(Level level, String msg, Throwable thrown) {
+        throw new AssertionError("logged eventhough not FINE level");
+      }
+    };
+
+    target(new FallbackFactory.Default<>(() -> "foo", logger)).invoke();
+  }
+
+  @Test
+  public void defaultFallbackFactory_logsAtFineLevel() {
+    server.enqueue(new MockResponse().setResponseCode(500));
+
+    AtomicBoolean logged = new AtomicBoolean();
+    Logger logger = new Logger("", null) {
+      @Override public void log(Level level, String msg, Throwable thrown) {
+        logged.set(true);
+
+        assertThat(msg).isEqualTo("fallback due to: status 500 reading TestInterface#invoke()");
+        assertThat(thrown).isInstanceOf(FeignException.class);
+      }
+    };
+    logger.setLevel(Level.FINE);
+
+    target(new FallbackFactory.Default<>(() -> "foo", logger)).invoke();
+    assertThat(logged.get()).isTrue();
+  }
+
+  TestInterface target(FallbackFactory<? extends TestInterface> factory) {
+    return HystrixFeign.builder()
+        .target(TestInterface.class, "http://localhost:" + server.getPort(), factory);
+  }
+}


### PR DESCRIPTION
The cause of the fallback is now logged by default to FINE level. You can programmatically inspect
the cause by making your own `FallbackFactory`. In many cases, the cause will be a `FeignException`,
which includes the http status.

Here's an example of using `FallbackFactory`:

```java
// This instance will be invoked if there are errors of any kind.
FallbackFactory<GitHub> fallbackFactory = cause -> (owner, repo) -> {
  if (cause instanceof FeignException && ((FeignException) cause).status() == 403) {
    return Collections.emptyList();
  } else {
    return Arrays.asList("yogi");
  }
};

GitHub github = HystrixFeign.builder()
                            ...
                            .target(GitHub.class, "https://api.github.com", fallbackFactory);
```

Fixes #431
See #432