### PR TITLE
fix gh-470, support the values of QueryMap starting with '{'

### DIFF
--- a/core/src/main/java/feign/ReflectiveFeign.java
+++ b/core/src/main/java/feign/ReflectiveFeign.java
@@ -273,18 +273,19 @@ public class ReflectiveFeign extends Feign {
 
         Collection<String> values = new ArrayList<String>();
 
+        boolean encoded = metadata.queryMapEncoded();
         Object currValue = currEntry.getValue();
         if (currValue instanceof Iterable<?>) {
           Iterator<?> iter = ((Iterable<?>) currValue).iterator();
           while (iter.hasNext()) {
             Object nextObject = iter.next();
-            values.add(nextObject == null ? null : nextObject.toString());
+            values.add(nextObject == null ? null : encoded ? nextObject.toString() : RequestTemplate.urlEncode(nextObject.toString()));
           }
         } else {
-          values.add(currValue == null ? null : currValue.toString());
+          values.add(currValue == null ? null : encoded ? currValue.toString() : RequestTemplate.urlEncode(currValue.toString()));
         }
 
-        mutable.query(metadata.queryMapEncoded(), (String) currEntry.getKey(), values);
+        mutable.query(true, encoded ? (String) currEntry.getKey() : RequestTemplate.urlEncode(currEntry.getKey()), values);
       }
       return mutable;
     }

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -83,7 +83,7 @@ public final class RequestTemplate implements Serializable {
     }
   }
 
-  private static String urlEncode(Object arg) {
+  static String urlEncode(Object arg) {
     try {
       return URLEncoder.encode(String.valueOf(arg), UTF_8.name());
     } catch (UnsupportedEncodingException e) {

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -368,6 +368,39 @@ public class FeignTest {
   }
 
   @Test
+  public void queryMapValueStartingWithBrace() throws Exception {
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+
+    server.enqueue(new MockResponse());
+    Map<String, Object> queryMap = new LinkedHashMap<String, Object>();
+    queryMap.put("name", "{alice");
+    api.queryMap(queryMap);
+    assertThat(server.takeRequest())
+        .hasPath("/?name=%7Balice");
+
+    server.enqueue(new MockResponse());
+    queryMap = new LinkedHashMap<String, Object>();
+    queryMap.put("{name", "alice");
+    api.queryMap(queryMap);
+    assertThat(server.takeRequest())
+        .hasPath("/?%7Bname=alice");
+
+    server.enqueue(new MockResponse());
+    queryMap = new LinkedHashMap<String, Object>();
+    queryMap.put("name", "%7Balice");
+    api.queryMapEncoded(queryMap);
+    assertThat(server.takeRequest())
+        .hasPath("/?name=%7Balice");
+
+    server.enqueue(new MockResponse());
+    queryMap = new LinkedHashMap<String, Object>();
+    queryMap.put("%7Bname", "%7Balice");
+    api.queryMapEncoded(queryMap);
+    assertThat(server.takeRequest())
+        .hasPath("/?%7Bname=%7Balice");
+  }
+
+  @Test
   public void configKeyFormatsAsExpected() throws Exception {
     assertEquals("TestInterface#post()",
                  Feign.configKey(TestInterface.class.getDeclaredMethod("post")));
@@ -714,6 +747,9 @@ public class FeignTest {
 
     @RequestLine("GET /")
     void queryMap(@QueryMap Map<String, Object> queryMap);
+
+    @RequestLine("GET /")
+    void queryMapEncoded(@QueryMap(encoded = true) Map<String, Object> queryMap);
 
     @RequestLine("GET /?name={name}")
     void queryMapWithQueryParams(@Param("name") String name, @QueryMap Map<String, Object> queryMap);


### PR DESCRIPTION
see https://github.com/OpenFeign/feign/issues/470#issuecomment-286992065