### PR TITLE
Introducing ResponseInterceptors and properties for RequestTemplate

### DIFF
--- a/core/src/main/java/feign/Feign.java
+++ b/core/src/main/java/feign/Feign.java
@@ -95,6 +95,8 @@ public abstract class Feign {
 
     private final List<RequestInterceptor> requestInterceptors =
         new ArrayList<RequestInterceptor>();
+    private final List<ResponseInterceptor> responseInterceptors =
+            new ArrayList<ResponseInterceptor>();
     private Logger.Level logLevel = Logger.Level.NONE;
     private Contract contract = new Contract.Default();
     private Client client = new Client.Default(null, null);
@@ -194,6 +196,26 @@ public abstract class Feign {
     }
 
     /**
+     * Adds a single response interceptor to the builder.
+     */
+    public Builder responseInterceptor(ResponseInterceptor responseInterceptor) {
+      this.responseInterceptors.add(responseInterceptor);
+      return this;
+    }
+
+    /**
+     * Sets the full set of response interceptors for the builder, overwriting any previous
+     * interceptors.
+     */
+    public Builder responseInterceptors(Iterable<ResponseInterceptor> responseInterceptors) {
+      this.responseInterceptors.clear();
+      for (ResponseInterceptor responseInterceptor : responseInterceptors) {
+        this.responseInterceptors.add(responseInterceptor);
+      }
+      return this;
+    }
+
+    /**
      * Allows you to override how reflective dispatch works inside of Feign.
      */
     public Builder invocationHandlerFactory(InvocationHandlerFactory invocationHandlerFactory) {
@@ -211,7 +233,7 @@ public abstract class Feign {
 
     public Feign build() {
       SynchronousMethodHandler.Factory synchronousMethodHandlerFactory =
-          new SynchronousMethodHandler.Factory(client, retryer, requestInterceptors, logger,
+          new SynchronousMethodHandler.Factory(client, retryer, requestInterceptors, responseInterceptors, logger,
                                                logLevel, decode404);
       ParseHandlersByName handlersByName =
           new ParseHandlersByName(contract, options, encoder, decoder,

--- a/core/src/main/java/feign/Request.java
+++ b/core/src/main/java/feign/Request.java
@@ -17,6 +17,8 @@ package feign;
 
 import java.nio.charset.Charset;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import static feign.Util.checkNotNull;
@@ -32,21 +34,29 @@ public final class Request {
    * effectively immutable, via safe copies, not mutating or otherwise.
    */
   public static Request create(String method, String url, Map<String, Collection<String>> headers,
+                               Map<String, Object> properties, byte[] body, Charset charset) {
+    return new Request(method, url, headers, properties, body, charset);
+  }
+
+  public static Request create(String method, String url, Map<String, Collection<String>> headers,
                                byte[] body, Charset charset) {
-    return new Request(method, url, headers, body, charset);
+    Map<String, Object> emptyUnmodifiableMap = Collections.unmodifiableMap(new HashMap<String, Object>(0));
+    return new Request(method, url, headers, emptyUnmodifiableMap, body, charset);
   }
 
   private final String method;
   private final String url;
   private final Map<String, Collection<String>> headers;
+  private final Map<String, Object> properties;
   private final byte[] body;
   private final Charset charset;
 
-  Request(String method, String url, Map<String, Collection<String>> headers, byte[] body,
-          Charset charset) {
+  Request(String method, String url, Map<String, Collection<String>> headers,
+          Map<String, Object> properties, byte[] body, Charset charset) {
     this.method = checkNotNull(method, "method of %s", url);
     this.url = checkNotNull(url, "url");
     this.headers = checkNotNull(headers, "headers of %s %s", method, url);
+    this.properties = checkNotNull(properties, "properties of %s %s", method, url);
     this.body = body; // nullable
     this.charset = charset; // nullable
   }
@@ -65,6 +75,12 @@ public final class Request {
   public Map<String, Collection<String>> headers() {
     return headers;
   }
+
+  /* List of properties that will be kept in the current client request response exchange context
+   * A property allows interceptors to exchange additional custom information not already provided
+    by this interface.
+  */
+  public Map<String, Object> properties() { return properties; }
 
   /**
    * The character set with which the body is encoded, or null if unknown or not applicable.  When

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -20,14 +20,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
 import static feign.Util.CONTENT_LENGTH;
@@ -51,6 +44,7 @@ public final class RequestTemplate implements Serializable {
       new LinkedHashMap<String, Collection<String>>();
   private final Map<String, Collection<String>> headers =
       new LinkedHashMap<String, Collection<String>>();
+  private final Map<String, Object> properties = new HashMap<String, Object>();
   private String method;
   /* final to encourage mutable use vs replacing the object. */
   private StringBuilder url = new StringBuilder();
@@ -69,6 +63,7 @@ public final class RequestTemplate implements Serializable {
     this.url.append(toCopy.url);
     this.queries.putAll(toCopy.queries);
     this.headers.putAll(toCopy.headers);
+    this.properties.putAll(toCopy.properties);
     this.charset = toCopy.charset;
     this.body = toCopy.body;
     this.bodyTemplate = toCopy.bodyTemplate;
@@ -238,11 +233,13 @@ public final class RequestTemplate implements Serializable {
   /* roughly analogous to {@code javax.ws.rs.client.Target.request()}. */
   public Request request() {
     Map<String, Collection<String>> safeCopy = new LinkedHashMap<String, Collection<String>>();
+    Map<String, Object> propertiesSafeCopy = new HashMap<String, Object>();
     safeCopy.putAll(headers);
+    propertiesSafeCopy.putAll(properties);
     return Request.create(
         method,
         new StringBuilder(url).append(queryLine()).toString(),
-        Collections.unmodifiableMap(safeCopy),
+        Collections.unmodifiableMap(safeCopy), Collections.unmodifiableMap(propertiesSafeCopy),
         body, charset
     );
   }
@@ -474,6 +471,8 @@ public final class RequestTemplate implements Serializable {
   public Map<String, Collection<String>> headers() {
     return Collections.unmodifiableMap(headers);
   }
+
+  public Map<String, Object> properties() { return properties; }
 
   /**
    * replaces the {@link feign.Util#CONTENT_LENGTH} header. <br> Usually populated by an {@link

--- a/core/src/main/java/feign/ResponseInterceptor.java
+++ b/core/src/main/java/feign/ResponseInterceptor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign;
+
+/**
+ * Zero or more {@code ResponseInterceptors} may be configured for purposes such as publishing stats to external
+ * monitoring systems. No guarantees are give with regards to the order that interceptors are applied.
+ */
+public interface ResponseInterceptor {
+
+    /**
+     * Called for every response received per request.
+     */
+    void apply(Request request, Response response, MethodMetadata methodMetadata);
+}

--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -39,6 +39,7 @@ final class SynchronousMethodHandler implements MethodHandler {
   private final Client client;
   private final Retryer retryer;
   private final List<RequestInterceptor> requestInterceptors;
+  private final List<ResponseInterceptor> responseInterceptors;
   private final Logger logger;
   private final Logger.Level logLevel;
   private final RequestTemplate.Factory buildTemplateFromArgs;
@@ -48,7 +49,8 @@ final class SynchronousMethodHandler implements MethodHandler {
   private final boolean decode404;
 
   private SynchronousMethodHandler(Target<?> target, Client client, Retryer retryer,
-                                   List<RequestInterceptor> requestInterceptors, Logger logger,
+                                   List<RequestInterceptor> requestInterceptors,
+                                   List<ResponseInterceptor> responseInterceptors, Logger logger,
                                    Logger.Level logLevel, MethodMetadata metadata,
                                    RequestTemplate.Factory buildTemplateFromArgs, Options options,
                                    Decoder decoder, ErrorDecoder errorDecoder, boolean decode404) {
@@ -57,6 +59,8 @@ final class SynchronousMethodHandler implements MethodHandler {
     this.retryer = checkNotNull(retryer, "retryer for %s", target);
     this.requestInterceptors =
         checkNotNull(requestInterceptors, "requestInterceptors for %s", target);
+    this.responseInterceptors =
+            checkNotNull(responseInterceptors, "responseInterceptors for %s", target);
     this.logger = checkNotNull(logger, "logger for %s", target);
     this.logLevel = checkNotNull(logLevel, "logLevel for %s", target);
     this.metadata = checkNotNull(metadata, "metadata for %s", target);
@@ -113,6 +117,9 @@ final class SynchronousMethodHandler implements MethodHandler {
         // ensure the request is set. TODO: remove in Feign 10
         response.toBuilder().request(request).build();
       }
+      // call response interceptors registered for this method handler
+      targetResponse(request, response);
+
       if (Response.class == metadata.returnType()) {
         if (response.body() == null) {
           return response;
@@ -160,6 +167,12 @@ final class SynchronousMethodHandler implements MethodHandler {
     return target.apply(new RequestTemplate(template));
   }
 
+  void targetResponse(Request request, Response response) {
+    for (ResponseInterceptor interceptor : responseInterceptors) {
+      interceptor.apply(request, response, metadata);
+    }
+  }
+
   Object decode(Response response) throws Throwable {
     try {
       return decoder.decode(response, metadata.returnType());
@@ -175,15 +188,17 @@ final class SynchronousMethodHandler implements MethodHandler {
     private final Client client;
     private final Retryer retryer;
     private final List<RequestInterceptor> requestInterceptors;
+    private final List<ResponseInterceptor> responseInterceptors;
     private final Logger logger;
     private final Logger.Level logLevel;
     private final boolean decode404;
 
     Factory(Client client, Retryer retryer, List<RequestInterceptor> requestInterceptors,
-            Logger logger, Logger.Level logLevel, boolean decode404) {
+            List<ResponseInterceptor> responseInterceptors, Logger logger, Logger.Level logLevel, boolean decode404) {
       this.client = checkNotNull(client, "client");
       this.retryer = checkNotNull(retryer, "retryer");
       this.requestInterceptors = checkNotNull(requestInterceptors, "requestInterceptors");
+      this.responseInterceptors = checkNotNull(responseInterceptors, "responseInterceptors");
       this.logger = checkNotNull(logger, "logger");
       this.logLevel = checkNotNull(logLevel, "logLevel");
       this.decode404 = decode404;
@@ -192,7 +207,7 @@ final class SynchronousMethodHandler implements MethodHandler {
     public MethodHandler create(Target<?> target, MethodMetadata md,
                                 RequestTemplate.Factory buildTemplateFromArgs,
                                 Options options, Decoder decoder, ErrorDecoder errorDecoder) {
-      return new SynchronousMethodHandler(target, client, retryer, requestInterceptors, logger,
+      return new SynchronousMethodHandler(target, client, retryer, requestInterceptors, responseInterceptors, logger,
                                           logLevel, md, buildTemplateFromArgs, options, decoder,
                                           errorDecoder, decode404);
     }


### PR DESCRIPTION
This is much similar to jax-rs ClientResponseFilter. It is useful for monitoring request/reponse flow, if you need to publish stats to an external monitoring service.

<string, object> HashMap attribute is introduced to RequestTemplate to allow additional information to be passed in a client request/response context. This can be used to correlate tracking/origin id. 