### PR TITLE
Bump the version to prepare for the next release

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.github.openfeign</groupId>
     <artifactId>parent</artifactId>
-    <version>9.5.2-SNAPSHOT</version>
+    <version>9.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>feign-core</artifactId>

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.github.openfeign</groupId>
     <artifactId>parent</artifactId>
-    <version>9.5.2-SNAPSHOT</version>
+    <version>9.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>feign-gson</artifactId>

--- a/httpclient/pom.xml
+++ b/httpclient/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.github.openfeign</groupId>
     <artifactId>parent</artifactId>
-    <version>9.5.2-SNAPSHOT</version>
+    <version>9.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>feign-httpclient</artifactId>

--- a/hystrix/pom.xml
+++ b/hystrix/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.github.openfeign</groupId>
     <artifactId>parent</artifactId>
-    <version>9.5.2-SNAPSHOT</version>
+    <version>9.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>feign-hystrix</artifactId>

--- a/jackson-jaxb/pom.xml
+++ b/jackson-jaxb/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.github.openfeign</groupId>
     <artifactId>parent</artifactId>
-    <version>9.5.2-SNAPSHOT</version>
+    <version>9.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>feign-jackson-jaxb</artifactId>

--- a/jackson/pom.xml
+++ b/jackson/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.github.openfeign</groupId>
     <artifactId>parent</artifactId>
-    <version>9.5.2-SNAPSHOT</version>
+    <version>9.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>feign-jackson</artifactId>

--- a/java8/pom.xml
+++ b/java8/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.github.openfeign</groupId>
-        <version>9.5.2-SNAPSHOT</version>
+        <version>9.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.github.openfeign</groupId>
     <artifactId>parent</artifactId>
-    <version>9.5.2-SNAPSHOT</version>
+    <version>9.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>feign-jaxb</artifactId>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.github.openfeign</groupId>
     <artifactId>parent</artifactId>
-    <version>9.5.2-SNAPSHOT</version>
+    <version>9.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>feign-jaxrs</artifactId>

--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.github.openfeign</groupId>
     <artifactId>parent</artifactId>
-    <version>9.5.2-SNAPSHOT</version>
+    <version>9.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>feign-okhttp</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>io.github.openfeign</groupId>
   <artifactId>parent</artifactId>
-  <version>9.5.2-SNAPSHOT</version>
+  <version>9.6.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/ribbon/pom.xml
+++ b/ribbon/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.github.openfeign</groupId>
     <artifactId>parent</artifactId>
-    <version>9.5.2-SNAPSHOT</version>
+    <version>9.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>feign-ribbon</artifactId>

--- a/sax/pom.xml
+++ b/sax/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.github.openfeign</groupId>
     <artifactId>parent</artifactId>
-    <version>9.5.2-SNAPSHOT</version>
+    <version>9.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>feign-sax</artifactId>

--- a/slf4j/pom.xml
+++ b/slf4j/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>io.github.openfeign</groupId>
     <artifactId>parent</artifactId>
-    <version>9.5.2-SNAPSHOT</version>
+    <version>9.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>feign-slf4j</artifactId>


### PR DESCRIPTION
ran the command `./mvnw versions:set -DnewVersion=9.6.0-SNAPSHOT -DgenerateBackupPoms=false` to prepare the repo for the next release. 

Tagging @adriancole and @velo who are working on the release. 