### PR TITLE
Support of Java 8 Stream Decoder and Jackson Iterator Decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 ### Version 9.6
 * Feign builder now supports flag `doNotCloseAfterDecode` to support lazy iteration of responses.
-* Introduces `JacksonIteratorDecoder` in `feign-jackson` which provides a closeable iterator for lazy processing json arrays. This decoder has to be used with `Feign.Builder.doNotCloseAfterDecode()` option disabled. Built-in iterator auto closes the `Response` when it reached json array end or failed to parse stream.
-  If this iterator is not fetched till the end, it has to be casted to `Closeable` and explicity `Closeable.close()` by the consumer.
-* Introduces `StreamDecoder` in `feign-java8` which provides a `java.util.stream.Stream` for lazy processing response based on a wrapped decoder that is responsible to transform the `Response` to an `Iterator`.
- This decoder has to be used with `Feign.Builder.doNotCloseAfterDecode()` option disabled.
+* Adds `JacksonIteratorDecoder` and `StreamDecoder` to decode responses as `java.util.Iterator` or `java.util.stream.Stream`.
 
 ### Version 9.5.1
 * When specified, Content-Type header is now included on OkHttp requests lacking a body.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Version 9.6
 * Feign builder now supports flag `doNotCloseAfterDecode` to support lazy iteration of responses.
+* Introduces `JacksonIteratorDecoder` in `feign-jackson` which provides a closeable iterator for lazy processing json arrays. This decoder has to be used with `Feign.Builder.doNotCloseAfterDecode()` option disabled. Built-in iterator auto closes the `Response` when it reached json array end or failed to parse stream.
+  If this iterator is not fetched till the end, it has to be casted to `Closeable` and explicity `Closeable.close()` by the consumer.
+* Introduces `StreamDecoder` in `feign-java8` which provides a `java.util.stream.Stream` for lazy processing response based on a wrapped decoder that is responsible to transform the `Response` to an `Iterator`.
+ This decoder has to be used with `Feign.Builder.doNotCloseAfterDecode()` option disabled.
 
 ### Version 9.5.1
 * When specified, Content-Type header is now included on OkHttp requests lacking a body.

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -24,26 +24,38 @@
     <version>9</version>
   </parent>
 
-  <!-- TODO: change group id when 9.0 is released -->
-  <groupId>com.netflix.feign</groupId>
   <artifactId>feign-benchmark</artifactId>
-  <packaging>jar</packaging>
-  <version>8.1.0-SNAPSHOT</version>
+  <version>9.6.0-SNAPSHOT</version>
   <name>Feign Benchmark (JMH)</name>
 
   <properties>
-    <jmh.version>1.11.2</jmh.version>
+    <jmh.version>1.20</jmh.version>
+    <!-- override default bytecode version for src/main from parent pom -->
+    <main.java.version>1.8</main.java.version>
+    <main.signature.artifact>java18</main.signature.artifact>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <dependencies>
     <dependency>
-      <groupId>com.netflix.feign</groupId>
+      <groupId>io.github.openfeign</groupId>
       <artifactId>feign-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.netflix.feign</groupId>
+      <groupId>io.github.openfeign</groupId>
       <artifactId>feign-okhttp</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.github.openfeign</groupId>
+      <artifactId>feign-jackson</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.github.openfeign</groupId>
+      <artifactId>feign-java8</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -24,6 +24,7 @@
     <version>9</version>
   </parent>
 
+  <groupId>io.github.openfeign</groupId>
   <artifactId>feign-benchmark</artifactId>
   <version>9.6.0-SNAPSHOT</version>
   <name>Feign Benchmark (JMH)</name>

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -40,22 +40,22 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.github.openfeign</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>feign-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.github.openfeign</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>feign-okhttp</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.github.openfeign</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>feign-jackson</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.github.openfeign</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>feign-java8</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/benchmark/src/main/java/feign/benchmark/DecoderIteratorsBenchmark.java
+++ b/benchmark/src/main/java/feign/benchmark/DecoderIteratorsBenchmark.java
@@ -93,12 +93,12 @@ public class DecoderIteratorsBenchmark {
         }.getType();
         break;
       case "iterator":
-        decoder = JacksonIteratorDecoder.Factory.create();
+        decoder = JacksonIteratorDecoder.create();
         type = new TypeReference<Iterator<Car>>() {
         }.getType();
         break;
       case "stream":
-        decoder = StreamDecoder.Factory.create(JacksonIteratorDecoder.Factory.create());
+        decoder = StreamDecoder.create(JacksonIteratorDecoder.create());
         type = new TypeReference<Stream<Car>>() {
         }.getType();
         break;

--- a/benchmark/src/main/java/feign/benchmark/DecoderIteratorsBenchmark.java
+++ b/benchmark/src/main/java/feign/benchmark/DecoderIteratorsBenchmark.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2012-2018 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.benchmark;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import feign.Response;
+import feign.Util;
+import feign.codec.Decoder;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonIteratorDecoder;
+import feign.stream.StreamDecoder;
+import org.openjdk.jmh.annotations.*;
+
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+/**
+ * This test shows up how fast different json array response processing implementations are.
+ */
+@State(Scope.Thread)
+public class DecoderIteratorsBenchmark {
+
+  @Param({"list", "iterator", "stream"})
+  private String api;
+
+  @Param({"10", "100"})
+  private String size;
+
+  private Response response;
+
+  private Decoder decoder;
+  private Type type;
+
+  @Benchmark
+  @Warmup(iterations = 5, time = 1)
+  @Measurement(iterations = 10, time = 1)
+  @Fork(3)
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public void decode() throws Exception {
+    fetch(decoder.decode(response, type));
+  }
+
+  @SuppressWarnings("unchecked")
+  private void fetch(Object o) {
+    Iterator<Car> cars;
+
+    if (o instanceof Collection) {
+      cars = ((Collection<Car>) o).iterator();
+    } else if (o instanceof Stream) {
+      cars = ((Stream<Car>) o).iterator();
+    } else {
+      cars = (Iterator<Car>) o;
+    }
+
+    while (cars.hasNext()) {
+      cars.next();
+    }
+  }
+
+  @Setup(Level.Invocation)
+  public void buildResponse() {
+    response = Response.builder()
+        .status(200)
+        .reason("OK")
+        .headers(Collections.emptyMap())
+        .body(carsJson(Integer.valueOf(size)), Util.UTF_8)
+        .build();
+  }
+
+  @Setup(Level.Trial)
+  public void buildDecoder() {
+    switch (api) {
+      case "list":
+        decoder = new JacksonDecoder();
+        type = new TypeReference<List<Car>>() {
+        }.getType();
+        break;
+      case "iterator":
+        decoder = JacksonIteratorDecoder.Factory.create();
+        type = new TypeReference<Iterator<Car>>() {
+        }.getType();
+        break;
+      case "stream":
+        decoder = StreamDecoder.Factory.create(JacksonIteratorDecoder.Factory.create());
+        type = new TypeReference<Stream<Car>>() {
+        }.getType();
+        break;
+      default:
+        throw new IllegalStateException("Unknown api: " + api);
+    }
+  }
+
+  private String carsJson(int count) {
+    String car = "{\"name\":\"c4\",\"manufacturer\":\"Citroën\"}";
+    StringBuilder builder = new StringBuilder("[");
+    builder.append(car);
+    for (int i = 1; i < count; i++) {
+      builder.append(",").append(car);
+    }
+    return builder.append("]").toString();
+  }
+
+  static class Car {
+    public String name;
+    public String manufacturer;
+  }
+}

--- a/benchmark/src/main/java/feign/benchmark/DecoderIteratorsBenchmark.java
+++ b/benchmark/src/main/java/feign/benchmark/DecoderIteratorsBenchmark.java
@@ -30,9 +30,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
-/**
- * This test shows up how fast different json array response processing implementations are.
- */
 @State(Scope.Thread)
 public class DecoderIteratorsBenchmark {
 

--- a/benchmark/src/main/java/feign/benchmark/DecoderIteratorsBenchmark.java
+++ b/benchmark/src/main/java/feign/benchmark/DecoderIteratorsBenchmark.java
@@ -30,6 +30,9 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
+/**
+ * This test shows up how fast different json array response processing implementations are.
+ */
 @State(Scope.Thread)
 public class DecoderIteratorsBenchmark {
 

--- a/benchmark/src/main/java/feign/benchmark/RealRequestBenchmarks.java
+++ b/benchmark/src/main/java/feign/benchmark/RealRequestBenchmarks.java
@@ -64,7 +64,7 @@ public class RealRequestBenchmarks {
     });
     server.start();
     client = new OkHttpClient();
-    client.setRetryOnConnectionFailure(false);
+    client.retryOnConnectionFailure();
     okFeign = Feign.builder()
         .client(new feign.okhttp.OkHttpClient(client))
         .target(FeignTestInterface.class, "http://localhost:" + SERVER_PORT);
@@ -82,8 +82,8 @@ public class RealRequestBenchmarks {
    * How fast can we execute get commands synchronously?
    */
   @Benchmark
-  public com.squareup.okhttp.Response query_baseCaseUsingOkHttp() throws IOException {
-    com.squareup.okhttp.Response result = client.newCall(queryRequest).execute();
+  public okhttp3.Response query_baseCaseUsingOkHttp() throws IOException {
+    okhttp3.Response result = client.newCall(queryRequest).execute();
     result.body().close();
     return result;
   }

--- a/jackson/src/main/java/feign/jackson/JacksonIteratorDecoder.java
+++ b/jackson/src/main/java/feign/jackson/JacksonIteratorDecoder.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright 2012-2018 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.*;
+import feign.Response;
+import feign.Util;
+import feign.codec.DecodeException;
+import feign.codec.Decoder;
+
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.Reader;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.Iterator;
+
+import static feign.Util.ensureClosed;
+
+/**
+ * Jackson decoder which return a closeable iterator.
+ * Returned iterator auto-close the {@code Response} when it reached json array end or failed to parse stream.
+ * If this iterator is not fetched till the end, it has to be casted to {@code Closeable} and explicity {@code Closeable#close} by the consumer.
+ * <p>
+ * <p>
+ * <p>Example: <br>
+ * <pre><code>
+ * Feign.builder()
+ *   .decoder(JacksonIteratorDecoder.Factory.create())
+ *   .doNotCloseAfterDecode() // Required to fetch the iterator after the response is processed, need to be close
+ *   .target(GitHub.class, "https://api.github.com");
+ * interface GitHub {
+ *  {@literal @}RequestLine("GET /repos/{owner}/{repo}/contributors")
+ *   Iterator<Contributor> contributors(@Param("owner") String owner, @Param("repo") String repo);
+ * }</code></pre>
+ */
+public class JacksonIteratorDecoder implements Decoder {
+
+  private final ObjectMapper mapper;
+
+  private JacksonIteratorDecoder(ObjectMapper mapper) {
+    this.mapper = mapper;
+  }
+
+  @Override
+  public Object decode(Response response, Type type) throws IOException {
+    if (response.status() == 404) return Util.emptyValueOf(type);
+    if (response.body() == null) return null;
+    Reader reader = response.body().asReader();
+    if (!reader.markSupported()) {
+      reader = new BufferedReader(reader, 1);
+    }
+    try {
+      // Read the first byte to see if we have any data
+      reader.mark(1);
+      if (reader.read() == -1) {
+        return null; // Eagerly returning null avoids "No content to map due to end-of-input"
+      }
+      reader.reset();
+      return new JacksonIterator<Object>(actualIteratorTypeArgument(type), mapper, response, reader);
+    } catch (RuntimeJsonMappingException e) {
+      if (e.getCause() != null && e.getCause() instanceof IOException) {
+        throw IOException.class.cast(e.getCause());
+      }
+      throw e;
+    }
+  }
+
+  private Type actualIteratorTypeArgument(Type type) {
+    if (!(type instanceof ParameterizedType)) {
+      throw new IllegalArgumentException("Not supported type " + type.toString());
+    }
+    ParameterizedType parameterizedType = (ParameterizedType) type;
+    if (!Iterator.class.equals(parameterizedType.getRawType())) {
+      throw new IllegalArgumentException("Not an iterator type " + parameterizedType.getRawType().toString());
+    }
+    return ((ParameterizedType) type).getActualTypeArguments()[0];
+  }
+
+  public static final class Factory {
+    public static JacksonIteratorDecoder create() {
+       return create(Collections.<Module>emptyList());
+    }
+    public static JacksonIteratorDecoder create(Iterable<Module> modules) {
+      return new JacksonIteratorDecoder(new ObjectMapper()
+          .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+          .registerModules(modules));
+    }
+    public static JacksonIteratorDecoder create(ObjectMapper objectMapper) {
+      return new JacksonIteratorDecoder(objectMapper);
+    }
+  }
+
+  private final class JacksonIterator<T> implements Iterator<T>, Closeable {
+    private final Response response;
+    private final JsonParser parser;
+    private final ObjectReader objectReader;
+
+    private T current;
+
+    private JacksonIterator(Type type, ObjectMapper mapper, Response response, Reader reader)
+        throws IOException {
+      this.response = response;
+      this.parser = mapper.getFactory().createParser(reader);
+      this.objectReader = mapper.reader().forType(mapper.constructType(type));
+    }
+
+    @Override
+    public boolean hasNext() {
+      try {
+        JsonToken jsonToken = parser.nextToken();
+        if (jsonToken == null) {
+          return false;
+        }
+
+        if (jsonToken == JsonToken.START_ARRAY) {
+          jsonToken = parser.nextToken();
+        }
+
+        if (jsonToken == JsonToken.END_ARRAY) {
+          current = null;
+          ensureClosed(this);
+          return false;
+        }
+
+        if (jsonToken != JsonToken.START_OBJECT) {
+          throw new IOException("Unexpected json token in response body " + jsonToken);
+        }
+
+        current = objectReader.readValue(parser);
+      } catch (IOException e) {
+        ensureClosed(this);
+        throw new DecodeException(e.getMessage(), e);
+      }
+      return current != null;
+    }
+
+    @Override
+    public T next() {
+      return current;
+    }
+
+    @Override
+    public void remove() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void close() throws IOException {
+      ensureClosed(this.response);
+    }
+  }
+}

--- a/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
+++ b/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
@@ -26,10 +26,13 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 import org.junit.Test;
 
+import java.io.Closeable;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -42,6 +45,7 @@ import static feign.Util.UTF_8;
 import static feign.assertj.FeignAssertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class JacksonCodecTest {
 
@@ -164,6 +168,52 @@ public class JacksonCodecTest {
                                  + "  \"name\" : \"DENOMINATOR.IO.\",\n"
                                  + "  \"id\" : \"ABCD\"\n"
                                  + "} ]");
+  }
+
+  @Test
+  public void decodesIterator() throws Exception {
+    List<Zone> zones = new LinkedList<Zone>();
+    zones.add(new Zone("denominator.io."));
+    zones.add(new Zone("denominator.io.", "ABCD"));
+
+    Response response = Response.builder()
+            .status(200)
+            .reason("OK")
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .body(zonesJson, UTF_8)
+            .build();
+    Object decoded = JacksonIteratorDecoder.Factory.create().decode(response, new TypeReference<Iterator<Zone>>() {}.getType());
+    assertTrue(Iterator.class.isAssignableFrom(decoded.getClass()));
+    assertTrue(Closeable.class.isAssignableFrom(decoded.getClass()));
+    assertEquals(zones, asList((Iterator<?>) decoded));
+  }
+
+  private <T> List<T> asList(Iterator<T> iter) {
+    final List<T> copy = new ArrayList<T>();
+    while (iter.hasNext())
+      copy.add(iter.next());
+    return copy;
+  }
+
+  @Test
+  public void nullBodyDecodesToNullIterator() throws Exception {
+    Response response = Response.builder()
+            .status(204)
+            .reason("OK")
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .build();
+    assertNull(JacksonIteratorDecoder.Factory.create().decode(response, Iterator.class));
+  }
+
+  @Test
+  public void emptyBodyDecodesToNullIterator() throws Exception {
+    Response response = Response.builder()
+            .status(204)
+            .reason("OK")
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .body(new byte[0])
+            .build();
+    assertNull(JacksonIteratorDecoder.Factory.create().decode(response, Iterator.class));
   }
 
   static class Zone extends LinkedHashMap<String, Object> {

--- a/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
+++ b/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
@@ -182,7 +182,7 @@ public class JacksonCodecTest {
             .headers(Collections.<String, Collection<String>>emptyMap())
             .body(zonesJson, UTF_8)
             .build();
-    Object decoded = JacksonIteratorDecoder.Factory.create().decode(response, new TypeReference<Iterator<Zone>>() {}.getType());
+    Object decoded = JacksonIteratorDecoder.create().decode(response, new TypeReference<Iterator<Zone>>() {}.getType());
     assertTrue(Iterator.class.isAssignableFrom(decoded.getClass()));
     assertTrue(Closeable.class.isAssignableFrom(decoded.getClass()));
     assertEquals(zones, asList((Iterator<?>) decoded));
@@ -202,7 +202,7 @@ public class JacksonCodecTest {
             .reason("OK")
             .headers(Collections.<String, Collection<String>>emptyMap())
             .build();
-    assertNull(JacksonIteratorDecoder.Factory.create().decode(response, Iterator.class));
+    assertNull(JacksonIteratorDecoder.create().decode(response, Iterator.class));
   }
 
   @Test
@@ -213,7 +213,7 @@ public class JacksonCodecTest {
             .headers(Collections.<String, Collection<String>>emptyMap())
             .body(new byte[0])
             .build();
-    assertNull(JacksonIteratorDecoder.Factory.create().decode(response, Iterator.class));
+    assertNull(JacksonIteratorDecoder.create().decode(response, Iterator.class));
   }
 
   static class Zone extends LinkedHashMap<String, Object> {
@@ -284,5 +284,16 @@ public class JacksonCodecTest {
             .headers(Collections.<String, Collection<String>>emptyMap())
             .build();
     assertThat((byte[]) new JacksonDecoder().decode(response, byte[].class)).isEmpty();
+  }
+
+  /** Enabled via {@link feign.Feign.Builder#decode404()} */
+  @Test
+  public void notFoundDecodesToEmptyIterator() throws Exception {
+    Response response = Response.builder()
+        .status(404)
+        .reason("NOT FOUND")
+        .headers(Collections.<String, Collection<String>>emptyMap())
+        .build();
+    assertThat((byte[]) JacksonIteratorDecoder.create().decode(response, byte[].class)).isEmpty();
   }
 }

--- a/jackson/src/test/java/feign/jackson/JacksonIteratorTest.java
+++ b/jackson/src/test/java/feign/jackson/JacksonIteratorTest.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright 2012-2018 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.Response;
+import feign.codec.DecodeException;
+import feign.jackson.JacksonIteratorDecoder.JacksonIterator;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static feign.Util.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.core.Is.isA;
+
+public class JacksonIteratorTest {
+
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void shouldDecodePrimitiveArrays() throws IOException {
+    assertThat(iterator(Integer.class, "[0,1,2,3]")).containsExactly(0, 1, 2, 3);
+  }
+
+  @Test
+  public void shouldDecodeObjects() throws IOException {
+    assertThat(iterator(User.class, "[{\"login\":\"bob\"},{\"login\":\"joe\"}]")).containsExactly(new User("bob"), new User("joe"));
+  }
+
+  @Test
+  public void malformedObjectThrowsDecodeException() throws IOException {
+    thrown.expect(DecodeException.class);
+    thrown.expectCause(isA(IOException.class));
+
+    assertThat(iterator(User.class, "[{\"login\":\"bob\"},{\"login\":\"joe...")).containsOnly(new User("bob"));
+  }
+
+  @Test
+  public void emptyBodyDecodesToEmptyIterator() throws IOException {
+    assertThat(iterator(String.class, "")).isEmpty();
+  }
+
+  @Test
+  public void unmodifiable() throws IOException {
+    thrown.expect(UnsupportedOperationException.class);
+
+    JacksonIterator<String> it = iterator(String.class, "[\"test\"]");
+
+    assertThat(it).containsExactly("test");
+    it.remove();
+  }
+
+  @Test
+  public void responseIsClosedAfterIteration() throws IOException {
+    final AtomicBoolean closed = new AtomicBoolean();
+
+    byte[] jsonBytes = "[false, true]".getBytes(UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(jsonBytes) {
+      @Override
+      public void close() throws IOException {
+        closed.set(true);
+        super.close();
+      }
+    };
+    Response response = Response.builder()
+        .status(200)
+        .reason("OK")
+        .headers(Collections.<String, Collection<String>>emptyMap())
+        .body(inputStream, jsonBytes.length)
+        .build();
+
+    assertThat(iterator(Boolean.class, response)).hasSize(2);
+    assertThat(closed.get()).isTrue();
+  }
+
+  @Test
+  public void responseIsClosedOnParseError() throws IOException {
+    final AtomicBoolean closed = new AtomicBoolean();
+
+    byte[] jsonBytes = "[error".getBytes(UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(jsonBytes) {
+      @Override
+      public void close() throws IOException {
+        closed.set(true);
+        super.close();
+      }
+    };
+    Response response = Response.builder()
+        .status(200)
+        .reason("OK")
+        .headers(Collections.<String, Collection<String>>emptyMap())
+        .body(inputStream, jsonBytes.length)
+        .build();
+
+    try {
+      thrown.expect(DecodeException.class);
+      assertThat(iterator(Boolean.class, response)).hasSize(1);
+    } finally {
+      assertThat(closed.get()).isTrue();
+    }
+  }
+
+  static class User extends LinkedHashMap<String, Object> {
+
+    private static final long serialVersionUID = 1L;
+
+    User() {
+      // for reflective instantiation.
+    }
+
+    User(String login) {
+      put("login", login);
+    }
+  }
+
+  <T> JacksonIterator<T> iterator(Class<T> type, String json) throws IOException {
+    Response response = Response.builder()
+        .status(200)
+        .reason("OK")
+        .headers(Collections.<String, Collection<String>>emptyMap())
+        .body(json, UTF_8)
+        .build();
+    return iterator(type, response);
+  }
+
+  <T> JacksonIterator<T> iterator(Class<T> type, Response response) throws IOException {
+    return new JacksonIterator<T>(type.getGenericSuperclass(), new ObjectMapper(),
+        response, response.body().asReader());
+  }
+
+}

--- a/jackson/src/test/java/feign/jackson/examples/GitHubIteratorExample.java
+++ b/jackson/src/test/java/feign/jackson/examples/GitHubIteratorExample.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2012-2018 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.jackson.examples;
+
+import feign.Feign;
+import feign.Param;
+import feign.RequestLine;
+import feign.jackson.JacksonIteratorDecoder;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Iterator;
+
+/**
+ * adapted from {@code com.example.retrofit.GitHubClient}
+ */
+public class GitHubIteratorExample {
+
+  public static void main(String... args) throws IOException {
+    GitHub github = Feign.builder()
+        .decoder(JacksonIteratorDecoder.Factory.create())
+        .doNotCloseAfterDecode()
+        .target(GitHub.class, "https://api.github.com");
+
+    System.out.println("Let's fetch and print a list of the contributors to this library.");
+    Iterator<Contributor> contributors = github.contributors("OpenFeign", "feign");
+    try {
+      while (contributors.hasNext()) {
+        Contributor contributor = contributors.next();
+        System.out.println(contributor.login + " (" + contributor.contributions + ")");
+      }
+    } finally {
+      ((Closeable) contributors).close();
+    }
+  }
+
+  interface GitHub {
+
+    @RequestLine("GET /repos/{owner}/{repo}/contributors")
+    Iterator<Contributor> contributors(@Param("owner") String owner, @Param("repo") String repo);
+  }
+
+  static class Contributor {
+
+    private String login;
+    private int contributions;
+
+    void setLogin(String login) {
+      this.login = login;
+    }
+
+    void setContributions(int contributions) {
+      this.contributions = contributions;
+    }
+  }
+}

--- a/jackson/src/test/java/feign/jackson/examples/GitHubIteratorExample.java
+++ b/jackson/src/test/java/feign/jackson/examples/GitHubIteratorExample.java
@@ -29,7 +29,7 @@ public class GitHubIteratorExample {
 
   public static void main(String... args) throws IOException {
     GitHub github = Feign.builder()
-        .decoder(JacksonIteratorDecoder.Factory.create())
+        .decoder(JacksonIteratorDecoder.create())
         .doNotCloseAfterDecode()
         .target(GitHub.class, "https://api.github.com");
 

--- a/java8/pom.xml
+++ b/java8/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>feign-gson</artifactId>
+            <artifactId>feign-jackson</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -51,5 +51,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
 </project>

--- a/java8/src/main/java/feign/stream/StreamDecoder.java
+++ b/java8/src/main/java/feign/stream/StreamDecoder.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2012-2018 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.stream;
+
+import feign.FeignException;
+import feign.Response;
+import feign.codec.Decoder;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static feign.Util.ensureClosed;
+
+/**
+ * Iterator based decoder that support streaming.
+ * <p>
+ * <p>Example: <br>
+ * <pre><code>
+ * Feign.builder()
+ *   .decoder(StreamDecoder.Factory.create(JacksonIteratorDecoder.Factory.create()))
+ *   .doNotCloseAfterDecode() // Required for streaming
+ *   .target(GitHub.class, "https://api.github.com");
+ * interface GitHub {
+ *  {@literal @}RequestLine("GET /repos/{owner}/{repo}/contributors")
+ *   Stream<Contributor> contributors(@Param("owner") String owner, @Param("repo") String repo);
+ * }</code></pre>
+ */
+public class StreamDecoder implements Decoder {
+
+  private final Decoder iteratorDecoder;
+
+  private StreamDecoder(Decoder iteratorDecoder) {
+    this.iteratorDecoder = iteratorDecoder;
+  }
+
+  @Override
+  public Object decode(Response response, Type type)
+      throws IOException, FeignException {
+    if (!(type instanceof ParameterizedType)) {
+      throw new IllegalArgumentException(
+          "StreamDecoder supports only stream: unknown " + type);
+    }
+    ParameterizedType streamType = (ParameterizedType) type;
+    if (!Stream.class.equals(streamType.getRawType())) {
+      throw new IllegalArgumentException(
+          "StreamDecoder supports only stream: unknown " + type);
+    }
+    Iterator<?> iterator = (Iterator) iteratorDecoder.decode(response,
+        new IteratorParameterizedType(streamType));
+
+    return StreamSupport.stream(
+        Spliterators.spliteratorUnknownSize(iterator,
+            Spliterator.DISTINCT | Spliterator.NONNULL), false)
+        .onClose(() -> {
+          if (iterator instanceof Closeable) {
+            ensureClosed((Closeable) iterator);
+          } else {
+            ensureClosed(response);
+          }
+        });
+  }
+
+  public static final class Factory {
+    public static StreamDecoder create(Decoder iteratorDecoder) {
+      return new StreamDecoder(iteratorDecoder);
+    }
+  }
+
+  private static final class IteratorParameterizedType implements ParameterizedType {
+
+    private final ParameterizedType streamType;
+
+    private IteratorParameterizedType(ParameterizedType streamType) {
+      this.streamType = streamType;
+    }
+
+    @Override
+    public Type[] getActualTypeArguments() {
+      return streamType.getActualTypeArguments();
+    }
+
+    @Override
+    public Type getRawType() {
+      return Iterator.class;
+    }
+
+    @Override
+    public Type getOwnerType() {
+      return streamType.getOwnerType();
+    }
+  }
+}

--- a/java8/src/main/java/feign/stream/StreamDecoder.java
+++ b/java8/src/main/java/feign/stream/StreamDecoder.java
@@ -30,9 +30,7 @@ import java.util.stream.StreamSupport;
 import static feign.Util.ensureClosed;
 
 /**
- * Iterator based decoder that support streaming.
- * <p>
- * <p>Example: <br>
+ * Iterator based decoder that support streaming. <p> <p>Example: <br>
  * <pre><code>
  * Feign.builder()
  *   .decoder(StreamDecoder.create(JacksonIteratorDecoder.create()))
@@ -55,20 +53,17 @@ public final class StreamDecoder implements Decoder {
   public Object decode(Response response, Type type)
       throws IOException, FeignException {
     if (!(type instanceof ParameterizedType)) {
-      throw new IllegalArgumentException(
-          "StreamDecoder supports only stream: unknown " + type);
+      throw new IllegalArgumentException("StreamDecoder supports only stream: unknown " + type);
     }
     ParameterizedType streamType = (ParameterizedType) type;
     if (!Stream.class.equals(streamType.getRawType())) {
-      throw new IllegalArgumentException(
-          "StreamDecoder supports only stream: unknown " + type);
+      throw new IllegalArgumentException("StreamDecoder supports only stream: unknown " + type);
     }
-    Iterator<?> iterator = (Iterator) iteratorDecoder.decode(response,
-        new IteratorParameterizedType(streamType));
+    Iterator<?> iterator =
+        (Iterator) iteratorDecoder.decode(response, new IteratorParameterizedType(streamType));
 
     return StreamSupport.stream(
-        Spliterators.spliteratorUnknownSize(iterator,
-            Spliterator.DISTINCT | Spliterator.NONNULL), false)
+        Spliterators.spliteratorUnknownSize(iterator, 0), false)
         .onClose(() -> {
           if (iterator instanceof Closeable) {
             ensureClosed((Closeable) iterator);
@@ -79,7 +74,7 @@ public final class StreamDecoder implements Decoder {
   }
 
   public static StreamDecoder create(Decoder iteratorDecoder) {
-      return new StreamDecoder(iteratorDecoder);
+    return new StreamDecoder(iteratorDecoder);
   }
 
   static final class IteratorParameterizedType implements ParameterizedType {

--- a/java8/src/main/java/feign/stream/StreamDecoder.java
+++ b/java8/src/main/java/feign/stream/StreamDecoder.java
@@ -35,7 +35,7 @@ import static feign.Util.ensureClosed;
  * <p>Example: <br>
  * <pre><code>
  * Feign.builder()
- *   .decoder(StreamDecoder.Factory.create(JacksonIteratorDecoder.Factory.create()))
+ *   .decoder(StreamDecoder.create(JacksonIteratorDecoder.create()))
  *   .doNotCloseAfterDecode() // Required for streaming
  *   .target(GitHub.class, "https://api.github.com");
  * interface GitHub {
@@ -43,11 +43,11 @@ import static feign.Util.ensureClosed;
  *   Stream<Contributor> contributors(@Param("owner") String owner, @Param("repo") String repo);
  * }</code></pre>
  */
-public class StreamDecoder implements Decoder {
+public final class StreamDecoder implements Decoder {
 
   private final Decoder iteratorDecoder;
 
-  private StreamDecoder(Decoder iteratorDecoder) {
+  StreamDecoder(Decoder iteratorDecoder) {
     this.iteratorDecoder = iteratorDecoder;
   }
 
@@ -78,17 +78,15 @@ public class StreamDecoder implements Decoder {
         });
   }
 
-  public static final class Factory {
-    public static StreamDecoder create(Decoder iteratorDecoder) {
+  public static StreamDecoder create(Decoder iteratorDecoder) {
       return new StreamDecoder(iteratorDecoder);
-    }
   }
 
-  private static final class IteratorParameterizedType implements ParameterizedType {
+  static final class IteratorParameterizedType implements ParameterizedType {
 
     private final ParameterizedType streamType;
 
-    private IteratorParameterizedType(ParameterizedType streamType) {
+    IteratorParameterizedType(ParameterizedType streamType) {
       this.streamType = streamType;
     }
 
@@ -104,7 +102,7 @@ public class StreamDecoder implements Decoder {
 
     @Override
     public Type getOwnerType() {
-      return streamType.getOwnerType();
+      return null;
     }
   }
 }

--- a/java8/src/test/java/feign/stream/StreamDecoderTest.java
+++ b/java8/src/test/java/feign/stream/StreamDecoderTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2012-2018 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.stream;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import feign.Feign;
+import feign.RequestLine;
+import feign.codec.DecodeException;
+import feign.jackson.JacksonIteratorDecoder;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StreamDecoderTest {
+
+  interface StreamInterface {
+    @RequestLine("GET /")
+    Stream<String> get();
+
+    @RequestLine("GET /cars")
+    Stream<Car> getCars();
+
+    class Car {
+      public String name;
+      public String manufacturer;
+    }
+  }
+
+  private String carsJson = ""//
+      + "[\n"//
+      + "  {\n"//
+      + "    \"name\": \"Megane\",\n"//
+      + "    \"manufacturer\": \"Renault\"\n"//
+      + "  },\n"//
+      + "  {\n"//
+      + "    \"name\": \"C4\",\n"//
+      + "    \"manufacturer\": \"Citroën\"\n"//
+      + "  }\n"//
+      + "]\n";
+
+  @Test
+  public void simpleStreamTest() throws IOException, InterruptedException {
+    MockWebServer server = new MockWebServer();
+    server.enqueue(new MockResponse().setBody("foo\nbar"));
+
+    StreamInterface api = Feign.builder()
+        .decoder(StreamDecoder.Factory.create((response, type) -> new BufferedReader(response.body().asReader()).lines().iterator()))
+        .doNotCloseAfterDecode()
+        .target(StreamInterface.class, server.url("/").toString());
+
+    try (Stream<String> stream = api.get()) {
+      assertThat(stream.collect(Collectors.toList())).isEqualTo(Arrays.asList("foo", "bar"));
+    }
+  }
+
+  @Test
+  public void simpleJsonStreamTest() throws IOException, InterruptedException {
+    MockWebServer server = new MockWebServer();
+    server.enqueue(new MockResponse().setBody(carsJson));
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    StreamInterface api = Feign.builder()
+        .decoder(StreamDecoder.Factory.create(JacksonIteratorDecoder.Factory.create()))
+        .doNotCloseAfterDecode()
+        .target(StreamInterface.class, server.url("/").toString());
+
+    try (Stream<StreamInterface.Car> stream = api.getCars()) {
+      assertThat(stream.collect(Collectors.toList())).hasSize(2);
+    }
+  }
+}

--- a/java8/src/test/java/feign/stream/StreamDecoderTest.java
+++ b/java8/src/test/java/feign/stream/StreamDecoderTest.java
@@ -66,7 +66,7 @@ public class StreamDecoderTest {
     server.enqueue(new MockResponse().setBody("foo\nbar"));
 
     StreamInterface api = Feign.builder()
-        .decoder(StreamDecoder.Factory.create((response, type) -> new BufferedReader(response.body().asReader()).lines().iterator()))
+        .decoder(StreamDecoder.create((response, type) -> new BufferedReader(response.body().asReader()).lines().iterator()))
         .doNotCloseAfterDecode()
         .target(StreamInterface.class, server.url("/").toString());
 
@@ -83,7 +83,7 @@ public class StreamDecoderTest {
     ObjectMapper mapper = new ObjectMapper();
 
     StreamInterface api = Feign.builder()
-        .decoder(StreamDecoder.Factory.create(JacksonIteratorDecoder.Factory.create()))
+        .decoder(StreamDecoder.create(JacksonIteratorDecoder.create()))
         .doNotCloseAfterDecode()
         .target(StreamInterface.class, server.url("/").toString());
 


### PR DESCRIPTION
Introduces 2 new decoders:

**JacksonIteratorDecoder** in feign-jackson provides a closeable iterator for lazy processing json arrays. This decoder has to be used with `Feign.Builder.doNotCloseAfterDecode()` option disabled. Built-in iterator auto closes the Response when it reached json array end or failed to parse stream. If this iterator is not fetched till the end, it has to be casted to Closeable and explicity `Closeable.close()` by the consumer.

**StreamDecoder** in feign-java8 provides a `java.util.stream.Stream` for lazy processing response based on a wrapped decoder that is responsible to transform the Response to an Iterator. This decoder has to be used with `Feign.Builder.doNotCloseAfterDecode()` option disabled.

Added decoders benchmark to compare performance of 3 differents implementations to process json arrays.
