### PR TITLE
Avoid `Decoder.decode` on 404 when void response type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 9.4.1
+* 404 responses are no longer swallowed for `void` return types.
+
 ### Version 9.4
 * Adds Builder class to JAXBDecoder for disabling namespace-awareness (defaults to true).
 

--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -132,7 +132,7 @@ final class SynchronousMethodHandler implements MethodHandler {
         } else {
           return decode(response);
         }
-      } else if (decode404 && response.status() == 404) {
+      } else if (decode404 && response.status() == 404 && void.class != metadata.returnType()) {
         return decode(response);
       } else {
         throw errorDecoder.decode(metadata.configKey(), response);

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -23,6 +23,7 @@ import okhttp3.mockwebserver.SocketPolicy;
 import okhttp3.mockwebserver.MockWebServer;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import okio.Buffer;
 import org.assertj.core.api.Fail;
@@ -598,6 +599,18 @@ public class FeignTest {
   }
 
   @Test
+  public void decodingDoesNotSwallow404ErrorsInDecode404Mode() throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(404));
+    thrown.expect(IllegalArgumentException.class);
+
+    TestInterface api = new TestInterfaceBuilder()
+        .decode404()
+        .errorDecoder(new IllegalArgumentExceptionOn404())
+        .target("http://localhost:" + server.getPort());
+    api.queryMap(Collections.emptyMap());
+  }
+
+  @Test
   public void okIfEncodeRootCauseHasNoMessage() throws Exception {
     server.enqueue(new MockResponse().setBody("success!"));
     thrown.expect(EncodeException.class);
@@ -799,6 +812,17 @@ public class FeignTest {
     @Override
     public Exception decode(String methodKey, Response response) {
       if (response.status() == 400) {
+        return new IllegalArgumentException("bad zone name");
+      }
+      return super.decode(methodKey, response);
+    }
+  }
+
+  static class IllegalArgumentExceptionOn404 extends ErrorDecoder.Default {
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+      if (response.status() == 404) {
         return new IllegalArgumentException("bad zone name");
       }
       return super.decode(methodKey, response);


### PR DESCRIPTION
Avoid calling `decode` when receiving a 404 error and `decode404` is set and the response type is `void`.

This PR fixes #518.