### PR TITLE
Add an option to not follow redirects (302) and add a unit test for that

### DIFF
--- a/core/src/main/java/feign/Client.java
+++ b/core/src/main/java/feign/Client.java
@@ -88,7 +88,7 @@ public interface Client {
       connection.setConnectTimeout(options.connectTimeoutMillis());
       connection.setReadTimeout(options.readTimeoutMillis());
       connection.setAllowUserInteraction(false);
-      connection.setInstanceFollowRedirects(true);
+      connection.setInstanceFollowRedirects(options.isFollowRedirects());
       connection.setRequestMethod(request.method());
 
       Collection<String> contentEncodingValues = request.headers().get(CONTENT_ENCODING);

--- a/core/src/main/java/feign/Request.java
+++ b/core/src/main/java/feign/Request.java
@@ -13,6 +13,7 @@
  */
 package feign;
 
+import java.net.HttpURLConnection;
 import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.Map;
@@ -103,10 +104,16 @@ public final class Request {
 
     private final int connectTimeoutMillis;
     private final int readTimeoutMillis;
+    private final boolean followRedirects;
 
-    public Options(int connectTimeoutMillis, int readTimeoutMillis) {
+    public Options(int connectTimeoutMillis, int readTimeoutMillis, boolean followRedirects) {
       this.connectTimeoutMillis = connectTimeoutMillis;
       this.readTimeoutMillis = readTimeoutMillis;
+      this.followRedirects = followRedirects;
+    }
+
+    public Options(int connectTimeoutMillis, int readTimeoutMillis){
+      this(connectTimeoutMillis, readTimeoutMillis, true);
     }
 
     public Options() {
@@ -129,6 +136,16 @@ public final class Request {
      */
     public int readTimeoutMillis() {
       return readTimeoutMillis;
+    }
+
+
+    /**
+     * Defaults to true. {@code false} tells the client to not follow the redirections.
+     *
+     * @see HttpURLConnection#getFollowRedirects()
+     */
+    public boolean isFollowRedirects() {
+      return followRedirects;
     }
   }
 }

--- a/core/src/test/java/feign/FeignBuilderTest.java
+++ b/core/src/test/java/feign/FeignBuilderTest.java
@@ -24,6 +24,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -78,6 +79,31 @@ public class FeignBuilderTest {
       assertThat(e.status()).isEqualTo(400);
     }
   }
+
+
+
+  @Test public void testNoFollowRedirect() {
+    server.enqueue(new MockResponse().setResponseCode(302).addHeader("Location","/"));
+
+    String url = "http://localhost:" + server.getPort();
+    TestInterface noFollowApi = Feign.builder()
+                                     .options(new Request.Options(100, 600, false))
+                                     .target(TestInterface.class, url);
+
+    Response response = noFollowApi.defaultMethodPassthrough();
+    assertThat(response.status()).isEqualTo(302);
+    assertThat(response.headers().getOrDefault("Location", null))
+        .isNotNull()
+        .isEqualTo(Collections.singletonList("/"));
+
+    server.enqueue(new MockResponse().setResponseCode(302).addHeader("Location","/"));
+    server.enqueue(new MockResponse().setResponseCode(200));
+    TestInterface defaultApi = Feign.builder()
+                                    .options(new Request.Options(100, 600, true))
+                                    .target(TestInterface.class, url);
+    assertThat(defaultApi.defaultMethodPassthrough().status()).isEqualTo(200);
+  }
+
 
   @Test
   public void testUrlPathConcatUrlTrailingSlash() throws Exception {
@@ -208,7 +234,7 @@ public class FeignBuilderTest {
     assertThat(server.takeRequest())
         .hasBody("request data");
   }
-  
+
   @Test
   public void testSlashIsEncodedInPathParams() throws Exception {
     server.enqueue(new MockResponse().setBody("response data"));
@@ -318,7 +344,7 @@ public class FeignBuilderTest {
 
     @RequestLine("POST /")
     Iterator<String> decodedLazyPost();
-    
+
     @RequestLine(value = "GET /api/queues/{vhost}", decodeSlash = false)
     byte[] getQueues(@Param("vhost") String vhost);
 

--- a/okhttp/src/main/java/feign/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/feign/okhttp/OkHttpClient.java
@@ -151,6 +151,7 @@ public final class OkHttpClient implements Client {
        requestScoped = delegate.newBuilder()
                .connectTimeout(options.connectTimeoutMillis(), TimeUnit.MILLISECONDS)
                .readTimeout(options.readTimeoutMillis(), TimeUnit.MILLISECONDS)
+               .followRedirects(options.isFollowRedirects())
                .build();
     } else {
       requestScoped = delegate;

--- a/ribbon/src/main/java/feign/ribbon/LBClient.java
+++ b/ribbon/src/main/java/feign/ribbon/LBClient.java
@@ -44,6 +44,7 @@ public final class LBClient extends
   private final int readTimeout;
   private final IClientConfig clientConfig;
   private final Set<Integer> retryableStatusCodes;
+  private final Boolean followRedirects;
 
   public static LBClient create(ILoadBalancer lb, IClientConfig clientConfig) {
     return new LBClient(lb, clientConfig);
@@ -66,6 +67,7 @@ public final class LBClient extends
     connectTimeout = clientConfig.get(CommonClientConfigKey.ConnectTimeout);
     readTimeout = clientConfig.get(CommonClientConfigKey.ReadTimeout);
     retryableStatusCodes = parseStatusCodes(clientConfig.get(LBClientFactory.RetryableStatusCodes));
+    followRedirects = clientConfig.get(CommonClientConfigKey.FollowRedirects);
   }
 
   @Override
@@ -76,7 +78,8 @@ public final class LBClient extends
       options =
           new Request.Options(
               configOverride.get(CommonClientConfigKey.ConnectTimeout, connectTimeout),
-              (configOverride.get(CommonClientConfigKey.ReadTimeout, readTimeout)));
+              (configOverride.get(CommonClientConfigKey.ReadTimeout, readTimeout)),
+              configOverride.get(CommonClientConfigKey.FollowRedirects,followRedirects));
     } else {
       options = new Request.Options(connectTimeout, readTimeout);
     }

--- a/ribbon/src/main/java/feign/ribbon/RibbonClient.java
+++ b/ribbon/src/main/java/feign/ribbon/RibbonClient.java
@@ -107,6 +107,7 @@ public class RibbonClient implements Client {
     public FeignOptionsClientConfig(Request.Options options) {
       setProperty(CommonClientConfigKey.ConnectTimeout, options.connectTimeoutMillis());
       setProperty(CommonClientConfigKey.ReadTimeout, options.readTimeoutMillis());
+      setProperty(CommonClientConfigKey.FollowRedirects, options.isFollowRedirects());
     }
 
     @Override

--- a/ribbon/src/test/java/feign/ribbon/RibbonClientTest.java
+++ b/ribbon/src/test/java/feign/ribbon/RibbonClientTest.java
@@ -345,7 +345,8 @@ public class RibbonClientTest {
     assertThat(config.get(CommonClientConfigKey.ConnectTimeout),
         equalTo(options.connectTimeoutMillis()));
     assertThat(config.get(CommonClientConfigKey.ReadTimeout), equalTo(options.readTimeoutMillis()));
-    assertEquals(2, config.getProperties().size());
+    assertThat(config.get(CommonClientConfigKey.FollowRedirects), equalTo(options.isFollowRedirects()));
+    assertEquals(3, config.getProperties().size());
   }
 
   @Test


### PR DESCRIPTION
This change allows the Options() constructor to specify whether the HttpConnection should follow redirects or not. The default is yes (as has been from the beginning) but you can now specify that the connection should return the 3xx response if received.

This might fix the #249 issue. At least it solves it in my case: I wanted to receive the 302 response of the API I'm interrogating and act upon that.