### PR TITLE
Set empty HttpEntity if request body is null.

### DIFF
--- a/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
+++ b/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
@@ -145,6 +145,8 @@ public final class ApacheHttpClient implements Client {
       }
 
       requestBuilder.setEntity(entity);
+    } else {
+      requestBuilder.setEntity(new ByteArrayEntity(new byte[0]));
     }
 
     return requestBuilder.build();


### PR DESCRIPTION
This fixes the issue I raised in #510 where Feign did not account for Apache HttpClient behaviour difference in case `HttpEntity` was not set at all (e.g. due to null body in this case). This resulted in `RequestBuilder` creating `HttpEntity` from query parameters.