### PR TITLE
Make Hystrix Command keys more unique

### DIFF
--- a/hystrix/src/main/java/feign/hystrix/HystrixInvocationHandler.java
+++ b/hystrix/src/main/java/feign/hystrix/HystrixInvocationHandler.java
@@ -87,7 +87,7 @@ final class HystrixInvocationHandler implements InvocationHandler {
     }
 
     String groupKey = this.target.name();
-    String commandKey = "feign#" + method.toString();
+    String commandKey = generateCommandKey(method);
     HystrixCommand.Setter setter = HystrixCommand.Setter
         .withGroupKey(HystrixCommandGroupKey.Factory.asKey(groupKey))
         .andCommandKey(HystrixCommandKey.Factory.asKey(commandKey));
@@ -153,13 +153,11 @@ final class HystrixInvocationHandler implements InvocationHandler {
   /**
    * Generates the key for the Hystrix command.  This key is used by
    * Hystrix in a cache, so we try and make the key as unique as possible.
-   * The default implementation uses the result of calling 
-   * {@link java.lang.Method.html#toString() toString} on the fallback Method.
    * @param method The fallback method.
    * @return A unique key to be used to cache the Hystrix command.
    */
-  protected String generateCommandKey(Method method) {
-	  return method.toString();
+  private String generateCommandKey(Method method) {
+	  return "feign#" + method.toString();
   }
 
   private boolean isReturnsCompletable(Method method) {

--- a/hystrix/src/main/java/feign/hystrix/HystrixInvocationHandler.java
+++ b/hystrix/src/main/java/feign/hystrix/HystrixInvocationHandler.java
@@ -87,7 +87,7 @@ final class HystrixInvocationHandler implements InvocationHandler {
     }
 
     String groupKey = this.target.name();
-    String commandKey = method.getName();
+    String commandKey = "feign#" + method.toString();
     HystrixCommand.Setter setter = HystrixCommand.Setter
         .withGroupKey(HystrixCommandGroupKey.Factory.asKey(groupKey))
         .andCommandKey(HystrixCommandKey.Factory.asKey(commandKey));
@@ -103,6 +103,7 @@ final class HystrixInvocationHandler implements InvocationHandler {
           throw (Error) t;
         }
       }
+      
 
       @Override
       protected Object getFallback() {
@@ -147,6 +148,18 @@ final class HystrixInvocationHandler implements InvocationHandler {
       return hystrixCommand.toObservable().toCompletable();
     }
     return hystrixCommand.execute();
+  }
+  
+  /**
+   * Generates the key for the Hystrix command.  This key is used by
+   * Hystrix in a cache, so we try and make the key as unique as possible.
+   * The default implementation uses the result of calling 
+   * {@link java.lang.Method.html#toString() toString} on the fallback Method.
+   * @param method The fallback method.
+   * @return A unique key to be used to cache the Hystrix command.
+   */
+  protected String generateCommandKey(Method method) {
+	  return method.toString();
   }
 
   private boolean isReturnsCompletable(Method method) {

--- a/hystrix/src/test/java/feign/hystrix/HystrixBuilderTest.java
+++ b/hystrix/src/test/java/feign/hystrix/HystrixBuilderTest.java
@@ -148,7 +148,7 @@ public class HystrixBuilderTest {
   @Test
   public void errorInFallbackHasExpectedBehavior() {
     thrown.expect(HystrixRuntimeException.class);
-    thrown.expectMessage("contributors failed and fallback failed.");
+    thrown.expectMessage("feign#public abstract java.util.List feign.hystrix.HystrixBuilderTest$GitHub.contributors(java.lang.String,java.lang.String) failed and fallback failed.");
     thrown.expectCause(
         isA(FeignException.class)); // as opposed to RuntimeException (from the fallback)
 
@@ -170,7 +170,7 @@ public class HystrixBuilderTest {
   @Test
   public void hystrixRuntimeExceptionPropagatesOnException() {
     thrown.expect(HystrixRuntimeException.class);
-    thrown.expectMessage("contributors failed and no fallback available.");
+    thrown.expectMessage("feign#public abstract java.util.List feign.hystrix.HystrixBuilderTest$GitHub.contributors(java.lang.String,java.lang.String) failed and no fallback available.");
     thrown.expectCause(isA(FeignException.class));
 
     server.enqueue(new MockResponse().setResponseCode(500));
@@ -301,7 +301,7 @@ public class HystrixBuilderTest {
     assertThat(testSubscriber.getOnNextEvents()).isEmpty();
     assertThat(testSubscriber.getOnErrorEvents().get(0))
         .isInstanceOf(HystrixRuntimeException.class)
-        .hasMessage("listObservable failed and no fallback available.");
+        .hasMessage("feign#public abstract rx.Observable feign.hystrix.HystrixBuilderTest$TestInterface.listObservable() failed and no fallback available.");
   }
 
   @Test


### PR DESCRIPTION
Uses fallback method signature as the Hystrix command key.  Fixes #434.