### PR TITLE
Fix ApacheHttpClient.getContentType() to use request charset as default

### DIFF
--- a/core/src/test/java/feign/client/AbstractClientTest.java
+++ b/core/src/test/java/feign/client/AbstractClientTest.java
@@ -243,6 +243,19 @@ public abstract class AbstractClientTest {
         assertEquals("AAAAAAAA", Util.toString(response.body().asReader()));
     }
 
+    @Test
+    public void testContentTypeDefaultsToRequestCharset() throws Exception {
+        server.enqueue(new MockResponse().setBody("foo"));
+        TestInterface api = newBuilder()
+                .target(TestInterface.class, "http://localhost:" + server.getPort());
+
+        // should use utf-8 encoding by default
+        api.postWithContentType("àáâãäåèéêë", "text/plain");
+
+        MockWebServerAssertions.assertThat(server.takeRequest()).hasMethod("POST")
+                .hasBody("àáâãäåèéêë");
+    }
+
     public interface TestInterface {
 
         @RequestLine("POST /?foo=bar&foo=baz&qux=")

--- a/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
+++ b/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
@@ -157,6 +157,9 @@ public final class ApacheHttpClient implements Client {
         Collection<String> values = entry.getValue();
         if (values != null && !values.isEmpty()) {
           contentType = ContentType.parse(values.iterator().next());
+          if (contentType.getCharset() == null) {
+            contentType = contentType.withCharset(request.charset());
+          }
           break;
         }
       }


### PR DESCRIPTION
This fix is to address an issue in `ApacheHttpClient` where there is a charset specified in `request.charset()` but not in the `Content-Type` header.

This causes a charset mismatch in the code below -

```
      if (request.charset() != null) {
        ContentType contentType = getContentType(request);
        String content = new String(request.body(), request.charset());
        entity = new StringEntity(content, contentType);
```

For example -
- `request.charset()` = `utf-8`
- `Content-Type` = `application/json`

The `content` string will be encoded in `utf-8` but `StringEntity` will use `ISO-8859-1` by default because there is no charset in the content type.

```
    public StringEntity(String string, ContentType contentType) throws UnsupportedCharsetException {
        Charset charset = contentType != null ? contentType.getCharset() : null;
        if (charset == null) {
            charset = HTTP.DEF_CONTENT_CHARSET;
        }
```

This bug appears to have been introduced in 9.4.0 by pull request #453 .
