### PR TITLE
Allow ErrorDecoder.decode(...) to return null.

### DIFF
--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -133,7 +133,7 @@ final class SynchronousMethodHandler implements MethodHandler {
           return decode(response);
         }
       } else if (decode404 && response.status() == 404) {
-        return decoder.decode(response, metadata.returnType());
+        return decode(response);
       } else {
         throw errorDecoder.decode(metadata.configKey(), response);
       }

--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -129,14 +129,14 @@ final class SynchronousMethodHandler implements MethodHandler {
       if (response.status() >= 200 && response.status() < 300) {
         if (void.class == metadata.returnType()) {
           return null;
-        } else {
-          return decode(response);
         }
-      } else if (decode404 && response.status() == 404) {
-        return decode(response);
-      } else {
-        throw errorDecoder.decode(metadata.configKey(), response);
+      } else if (!decode404 || response.status() != 404) {
+        Exception exception = errorDecoder.decode(metadata.configKey(), response);
+        if (exception != null) {
+          throw exception;
+        }
       }
+      return decode(response);
     } catch (IOException e) {
       if (logLevel != Logger.Level.NONE) {
         logger.logIOException(metadata.configKey(), logLevel, e, elapsedTime);

--- a/core/src/main/java/feign/codec/ErrorDecoder.java
+++ b/core/src/main/java/feign/codec/ErrorDecoder.java
@@ -30,14 +30,13 @@ import static feign.FeignException.errorStatus;
 import static feign.Util.RETRY_AFTER;
 import static feign.Util.checkNotNull;
 import static java.util.Locale.US;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Allows you to massage an exception into a application-specific one. Converting out to a throttle
  * exception are examples of this in use.
  *
- * <p/>Ex:
+ * <p/>Example:
  * <pre>
  * class IllegalArgumentExceptionOn404Decoder implements ErrorDecoder {
  *
@@ -47,7 +46,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  *        throw new IllegalArgumentException(&quot;bad zone name&quot;);
  *    return new ErrorDecoder.Default().decode(methodKey, response);
  *   }
- *
  * }
  * </pre>
  *
@@ -62,7 +60,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  *
  * <p/><b>Not Found Semantics</b>
  * <p/> It is commonly the case that 404 (Not Found) status has semantic value in HTTP apis. While
- * the default behavior is to raise exeception, users can alternatively enable 404 processing via
+ * the default behavior is to raise an exception, users can alternatively enable 404 processing via
  * {@link feign.Feign.Builder#decode404()}.
  */
 public interface ErrorDecoder {
@@ -76,9 +74,11 @@ public interface ErrorDecoder {
    *                  ex. {@code IAM#getUser()}
    * @param response  HTTP response where {@link Response#status() status} is greater than or equal
    *                  to {@code 300}.
-   * @return Exception IOException, if there was a network error reading the response or an
-   * application-specific exception decoded by the implementation. If the throwable is retryable, it
-   * should be wrapped, or a subtype of {@link RetryableException}
+   * @return Exception An Exception or <code>null</code>. IOException, if there was a network error
+   * reading the response or an application-specific exception decoded by the implementation. If
+   * the throwable is retryable, it should be wrapped, or a subtype of {@link RetryableException}.
+   * If <code>null</code> is returned no exception is thrown and the normal {@link Decoder} will
+   * be asked to decode the response.
    */
   public Exception decode(String methodKey, Response response);
 

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -565,6 +565,27 @@ public class FeignTest {
   }
 
   @Test
+  public void nullFromErrorDecoderResultsInDecoderAsked() throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(403));
+
+    TestInterface api = new TestInterfaceBuilder()
+        .errorDecoder(new ErrorDecoder() {
+          @Override
+          public Exception decode(String methodKey, Response response) {
+            return null;
+          }
+        })
+        .decoder(new Decoder() {
+          @Override
+          public Object decode(Response response, Type type) throws IOException {
+            assertEquals(403, response.status());
+            return "Sadly forbidden";
+          }
+        }).target("http://localhost:" + server.getPort());
+    assertEquals("Sadly forbidden", api.post());
+  }
+
+  @Test
   public void okIfEncodeRootCauseHasNoMessage() throws Exception {
     server.enqueue(new MockResponse().setBody("success!"));
     thrown.expect(EncodeException.class);

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -52,6 +52,7 @@ import feign.codec.StringDecoder;
 
 import static feign.Util.UTF_8;
 import static feign.assertj.MockWebServerAssertions.assertThat;
+import static org.hamcrest.CoreMatchers.isA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -546,9 +547,10 @@ public class FeignTest {
   }
 
   @Test
-  public void decoderCanThrowUnwrappedExceptionInDecode404Mode() throws Exception {
+  public void decodingExceptionGetWrappedInDecode404Mode() throws Exception {
     server.enqueue(new MockResponse().setResponseCode(404));
-    thrown.expect(NoSuchElementException.class);
+    thrown.expect(DecodeException.class);
+    thrown.expectCause(isA(NoSuchElementException.class));;
 
     TestInterface api = new TestInterfaceBuilder()
         .decode404()


### PR DESCRIPTION
Null signals that no exception should be thrown. This allows to
react to non-200 statuses not only with an exception but also
to return such statuses encoded somehow in the return object.