### PR TITLE
Allow QueryMap to expand values with an expander.

### DIFF
--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -274,9 +274,20 @@ public interface Contract {
             data.formParams().add(name);
           }
         } else if (annotationType == QueryMap.class) {
+          QueryMap queryMapAnnotation = QueryMap.class.cast(annotation);
           checkState(data.queryMapIndex() == null, "QueryMap annotation was present on multiple parameters.");
           data.queryMapIndex(paramIndex);
-          data.queryMapEncoded(QueryMap.class.cast(annotation).encoded());
+          data.queryMapEncoded(queryMapAnnotation.encoded());
+          Class<? extends Param.Expander> expander = queryMapAnnotation.expander();
+          if (expander != Param.ToStringExpander.class) {
+            try {
+              data.queryMapExpander(expander.newInstance());
+            } catch (InstantiationException e) {
+              throw new IllegalStateException(e);
+            } catch (IllegalAccessException e) {
+              throw new IllegalStateException(e);
+            }
+          }
           isHttpAnnotation = true;
         } else if (annotationType == HeaderMap.class) {
           checkState(data.headerMapIndex() == null, "HeaderMap annotation was present on multiple parameters.");

--- a/core/src/main/java/feign/MethodMetadata.java
+++ b/core/src/main/java/feign/MethodMetadata.java
@@ -13,6 +13,8 @@
  */
 package feign;
 
+import feign.Param.Expander;
+
 import java.io.Serializable;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -20,8 +22,6 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
-import feign.Param.Expander;
 
 public final class MethodMetadata implements Serializable {
 
@@ -33,6 +33,7 @@ public final class MethodMetadata implements Serializable {
   private Integer headerMapIndex;
   private Integer queryMapIndex;
   private boolean queryMapEncoded;
+  private transient Expander queryMapExpander = new Param.ToStringExpander();
   private transient Type bodyType;
   private RequestTemplate template = new RequestTemplate();
   private List<String> formParams = new ArrayList<String>();
@@ -141,6 +142,16 @@ public final class MethodMetadata implements Serializable {
 
   public Map<Integer, Boolean> indexToEncoded() {
     return indexToEncoded;
+  }
+
+  public Expander queryMapExpander() {
+    return queryMapExpander;
+  }
+
+  public void queryMapExpander(Expander queryMapExpander) {
+    if (queryMapExpander != null) {
+      this.queryMapExpander = queryMapExpander;
+    }
   }
 
   /**

--- a/core/src/main/java/feign/QueryMap.java
+++ b/core/src/main/java/feign/QueryMap.java
@@ -58,6 +58,12 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @java.lang.annotation.Target(PARAMETER)
 public @interface QueryMap {
+
+    /**
+     * How to expand all values of this map, if {@link Param.ToStringExpander} isn't adequate.
+     */
+    Class<? extends Param.Expander> expander() default Param.ToStringExpander.class;
+
     /**
      * Specifies whether parameter names and values are already encoded.
      *


### PR DESCRIPTION
Add a method expander() in the annotation @QueryMap. So we can control the way to expand the value when using dynamic params other than call the method toString() only.