### PR TITLE
make `animal-sniffer-annotation` optional (gh571)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,6 +20,7 @@
     <dependency>
       <groupId>org.jvnet</groupId>
       <artifactId>animal-sniffer-annotation</artifactId>
+      <optional>true</optional>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
make `animal-sniffer-annotation` optional as it is required only for compilation.
See https://github.com/OpenFeign/feign/issues/571