### PR TITLE
More compact version of Slf4jLogger

### DIFF
--- a/slf4j/README.md
+++ b/slf4j/README.md
@@ -10,3 +10,28 @@ GitHub github = Feign.builder()
                      .logger(new Slf4jLogger())
                      .target(GitHub.class, "https://api.github.com");
 ```
+
+
+## Tab-separated key-value SLF4J logger
+
+To use more compact version of slf4j logger implementation, you can add:
+
+```
+// ...
+.logger(new Slf4jTskvLogger())
+// ...
+```
+
+It very close to `Slf4jLogger`, but writes logs in format:
+
+```
+DEBUG feign.Logger - http	req-id=[701d8882-e43b-4af3-b5e5-7dc4b4cf4de7]   call=[someMethod()]	method=[GET]	uri=[http://api.example.com]
+DEBUG feign.Logger - http	req-id=[701d8882-e43b-4af3-b5e5-7dc4b4cf4de7]	status=[200]	reason=[OK] elapsed-ms=[273]	length=[0]
+
+```
+
+Then you can grep such logs with `| cut -f 3` (with right column number)
+
+Also this logger adds unique `req-id` string to merge request and response.
+All retries and error log lines have such string too.
+This string is changed each request.

--- a/slf4j/src/main/java/feign/slf4j/Slf4jTskvLogger.java
+++ b/slf4j/src/main/java/feign/slf4j/Slf4jTskvLogger.java
@@ -1,0 +1,218 @@
+package feign.slf4j;
+
+import feign.Logger;
+import feign.Request;
+import feign.Response;
+import feign.Util;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static feign.Util.UTF_8;
+import static feign.Util.checkNotNull;
+import static java.util.Arrays.asList;
+
+/**
+ * Logs to SLF4J at the debug level, if the underlying logger has debug logging enabled.
+ * The underlying logger can be specified at construction-time, defaulting to the logger
+ * for {@link feign.Logger}.
+ *
+ * Logs one line per request/response/retry/error
+ * Adds request-id to match request with response
+ * Uses tab-separated key-value format.
+ * It's very convenient to grep such logs in file by using {@code | cut -f 2} to fetch some column
+ *
+ * Example:
+ *
+ * {@code
+ *  DEBUG feign.Logger - http	req-id=[701d8882-e43b-4af3-b5e5-7dc4b4cf4de7]
+ *  call=[someMethod()]	method=[GET]	uri=[http://api.example.com]
+ *
+ *  DEBUG feign.Logger - http	req-id=[701d8882-e43b-4af3-b5e5-7dc4b4cf4de7]	status=[200]	reason=[OK]
+ *  elapsed-ms=[273]	length=[0]
+ * }
+ *
+ * @author lanwen (Merkushev Kirill)
+ */
+public class Slf4jTskvLogger extends Logger {
+    private static final String REQ_ID_KEY = "req-id";
+    private static final int HTTP_NO_CONTENT_204 = 204;
+    private static final int HTTP_RESET_CONTENT_205 = 205;
+    private final ThreadLocal<String> requestId = new ThreadLocal<String>();
+    private final org.slf4j.Logger log;
+
+    public Slf4jTskvLogger() {
+        this(feign.Logger.class);
+    }
+
+    public Slf4jTskvLogger(Class<?> clazz) {
+        this(LoggerFactory.getLogger(clazz));
+    }
+
+    public Slf4jTskvLogger(String name) {
+        this(LoggerFactory.getLogger(name));
+    }
+
+    Slf4jTskvLogger(org.slf4j.Logger logger) {
+        this.log = logger;
+    }
+
+    @Override
+    protected void logRequest(String configKey, Level logLevel, Request request) {
+        if (!log.isDebugEnabled()) {
+            return;
+        }
+
+        List<Map.Entry<String, Object>> fields = new ArrayList<Map.Entry<String, Object>>(asList(
+                field(REQ_ID_KEY, reqId()),
+                field("call", configKey),
+                field("method", request.method()),
+                field("uri", request.url())
+        ));
+
+        if (logLevel.ordinal() >= Level.HEADERS.ordinal()) {
+            fields.add(field("headers", request.headers()));
+        }
+
+        if (request.body() != null) {
+            fields.add(field("length", request.body().length));
+            if (logLevel.ordinal() >= Level.FULL.ordinal()) {
+                String bodyText = request.charset() != null ? new String(request.body(), request.charset()) : null;
+                fields.add(field("body", bodyText != null ? bodyText.replaceAll("\t", "\\\\t") : "binary_data"));
+            }
+        }
+
+        log(fields);
+    }
+
+    @Override
+    protected Response logAndRebufferResponse(String configKey, Level logLevel, Response response, long elapsedTime)
+            throws IOException {
+
+        if (!log.isDebugEnabled()) {
+            return response;
+        }
+
+        List<Map.Entry<String, Object>> fields = new ArrayList<Map.Entry<String, Object>>(asList(
+                field(REQ_ID_KEY, reqId()),
+                field("status", response.status()),
+                field("reason", response.reason()),
+                field("elapsed-ms", elapsedTime)
+        ));
+
+        if (logLevel.ordinal() >= Level.HEADERS.ordinal()) {
+            fields.add(field("headers", response.headers()));
+        }
+
+        int bodyLength;
+        if (response.body() != null
+                // HTTP 204 No Content "...response MUST NOT include a message-body"
+                && !(response.status() == HTTP_NO_CONTENT_204
+                // HTTP 205 Reset Content "...response MUST NOT include an entity"
+                || response.status() == HTTP_RESET_CONTENT_205)) {
+
+            byte[] bodyData = Util.toByteArray(response.body().asInputStream());
+            bodyLength = bodyData.length;
+            fields.add(field("length", bodyLength));
+            if (logLevel.ordinal() >= Level.FULL.ordinal() && bodyLength > 0) {
+                fields.add(
+                        field("body", decodeOrDefault(bodyData, UTF_8, "binary_data")
+                                .replaceAll("\t", "\\\\t"))
+                );
+            }
+            log(fields);
+            requestId.remove();
+            return response.toBuilder().body(bodyData).build();
+        }
+
+        log(fields);
+        requestId.remove();
+        return response;
+    }
+
+    @Override
+    protected void logRetry(String configKey, Level logLevel) {
+        if (!log.isDebugEnabled()) {
+            return;
+        }
+
+        log(asList(
+                field("state", "retry"),
+                field(REQ_ID_KEY, requestId.get())
+        ));
+    }
+
+    @Override
+    protected IOException logIOException(String configKey, Level logLevel, IOException ioe, long elapsedTime) {
+        if (!log.isDebugEnabled()) {
+            return ioe;
+        }
+
+        List<Map.Entry<String, Object>> fields = new ArrayList<Map.Entry<String, Object>>(asList(
+                field("state", "error"),
+                field(REQ_ID_KEY, reqId()),
+                field("class", ioe.getClass().getSimpleName()),
+                field("message", ioe.getMessage()),
+                field("elapsed-ms", elapsedTime)
+        ));
+
+        if (logLevel.ordinal() >= Level.FULL.ordinal()) {
+            StringWriter sw = new StringWriter();
+            ioe.printStackTrace(new PrintWriter(sw));
+            fields.add(field("trace", sw.toString().replaceAll("\t", " ")));
+        }
+
+        log(fields);
+        return ioe;
+    }
+
+
+    @Override
+    protected void log(String configKey, String format, Object... args) {
+        log.debug(format, args);
+    }
+
+    private String reqId() {
+        if (requestId.get() == null) {
+            requestId.set(UUID.randomUUID().toString());
+        }
+        return requestId.get();
+    }
+
+    private void log(Collection<Map.Entry<String, Object>> tskv) {
+        StringBuilder log = new StringBuilder();
+        for (Map.Entry<String, Object> entry : tskv) {
+            log.append("\t").append(entry.getKey()).append("=[").append(entry.getValue()).append("]");
+        }
+
+        log("", "http{}", log);
+    }
+
+    private static Map.Entry<String, Object> field(String key, Object value) {
+        return new AbstractMap.SimpleImmutableEntry<String, Object>(key, value);
+    }
+
+    static String decodeOrDefault(byte[] data, Charset charset, String defaultValue) {
+        if (data == null) {
+            return defaultValue;
+        }
+        checkNotNull(charset, "charset");
+        try {
+            return charset.newDecoder().decode(ByteBuffer.wrap(data)).toString();
+        } catch (CharacterCodingException ex) {
+            return defaultValue;
+        }
+    }
+
+}

--- a/slf4j/src/test/java/feign/slf4j/RecordingSimpleLogger.java
+++ b/slf4j/src/test/java/feign/slf4j/RecordingSimpleLogger.java
@@ -15,6 +15,7 @@
  */
 package feign.slf4j;
 
+import org.hamcrest.Matcher;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -27,7 +28,8 @@ import java.io.PrintStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
 import static org.slf4j.impl.SimpleLogger.DEFAULT_LOG_LEVEL_KEY;
 import static org.slf4j.impl.SimpleLogger.SHOW_THREAD_NAME_KEY;
 
@@ -37,7 +39,7 @@ import static org.slf4j.impl.SimpleLogger.SHOW_THREAD_NAME_KEY;
  */
 final class RecordingSimpleLogger implements TestRule {
 
-  private String expectedMessages = "";
+  private Matcher<String> expectedMessages = equalTo("");
 
   /**
    * Resets {@link org.slf4j.impl.SimpleLogger} to the new log level.
@@ -60,6 +62,14 @@ final class RecordingSimpleLogger implements TestRule {
    * Newline delimited output that would be sent to stderr.
    */
   RecordingSimpleLogger expectMessages(String expectedMessages) {
+    return expectMessages(equalTo(expectedMessages));
+  }
+
+
+  /**
+   * Matcher to verify log output
+   */
+  RecordingSimpleLogger expectMessages(Matcher<String> expectedMessages) {
     this.expectedMessages = expectedMessages;
     return this;
   }
@@ -77,7 +87,7 @@ final class RecordingSimpleLogger implements TestRule {
         try {
           System.setErr(new PrintStream(buff));
           base.evaluate();
-          assertEquals(expectedMessages, buff.toString());
+          assertThat(buff.toString(), expectedMessages);
         } finally {
           System.setErr(stderr);
         }

--- a/slf4j/src/test/java/feign/slf4j/Slf4jTskvLoggerTest.java
+++ b/slf4j/src/test/java/feign/slf4j/Slf4jTskvLoggerTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.slf4j;
+
+import feign.Feign;
+import feign.Logger;
+import feign.Request;
+import feign.RequestTemplate;
+import feign.Response;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+
+public class Slf4jTskvLoggerTest {
+
+    private static final String CONFIG_KEY = "someMethod()";
+    private static final Request REQUEST =
+            new RequestTemplate().method("GET").append("http://api.example.com").request();
+    private static final Response RESPONSE =
+            Response.builder()
+                    .status(200)
+                    .reason("OK")
+                    .headers(Collections.<String, Collection<String>>emptyMap())
+                    .body(new byte[0])
+                    .build();
+    @Rule
+    public final RecordingSimpleLogger slf4j = new RecordingSimpleLogger();
+    private Slf4jTskvLogger logger;
+
+    @Test
+    public void useFeignLoggerByDefault() throws Exception {
+        slf4j.logLevel("debug");
+        slf4j.expectMessages("DEBUG feign.Logger - This is my message\n");
+
+        logger = new Slf4jTskvLogger();
+        logger.log(CONFIG_KEY, "This is my message");
+    }
+
+    @Test
+    public void useLoggerByNameIfRequested() throws Exception {
+        slf4j.logLevel("debug");
+        slf4j.expectMessages("DEBUG named.logger - This is my message\n");
+
+        logger = new Slf4jTskvLogger("named.logger");
+        logger.log(CONFIG_KEY, "This is my message");
+    }
+
+    @Test
+    public void useLoggerByClassIfRequested() throws Exception {
+        slf4j.logLevel("debug");
+        slf4j.expectMessages("DEBUG feign.Feign - This is my message\n");
+
+        logger = new Slf4jTskvLogger(Feign.class);
+        logger.log(CONFIG_KEY, "This is my message");
+    }
+
+    @Test
+    public void useSpecifiedLoggerIfRequested() throws Exception {
+        slf4j.logLevel("debug");
+        slf4j.expectMessages("DEBUG specified.logger - This is my message\n");
+
+        logger = new Slf4jTskvLogger(LoggerFactory.getLogger("specified.logger"));
+        logger.log(CONFIG_KEY, "This is my message");
+    }
+
+    @Test
+    public void logOnlyIfDebugEnabled() throws Exception {
+        slf4j.logLevel("info");
+
+        logger = new Slf4jTskvLogger();
+        logger.log(CONFIG_KEY, "A message with %d formatting %s.", 2, "tokens");
+        logger.logRequest(CONFIG_KEY, Logger.Level.BASIC, REQUEST);
+        logger.logAndRebufferResponse(CONFIG_KEY, Logger.Level.BASIC, RESPONSE, 273);
+    }
+
+    @Test
+    public void logRequestsAndResponses() throws Exception {
+        slf4j.logLevel("debug");
+        slf4j.expectMessages(
+                allOf(
+                        containsString("DEBUG feign.Logger - A message with 2 formatting tokens."),
+                        containsString("DEBUG feign.Logger - http\treq-id=["),
+                        containsString("]\tcall=[someMethod()]\tmethod=[GET]\turi=[http://api.example.com]"),
+                        containsString("]\tstatus=[200]\treason=[OK]\telapsed-ms=[273]\tlength=[0]\n")
+                )
+        );
+
+        logger = new Slf4jTskvLogger();
+        logger.log(CONFIG_KEY, "A message with {} formatting {}.", 2, "tokens");
+        logger.logRequest(CONFIG_KEY, Logger.Level.BASIC, REQUEST);
+        logger.logAndRebufferResponse(CONFIG_KEY, Logger.Level.BASIC, RESPONSE, 273);
+    }
+
+    @Test
+    public void logRetry() throws Exception {
+        slf4j.logLevel("debug");
+        slf4j.expectMessages(
+                allOf(
+                        containsString("DEBUG feign.Logger - http\treq-id=["),
+                        containsString("]\tcall=[someMethod()]\tmethod=[GET]\turi=[http://api.example.com]"),
+                        containsString("DEBUG feign.Logger - http\tstate=[retry]\treq-id=["),
+                        not(containsString("[null]"))
+                )
+        );
+
+        logger = new Slf4jTskvLogger();
+        logger.logRequest(CONFIG_KEY, Logger.Level.BASIC, REQUEST);
+        logger.logRetry(CONFIG_KEY, Logger.Level.BASIC);
+    }
+}


### PR DESCRIPTION
Writes logs in format:

```
DEBUG feign.Logger - http	req-id=[701d8882-e43b-4af3-b5e5-7dc4b4cf4de7]   call=[someMethod()]	method=[GET]	uri=[http://api.example.com]
DEBUG feign.Logger - http	req-id=[701d8882-e43b-4af3-b5e5-7dc4b4cf4de7]	status=[200]	reason=[OK] elapsed-ms=[273]	length=[0]

```

Then you can grep such logs with `| cut -f 3` (with right column number)

Also this logger adds unique `req-id` string to merge request and response.
All retries and error log lines have such string too.
This string is changed each request.