### PR TITLE
Make Util.decodeOrDefault(...) public.

### DIFF
--- a/core/src/main/java/feign/Util.java
+++ b/core/src/main/java/feign/Util.java
@@ -314,7 +314,7 @@ public class Util {
     return total;
   }
 
-  static String decodeOrDefault(byte[] data, Charset charset, String defaultValue) {
+  public static String decodeOrDefault(byte[] data, Charset charset, String defaultValue) {
     if (data == null) {
       return defaultValue;
     }


### PR DESCRIPTION
The method is used for Loggers which may not live in the feign package.