### PR TITLE
Support Object Query with GET request

### DIFF
--- a/core/src/main/java/feign/QueryObject.java
+++ b/core/src/main/java/feign/QueryObject.java
@@ -1,0 +1,23 @@
+package feign;
+
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * This is a tag annotation to support Object Query. By default, Feign does not support object query with a GET request,
+ * You can use use QueryObjectEncoder to support this.
+ */
+@Retention(RUNTIME)
+@java.lang.annotation.Target(TYPE)
+public @interface QueryObject {
+
+    @Retention(RUNTIME)
+    @java.lang.annotation.Target(TYPE)
+    @interface Param {
+        String value();
+    }
+
+}
+

--- a/core/src/main/java/feign/QueryObject.java
+++ b/core/src/main/java/feign/QueryObject.java
@@ -2,6 +2,7 @@ package feign;
 
 import java.lang.annotation.Retention;
 
+import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
@@ -14,7 +15,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface QueryObject {
 
     @Retention(RUNTIME)
-    @java.lang.annotation.Target(TYPE)
+    @java.lang.annotation.Target(METHOD)
     @interface Param {
         String value();
     }

--- a/core/src/main/java/feign/codec/QueryObjectEncoder.java
+++ b/core/src/main/java/feign/codec/QueryObjectEncoder.java
@@ -1,7 +1,6 @@
 package feign.codec;
 
 
-import feign.Param;
 import feign.QueryObject;
 import feign.RequestTemplate;
 
@@ -9,9 +8,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class QueryObjectEncoder implements Encoder {
 
@@ -24,7 +21,7 @@ public class QueryObjectEncoder implements Encoder {
     @Override
     public void encode(Object parametersObject, Type bodyType, RequestTemplate template) throws EncodeException {
         if (parametersObject.getClass().getAnnotation(QueryObject.class) != null) {
-            Map<String, Object> params = new HashMap<>();
+            Map<String, Object> params = new HashMap<String, Object>();
             try {
                 for (Method method : parametersObject.getClass().getMethods()) {
                     QueryObject.Param param = method.getAnnotation(QueryObject.Param.class);
@@ -32,18 +29,16 @@ public class QueryObjectEncoder implements Encoder {
                         String key = param.value();
                         Object value = method.invoke(parametersObject);
                         if (value != null) {
-                            if (List.class.isAssignableFrom(method.getReturnType())) {
-                                value = ((List<?>) value).stream().map(String::valueOf).collect(Collectors.toList());
-                            } else {
-                                value = String.valueOf(value);
-                            }
-                            params.put(key, value);
-                            template.query(key, keyToTemplate(key));
+                            value = String.valueOf(value);
                         }
+                        params.put(key, value);
+                        template.query(key, keyToTemplate(key));
                     }
                 }
                 template.resolve(params);
-            } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+            } catch (IllegalAccessException e) {
+                throw new EncodeException("Could not encode object query correctly", e);
+            } catch (InvocationTargetException e) {
                 throw new EncodeException("Could not encode object query correctly", e);
             }
         } else {

--- a/core/src/main/java/feign/codec/QueryObjectEncoder.java
+++ b/core/src/main/java/feign/codec/QueryObjectEncoder.java
@@ -10,6 +10,26 @@ import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * You can create an QueryObject like this
+ * <pre>
+ * {@code
+ * @QueryObject
+ * class FindUsersQuery {
+ *    .....
+ *    @QueryObject.Param("userId")
+ *    long getUserId() {...}
+ *    @QueryObject.Param("userName")
+ *    long getUserName() {...}
+ * }
+ * </pre>
+ * Then you can declare the client like this:
+ * <pre>
+ * {@code
+ * @RequestLine("GET /users?userId={userId}&userName={userName}")
+ * List<User> getUsers(FindUsersQuery query);
+ * </pre>
+ */
 public class QueryObjectEncoder implements Encoder {
 
     private Encoder fallbackEncoder;

--- a/core/src/main/java/feign/codec/QueryObjectEncoder.java
+++ b/core/src/main/java/feign/codec/QueryObjectEncoder.java
@@ -1,0 +1,59 @@
+package feign.codec;
+
+
+import feign.Param;
+import feign.QueryObject;
+import feign.RequestTemplate;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class QueryObjectEncoder implements Encoder {
+
+    private Encoder fallbackEncoder;
+
+    public QueryObjectEncoder(Encoder fallbackEncoder) {
+        this.fallbackEncoder = fallbackEncoder;
+    }
+
+    @Override
+    public void encode(Object parametersObject, Type bodyType, RequestTemplate template) throws EncodeException {
+        if (parametersObject.getClass().getAnnotation(QueryObject.class) != null) {
+            Map<String, Object> params = new HashMap<>();
+            try {
+                for (Method method : parametersObject.getClass().getMethods()) {
+                    QueryObject.Param param = method.getAnnotation(QueryObject.Param.class);
+                    if (param != null && method.getName().startsWith("get")) {
+                        String key = param.value();
+                        Object value = method.invoke(parametersObject);
+                        if (value != null) {
+                            if (List.class.isAssignableFrom(method.getReturnType())) {
+                                value = ((List<?>) value).stream().map(String::valueOf).collect(Collectors.toList());
+                            } else {
+                                value = String.valueOf(value);
+                            }
+                            params.put(key, value);
+                            template.query(key, keyToTemplate(key));
+                        }
+                    }
+                }
+                template.resolve(params);
+            } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+                throw new EncodeException("Could not encode object query correctly", e);
+            }
+        } else {
+            fallbackEncoder.encode(parametersObject, bodyType, template);
+        }
+    }
+
+    private String keyToTemplate(String key) {
+        return "{" + key + "}";
+    }
+
+}
+


### PR DESCRIPTION
Let's say you have two mandatory parameters and an optional parameters, you will have to implement it this way:
```
foo(m1, m2, o1)
```

If you have more optional parameters you will have to implement a lot of overloaded methods, otherwise you can only implement a method with a lot of parameters and when it is called, you have to pass in a bunch of null values like this:
```
foo(m1, m2, null, null, null, null, o5, null, null, o8) 
```

This is very ugly, if we have object parameter we can do this: first, use a constructor to pass in all mandatory parameters, then use setters to set the optional parameters like this:

```
q = new FindUsersRequest(category, type);
q.setRowStart(10);
q.setGender(M);
feign.findUsers(q);

```
Relaated to #520 