### PR TITLE
Fixing Archaius version

### DIFF
--- a/hystrix/pom.xml
+++ b/hystrix/pom.xml
@@ -22,6 +22,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.netflix.archaius</groupId>
+      <artifactId>archaius-core</artifactId>
+      <version>0.6.6</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.netflix.hystrix</groupId>
       <artifactId>hystrix-core</artifactId>
       <version>1.4.26</version>


### PR DESCRIPTION
Fix for #498 Forcibly set the Archaius version to allow Ribbon/Hystrix to work in tandem.