### PR TITLE
Added body field in FeignException, removed body from message

### DIFF
--- a/core/src/main/java/feign/FeignException.java
+++ b/core/src/main/java/feign/FeignException.java
@@ -14,7 +14,6 @@
 package feign;
 
 import static java.lang.String.format;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
@@ -25,9 +24,9 @@ public class FeignException extends RuntimeException {
 
   private static final long serialVersionUID = 0;
   private int status;
-  
+
   protected String body;
-  
+
   protected FeignException(String message, Throwable cause) {
     super(message, cause);
   }
@@ -44,68 +43,69 @@ public class FeignException extends RuntimeException {
   public int status() {
     return this.status;
   }
-  
+
 
   public String body() {
-		return body;
-	}
-
-	static FeignException errorReading(Request request, Response ignored, IOException cause) {
-    FeignException exc = new FeignException(
-        format("%s reading %s %s", cause.getMessage(), request.method(), request.url()),
-        cause);
-    
-    exc.body = fetchRequestBody(request);
-		
-		return exc;
+    return body;
   }
 
-	
+  static FeignException errorReading(Request request, Response ignored, IOException cause) {
+    FeignException exc = new FeignException(
+        format("%s reading %s %s", cause.getMessage(), request.method(), request.url()), cause);
+
+    exc.body = fetchRequestBody(request);
+
+    return exc;
+  }
+
+
   public static FeignException errorStatus(String methodKey, Response response) {
     String message = format("status %s reading %s", response.status(), methodKey);
-    
+
     FeignException exception = new FeignException(response.status(), message);
     exception.body = fetchResponseBody(response);
-    
-		return exception;
+
+    return exception;
   }
-  
+
   static FeignException errorExecuting(Request request, IOException cause) {
     RetryableException exception = new RetryableException(
         format("%s executing %s %s", cause.getMessage(), request.method(), request.url()), cause,
         null);
-    
+
     String body = fetchRequestBody(request);
     exception.body = body;
-    
-		return exception;
+
+    return exception;
   }
-  
+
   private static String fetchRequestBody(Request request) {
     if (request.body() != null) {
-    	try {
-    		// no way of getting body's charset, assuming UTF-8, other charsets may generate errors, hence the catch and ignore
-				String body = new String(request.body(), StandardCharsets.UTF_8);
-				return body;
-    	} catch (Exception e) {
-    		// ignore, no body available, sorry
-    	}
+      try {
+        // no way of getting body's charset, assuming UTF-8, other charsets may generate
+        // errors,
+        // hence the catch and ignore
+        String body = new String(request.body(), StandardCharsets.UTF_8);
+        return body;
+      } catch (Exception e) {
+        // ignore, no body available, sorry
+      }
     }
     return null;
-	}
+  }
 
-	private static String fetchResponseBody(Response response){
+  private static String fetchResponseBody(Response response) {
     try {
       if (response.body() != null) {
-				String body;
-				body = Util.toString(response.body().asReader());
-				return body;
-		  }
-		} catch (IOException ignored) {
-  		// ignore, no body available, sorry
-		}
+        String body;
+        body = Util.toString(response.body().asReader());
+        return body;
+      }
+    } catch (IOException ignored) {
+      // ignore, no body available, sorry
+    }
     return null;
-	}
+  }
 
- 
+
 }

--- a/core/src/main/java/feign/FeignException.java
+++ b/core/src/main/java/feign/FeignException.java
@@ -50,9 +50,9 @@ public class FeignException extends RuntimeException {
   }
 
   static FeignException errorReading(Request request, Response ignored, IOException cause) {
-    FeignException exc = new FeignException(
-        format("%s reading %s %s", cause.getMessage(), request.method(), request.url()), cause);
-
+    String message = format("%s reading %s %s", cause.getMessage(), request.method(), request.url());
+    
+    FeignException exc = new FeignException(message, cause);
     exc.body = fetchRequestBody(request);
 
     return exc;
@@ -69,12 +69,10 @@ public class FeignException extends RuntimeException {
   }
 
   static FeignException errorExecuting(Request request, IOException cause) {
-    RetryableException exception = new RetryableException(
-        format("%s executing %s %s", cause.getMessage(), request.method(), request.url()), cause,
-        null);
-
-    String body = fetchRequestBody(request);
-    exception.body = body;
+    String message = format("%s executing %s %s", cause.getMessage(), request.method(), request.url());
+    
+    RetryableException exception = new RetryableException(message, cause,null);
+    exception.body = fetchRequestBody(request);
 
     return exception;
   }
@@ -83,8 +81,7 @@ public class FeignException extends RuntimeException {
     if (request.body() != null) {
       try {
         // no way of getting body's charset, assuming UTF-8, other charsets may generate
-        // errors,
-        // hence the catch and ignore
+        // errors, hence the catch and ignore
         String body = new String(request.body(), StandardCharsets.UTF_8);
         return body;
       } catch (Exception e) {

--- a/core/src/main/java/feign/Util.java
+++ b/core/src/main/java/feign/Util.java
@@ -13,6 +13,8 @@
  */
 package feign;
 
+import static java.lang.String.format;
+
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
@@ -38,8 +40,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
-
-import static java.lang.String.format;
 
 /**
  * Utilities, typically copied in from guava, so as to avoid dependency conflicts.
@@ -321,6 +321,14 @@ public class Util {
       return charset.newDecoder().decode(ByteBuffer.wrap(data)).toString();
     } catch (CharacterCodingException ex) {
       return defaultValue;
+    }
+  }
+  
+  public static String abbreviate(String text, int maxLength) {
+    if (text.length() <= maxLength) { 
+        return text;
+    } else { 
+        return text.substring(0, maxLength-2) + "..";
     }
   }
 }

--- a/core/src/main/java/feign/Util.java
+++ b/core/src/main/java/feign/Util.java
@@ -323,12 +323,12 @@ public class Util {
       return defaultValue;
     }
   }
-  
+
   public static String abbreviate(String text, int maxLength) {
-    if (text.length() <= maxLength) { 
-        return text;
-    } else { 
-        return text.substring(0, maxLength-2) + "..";
+    if (text.length() <= maxLength) {
+      return text;
+    } else {
+      return text.substring(0, maxLength - 2) + "..";
     }
   }
 }

--- a/core/src/test/java/feign/TestUtil.java
+++ b/core/src/test/java/feign/TestUtil.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2012-2018 Dariusz Wawer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package feign;
 
 import org.hamcrest.BaseMatcher;
@@ -6,22 +19,22 @@ import org.hamcrest.Matcher;
 
 public class TestUtil {
 
-	public static Matcher<?> bodyMatcher(String string) {
-		return new BaseMatcher<Exception>() {
-			@Override
-			public boolean matches(Object item) {
-				if (item instanceof FeignException) {
-					FeignException e = (FeignException) item;
-					return string.equals(e.body());
-				}
-				return false;
-			}
-	
-			@Override
-			public void describeTo(Description description) { 
-				// empty on purpose
-			}
-		};
-	}
+  public static Matcher<?> bodyMatcher(String string) {
+    return new BaseMatcher<Exception>() {
+      @Override
+      public boolean matches(Object item) {
+        if (item instanceof FeignException) {
+          FeignException e = (FeignException) item;
+          return string.equals(e.body());
+        }
+        return false;
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        // empty on purpose
+      }
+    };
+  }
 
 }

--- a/core/src/test/java/feign/TestUtil.java
+++ b/core/src/test/java/feign/TestUtil.java
@@ -1,0 +1,27 @@
+package feign;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+public class TestUtil {
+
+	public static Matcher<?> bodyMatcher(String string) {
+		return new BaseMatcher<Exception>() {
+			@Override
+			public boolean matches(Object item) {
+				if (item instanceof FeignException) {
+					FeignException e = (FeignException) item;
+					return string.equals(e.body());
+				}
+				return false;
+			}
+	
+			@Override
+			public void describeTo(Description description) { 
+				// empty on purpose
+			}
+		};
+	}
+
+}

--- a/core/src/test/java/feign/client/AbstractClientTest.java
+++ b/core/src/test/java/feign/client/AbstractClientTest.java
@@ -13,6 +13,11 @@
  */
 package feign.client;
 
+import static feign.Util.UTF_8;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
@@ -28,17 +33,11 @@ import feign.Logger;
 import feign.Param;
 import feign.RequestLine;
 import feign.Response;
+import feign.TestUtil;
 import feign.Util;
 import feign.assertj.MockWebServerAssertions;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
-
-import static java.util.Arrays.asList;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-
-import static feign.Util.UTF_8;
 
 /**
  * {@link AbstractClientTest} can be extended to run a set of tests against any {@link Client} implementation.
@@ -114,9 +113,10 @@ public abstract class AbstractClientTest {
     @Test
     public void parsesErrorResponse() throws IOException, InterruptedException {
         thrown.expect(FeignException.class);
-        thrown.expectMessage("status 500 reading TestInterface#get(); content:\n" + "ARGHH");
+        thrown.expectMessage("status 500 reading TestInterface#get()");
+        thrown.expect(TestUtil.bodyMatcher("message content"));
 
-        server.enqueue(new MockResponse().setResponseCode(500).setBody("ARGHH"));
+        server.enqueue(new MockResponse().setResponseCode(500).setBody("message content"));
 
         TestInterface api = newBuilder()
                 .target(TestInterface.class, "http://localhost:" + server.getPort());

--- a/core/src/test/java/feign/codec/DefaultErrorDecoderTest.java
+++ b/core/src/test/java/feign/codec/DefaultErrorDecoderTest.java
@@ -13,21 +13,22 @@
  */
 package feign.codec;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import static feign.Util.RETRY_AFTER;
+import static feign.Util.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
 import feign.FeignException;
 import feign.Response;
-
-import static feign.Util.RETRY_AFTER;
-import static feign.Util.UTF_8;
-import static org.assertj.core.api.Assertions.assertThat;
+import feign.TestUtil;
 
 public class DefaultErrorDecoderTest {
 
@@ -55,7 +56,8 @@ public class DefaultErrorDecoderTest {
   @Test
   public void throwsFeignExceptionIncludingBody() throws Throwable {
     thrown.expect(FeignException.class);
-    thrown.expectMessage("status 500 reading Service#foo(); content:\nhello world");
+    thrown.expectMessage("status 500 reading Service#foo()");
+    thrown.expect(TestUtil.bodyMatcher("hello world"));
 
     Response response = Response.builder()
             .status(500)
@@ -66,8 +68,8 @@ public class DefaultErrorDecoderTest {
 
     throw errorDecoder.decode("Service#foo()", response);
   }
-
-  @Test
+  
+	@Test
   public void testFeignExceptionIncludesStatus() throws Throwable {
     Response response = Response.builder()
             .status(400)
@@ -95,4 +97,5 @@ public class DefaultErrorDecoderTest {
 
     throw errorDecoder.decode("Service#foo()", response);
   }
+
 }


### PR DESCRIPTION
I forked master and made the changes, then updated the tests. I did my best to follow your coventions. 

Note that it's my first PR for a public project, sorry if I did something formally incorrect. Please advise if I have.

Note that those changes are breaking if someone relies on parsing the message for getting body. Should probably be mentioned in changelog, I haven't dont this, having to put a version number scared me off :)

One test fails, but I'm pretty sure its unrelated to my changes, as it fails on unchanged master too: 
`feign.DefaultContractTest.overrideBaseApiUnsupported()`

Fixes #642 