### PR TITLE
Fixes retrials without Thread.sleep when thread gets interrupted

### DIFF
--- a/core/src/main/java/feign/Retryer.java
+++ b/core/src/main/java/feign/Retryer.java
@@ -75,6 +75,7 @@ public interface Retryer extends Cloneable {
         Thread.sleep(interval);
       } catch (InterruptedException ignored) {
         Thread.currentThread().interrupt();
+        throw e;
       }
       sleptForMillis += interval;
     }

--- a/core/src/test/java/feign/RetryerTest.java
+++ b/core/src/test/java/feign/RetryerTest.java
@@ -15,6 +15,7 @@
  */
 package feign;
 
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -73,5 +74,22 @@ public class RetryerTest {
   @Test(expected = RetryableException.class)
   public void neverRetryAlwaysPropagates() {
     Retryer.NEVER_RETRY.continueOrPropagate(new RetryableException(null, null, new Date(5000)));
+  }
+
+  @Test
+  public void defaultRetryerFailsOnInterruptedException() {
+    Default retryer = new Retryer.Default();
+
+    Thread.currentThread().interrupt();
+    RetryableException expected = new RetryableException(null, null, new Date(System.currentTimeMillis() + 5000));
+    try {
+      retryer.continueOrPropagate(expected);
+      Thread.interrupted(); // reset interrupted flag in case it wasn't
+      Assert.fail("Retryer continued despite interruption");
+    } catch (RetryableException e) {
+      Assert.assertTrue("Interrupted status not reset", Thread.interrupted());
+      Assert.assertEquals("Retry attempt not registered as expected", 2, retryer.attempt);
+      Assert.assertEquals("Unexpected exception found", expected, e);
+    }
   }
 }


### PR DESCRIPTION
This PR aims to avoid flood of retries when thread, in which retryer is running, gets interrupted. Default retryer will rethrow FeignException in case of interrupted state.
Fixes #624 
Fixes #643