### PR TITLE
Perform Map validation of @QueryMap and @HeaderMap lazily

### DIFF
--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -117,16 +117,6 @@ public interface Contract {
         }
       }
 
-      if (data.headerMapIndex() != null) {
-        checkState(Map.class.isAssignableFrom(parameterTypes[data.headerMapIndex()]),
-                "HeaderMap parameter must be a Map: %s", parameterTypes[data.headerMapIndex()]);
-      }
-
-      if (data.queryMapIndex() != null) {
-        checkState(Map.class.isAssignableFrom(parameterTypes[data.queryMapIndex()]),
-                "QueryMap parameter must be a Map: %s", parameterTypes[data.queryMapIndex()]);
-      }
-
       return data;
     }
 

--- a/core/src/main/java/feign/ReflectiveFeign.java
+++ b/core/src/main/java/feign/ReflectiveFeign.java
@@ -214,11 +214,11 @@ public class ReflectiveFeign extends Feign {
       if (metadata.queryMapIndex() != null) {
         // add query map parameters after initial resolve so that they take
         // precedence over any predefined values
-        template = addQueryMapQueryParameters(argv, template);
+        template = addQueryMapQueryParameters(argv[metadata.queryMapIndex()], template);
       }
 
       if (metadata.headerMapIndex() != null) {
-        template = addHeaderMapHeaders(argv, template);
+        template = addHeaderMapHeaders(argv[metadata.headerMapIndex()], template);
       }
 
       return template;
@@ -242,8 +242,10 @@ public class ReflectiveFeign extends Feign {
     }
 
     @SuppressWarnings("unchecked")
-    private RequestTemplate addHeaderMapHeaders(Object[] argv, RequestTemplate mutable) {
-      Map<Object, Object> headerMap = (Map<Object, Object>) argv[metadata.headerMapIndex()];
+    private RequestTemplate addHeaderMapHeaders(Object headerMapArg, RequestTemplate mutable) {
+      checkState(Map.class.isAssignableFrom(headerMapArg.getClass()),
+              "HeaderMap parameter must be a Map: %s", headerMapArg.getClass());
+      Map<Object, Object> headerMap = (Map<Object, Object>) headerMapArg;
       for (Entry<Object, Object> currEntry : headerMap.entrySet()) {
         checkState(currEntry.getKey().getClass() == String.class, "HeaderMap key must be a String: %s", currEntry.getKey());
 
@@ -266,8 +268,10 @@ public class ReflectiveFeign extends Feign {
     }
 
     @SuppressWarnings("unchecked")
-    private RequestTemplate addQueryMapQueryParameters(Object[] argv, RequestTemplate mutable) {
-      Map<Object, Object> queryMap = (Map<Object, Object>) argv[metadata.queryMapIndex()];
+    private RequestTemplate addQueryMapQueryParameters(Object queryMapArg, RequestTemplate mutable) {
+      checkState(Map.class.isAssignableFrom(queryMapArg.getClass()),
+              "QueryMap parameter must be a Map: %s", queryMapArg);
+      Map<Object, Object> queryMap = (Map<Object, Object>) queryMapArg;
       for (Entry<Object, Object> currEntry : queryMap.entrySet()) {
         checkState(currEntry.getKey().getClass() == String.class, "QueryMap key must be a String: %s", currEntry.getKey());
 

--- a/core/src/test/java/feign/DefaultContractTest.java
+++ b/core/src/test/java/feign/DefaultContractTest.java
@@ -319,16 +319,6 @@ public class DefaultContractTest {
   }
 
   @Test
-  public void queryMapMustBeInstanceOfMap() throws Exception {
-    try {
-      parseAndValidateMetadata(QueryMapTestInterface.class, "nonMapQueryMap", String.class);
-      Fail.failBecauseExceptionWasNotThrown(IllegalStateException.class);
-    } catch (IllegalStateException ex) {
-      assertThat(ex).hasMessage("QueryMap parameter must be a Map: class java.lang.String");
-    }
-  }
-
-  @Test
   public void slashAreEncodedWhenNeeded() throws Exception {
     MethodMetadata md = parseAndValidateMetadata(SlashNeedToBeEncoded.class,
                                                  "getQueues", String.class);


### PR DESCRIPTION
This allows an InvocationHandlerFactory to convert a parameter to a
Map<String, Object> after the method is invoked. This is useful for
parameter expansion.