### PR TITLE
Remove overriding of retry handler.

### DIFF
--- a/ribbon/src/main/java/feign/ribbon/LBClient.java
+++ b/ribbon/src/main/java/feign/ribbon/LBClient.java
@@ -48,7 +48,6 @@ public final class LBClient extends
 
   LBClient(ILoadBalancer lb, IClientConfig clientConfig) {
     super(lb, clientConfig);
-    this.setRetryHandler(RetryHandler.DEFAULT);
     this.clientConfig = clientConfig;
     connectTimeout = clientConfig.get(CommonClientConfigKey.ConnectTimeout);
     readTimeout = clientConfig.get(CommonClientConfigKey.ReadTimeout);

--- a/ribbon/src/main/java/feign/ribbon/LBClientFactory.java
+++ b/ribbon/src/main/java/feign/ribbon/LBClientFactory.java
@@ -1,6 +1,7 @@
 package feign.ribbon;
 
 import com.netflix.client.ClientFactory;
+import com.netflix.client.config.DefaultClientConfigImpl;
 import com.netflix.client.config.IClientConfig;
 import com.netflix.loadbalancer.ILoadBalancer;
 
@@ -14,9 +15,16 @@ public interface LBClientFactory {
   public static final class Default implements LBClientFactory {
     @Override
     public LBClient create(String clientName) {
-      IClientConfig config = ClientFactory.getNamedConfig(clientName);
+      IClientConfig config = ClientFactory.getNamedConfig(clientName, DisableAutoRetriesByDefaultClientConfig.class);
       ILoadBalancer lb = ClientFactory.getNamedLoadBalancer(clientName);
       return LBClient.create(lb, config);
+    }
+  }
+
+  final class DisableAutoRetriesByDefaultClientConfig extends DefaultClientConfigImpl {
+    @Override
+    public int getDefaultMaxAutoRetriesNextServer() {
+      return 0;
     }
   }
 }


### PR DESCRIPTION
Setting the retry handler explicitly to the DEFAULT instance overrides
the retry configuration, making it impossible to specify a configuration.
It seems to be unnecessary since allowing LoadBalancerContext to
initialize it in initWithNiwsConfig appears to be sufficient, as if
there's no configuration the defaults from there should be appropriate.