### PR TITLE
Add the ability to pass request parameters as object

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,27 @@ LoginClient client = Feign.builder()
 client.login(new Credentials("denominator", "secret"));
 ```
 
+Sending `Get` request using an object containing request parameters can be achieved using `ObjectToQueryParamEncoder`.
+
+This encoder uses an Object as source for query parameters. Add non null values of properties as query parameters using the property name as the query parameter name.
+
+```Java
+
+interface LoginClient {
+  @RequestLine("GET /")
+  void login(Credentials creds);
+}
+...
+LoginClient client = Feign.builder()
+                          .encoder(new ObjectToQueryParamEncoder())
+                          .logLevel(Logger.Level.FULL)
+                          .target(LoginClient.class, "https://foo.com");
+
+client.login(new Credentials("denominator", "secret"));
+```
+
+This will generate a get request `https://foo.com?user_name=denominator&password=secret`
+
 ### @Body templates
 The `@Body` annotation indicates a template to expand using parameters annotated with `@Param`. You will likely need to add a `Content-Type` header.
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -41,6 +41,12 @@
       <version>4.2.5.RELEASE</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.13.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/src/main/java/feign/codec/ObjectToQueryParamEncoder.java
+++ b/core/src/main/java/feign/codec/ObjectToQueryParamEncoder.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.codec;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+
+import feign.RequestTemplate;
+
+/**
+ * Use an Object as source for query parameters.
+ * Add non null values of properties as query parameters using the property name as the query parameter name
+ */
+public class ObjectToQueryParamEncoder implements Encoder {
+
+  static String toParamTemplate(String queryParamName) {
+    return "{" + queryParamName + "}";
+  }
+
+  private String decapitalize(String name) {
+    if (name == null || name.length() == 0) {
+      return name;
+    }
+    char chars[] = name.toCharArray();
+    chars[0] = Character.toLowerCase(chars[0]);
+    return new String(chars);
+  }
+
+  @Override
+  public void encode(Object queryParametersObject, Type bodyType, RequestTemplate template) throws EncodeException {
+    if (queryParametersObject != null) {
+      // Store query parameters values
+      Map<String, Object> queryParams = new HashMap<String, Object>();
+      try {
+        for (Method method : queryParametersObject.getClass().getMethods()) {
+          analyseMethod(queryParametersObject, method, template, queryParams);
+        }
+      }
+      catch (InvocationTargetException e) {
+        throw new EncodeException("Could not encode query parameters from object", e);
+      }
+      catch (IllegalAccessException e) {
+        throw new EncodeException("Could not encode query parameters from object", e);
+      }
+      // resolve newly added parameters
+      if (!queryParams.isEmpty()) {
+        template.resolve(queryParams);
+      }
+    }
+  }
+
+  /**
+   * Add non null values of properties as query parameters using the property name as the query parameter name
+   */
+  private void analyseMethod(Object queryParametersObject,
+                             Method method,
+                             RequestTemplate template,
+                             Map<String, Object> queryParams) throws IllegalAccessException, InvocationTargetException {
+    // filter method to "getter" like but not those from Object (ex: getClass())
+    if (!Object.class.equals(method.getDeclaringClass()) && method.getParameterTypes() != null && method.getParameterTypes().length == 0) {
+      String queryParamName = findPropertyName(method);
+      if (queryParamName != null) {
+        Object queryParamValue = method.invoke(queryParametersObject);
+
+        // Add discovered parameter if present
+        if (queryParamName != null && queryParamValue != null) {
+          queryParams.put(queryParamName, queryParamValue);
+          template.query(queryParamName, toParamTemplate(queryParamName));
+        }
+      }
+    }
+  }
+
+  /**
+   * @param method
+   * @return property name associated to a getter or null if the method is not a getter
+   */
+  private String findPropertyName(Method method) {
+    String queryParamName = null;
+    if (method.getName().startsWith("get")) {
+      queryParamName = decapitalize(method.getName().substring(3));
+    }
+    else if (method.getName().startsWith("is")) {
+      queryParamName = decapitalize(method.getName().substring(2));
+    }
+    return queryParamName;
+  }
+}

--- a/core/src/test/java/feign/codec/ObjectToQueryParamEncoderTest.java
+++ b/core/src/test/java/feign/codec/ObjectToQueryParamEncoderTest.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright 2013 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.codec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+import feign.RequestTemplate;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Check the encoder can add expected parameters
+ */
+public class ObjectToQueryParamEncoderTest {
+
+  @InjectMocks
+  private ObjectToQueryParamEncoder encoder;
+  @Mock
+  private RequestTemplate template;
+  @Captor
+  private ArgumentCaptor<Map> mapArgumentCaptor;
+
+  @Before
+  public void initMock() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void encodeShouldIgnoreNonProperties() {
+    Type type = null;
+    encoder.encode(new NoPropertyBean(), type, template);
+    verifyNoMoreInteractions(template);
+  }
+
+  @Test
+  public void encodeShouldFindStringProperty() {
+    Type type = null;
+    String paramValue = "Yes";
+    String paramName = "stringParam";
+    DummyBen queryParametersObject = new DummyBen(null, paramValue, null, null);
+
+    assertEncoded(queryParametersObject, paramValue, paramName, type);
+  }
+
+  @Test
+  public void encodeShouldFindBooleanProperty() {
+    Type type = null;
+    boolean paramValue = true;
+    String paramName = "booleanParam";
+    DummyBen queryParametersObject = new DummyBen(null, null, paramValue, null);
+
+    assertEncoded(queryParametersObject, paramValue, paramName, type);
+  }
+
+  private void assertEncoded(DummyBen queryParametersObject, Object paramValue, String paramName, Type type) {
+    encoder.encode(queryParametersObject, type, template);
+
+    verify(template).query(paramName, ObjectToQueryParamEncoder.toParamTemplate(paramName));
+    verify(template).resolve(mapArgumentCaptor.capture());
+    assertThat(mapArgumentCaptor.getValue())
+      .containsOnlyKeys(paramName)
+      .containsValue(paramValue)
+    ;
+    verifyNoMoreInteractions(template);
+  }
+
+  static class DummyBen {
+    private final Character charParam;
+    private String stringParam;
+    private Boolean booleanParam;
+    private Integer intParam;
+
+    public DummyBen() {
+      charParam = 'M';
+    }
+
+    public DummyBen(Character charParam, String stringParam, Boolean booleanParam, Integer intParam) {
+      this.charParam = charParam;
+      this.stringParam = stringParam;
+      this.booleanParam = booleanParam;
+      this.intParam = intParam;
+    }
+
+    public Character getCharParam() {
+      return charParam;
+    }
+
+    public String getStringParam() {
+      return stringParam;
+    }
+
+    public void setStringParam(String stringParam) {
+      this.stringParam = stringParam;
+    }
+
+    public Boolean getBooleanParam() {
+      return booleanParam;
+    }
+
+    public void setBooleanParam(Boolean booleanParam) {
+      this.booleanParam = booleanParam;
+    }
+
+    public Integer getIntParam() {
+      return intParam;
+    }
+
+    public void setIntParam(Integer intParam) {
+      this.intParam = intParam;
+    }
+
+    @Override
+    public String toString() {
+      return "DummyBen{" +
+        "charParam=" + charParam +
+        ", stringParam='" + stringParam + '\'' +
+        ", booleanParam=" + booleanParam +
+        ", intParam=" + intParam +
+        '}';
+    }
+  }
+
+  static class NoPropertyBean {
+    public void get() {
+      //noop
+    }
+
+    public Object getObject(Object o) {
+      return o;
+    }
+
+    public String getNo(String way) {
+      return "no";
+    }
+  }
+
+}

--- a/core/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/core/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
* Adds an encoder using a parameter object to add query parameters to the request from its non null properties
  * encoder introspects the object to find getters
  * only add parameters to the query if the value is non null
  * uses the property name as the query parameter name
* Does not require to add any annotation in the parameter object class (sometime you don't have this possibility; as with external lib)

Fixes #520