### PR TITLE
Add the Content-Type if specified, unless we are setting the body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 9.5.1
+* Update Okhttp client so that if specified, the content-type is included even without a body.
+
 ### Version 9.5
 * Introduces `feign-java8` with support for `java.util.Optional`
 * Adds `Feign.Builder.mapAndDecode()` to allow response preprocessing before decoding it.

--- a/okhttp/src/main/java/feign/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/feign/okhttp/OkHttpClient.java
@@ -62,13 +62,12 @@ public final class OkHttpClient implements Client {
       }
 
       for (String value : input.headers().get(field)) {
+        requestBuilder.addHeader(field, value);
         if (field.equalsIgnoreCase("Content-Type")) {
           mediaType = MediaType.parse(value);
           if (input.charset() != null) {
             mediaType.charset(input.charset());
           }
-        } else {
-          requestBuilder.addHeader(field, value);
         }
       }
     }
@@ -79,10 +78,13 @@ public final class OkHttpClient implements Client {
 
     byte[] inputBody = input.body();
     boolean isMethodWithBody = "POST".equals(input.method()) || "PUT".equals(input.method());
-    if (isMethodWithBody && inputBody == null) {
-      // write an empty BODY to conform with okhttp 2.4.0+
-      // http://johnfeng.github.io/blog/2015/06/30/okhttp-updates-post-wouldnt-be-allowed-to-have-null-body/
-      inputBody = new byte[0];
+    if (isMethodWithBody) {
+      requestBuilder.removeHeader("Content-Type");
+      if (inputBody == null) {
+        // write an empty BODY to conform with okhttp 2.4.0+
+        // http://johnfeng.github.io/blog/2015/06/30/okhttp-updates-post-wouldnt-be-allowed-to-have-null-body/
+        inputBody = new byte[0];
+      }
     }
 
     RequestBody body = inputBody != null ? RequestBody.create(mediaType, inputBody) : null;

--- a/okhttp/src/test/java/feign/okhttp/OkHttpClientTest.java
+++ b/okhttp/src/test/java/feign/okhttp/OkHttpClientTest.java
@@ -16,9 +16,22 @@
 package feign.okhttp;
 
 import feign.Feign.Builder;
+import feign.Headers;
+import feign.Param;
+import feign.RequestLine;
+import feign.Response;
+import feign.Util;
+import feign.assertj.MockWebServerAssertions;
 import feign.client.AbstractClientTest;
 
 import feign.Feign;
+import okhttp3.mockwebserver.MockResponse;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
 
 /** Tests client-specific behavior, such as ensuring Content-Length is sent when specified. */
 public class OkHttpClientTest extends AbstractClientTest {
@@ -26,5 +39,30 @@ public class OkHttpClientTest extends AbstractClientTest {
   @Override
   public Builder newBuilder() {
     return Feign.builder().client(new OkHttpClient());
+  }
+
+
+  @Test
+  public void testContentTypeWithoutCharset() throws Exception {
+    server.enqueue(new MockResponse()
+            .setBody("AAAAAAAA"));
+    OkHttpClientTestInterface api = newBuilder()
+            .target(OkHttpClientTestInterface.class, "http://localhost:" + server.getPort());
+
+    Response response = api.getWithContentType();
+    // Response length should not be null
+    assertEquals("AAAAAAAA", Util.toString(response.body().asReader()));
+
+    MockWebServerAssertions.assertThat(server.takeRequest())
+            .hasHeaders("Accept: text/plain", "Content-Type: text/plain") // Note: OkHttp adds content length.
+            .hasMethod("GET");
+  }
+
+
+  public interface OkHttpClientTestInterface {
+
+    @RequestLine("GET /")
+    @Headers({"Accept: text/plain", "Content-Type: text/plain"})
+    Response getWithContentType();
   }
 }


### PR DESCRIPTION
Fixes #391 
If we specify the Content-Type we should send it, even without a body. 

The Apache client does the same.
https://github.com/OpenFeign/feign/blob/release-9.5.0/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java#L127-L129