### PR TITLE
Null values handling in templates

### DIFF
--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -692,6 +692,23 @@ public class FeignTest {
   }
 
   @Test
+  public void postBodyWithNullValue() throws InterruptedException {
+    server.enqueue(new MockResponse());
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+    api.login(null, null, null);
+    assertThat(server.takeRequest())
+            .hasBody("{\"customer_name\": null, \"user_name\": null, \"password\": null}");
+  }
+
+  @Test
+  public void postBodyPlainText() throws InterruptedException {
+    server.enqueue(new MockResponse());
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+    api.postBodyPlainText(null);
+    assertThat(server.takeRequest()).hasBody("");
+  }
+
+  @Test
   public void responseMapperIsAppliedBeforeDelegate() throws IOException {
     ResponseMappingDecoder decoder = new ResponseMappingDecoder(upperCaseResponseMapper(), new StringDecoder());
     String output = (String) decoder.decode(responseWithText("response"), String.class);
@@ -797,6 +814,11 @@ public class FeignTest {
 
     @RequestLine("GET /?trim={trim}")
     void encodedQueryParam(@Param(value = "trim", encoded = true) String trim);
+
+    @RequestLine("POST /")
+    @Headers("Content-Type: text/plain")
+    @Body("{body}")
+    void postBodyPlainText(@Param("body") String body);
 
     class DateToMillis implements Param.Expander {
 

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -77,7 +77,7 @@ public class RequestTemplateTest {
   @Test
   public void expandMissingParamProceeds() {
     assertThat(expand("/{user-dir}", mapOf("user_dir", "foo")))
-        .isEqualTo("/{user-dir}");
+        .isEqualTo("/");
   }
 
   @Test


### PR DESCRIPTION
Fixes [#503](https://github.com/OpenFeign/feign/issues/503). Replace null values in template with "null" if it is json object(begins from "%7B" and ends "%7D") and ignores them in all other conditions. Although, it removes double quotes around null values in case it is json object.
 