### PR TITLE
Adds Hystrix SetterFactory to customize group and command keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Version 9.2
+* Adds Hystrix `SetterFactory` to customize group and command keys
 * Supports context path when using Ribbon `LoadBalancingTarget`
 * Adds builder methods for the Response object
 * Deprecates Response factory methods

--- a/hystrix/README.md
+++ b/hystrix/README.md
@@ -50,6 +50,34 @@ api.getYourType("a").execute();
 api.getYourTypeSynchronous("a");
 ```
 
+### Group and Command keys
+
+By default, Hystrix group keys match the target name, and the target name is usually the base url.
+Hystrix command keys are the same as logging keys, which are equivalent to javadoc references.
+
+For example, for the canonical GitHub example...
+
+* the group key would be "https://api.github.com" and
+* the command key would be "GitHub#contributors(String,String)"
+
+You can use `HystrixFeign.Builder#setterFactory(SetterFactory)` to customize this, for example, to
+read key mappings from configuration or annotations.
+
+Ex.
+```java
+SetterFactory commandKeyIsRequestLine = (target, method) -> {
+  String groupKey = target.name();
+  String commandKey = method.getAnnotation(RequestLine.class).value();
+  return HystrixCommand.Setter
+      .withGroupKey(HystrixCommandGroupKey.Factory.asKey(groupKey))
+      .andCommandKey(HystrixCommandKey.Factory.asKey(commandKey));
+};
+
+api = HystrixFeign.builder()
+                  .setterFactory(commandKeyIsRequestLine)
+                  ...
+```
+
 ### Fallback support
 
 Fallbacks are known values, which you return when there's an error invoking an http method.

--- a/hystrix/src/main/java/feign/hystrix/HystrixFeign.java
+++ b/hystrix/src/main/java/feign/hystrix/HystrixFeign.java
@@ -33,6 +33,15 @@ public final class HystrixFeign {
   public static final class Builder extends Feign.Builder {
 
     private Contract contract = new Contract.Default();
+    private SetterFactory setterFactory = new SetterFactory.Default();
+
+    /**
+     * Allows you to override hystrix properties such as thread pools and command keys.
+     */
+    public Builder setterFactory(SetterFactory setterFactory) {
+      this.setterFactory = setterFactory;
+      return this;
+    }
 
     /**
      * @see #target(Class, String, Object)
@@ -101,7 +110,7 @@ public final class HystrixFeign {
       super.invocationHandlerFactory(new InvocationHandlerFactory() {
         @Override public InvocationHandler create(Target target,
             Map<Method, MethodHandler> dispatch) {
-          return new HystrixInvocationHandler(target, dispatch, nullableFallback);
+          return new HystrixInvocationHandler(target, dispatch, setterFactory, nullableFallback);
         }
       });
       super.contract(new HystrixDelegatingContract(contract));

--- a/hystrix/src/main/java/feign/hystrix/SetterFactory.java
+++ b/hystrix/src/main/java/feign/hystrix/SetterFactory.java
@@ -1,0 +1,44 @@
+package feign.hystrix;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandKey;
+
+import java.lang.reflect.Method;
+
+import feign.Feign;
+import feign.Target;
+
+/**
+ * Used to control properties of a hystrix command. Use cases include reading from static
+ * configuration or custom annotations.
+ *
+ * <p>This is parsed up-front, like {@link feign.Contract}, so will not be invoked for each command
+ * invocation.
+ *
+ * <p>Note: when deciding the {@link com.netflix.hystrix.HystrixCommand.Setter#andCommandKey(HystrixCommandKey)
+ * command key}, recall it lives in a shared cache, so make sure it is unique.
+ */
+public interface SetterFactory {
+
+  /**
+   * Returns a hystrix setter appropriate for the given target and method
+   */
+  HystrixCommand.Setter create(Target<?> target, Method method);
+
+  /**
+   * Default behavior is to derive the group key from {@link Target#name()} and the command key from
+   * {@link Feign#configKey(Class, Method)}.
+   */
+  final class Default implements SetterFactory {
+
+    @Override
+    public HystrixCommand.Setter create(Target<?> target, Method method) {
+      String groupKey = target.name();
+      String commandKey = Feign.configKey(target.type(), method);
+      return HystrixCommand.Setter
+          .withGroupKey(HystrixCommandGroupKey.Factory.asKey(groupKey))
+          .andCommandKey(HystrixCommandKey.Factory.asKey(commandKey));
+    }
+  }
+}

--- a/hystrix/src/test/java/feign/hystrix/HystrixBuilderTest.java
+++ b/hystrix/src/test/java/feign/hystrix/HystrixBuilderTest.java
@@ -148,7 +148,7 @@ public class HystrixBuilderTest {
   @Test
   public void errorInFallbackHasExpectedBehavior() {
     thrown.expect(HystrixRuntimeException.class);
-    thrown.expectMessage("contributors failed and fallback failed.");
+    thrown.expectMessage("GitHub#contributors(String,String) failed and fallback failed.");
     thrown.expectCause(
         isA(FeignException.class)); // as opposed to RuntimeException (from the fallback)
 
@@ -170,7 +170,7 @@ public class HystrixBuilderTest {
   @Test
   public void hystrixRuntimeExceptionPropagatesOnException() {
     thrown.expect(HystrixRuntimeException.class);
-    thrown.expectMessage("contributors failed and no fallback available.");
+    thrown.expectMessage("GitHub#contributors(String,String) failed and no fallback available.");
     thrown.expectCause(isA(FeignException.class));
 
     server.enqueue(new MockResponse().setResponseCode(500));
@@ -301,7 +301,7 @@ public class HystrixBuilderTest {
     assertThat(testSubscriber.getOnNextEvents()).isEmpty();
     assertThat(testSubscriber.getOnErrorEvents().get(0))
         .isInstanceOf(HystrixRuntimeException.class)
-        .hasMessage("listObservable failed and no fallback available.");
+        .hasMessage("TestInterface#listObservable() failed and no fallback available.");
   }
 
   @Test

--- a/hystrix/src/test/java/feign/hystrix/SetterFactoryTest.java
+++ b/hystrix/src/test/java/feign/hystrix/SetterFactoryTest.java
@@ -1,0 +1,49 @@
+package feign.hystrix;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandKey;
+import com.netflix.hystrix.exception.HystrixRuntimeException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import feign.RequestLine;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+public class SetterFactoryTest {
+
+  interface TestInterface {
+    @RequestLine("POST /")
+    String invoke();
+  }
+
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+  @Rule
+  public final MockWebServer server = new MockWebServer();
+
+  @Test
+  public void customSetter() {
+    thrown.expect(HystrixRuntimeException.class);
+    thrown.expectMessage("POST / failed and no fallback available.");
+
+    server.enqueue(new MockResponse().setResponseCode(500));
+
+SetterFactory commandKeyIsRequestLine = (target, method) -> {
+  String groupKey = target.name();
+  String commandKey = method.getAnnotation(RequestLine.class).value();
+  return HystrixCommand.Setter
+      .withGroupKey(HystrixCommandGroupKey.Factory.asKey(groupKey))
+      .andCommandKey(HystrixCommandKey.Factory.asKey(commandKey));
+};
+
+    TestInterface api = HystrixFeign.builder()
+        .setterFactory(commandKeyIsRequestLine)
+        .target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    api.invoke();
+  }
+}


### PR DESCRIPTION
By default, Hystrix group keys match the target name, and the target name is usually the base url. Hystrix command keys are now the same as logging keys, which are equivalent to javadoc references.

For example, for the canonical GitHub example...

* the group key would be "https://api.github.com" and
* the command key would be "GitHub#contributors(String,String)"

You can use `HystrixFeign.Builder#setterFactory(SetterFactory)` to customize this, for example, to read key mappings from configuration or annotations.

Ex.
```java
SetterFactory commandKeyIsRequestLine = (target, method) -> {
  String groupKey = target.name();
  String commandKey = method.getAnnotation(RequestLine.class).value();
  return HystrixCommand.Setter
      .withGroupKey(HystrixCommandGroupKey.Factory.asKey(groupKey))
      .andCommandKey(HystrixCommandKey.Factory.asKey(commandKey));
};
```

Fixes #334
Fixes #434
Fixes #333
Obviates #444