### PR TITLE
Allows different collection encodings

### DIFF
--- a/core/src/main/java/feign/CollectionFormat.java
+++ b/core/src/main/java/feign/CollectionFormat.java
@@ -1,20 +1,85 @@
+/**
+ * Copyright 2012-2018 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package feign;
+
+import java.util.Collection;
 
 /**
  * Various ways to encode collections in URL parameters.
  *
- * These specific cases are inspired by the
- * <a href="http://swagger.io/specification/">OpenAPI specification</a>.
+ * <p>These specific cases are inspired by the
+ * <a href="http://swagger.io/specification/">OpenAPI specification</a>.</p>
  */
 public enum CollectionFormat {
   /** Comma separated values, eg foo=bar,baz */
-  CSV,
+  CSV(","),
   /** Space separated values, eg foo=bar baz */
-  SSV,
+  SSV(" "),
   /** Tab separated values, eg foo=bar[tab]baz */
-  TSV,
+  TSV("\t"),
   /** Values separated with the pipe (|) character, eg foo=bar|baz */
-  PIPES,
+  PIPES("|"),
   /** Parameter name repeated for each value, eg foo=bar&foo=baz */
-  MULTI,
+  // Using null as a special case since there is no single separator character
+  EXPLODED(null);
+
+  private final String separator;
+
+  CollectionFormat(String separator) {
+    this.separator = separator;
+  }
+
+  /**
+   * Joins the field and possibly multiple values with the given separator.
+   *
+   * <p>Calling EXPLODED.join("foo", ["bar"]) will return "foo=bar".</p>
+   *
+   * <p>Calling CSV.join("foo", ["bar", "baz"]) will return "foo=bar,baz". </p>
+   *
+   * <p>Null values are treated somewhat specially. With EXPLODED, the field
+   * is repeated without any "=" for backwards compatibility. With all other
+   * formats, null values are not included in the joined value list.</p>
+   *
+   * @param field The field name corresponding to these values.
+   * @param values A collection of value strings for the given field.
+   * @return The formatted char sequence of the field and joined values. If the
+   *         value collection is empty, an empty char sequence will be returned.
+   */
+  CharSequence join(String field, Collection<String> values) {
+    StringBuilder builder = new StringBuilder();
+    int valueCount = 0;
+    for (String value : values) {
+      if (separator == null) {
+        // exploded
+        builder.append(valueCount++ == 0 ? "" : "&");
+        builder.append(field);
+        if (value != null) {
+          builder.append('=');
+          builder.append(value);
+        }
+      } else {
+        // delimited with a separator character
+        if (builder.length() == 0) {
+          builder.append(field);
+        }
+        if (value == null) {
+          continue;
+        }
+        builder.append(valueCount++ == 0 ? "=" : separator);
+        builder.append(value);
+      }
+    }
+    return builder;
+  }
 }

--- a/core/src/main/java/feign/CollectionFormat.java
+++ b/core/src/main/java/feign/CollectionFormat.java
@@ -1,0 +1,20 @@
+package feign;
+
+/**
+ * Various ways to encode collections in URL parameters.
+ *
+ * These specific cases are inspired by the
+ * <a href="http://swagger.io/specification/">OpenAPI specification</a>.
+ */
+public enum CollectionFormat {
+  /** Comma separated values, eg foo=bar,baz */
+  CSV,
+  /** Space separated values, eg foo=bar baz */
+  SSV,
+  /** Tab separated values, eg foo=bar[tab]baz */
+  TSV,
+  /** Values separated with the pipe (|) character, eg foo=bar|baz */
+  PIPES,
+  /** Parameter name repeated for each value, eg foo=bar&foo=baz */
+  MULTI,
+}

--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -232,6 +232,7 @@ public interface Contract {
         }
 
         data.template().decodeSlash(RequestLine.class.cast(methodAnnotation).decodeSlash());
+        data.template().collectionFormat(RequestLine.class.cast(methodAnnotation).collectionFormat());
 
       } else if (annotationType == Body.class) {
         String body = Body.class.cast(methodAnnotation).value();

--- a/core/src/main/java/feign/RequestLine.java
+++ b/core/src/main/java/feign/RequestLine.java
@@ -61,5 +61,5 @@ public @interface RequestLine {
 
   String value();
   boolean decodeSlash() default true;
-  CollectionFormat collectionFormat() default CollectionFormat.MULTI;
+  CollectionFormat collectionFormat() default CollectionFormat.EXPLODED;
 }

--- a/core/src/main/java/feign/RequestLine.java
+++ b/core/src/main/java/feign/RequestLine.java
@@ -61,4 +61,5 @@ public @interface RequestLine {
 
   String value();
   boolean decodeSlash() default true;
+  CollectionFormat collectionFormat() default CollectionFormat.MULTI;
 }

--- a/core/src/test/java/feign/assertj/RecordedRequestAssert.java
+++ b/core/src/test/java/feign/assertj/RecordedRequestAssert.java
@@ -62,6 +62,12 @@ public final class RecordedRequestAssert
     return this;
   }
 
+  public RecordedRequestAssert hasOneOfPath(String... expected) {
+    isNotNull();
+    objects.assertIsIn(info, actual.getPath(), expected);
+    return this;
+  }
+
   public RecordedRequestAssert hasBody(String utf8Expected) {
     isNotNull();
     objects.assertEqual(info, actual.getBody().readUtf8(), utf8Expected);

--- a/core/src/test/java/feign/client/AbstractClientTest.java
+++ b/core/src/test/java/feign/client/AbstractClientTest.java
@@ -272,6 +272,7 @@ public abstract class AbstractClientTest {
                 .hasBody("àáâãäåèéêë");
     }
 
+    @Test
     public void testDefaultCollectionFormat() throws Exception {
         server.enqueue(new MockResponse().setBody("body"));
 

--- a/core/src/test/java/feign/client/AbstractClientTest.java
+++ b/core/src/test/java/feign/client/AbstractClientTest.java
@@ -15,12 +15,15 @@ package feign.client;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import feign.Client;
+import feign.CollectionFormat;
 import feign.Feign.Builder;
 import feign.FeignException;
 import feign.Headers;
@@ -269,6 +272,37 @@ public abstract class AbstractClientTest {
                 .hasBody("àáâãäåèéêë");
     }
 
+    public void testDefaultCollectionFormat() throws Exception {
+        server.enqueue(new MockResponse().setBody("body"));
+
+        TestInterface api = newBuilder()
+                .target(TestInterface.class, "http://localhost:" + server.getPort());
+
+        Response response = api.get(Arrays.asList(new String[] {"bar","baz"}));
+
+        assertThat(response.status()).isEqualTo(200);
+        assertThat(response.reason()).isEqualTo("OK");
+
+        MockWebServerAssertions.assertThat(server.takeRequest()).hasMethod("GET")
+                .hasPath("/?foo=bar&foo=baz");
+    }
+    @Test
+    public void testAlternativeCollectionFormat() throws Exception {
+        server.enqueue(new MockResponse().setBody("body"));
+
+        TestInterface api = newBuilder()
+                .target(TestInterface.class, "http://localhost:" + server.getPort());
+
+        Response response = api.getCSV(Arrays.asList(new String[] {"bar","baz"}));
+
+        assertThat(response.status()).isEqualTo(200);
+        assertThat(response.reason()).isEqualTo("OK");
+
+        // Some HTTP libraries percent-encode commas in query parameters and others don't.
+        MockWebServerAssertions.assertThat(server.takeRequest()).hasMethod("GET")
+                .hasOneOfPath("/?foo=bar,baz", "/?foo=bar%2Cbaz");
+    }
+
     public interface TestInterface {
 
         @RequestLine("POST /?foo=bar&foo=baz&qux=")
@@ -282,6 +316,12 @@ public abstract class AbstractClientTest {
         @RequestLine("GET /")
         @Headers("Accept: text/plain")
         String get();
+
+        @RequestLine("GET /?foo={multiFoo}")
+        Response get(@Param("multiFoo") List<String> multiFoo);
+
+        @RequestLine(value = "GET /?foo={multiFoo}", collectionFormat = CollectionFormat.CSV)
+        Response getCSV(@Param("multiFoo") List<String> multiFoo);
 
         @RequestLine("PATCH /")
         @Headers("Accept: text/plain")


### PR DESCRIPTION
In the case where a parameter represents a collection of values, there are
conflicting ways of encoding that collection. Common ways are repeating the
parameter name (foo=bar&foo=baz) and using comma separated values (foo=bar,baz).
The current behavior repeats the parameter name. This change introduces an
additional RequestLine parameter that explicitly specifies the encoding type,
one of CSV, TSV, space-delimited, pipe-delimited, and repeating the parameter
name. The default value for this option is repeating the parameter name, so
backwards compatibility is maintained.

Possible implementation for #542.