### PR TITLE
Support request content-type with charset

### DIFF
--- a/core/src/test/java/feign/client/AbstractClientTest.java
+++ b/core/src/test/java/feign/client/AbstractClientTest.java
@@ -15,6 +15,7 @@ import feign.Logger;
 import feign.Param;
 import feign.RequestLine;
 import feign.Response;
+import feign.Util;
 import feign.assertj.MockWebServerAssertions;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -218,6 +219,18 @@ public abstract class AbstractClientTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    public void testContentTypeWithCharset() throws Exception {
+        server.enqueue(new MockResponse()
+                .setBody("AAAAAAAA"));
+        TestInterface api = newBuilder()
+                .target(TestInterface.class, "http://localhost:" + server.getPort());
+
+        Response response = api.postContentTypeWithCharset("foo");
+        // Response length should not be null
+        assertEquals("AAAAAAAA", Util.toString(response.body().asReader()));
+    }
+
     public interface TestInterface {
 
         @RequestLine("POST /?foo=bar&foo=baz&qux=")
@@ -241,6 +254,10 @@ public abstract class AbstractClientTest {
 
         @RequestLine("PUT")
         String noPutBody();
+
+        @RequestLine("POST /?foo=bar&foo=baz&qux=")
+        @Headers({"Foo: Bar", "Foo: Baz", "Qux: ", "Content-Type: text/plain;charset=utf-8"})
+        Response postContentTypeWithCharset(String body);
     }
 
 }

--- a/core/src/test/java/feign/client/AbstractClientTest.java
+++ b/core/src/test/java/feign/client/AbstractClientTest.java
@@ -226,7 +226,19 @@ public abstract class AbstractClientTest {
         TestInterface api = newBuilder()
                 .target(TestInterface.class, "http://localhost:" + server.getPort());
 
-        Response response = api.postContentTypeWithCharset("foo");
+        Response response = api.postWithContentType("foo", "text/plain;charset=utf-8");
+        // Response length should not be null
+        assertEquals("AAAAAAAA", Util.toString(response.body().asReader()));
+    }
+
+    @Test
+    public void testContentTypeWithoutCharset() throws Exception {
+        server.enqueue(new MockResponse()
+                .setBody("AAAAAAAA"));
+        TestInterface api = newBuilder()
+                .target(TestInterface.class, "http://localhost:" + server.getPort());
+
+        Response response = api.postWithContentType("foo", "text/plain");
         // Response length should not be null
         assertEquals("AAAAAAAA", Util.toString(response.body().asReader()));
     }
@@ -256,8 +268,8 @@ public abstract class AbstractClientTest {
         String noPutBody();
 
         @RequestLine("POST /?foo=bar&foo=baz&qux=")
-        @Headers({"Foo: Bar", "Foo: Baz", "Qux: ", "Content-Type: text/plain;charset=utf-8"})
-        Response postContentTypeWithCharset(String body);
+        @Headers({"Foo: Bar", "Foo: Baz", "Qux: ", "Content-Type: {contentType}"})
+        Response postWithContentType(String body, @Param("contentType") String contentType);
     }
 
 }

--- a/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
+++ b/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
@@ -157,11 +157,9 @@ public final class ApacheHttpClient implements Client {
         Collection<String> values = entry.getValue();
         if (values != null && !values.isEmpty()) {
           String mimeType = values.iterator().next();
-          try {
-            contentType = ContentType.create(mimeType, request.charset());
-          } catch (IllegalArgumentException e) {
-            // MIME type may not contain reserved characters, so try to parse content type
-            contentType = ContentType.parse(mimeType);
+          contentType = ContentType.parse(mimeType);
+          if (contentType.getCharset() == null) {
+            contentType = ContentType.create(contentType.getMimeType(), request.charset());
           }
           break;
         }

--- a/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
+++ b/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
@@ -156,11 +156,7 @@ public final class ApacheHttpClient implements Client {
       if (entry.getKey().equalsIgnoreCase("Content-Type")) {
         Collection<String> values = entry.getValue();
         if (values != null && !values.isEmpty()) {
-          String mimeType = values.iterator().next();
-          contentType = ContentType.parse(mimeType);
-          if (contentType.getCharset() == null) {
-            contentType = ContentType.create(contentType.getMimeType(), request.charset());
-          }
+          contentType = ContentType.parse(values.iterator().next());
           break;
         }
       }

--- a/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
+++ b/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
@@ -153,13 +153,19 @@ public final class ApacheHttpClient implements Client {
   private ContentType getContentType(Request request) {
     ContentType contentType = ContentType.DEFAULT_TEXT;
     for (Map.Entry<String, Collection<String>> entry : request.headers().entrySet())
-    if (entry.getKey().equalsIgnoreCase("Content-Type")) {
-      Collection values = entry.getValue();
-      if (values != null && !values.isEmpty()) {
-        contentType = ContentType.create(entry.getValue().iterator().next(), request.charset());
-        break;
+      if (entry.getKey().equalsIgnoreCase("Content-Type")) {
+        Collection<String> values = entry.getValue();
+        if (values != null && !values.isEmpty()) {
+          String mimeType = values.iterator().next();
+          try {
+            contentType = ContentType.create(mimeType, request.charset());
+          } catch (IllegalArgumentException e) {
+            // MIME type may not contain reserved characters, so try to parse content type
+            contentType = ContentType.parse(mimeType);
+          }
+          break;
+        }
       }
-    }
     return contentType;
   }
 


### PR DESCRIPTION
Hello,
This fix helps to resolve problem of using feign with spring cloud, when post request contains header like Content-Type = application/json;charset=utf-8