### PR TITLE
fix default method gets wrapped twice

### DIFF
--- a/hystrix/src/main/java/feign/hystrix/HystrixInvocationHandler.java
+++ b/hystrix/src/main/java/feign/hystrix/HystrixInvocationHandler.java
@@ -146,7 +146,9 @@ final class HystrixInvocationHandler implements InvocationHandler {
       }
     };
 
-    if (isReturnsHystrixCommand(method)) {
+    if (Util.isDefault(method)) {
+      return hystrixCommand.execute();
+    } else if (isReturnsHystrixCommand(method)) {
       return hystrixCommand;
     } else if (isReturnsObservable(method)) {
       // Create a cold Observable
@@ -161,19 +163,19 @@ final class HystrixInvocationHandler implements InvocationHandler {
   }
 
   private boolean isReturnsCompletable(Method method) {
-    return !Util.isDefault(method) && Completable.class.isAssignableFrom(method.getReturnType());
+    return Completable.class.isAssignableFrom(method.getReturnType());
   }
 
   private boolean isReturnsHystrixCommand(Method method) {
-    return !Util.isDefault(method) && HystrixCommand.class.isAssignableFrom(method.getReturnType());
+    return HystrixCommand.class.isAssignableFrom(method.getReturnType());
   }
 
   private boolean isReturnsObservable(Method method) {
-    return !Util.isDefault(method) && Observable.class.isAssignableFrom(method.getReturnType());
+    return Observable.class.isAssignableFrom(method.getReturnType());
   }
 
   private boolean isReturnsSingle(Method method) {
-    return !Util.isDefault(method) && Single.class.isAssignableFrom(method.getReturnType());
+    return Single.class.isAssignableFrom(method.getReturnType());
   }
 
   @Override

--- a/hystrix/src/main/java/feign/hystrix/HystrixInvocationHandler.java
+++ b/hystrix/src/main/java/feign/hystrix/HystrixInvocationHandler.java
@@ -28,6 +28,7 @@ import java.util.Set;
 
 import feign.InvocationHandlerFactory.MethodHandler;
 import feign.Target;
+import feign.Util;
 import rx.Completable;
 import rx.Observable;
 import rx.Single;
@@ -160,19 +161,19 @@ final class HystrixInvocationHandler implements InvocationHandler {
   }
 
   private boolean isReturnsCompletable(Method method) {
-    return Completable.class.isAssignableFrom(method.getReturnType());
+    return !Util.isDefault(method) && Completable.class.isAssignableFrom(method.getReturnType());
   }
 
   private boolean isReturnsHystrixCommand(Method method) {
-    return HystrixCommand.class.isAssignableFrom(method.getReturnType());
+    return !Util.isDefault(method) && HystrixCommand.class.isAssignableFrom(method.getReturnType());
   }
 
   private boolean isReturnsObservable(Method method) {
-    return Observable.class.isAssignableFrom(method.getReturnType());
+    return !Util.isDefault(method) && Observable.class.isAssignableFrom(method.getReturnType());
   }
 
   private boolean isReturnsSingle(Method method) {
-    return Single.class.isAssignableFrom(method.getReturnType());
+    return !Util.isDefault(method) && Single.class.isAssignableFrom(method.getReturnType());
   }
 
   @Override

--- a/hystrix/src/test/java/feign/hystrix/HystrixBuilderTest.java
+++ b/hystrix/src/test/java/feign/hystrix/HystrixBuilderTest.java
@@ -39,12 +39,12 @@ public class HystrixBuilderTest {
   public final MockWebServer server = new MockWebServer();
 
   @Test
-  public void defaultHystrixCommand() {
+  public void defaultMethodReturningHystrixCommand() {
     server.enqueue(new MockResponse().setBody("\"foo\""));
 
     TestInterface api = target();
 
-    HystrixCommand<String> command = api.defaultCommand();
+    HystrixCommand<String> command = api.defaultMethodReturningCommand();
 
     assertThat(command).isNotNull();
     assertThat(command.execute()).isEqualTo("foo");
@@ -194,23 +194,6 @@ public class HystrixBuilderTest {
   }
 
   @Test
-  public void defaultMethodRxObservable() {
-    server.enqueue(new MockResponse().setBody("\"foo\""));
-
-    TestInterface api = target();
-
-    Observable<String> observable = api.defaultObservable();
-
-    assertThat(observable).isNotNull();
-    assertThat(server.getRequestCount()).isEqualTo(0);
-
-    TestSubscriber<String> testSubscriber = new TestSubscriber<String>();
-    observable.subscribe(testSubscriber);
-    testSubscriber.awaitTerminalEvent();
-    Assertions.assertThat(testSubscriber.getOnNextEvents().get(0)).isEqualTo("foo");
-  }
-
-  @Test
   public void rxObservable() {
     server.enqueue(new MockResponse().setBody("\"foo\""));
 
@@ -334,23 +317,6 @@ public class HystrixBuilderTest {
   }
 
   @Test
-  public void defaultMethodRxSingle() {
-    server.enqueue(new MockResponse().setBody("\"foo\""));
-
-    TestInterface api = target();
-
-    Single<String> single = api.defaultSingle();
-
-    assertThat(single).isNotNull();
-    assertThat(server.getRequestCount()).isEqualTo(0);
-
-    TestSubscriber<String> testSubscriber = new TestSubscriber<String>();
-    single.subscribe(testSubscriber);
-    testSubscriber.awaitTerminalEvent();
-    Assertions.assertThat(testSubscriber.getOnNextEvents().get(0)).isEqualTo("foo");
-  }
-
-  @Test
   public void rxSingle() {
     server.enqueue(new MockResponse().setBody("\"foo\""));
 
@@ -450,25 +416,6 @@ public class HystrixBuilderTest {
     single.subscribe(testSubscriber);
     testSubscriber.awaitTerminalEvent();
     assertThat(testSubscriber.getOnNextEvents().get(0)).containsExactly("fallback");
-  }
-
-  @Test
-  public void defaultRxCompletableEmptyBody() {
-    server.enqueue(new MockResponse());
-
-    TestInterface api = target();
-
-    Completable completable = api.defaultCompletable();
-
-    assertThat(completable).isNotNull();
-    assertThat(server.getRequestCount()).isEqualTo(0);
-
-    TestSubscriber<String> testSubscriber = new TestSubscriber<String>();
-    completable.subscribe(testSubscriber);
-    testSubscriber.awaitTerminalEvent();
-
-    testSubscriber.assertCompleted();
-    testSubscriber.assertNoErrors();
   }
 
   @Test
@@ -658,7 +605,7 @@ public class HystrixBuilderTest {
     @Headers("Accept: application/json")
     HystrixCommand<String> command();
 
-    default HystrixCommand<String> defaultCommand() {
+    default HystrixCommand<String> defaultMethodReturningCommand() {
       return command();
     }
 
@@ -674,10 +621,6 @@ public class HystrixBuilderTest {
     @Headers("Accept: application/json")
     Observable<String> observable();
 
-    default Observable<String> defaultObservable() {
-      return observable();
-    }
-
     @RequestLine("GET /")
     @Headers("Accept: application/json")
     Single<Integer> intSingle();
@@ -689,10 +632,6 @@ public class HystrixBuilderTest {
     @RequestLine("GET /")
     @Headers("Accept: application/json")
     Single<String> single();
-
-    default Single<String> defaultSingle() {
-      return single();
-    }
 
     @RequestLine("GET /")
     @Headers("Accept: application/json")
@@ -709,10 +648,6 @@ public class HystrixBuilderTest {
 
     @RequestLine("GET /")
     Completable completable();
-
-    default Completable defaultCompletable() {
-      return completable();
-    }
   }
 
   class FallbackTestInterface implements TestInterface {


### PR DESCRIPTION
There is a bug on wrapping interface default methods on Hystrix Targetter:

`
interface test {
 default Observable<String> observable() {
return Observable.just("one", "two");
 }
}
`

becomes: 

`Observable<Observable<String>>`