### PR TITLE
Response is closed after decoder fails

### DIFF
--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -131,12 +131,14 @@ final class SynchronousMethodHandler implements MethodHandler {
         if (void.class == metadata.returnType()) {
           return null;
         } else {
+          Object result = decode(response);
           shouldClose = closeAfterDecode;
-          return decode(response);
+          return result;
         }
       } else if (decode404 && response.status() == 404 && void.class != metadata.returnType()) {
+        Object result = decode(response);
         shouldClose = closeAfterDecode;
-        return decode(response);
+        return result;
       } else {
         throw errorDecoder.decode(metadata.configKey(), response);
       }


### PR DESCRIPTION
Previously a decoder failure resulting in an exception would
fail to close responses when "doNotCloseAfterDecode" was enabled.