### PR TITLE
Add Builder class to JAXBDecoder for disabling namespace-awareness.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 9.4
+* Adds Builder class to JAXBDecoder for disabling namespace-awareness (defaults to true).
+
 ### Version 9.3
 * Adds `FallbackFactory`, allowing access to the cause of a Hystrix fallback
 * Adds support for encoded parameters via `@Param(encoded = true)`

--- a/jaxb/README.md
+++ b/jaxb/README.md
@@ -16,3 +16,12 @@ Response response = Feign.builder()
                          .decoder(new JAXBDecoder(jaxbFactory))
                          .target(Response.class, "https://apihost");
 ```
+
+`JAXBDecoder` can also be created with a builder to allow overriding some default parser options:
+
+```java
+JAXBDecoder jaxbDecoder = new JAXBDecoder.Builder()
+    .withJAXBContextFactory(jaxbFactory)
+    .withNamespaceAware(false) // true by default
+    .build();
+```


### PR DESCRIPTION
Makes the SAX parser namespace aware by default (as it was previously for JAXB).
Fixes #456