### PR TITLE
Enhancement to JAXBContextFactory to accept a list of binding classes.

### DIFF
--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -42,5 +42,10 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.vmlens</groupId>
+      <artifactId>concurrent-junit</artifactId>
+      <version>1.0.2</version>
+    </dependency>
   </dependencies>
 </project>

--- a/jaxb/src/main/java/feign/jaxb/JAXBContextFactory.java
+++ b/jaxb/src/main/java/feign/jaxb/JAXBContextFactory.java
@@ -13,10 +13,15 @@
  */
 package feign.jaxb;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -30,28 +35,38 @@ import javax.xml.bind.Unmarshaller;
  */
 public final class JAXBContextFactory {
 
-  private final ConcurrentHashMap<Class, JAXBContext>
-      jaxbContexts =
-      new ConcurrentHashMap<Class, JAXBContext>(64);
+  private final ConcurrentHashMap<Integer, JAXBContext> jaxbContexts = 
+          new ConcurrentHashMap<Integer, JAXBContext>(64);
   private final Map<String, Object> properties;
+  private final CopyOnWriteArraySet<Class<?>> jaxbClasses =
+          new CopyOnWriteArraySet<Class<?>>();
 
   private JAXBContextFactory(Map<String, Object> properties) {
     this.properties = properties;
   }
 
+  private JAXBContextFactory(Map<String, Object> properties, Set<Class<?>> jaxbClasses) {
+      this.properties = properties;
+      this.jaxbClasses.addAll(jaxbClasses);
+  }
+  
   /**
    * Creates a new {@link javax.xml.bind.Unmarshaller} that handles the supplied class.
    */
-  public Unmarshaller createUnmarshaller(Class<?> clazz) throws JAXBException {
-    JAXBContext ctx = getContext(clazz);
+  public Unmarshaller createUnmarshaller(Class<?>... classes) throws JAXBException {
+    if (this.jaxbClasses.size() > 0)
+        classes = this.jaxbClasses.toArray(new Class<?>[0]);
+    JAXBContext ctx = getContext(classes);
     return ctx.createUnmarshaller();
   }
 
   /**
    * Creates a new {@link javax.xml.bind.Marshaller} that handles the supplied class.
    */
-  public Marshaller createMarshaller(Class<?> clazz) throws JAXBException {
-    JAXBContext ctx = getContext(clazz);
+  public Marshaller createMarshaller(Class<?>... classes) throws JAXBException {
+    if (this.jaxbClasses.size() > 0)
+        classes = this.jaxbClasses.toArray(new Class<?>[0]);      
+    JAXBContext ctx = getContext(classes);
     Marshaller marshaller = ctx.createMarshaller();
     setMarshallerProperties(marshaller);
     return marshaller;
@@ -66,22 +81,31 @@ public final class JAXBContextFactory {
     }
   }
 
-  private JAXBContext getContext(Class<?> clazz) throws JAXBException {
-    JAXBContext jaxbContext = this.jaxbContexts.get(clazz);
-    if (jaxbContext == null) {
-      jaxbContext = JAXBContext.newInstance(clazz);
-      this.jaxbContexts.putIfAbsent(clazz, jaxbContext);
-    }
-    return jaxbContext;
+  private JAXBContext getContext(Class<?>... classes) throws JAXBException {
+      int hashCode = Arrays.hashCode(classes);
+      JAXBContext jaxbContext;
+      synchronized (this.jaxbContexts) {            
+          jaxbContext = this.jaxbContexts.get(hashCode);
+          if (jaxbContext == null) {
+              jaxbContext = JAXBContext.newInstance(classes);
+              this.jaxbContexts.putIfAbsent(hashCode, jaxbContext);
+          }
+      }
+      return jaxbContext;
   }
 
+  public Set<Class<?>> getJaxbClasses() {
+      return jaxbClasses;
+  }
+  
   /**
    * Creates instances of {@link feign.jaxb.JAXBContextFactory}
    */
   public static class Builder {
 
     private final Map<String, Object> properties = new HashMap<String, Object>(5);
-
+    private final Set<Class<?>> jaxbClasses = new HashSet<Class<?>>();
+    
     /**
      * Sets the jaxb.encoding property of any Marshaller created by this factory.
      */
@@ -121,12 +145,21 @@ public final class JAXBContextFactory {
       properties.put(Marshaller.JAXB_FRAGMENT, value);
       return this;
     }
+    
+    public Builder withJaxbClasses(Class<?>...classes) {
+        List<Class<?>> l = Arrays.asList(classes);
+        jaxbClasses.addAll(l);
+        return this;
+    }
 
     /**
      * Creates a new {@link feign.jaxb.JAXBContextFactory} instance.
      */
     public JAXBContextFactory build() {
-      return new JAXBContextFactory(properties);
+        if (this.jaxbClasses.size() > 0)
+            return new JAXBContextFactory(properties, jaxbClasses);
+        else
+            return new JAXBContextFactory(properties);
     }
   }
 }

--- a/jaxb/src/test/java/feign/jaxb/pojolist/ConcurrentTest.java
+++ b/jaxb/src/test/java/feign/jaxb/pojolist/ConcurrentTest.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2012-2018 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package feign.jaxb.pojolist;
+
+import static java.lang.System.out;
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.xml.bind.JAXBContext;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.anarsoft.vmlens.concurrent.junit.ConcurrentTestRunner;
+import com.anarsoft.vmlens.concurrent.junit.ThreadCount;
+
+import feign.jaxb.JAXBContextFactory;
+
+/**
+ * Instead of switching to http://testng.org/ to get concurrent unit testing, we stick with JUnit 
+ * but add <tt>concurrent-junit</tt> library.
+ * 
+ * @see https://github.com/ThomasKrieger/concurrent-junit
+ * @see http://vmlens.com/articles/a-new-way-to-junit-test-your-multithreaded-java-code/
+ * 
+ * @author wolfch
+ */
+@RunWith(ConcurrentTestRunner.class)
+public class ConcurrentTest {
+    
+    Class<?>[] pojos = {
+            NonSchemaMixedNamespacesTest.Envelope.class,
+            NonSchemaMixedNamespacesTest.Body.class,
+            NonSchemaMixedNamespacesTest.Login.class
+    };
+
+    JAXBContextFactory contextFactory ;
+    Method getContext;
+    
+    @Before
+    public void setup() throws Exception {
+        contextFactory = new JAXBContextFactory.Builder()
+                .withJaxbClasses(pojos)
+                .build();
+        Class<?>[] foo = new Class<?>[0];
+        getContext = JAXBContextFactory.class.getDeclaredMethod("getContext", foo.getClass());
+        getContext.setAccessible(true);
+        JAXBContext ctx = (JAXBContext) getContext.invoke(contextFactory, new Object[] {pojos});
+        out.printf("%s %08x\n", Thread.currentThread().getName(), ctx.hashCode());
+    }
+    
+    List<Result> results = Collections.synchronizedList(new ArrayList<>());
+    
+    @Test
+    @ThreadCount(7)
+    public void contextMap() throws Exception {
+
+        JAXBContext ctx = (JAXBContext) getContext.invoke(contextFactory, new Object[] {pojos});
+        // let's print after the test to maximize concurrency
+        results.add(new Result(Thread.currentThread().getName(), ctx));
+        
+    }
+    
+    @After
+    public void after() {
+        Result lastResult = null;
+        for (Result r : results) {
+            if (lastResult != null) {
+                assertEquals(lastResult, r);
+                lastResult = r;
+            }
+            out.printf("%s %08x\n", r.threadName, r.context.hashCode());
+        }
+    }
+    
+    static class Result {
+        public Result(final String threadName, final JAXBContext context) {
+            this.threadName = threadName;
+            this.context = context;
+        }
+        public final String threadName;
+        public final JAXBContext context;
+    }
+}

--- a/jaxb/src/test/java/feign/jaxb/pojolist/NonSchemaMixedNamespacesTest.java
+++ b/jaxb/src/test/java/feign/jaxb/pojolist/NonSchemaMixedNamespacesTest.java
@@ -1,0 +1,206 @@
+/**
+ * Copyright 2012-2018 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package feign.jaxb.pojolist;
+
+import static feign.Util.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.Collection;
+import java.util.Collections;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAnyElement;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+import org.junit.Test;
+
+import feign.RequestTemplate;
+import feign.Response;
+import feign.jaxb.JAXBContextFactory;
+import feign.jaxb.JAXBDecoder;
+import feign.jaxb.JAXBEncoder;
+
+/**
+ * We should be able to to just provide a list of POJOs with 
+ * JAXB annotations and not have to provide an ObjectFactory
+ * or jaxb.index (which requires ObjectFafctory)
+ * or special JAXB annotated package-info.java.
+ * 
+ * The use-case is a project with only uses a few JAXB classes
+ * and we don't want the whole JAXB package configuration,
+ * especially since JAXBContext.newInstance(...) supports
+ * a list of binding classes.
+ * 
+ */
+public class NonSchemaMixedNamespacesTest {
+
+    @Test
+    public void multiClassMarshalling() throws Exception {
+     
+        // These two binding classes have different namespaces...
+        JAXBContext ctx = JAXBContext.newInstance(
+                Envelope.class, Login.class);
+        
+        Envelope envelope = new Envelope(new Body(new Login("demo", "secret")));
+        
+        Marshaller m = ctx.createMarshaller();
+        StringWriter swriter = new StringWriter();
+        m.marshal(envelope, swriter); 
+        String xmlDoc = swriter.toString();
+        System.out.println(xmlDoc);
+        
+        Unmarshaller unmarshaller = ctx.createUnmarshaller();
+        StringReader sreader = new StringReader(xmlDoc);
+        Envelope envelope2 = (Envelope) unmarshaller.unmarshal(sreader);
+
+        // Can't do string compare because prefix name assignment seems non-deterministic
+        assertSoapLoginEquals(envelope, envelope2);
+    }
+    
+    @Test
+    public void requestAndResponseWithMixedNSClasses() throws Exception {
+        Envelope envelope = new Envelope(new Body(new Login("demo", "secret")));
+        
+        RequestTemplate template = new RequestTemplate();
+        
+        // These two binding classes have different namespaces...
+        JAXBContextFactory contextFactory = new JAXBContextFactory.Builder()
+                .withJaxbClasses(Envelope.class, Login.class)
+                .build();
+        
+        new JAXBEncoder(contextFactory)
+            .encode(envelope, Envelope.class, template);
+
+        String xmlDoc = new String(template.body());
+        System.out.println(xmlDoc);
+        
+        Response response = Response.builder()
+                .status(200)
+                .reason("OK")
+                .headers(Collections.<String, Collection<String>>emptyMap())
+                .body(xmlDoc, UTF_8)
+                .build();
+
+        JAXBDecoder decoder = new JAXBDecoder(contextFactory);
+        
+        // Can't do string compare because prefix name assignment seems non-deterministic
+        assertSoapLoginEquals(envelope, (Envelope)decoder.decode(response, Envelope.class));
+    }
+    
+    static void assertSoapLoginEquals(Envelope expected, Envelope actual) {
+        assertNotNull(expected.body);
+        assertNotNull(expected.body.payload);
+        assertTrue(expected.body.payload instanceof Login);
+        assertNotNull(actual.body);
+        assertNotNull(actual.body.payload);
+        assertTrue(actual.body.payload instanceof Login);
+        
+        assertEquals(((Login)expected.body.payload).username, ((Login)actual.body.payload).username);
+        assertEquals(((Login)expected.body.payload).password, ((Login)actual.body.payload).password);
+    }
+    
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {
+        "username",
+        "password"
+    })
+    @XmlRootElement(name = "login", namespace="urn:partner.soap.sforce.com")
+    public static class Login {
+
+        public Login() {}
+        
+        public Login(final String username, final String password) {
+            this.username = username;
+            this.password = password;
+        }
+        
+        @XmlElement(required = true)
+        protected String username;
+        @XmlElement(required = true)
+        protected String password;
+
+        public String getUsername() {
+            return username;
+        }
+
+        public void setUsername(String value) {
+            this.username = value;
+        }
+        
+        public String getPassword() {
+            return password;
+        }
+
+        public void setPassword(String value) {
+            this.password = value;
+        }
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {
+        "body"
+    })
+    @XmlRootElement(name = "Envelope", namespace="http://schemas.xmlsoap.org/soap/envelope/")
+    public static class Envelope {
+        
+        public Envelope() {}
+        public Envelope(final Body body) {
+            this.body = body;
+        }
+        
+        @XmlElement(name = "Body", namespace="http://schemas.xmlsoap.org/soap/envelope/", required = true)
+        protected Body body;
+
+        public Body getBody() {
+            return body;
+        }
+
+        public void setBody(Body value) {
+            this.body = value;
+        }
+    }
+    
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "body", propOrder = {
+        "payload"
+    })
+    @XmlRootElement(name = "Body", namespace="http://schemas.xmlsoap.org/soap/envelope/")
+    public static class Body {
+        public Body() {}
+        public Body(final Object payload) {
+            this.payload = payload;
+        }
+        @XmlAnyElement(lax = true)
+        protected Object payload;
+
+        public Object getAny() {
+            return payload;
+        }
+        
+        public void setAny(Object payload) {
+            this.payload = payload;
+        }
+    }
+}


### PR DESCRIPTION
We should be able to to just provide a list of POJOs with JAXB annotations and not have
to provide an ObjectFactory or jaxb.index (which requires ObjectFafctory) or special JAXB
annotated package-info.java or schema.

The use-case is a project with only uses a few JAXB classes and we don't want the whole
JAXB package configuration, especially since JAXBContext.newInstance(...) supports a list
of binding classes.