### PR TITLE
Add a method metadata property, in order to control whether need to c…

### DIFF
--- a/core/src/main/java/feign/MethodMetadata.java
+++ b/core/src/main/java/feign/MethodMetadata.java
@@ -44,6 +44,7 @@ public final class MethodMetadata implements Serializable {
       new LinkedHashMap<Integer, Class<? extends Expander>>();
   private Map<Integer, Boolean> indexToEncoded = new LinkedHashMap<Integer, Boolean>();
   private transient Map<Integer, Expander> indexToExpander;
+  private boolean required = true;
 
   MethodMetadata() {
   }
@@ -166,5 +167,13 @@ public final class MethodMetadata implements Serializable {
    */
   public Map<Integer, Expander> indexToExpander() {
     return indexToExpander;
+  }
+
+  public boolean isRequired() {
+    return required;
+  }
+
+  public void setRequired(boolean required) {
+    this.required = required;
   }
 }

--- a/core/src/main/java/feign/ReflectiveFeign.java
+++ b/core/src/main/java/feign/ReflectiveFeign.java
@@ -340,7 +340,9 @@ public class ReflectiveFeign extends Feign {
     protected RequestTemplate resolve(Object[] argv, RequestTemplate mutable,
                                       Map<String, Object> variables) {
       Object body = argv[metadata.bodyIndex()];
-      checkArgument(body != null, "Body parameter %s was null", metadata.bodyIndex());
+      if(metadata.isRequired()) {
+        checkArgument(body != null, "Body parameter %s was null", metadata.bodyIndex());
+      }
       try {
         encoder.encode(body, metadata.bodyType(), mutable);
       } catch (EncodeException e) {


### PR DESCRIPTION
hello, this pull request is to make the request Body to be an optional properties. 

Current version, if the body is null, feign will return error message “Body parameter %s was null”. 

If this PR can be accept. Then I can fix another issue in Spring Cloud Feign：https://github.com/spring-cloud/spring-cloud-netflix/issues/1047

Thanks.



