### PR TITLE
Fixes Map Based Parameter Checking for Generic Subclasses

### DIFF
--- a/core/src/test/java/feign/DefaultContractTest.java
+++ b/core/src/test/java/feign/DefaultContractTest.java
@@ -371,6 +371,12 @@ public class DefaultContractTest {
     }
   }
 
+  @Test
+  public void headerMapSubclass() throws Exception {
+    MethodMetadata md = parseAndValidateMetadata(HeaderMapInterface.class, "headerMapSubClass", SubClassHeaders.class);
+    assertThat(md.headerMapIndex()).isEqualTo(0);
+  }
+
   interface Methods {
 
     @RequestLine("POST /")
@@ -470,6 +476,9 @@ public class DefaultContractTest {
 
     @RequestLine("POST /")
     void multipleHeaderMap(@HeaderMap Map<String, String> headers, @HeaderMap Map<String,String> queries);
+
+    @RequestLine("POST /")
+    void headerMapSubClass(@HeaderMap SubClassHeaders httpHeaders);
   }
 
   interface HeaderParams {
@@ -626,6 +635,12 @@ public class DefaultContractTest {
 
     private List<Entity<K, M>> entities;
   }
+
+
+  interface SubClassHeaders extends Map<String, String> {
+
+  }
+
 
   @Headers("Version: 1")
   interface ParameterizedApi extends ParameterizedBaseApi<String, Long> {


### PR DESCRIPTION
Fixes #655

When verifying that any of the `@*Map` annotations are in fact
`Map` instances, we were assuming that all values are direct
extension of a `Map` with generic type information intact.  When
using frameworks like Spring, it is possible to have `Map` objects
that do not expose type information, like `HttpHeaders`, which
directly extend from a `Map` with the type information static.

This adds additional checking to the `checkMapKeys` function
to accomodate for `Map` subclasses without type information.  If
the map key information cannot be validated, we simply pass it
through.