### PR TITLE
Fix readme method name to produce client based in Target<T>

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ Feign can produce multiple api interfaces.  These are defined as `Target<T>` (de
 For example, the following pattern might decorate each request with the current url and auth token from the identity service.
 
 ```java
-Feign feign = Feign.builder().build();
-CloudDNS cloudDNS = feign.newInstance(new CloudIdentityTarget<CloudDNS>(user, apiKey));
+CloudDNS cloudDNS = Feign.builder().target(new CloudIdentityTarget<CloudDNS>(user, apiKey));
 ```
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For example, the following pattern might decorate each request with the current 
 
 ```java
 Feign feign = Feign.builder().build();
-CloudDNS cloudDNS = feign.target(new CloudIdentityTarget<CloudDNS>(user, apiKey));
+CloudDNS cloudDNS = feign.newInstance(new CloudIdentityTarget<CloudDNS>(user, apiKey));
 ```
 
 ### Examples


### PR DESCRIPTION
Fix readme method name to produce client based in Target<T>

From 
```java
Feign feign = Feign.builder().build();
CloudDNS cloudDNS = feign.target(new CloudIdentityTarget<CloudDNS>(user, apiKey));
``` 
To 
```java
CloudDNS cloudDNS = Feign.builder().target(new CloudIdentityTarget<CloudDNS>(user, apiKey));
```