### PR TITLE
Removes use of internal gson class

### DIFF
--- a/gson/README.md
+++ b/gson/README.md
@@ -15,7 +15,6 @@ GitHub github = Feign.builder()
 ### Map<String, Object> and Numbers
 The default constructors of `GsonEncoder` and `GsonDecoder` decoder numbers in
 `Map<String, Object>` as Integer type. This prevents reading `{"counter", "1"}`
-as `Map.of("counter", 1.0)`. This uses an internal class in gson.
+as `Map.of("counter", 1.0)`.
 
-If you want the default behavior, or cannot use gson internal classes (ex in
-OSGi), please use the constructors that accept a Gson object.
+To change this, please use constructors that accept a Gson object.

--- a/gson/src/main/java/feign/gson/DoubleToIntMapTypeAdapter.java
+++ b/gson/src/main/java/feign/gson/DoubleToIntMapTypeAdapter.java
@@ -16,31 +16,20 @@
 package feign.gson;
 
 import com.google.gson.Gson;
-import com.google.gson.InstanceCreator;
 import com.google.gson.TypeAdapter;
-import com.google.gson.internal.ConstructorConstructor;
-import com.google.gson.internal.bind.MapTypeAdapterFactory;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
-
 import java.io.IOException;
-import java.lang.reflect.Type;
-import java.util.Collections;
 import java.util.Map;
 
 /**
  * Deals with scenario where Gson Object type treats all numbers as doubles.
  */
 public class DoubleToIntMapTypeAdapter extends TypeAdapter<Map<String, Object>> {
-
-  final static TypeToken<Map<String, Object>> token = new TypeToken<Map<String, Object>>() {
-  };
-
-  private final TypeAdapter<Map<String, Object>>
-      delegate =
-      new MapTypeAdapterFactory(new ConstructorConstructor(
-          Collections.<Type, InstanceCreator<?>>emptyMap()), false).create(new Gson(), token);
+  private final TypeAdapter<Map<String, Object>> delegate =
+      new Gson().getAdapter(new TypeToken<Map<String, Object>>() {
+      });
 
   @Override
   public void write(JsonWriter out, Map<String, Object> value) throws IOException {


### PR DESCRIPTION
Turns out an api was added a very long time ago to do what we do in gson
without use of internal apis.

See #449