### PR TITLE
Mock: manage headers using RequestHeaders

### DIFF
--- a/mock/pom.xml
+++ b/mock/pom.xml
@@ -14,7 +14,9 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>

--- a/mock/pom.xml
+++ b/mock/pom.xml
@@ -14,50 +14,50 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>io.github.openfeign</groupId>
-    <artifactId>parent</artifactId>
-    <version>9.8.0-SNAPSHOT</version>
-  </parent>
+    <parent>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>parent</artifactId>
+        <version>9.8.0-SNAPSHOT</version>
+    </parent>
 
-  <artifactId>feign-mock</artifactId>
-  <name>Feign Mock</name>
-  <description>Feign Mock</description>
+    <artifactId>feign-mock</artifactId>
+    <name>Feign Mock</name>
+    <description>Feign Mock</description>
 
-  <properties>
-    <main.basedir>${project.basedir}/..</main.basedir>
+    <properties>
+        <main.basedir>${project.basedir}/..</main.basedir>
 
-    <hamcrest.version>1.3</hamcrest.version>
-  </properties>
+        <hamcrest.version>1.3</hamcrest.version>
+    </properties>
 
-  <dependencies>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>feign-core</artifactId>
-    </dependency>
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>feign-core</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>feign-gson</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <version>${hamcrest.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <version>${hamcrest.version}</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>feign-gson</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/mock/pom.xml
+++ b/mock/pom.xml
@@ -14,9 +14,7 @@
     the License.
 
 -->
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>

--- a/mock/pom.xml
+++ b/mock/pom.xml
@@ -15,47 +15,47 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>io.github.openfeign</groupId>
-        <artifactId>parent</artifactId>
-        <version>9.8.0-SNAPSHOT</version>
-    </parent>
+  <parent>
+    <groupId>io.github.openfeign</groupId>
+    <artifactId>parent</artifactId>
+    <version>9.8.0-SNAPSHOT</version>
+  </parent>
 
-    <artifactId>feign-mock</artifactId>
-    <name>Feign Mock</name>
-    <description>Feign Mock</description>
+  <artifactId>feign-mock</artifactId>
+  <name>Feign Mock</name>
+  <description>Feign Mock</description>
 
-    <properties>
-        <main.basedir>${project.basedir}/..</main.basedir>
+  <properties>
+    <main.basedir>${project.basedir}/..</main.basedir>
 
-        <hamcrest.version>1.3</hamcrest.version>
-    </properties>
+    <hamcrest.version>1.3</hamcrest.version>
+  </properties>
 
-    <dependencies>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>feign-core</artifactId>
-        </dependency>
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>feign-core</artifactId>
+    </dependency>
 
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>feign-gson</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <version>${hamcrest.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <version>${hamcrest.version}</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>feign-gson</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>${hamcrest.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <version>${hamcrest.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
 </project>

--- a/mock/src/main/java/feign/mock/MockClient.java
+++ b/mock/src/main/java/feign/mock/MockClient.java
@@ -13,261 +13,268 @@
  */
 package feign.mock;
 
+import static feign.Util.UTF_8;
+
 import feign.Client;
 import feign.Request;
 import feign.Response;
 import feign.Util;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
-import java.util.*;
-
-import static feign.Util.UTF_8;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 public class MockClient implements Client {
 
-    class RequestResponse {
+  class RequestResponse {
 
-        private final RequestKey requestKey;
+    private final RequestKey requestKey;
 
-        private final Response.Builder responseBuilder;
+    private final Response.Builder responseBuilder;
 
-        public RequestResponse(RequestKey requestKey, Response.Builder responseBuilder) {
-            this.requestKey = requestKey;
-            this.responseBuilder = responseBuilder;
-        }
-
+    public RequestResponse(RequestKey requestKey, Response.Builder responseBuilder) {
+      this.requestKey = requestKey;
+      this.responseBuilder = responseBuilder;
     }
 
-    private final List<RequestResponse> responses = new ArrayList<RequestResponse>();
+  }
 
-    private final Map<RequestKey, List<Request>> requests = new HashMap<RequestKey, List<Request>>();
+  private final List<RequestResponse> responses = new ArrayList<RequestResponse>();
 
-    private boolean sequential;
+  private final Map<RequestKey, List<Request>> requests = new HashMap<RequestKey, List<Request>>();
 
-    private Iterator<RequestResponse> responseIterator;
+  private boolean sequential;
 
-    public MockClient() {
+  private Iterator<RequestResponse> responseIterator;
+
+  public MockClient() {
+  }
+
+  public MockClient(boolean sequential) {
+    this.sequential = sequential;
+  }
+
+  @Override
+  public synchronized Response execute(Request request, Request.Options options)
+    throws IOException {
+    RequestKey requestKey = RequestKey.create(request);
+    Response.Builder responseBuilder;
+    if (sequential) {
+      responseBuilder = executeSequential(requestKey);
+    } else {
+      responseBuilder = executeAny(request, requestKey);
     }
 
-    public MockClient(boolean sequential) {
-        this.sequential = sequential;
+    return responseBuilder.request(request).build();
+  }
+
+  private Response.Builder executeSequential(RequestKey requestKey) {
+    Response.Builder responseBuilder;
+    if (responseIterator == null) {
+      responseIterator = responses.iterator();
+    }
+    if (!responseIterator.hasNext()) {
+      throw new VerificationAssertionError("Received excessive request %s", requestKey);
     }
 
-    @Override
-    public synchronized Response execute(Request request, Request.Options options)
-            throws IOException {
-        RequestKey requestKey = RequestKey.create(request);
-        Response.Builder responseBuilder;
-        if (sequential) {
-            responseBuilder = executeSequential(requestKey);
-        } else {
-            responseBuilder = executeAny(request, requestKey);
-        }
-
-        return responseBuilder.request(request).build();
+    RequestResponse expectedRequestResponse = responseIterator.next();
+    if (!expectedRequestResponse.requestKey.equalsExtended(requestKey)) {
+      throw new VerificationAssertionError("Expected %s, but was %s",
+        expectedRequestResponse.requestKey,
+        requestKey);
     }
 
-    private Response.Builder executeSequential(RequestKey requestKey) {
-        Response.Builder responseBuilder;
-        if (responseIterator == null) {
-            responseIterator = responses.iterator();
-        }
-        if (!responseIterator.hasNext()) {
-            throw new VerificationAssertionError("Received excessive request %s", requestKey);
-        }
+    responseBuilder = expectedRequestResponse.responseBuilder;
+    return responseBuilder;
+  }
 
-        RequestResponse expectedRequestResponse = responseIterator.next();
-        if (!expectedRequestResponse.requestKey.equalsExtended(requestKey)) {
-            throw new VerificationAssertionError("Expected %s, but was %s",
-                    expectedRequestResponse.requestKey,
-                    requestKey);
-        }
-
-        responseBuilder = expectedRequestResponse.responseBuilder;
-        return responseBuilder;
+  private Response.Builder executeAny(Request request, RequestKey requestKey) {
+    Response.Builder responseBuilder;
+    if (requests.containsKey(requestKey)) {
+      requests.get(requestKey).add(request);
+    } else {
+      requests.put(requestKey, new ArrayList<Request>(Arrays.asList(request)));
     }
 
-    private Response.Builder executeAny(Request request, RequestKey requestKey) {
-        Response.Builder responseBuilder;
-        if (requests.containsKey(requestKey)) {
-            requests.get(requestKey).add(request);
-        } else {
-            requests.put(requestKey, new ArrayList<Request>(Arrays.asList(request)));
-        }
+    responseBuilder = getResponseBuilder(request, requestKey);
+    return responseBuilder;
+  }
 
-        responseBuilder = getResponseBuilder(request, requestKey);
-        return responseBuilder;
+  private Response.Builder getResponseBuilder(Request request, RequestKey requestKey) {
+    Response.Builder responseBuilder = null;
+    for (RequestResponse requestResponse : responses) {
+      if (requestResponse.requestKey.equalsExtended(requestKey)) {
+        responseBuilder = requestResponse.responseBuilder;
+        // Don't break here, last one should win to be compatible with
+        // previous
+        // releases of this library!
+      }
+    }
+    if (responseBuilder == null) {
+      responseBuilder =
+        Response.builder().status(HttpURLConnection.HTTP_NOT_FOUND).reason("Not mocker")
+          .headers(request.headers());
+    }
+    return responseBuilder;
+  }
+
+  public MockClient ok(HttpMethod method, String url, InputStream responseBody)
+    throws IOException {
+    return ok(RequestKey.builder(method, url).build(), responseBody);
+  }
+
+  public MockClient ok(HttpMethod method, String url, String responseBody) {
+    return ok(RequestKey.builder(method, url).build(), responseBody);
+  }
+
+  public MockClient ok(HttpMethod method, String url, byte[] responseBody) {
+    return ok(RequestKey.builder(method, url).build(), responseBody);
+  }
+
+  public MockClient ok(HttpMethod method, String url) {
+    return ok(RequestKey.builder(method, url).build());
+  }
+
+  public MockClient ok(RequestKey requestKey, InputStream responseBody) throws IOException {
+    return ok(requestKey, Util.toByteArray(responseBody));
+  }
+
+  public MockClient ok(RequestKey requestKey, String responseBody) {
+    return ok(requestKey, responseBody.getBytes(UTF_8));
+  }
+
+  public MockClient ok(RequestKey requestKey, byte[] responseBody) {
+    return add(requestKey, HttpURLConnection.HTTP_OK, responseBody);
+  }
+
+  public MockClient ok(RequestKey requestKey) {
+    return ok(requestKey, (byte[]) null);
+  }
+
+  public MockClient add(HttpMethod method, String url, int status, InputStream responseBody)
+    throws IOException {
+    return add(RequestKey.builder(method, url).build(), status, responseBody);
+  }
+
+  public MockClient add(HttpMethod method, String url, int status, String responseBody) {
+    return add(RequestKey.builder(method, url).build(), status, responseBody);
+  }
+
+  public MockClient add(HttpMethod method, String url, int status, byte[] responseBody) {
+    return add(RequestKey.builder(method, url).build(), status, responseBody);
+  }
+
+  public MockClient add(HttpMethod method, String url, int status) {
+    return add(RequestKey.builder(method, url).build(), status);
+  }
+
+  /**
+   * @param response <ul>
+   * <li>the status defaults to 0, not 200!</li>
+   * <li>the internal feign-code requires the headers to be set</li>
+   * </ul>
+   */
+  public MockClient add(HttpMethod method, String url, Response.Builder response) {
+    return add(RequestKey.builder(method, url).build(), response);
+  }
+
+  public MockClient add(RequestKey requestKey, int status, InputStream responseBody)
+    throws IOException {
+    return add(requestKey, status, Util.toByteArray(responseBody));
+  }
+
+  public MockClient add(RequestKey requestKey, int status, String responseBody) {
+    return add(requestKey, status, responseBody.getBytes(UTF_8));
+  }
+
+  public MockClient add(RequestKey requestKey, int status, byte[] responseBody) {
+    return add(requestKey,
+      Response.builder().status(status).reason("Mocked").headers(RequestHeaders.EMPTY)
+        .body(responseBody));
+  }
+
+  public MockClient add(RequestKey requestKey, int status) {
+    return add(requestKey, status, (byte[]) null);
+  }
+
+  public MockClient add(RequestKey requestKey, Response.Builder response) {
+    responses.add(new RequestResponse(requestKey, response));
+    return this;
+  }
+
+  public MockClient add(HttpMethod method, String url, Response response) {
+    return this.add(method, url, response.toBuilder());
+  }
+
+  public MockClient noContent(HttpMethod method, String url) {
+    return add(method, url, HttpURLConnection.HTTP_NO_CONTENT);
+  }
+
+  public Request verifyOne(HttpMethod method, String url) {
+    return verifyTimes(method, url, 1).get(0);
+  }
+
+  public List<Request> verifyTimes(final HttpMethod method, final String url, final int times) {
+    if (times < 0) {
+      throw new IllegalArgumentException("times must be a non negative number");
     }
 
-    private Response.Builder getResponseBuilder(Request request, RequestKey requestKey) {
-        Response.Builder responseBuilder = null;
-        for (RequestResponse requestResponse : responses) {
-            if (requestResponse.requestKey.equalsExtended(requestKey)) {
-                responseBuilder = requestResponse.responseBuilder;
-                // Don't break here, last one should win to be compatible with
-                // previous
-                // releases of this library!
-            }
-        }
-        if (responseBuilder == null) {
-            responseBuilder =
-                    Response.builder().status(HttpURLConnection.HTTP_NOT_FOUND).reason("Not mocker")
-                            .headers(request.headers());
-        }
-        return responseBuilder;
+    if (times == 0) {
+      verifyNever(method, url);
+      return Collections.emptyList();
     }
 
-    public MockClient ok(HttpMethod method, String url, InputStream responseBody) throws IOException {
-        return ok(RequestKey.builder(method, url).build(), responseBody);
+    RequestKey requestKey = RequestKey.builder(method, url).build();
+    if (!requests.containsKey(requestKey)) {
+      throw new VerificationAssertionError("Wanted: '%s' but never invoked!", requestKey);
     }
 
-    public MockClient ok(HttpMethod method, String url, String responseBody) {
-        return ok(RequestKey.builder(method, url).build(), responseBody);
+    List<Request> result = requests.get(requestKey);
+    if (result.size() != times) {
+      throw new VerificationAssertionError(
+        "Wanted: '%s' to be invoked: '%s' times but got: '%s'!",
+        requestKey,
+        times, result.size());
     }
 
-    public MockClient ok(HttpMethod method, String url, byte[] responseBody) {
-        return ok(RequestKey.builder(method, url).build(), responseBody);
+    return result;
+  }
+
+  public void verifyNever(HttpMethod method, String url) {
+    RequestKey requestKey = RequestKey.builder(method, url).build();
+    if (requests.containsKey(requestKey)) {
+      throw new VerificationAssertionError("Do not wanted: '%s' but was invoked!",
+        requestKey);
     }
+  }
 
-    public MockClient ok(HttpMethod method, String url) {
-        return ok(RequestKey.builder(method, url).build());
+  /**
+   * To be called in an &#64;After method:
+   *
+   * <pre>
+   * &#64;After
+   * public void tearDown() {
+   *   mockClient.verifyStatus();
+   * }
+   * </pre>
+   */
+  public void verifyStatus() {
+    if (sequential) {
+      boolean unopenedIterator = responseIterator == null && !responses.isEmpty();
+      if (unopenedIterator || responseIterator.hasNext()) {
+        throw new VerificationAssertionError("More executions were expected");
+      }
     }
+  }
 
-    public MockClient ok(RequestKey requestKey, InputStream responseBody) throws IOException {
-        return ok(requestKey, Util.toByteArray(responseBody));
-    }
-
-    public MockClient ok(RequestKey requestKey, String responseBody) {
-        return ok(requestKey, responseBody.getBytes(UTF_8));
-    }
-
-    public MockClient ok(RequestKey requestKey, byte[] responseBody) {
-        return add(requestKey, HttpURLConnection.HTTP_OK, responseBody);
-    }
-
-    public MockClient ok(RequestKey requestKey) {
-        return ok(requestKey, (byte[]) null);
-    }
-
-    public MockClient add(HttpMethod method, String url, int status, InputStream responseBody)
-            throws IOException {
-        return add(RequestKey.builder(method, url).build(), status, responseBody);
-    }
-
-    public MockClient add(HttpMethod method, String url, int status, String responseBody) {
-        return add(RequestKey.builder(method, url).build(), status, responseBody);
-    }
-
-    public MockClient add(HttpMethod method, String url, int status, byte[] responseBody) {
-        return add(RequestKey.builder(method, url).build(), status, responseBody);
-    }
-
-    public MockClient add(HttpMethod method, String url, int status) {
-        return add(RequestKey.builder(method, url).build(), status);
-    }
-
-    /**
-     * @param response
-     *        <ul>
-     *        <li>the status defaults to 0, not 200!</li>
-     *        <li>the internal feign-code requires the headers to be set</li>
-     *        </ul>
-     */
-    public MockClient add(HttpMethod method, String url, Response.Builder response) {
-        return add(RequestKey.builder(method, url).build(), response);
-    }
-
-    public MockClient add(RequestKey requestKey, int status, InputStream responseBody)
-            throws IOException {
-        return add(requestKey, status, Util.toByteArray(responseBody));
-    }
-
-    public MockClient add(RequestKey requestKey, int status, String responseBody) {
-        return add(requestKey, status, responseBody.getBytes(UTF_8));
-    }
-
-    public MockClient add(RequestKey requestKey, int status, byte[] responseBody) {
-        return add(requestKey,
-                Response.builder().status(status).reason("Mocked").headers(RequestHeaders.EMPTY)
-                        .body(responseBody));
-    }
-
-    public MockClient add(RequestKey requestKey, int status) {
-        return add(requestKey, status, (byte[]) null);
-    }
-
-    public MockClient add(RequestKey requestKey, Response.Builder response) {
-        responses.add(new RequestResponse(requestKey, response));
-        return this;
-    }
-
-    public MockClient add(HttpMethod method, String url, Response response) {
-        return this.add(method, url, response.toBuilder());
-    }
-
-    public MockClient noContent(HttpMethod method, String url) {
-        return add(method, url, HttpURLConnection.HTTP_NO_CONTENT);
-    }
-
-    public Request verifyOne(HttpMethod method, String url) {
-        return verifyTimes(method, url, 1).get(0);
-    }
-
-    public List<Request> verifyTimes(final HttpMethod method, final String url, final int times) {
-        if (times < 0) {
-            throw new IllegalArgumentException("times must be a non negative number");
-        }
-
-        if (times == 0) {
-            verifyNever(method, url);
-            return Collections.emptyList();
-        }
-
-        RequestKey requestKey = RequestKey.builder(method, url).build();
-        if (!requests.containsKey(requestKey)) {
-            throw new VerificationAssertionError("Wanted: '%s' but never invoked!", requestKey);
-        }
-
-        List<Request> result = requests.get(requestKey);
-        if (result.size() != times) {
-            throw new VerificationAssertionError("Wanted: '%s' to be invoked: '%s' times but got: '%s'!",
-                    requestKey,
-                    times, result.size());
-        }
-
-        return result;
-    }
-
-    public void verifyNever(HttpMethod method, String url) {
-        RequestKey requestKey = RequestKey.builder(method, url).build();
-        if (requests.containsKey(requestKey)) {
-            throw new VerificationAssertionError("Do not wanted: '%s' but was invoked!", requestKey);
-        }
-    }
-
-    /**
-     * To be called in an &#64;After method:
-     *
-     * <pre>
-     * &#64;After
-     * public void tearDown() {
-     *   mockClient.verifyStatus();
-     * }
-     * </pre>
-     */
-    public void verifyStatus() {
-        if (sequential) {
-            boolean unopenedIterator = responseIterator == null && !responses.isEmpty();
-            if (unopenedIterator || responseIterator.hasNext()) {
-                throw new VerificationAssertionError("More executions were expected");
-            }
-        }
-    }
-
-    public void resetRequests() {
-        requests.clear();
-    }
+  public void resetRequests() {
+    requests.clear();
+  }
 
 }

--- a/mock/src/main/java/feign/mock/MockClient.java
+++ b/mock/src/main/java/feign/mock/MockClient.java
@@ -14,11 +14,6 @@
 package feign.mock;
 
 import static feign.Util.UTF_8;
-
-import feign.Client;
-import feign.Request;
-import feign.Response;
-import feign.Util;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
@@ -29,6 +24,10 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import feign.Client;
+import feign.Request;
+import feign.Response;
+import feign.Util;
 
 public class MockClient implements Client {
 
@@ -53,8 +52,7 @@ public class MockClient implements Client {
 
   private Iterator<RequestResponse> responseIterator;
 
-  public MockClient() {
-  }
+  public MockClient() {}
 
   public MockClient(boolean sequential) {
     this.sequential = sequential;
@@ -62,7 +60,7 @@ public class MockClient implements Client {
 
   @Override
   public synchronized Response execute(Request request, Request.Options options)
-    throws IOException {
+      throws IOException {
     RequestKey requestKey = RequestKey.create(request);
     Response.Builder responseBuilder;
     if (sequential) {
@@ -86,8 +84,8 @@ public class MockClient implements Client {
     RequestResponse expectedRequestResponse = responseIterator.next();
     if (!expectedRequestResponse.requestKey.equalsExtended(requestKey)) {
       throw new VerificationAssertionError("Expected %s, but was %s",
-        expectedRequestResponse.requestKey,
-        requestKey);
+          expectedRequestResponse.requestKey,
+          requestKey);
     }
 
     responseBuilder = expectedRequestResponse.responseBuilder;
@@ -118,14 +116,14 @@ public class MockClient implements Client {
     }
     if (responseBuilder == null) {
       responseBuilder =
-        Response.builder().status(HttpURLConnection.HTTP_NOT_FOUND).reason("Not mocker")
-          .headers(request.headers());
+          Response.builder().status(HttpURLConnection.HTTP_NOT_FOUND).reason("Not mocker")
+              .headers(request.headers());
     }
     return responseBuilder;
   }
 
   public MockClient ok(HttpMethod method, String url, InputStream responseBody)
-    throws IOException {
+      throws IOException {
     return ok(RequestKey.builder(method, url).build(), responseBody);
   }
 
@@ -158,7 +156,7 @@ public class MockClient implements Client {
   }
 
   public MockClient add(HttpMethod method, String url, int status, InputStream responseBody)
-    throws IOException {
+      throws IOException {
     return add(RequestKey.builder(method, url).build(), status, responseBody);
   }
 
@@ -175,17 +173,18 @@ public class MockClient implements Client {
   }
 
   /**
-   * @param response <ul>
-   * <li>the status defaults to 0, not 200!</li>
-   * <li>the internal feign-code requires the headers to be set</li>
-   * </ul>
+   * @param response
+   *        <ul>
+   *        <li>the status defaults to 0, not 200!</li>
+   *        <li>the internal feign-code requires the headers to be set</li>
+   *        </ul>
    */
   public MockClient add(HttpMethod method, String url, Response.Builder response) {
     return add(RequestKey.builder(method, url).build(), response);
   }
 
   public MockClient add(RequestKey requestKey, int status, InputStream responseBody)
-    throws IOException {
+      throws IOException {
     return add(requestKey, status, Util.toByteArray(responseBody));
   }
 
@@ -195,8 +194,8 @@ public class MockClient implements Client {
 
   public MockClient add(RequestKey requestKey, int status, byte[] responseBody) {
     return add(requestKey,
-      Response.builder().status(status).reason("Mocked").headers(RequestHeaders.EMPTY)
-        .body(responseBody));
+        Response.builder().status(status).reason("Mocked").headers(RequestHeaders.EMPTY)
+            .body(responseBody));
   }
 
   public MockClient add(RequestKey requestKey, int status) {
@@ -238,9 +237,9 @@ public class MockClient implements Client {
     List<Request> result = requests.get(requestKey);
     if (result.size() != times) {
       throw new VerificationAssertionError(
-        "Wanted: '%s' to be invoked: '%s' times but got: '%s'!",
-        requestKey,
-        times, result.size());
+          "Wanted: '%s' to be invoked: '%s' times but got: '%s'!",
+          requestKey,
+          times, result.size());
     }
 
     return result;
@@ -250,7 +249,7 @@ public class MockClient implements Client {
     RequestKey requestKey = RequestKey.builder(method, url).build();
     if (requests.containsKey(requestKey)) {
       throw new VerificationAssertionError("Do not wanted: '%s' but was invoked!",
-        requestKey);
+          requestKey);
     }
   }
 
@@ -276,5 +275,6 @@ public class MockClient implements Client {
   public void resetRequests() {
     requests.clear();
   }
+
 
 }

--- a/mock/src/main/java/feign/mock/MockClient.java
+++ b/mock/src/main/java/feign/mock/MockClient.java
@@ -122,8 +122,7 @@ public class MockClient implements Client {
     return responseBuilder;
   }
 
-  public MockClient ok(HttpMethod method, String url, InputStream responseBody)
-      throws IOException {
+  public MockClient ok(HttpMethod method, String url, InputStream responseBody) throws IOException {
     return ok(RequestKey.builder(method, url).build(), responseBody);
   }
 
@@ -236,8 +235,7 @@ public class MockClient implements Client {
 
     List<Request> result = requests.get(requestKey);
     if (result.size() != times) {
-      throw new VerificationAssertionError(
-          "Wanted: '%s' to be invoked: '%s' times but got: '%s'!",
+      throw new VerificationAssertionError("Wanted: '%s' to be invoked: '%s' times but got: '%s'!",
           requestKey,
           times, result.size());
     }
@@ -248,8 +246,7 @@ public class MockClient implements Client {
   public void verifyNever(HttpMethod method, String url) {
     RequestKey requestKey = RequestKey.builder(method, url).build();
     if (requests.containsKey(requestKey)) {
-      throw new VerificationAssertionError("Do not wanted: '%s' but was invoked!",
-          requestKey);
+      throw new VerificationAssertionError("Do not wanted: '%s' but was invoked!", requestKey);
     }
   }
 

--- a/mock/src/main/java/feign/mock/MockClient.java
+++ b/mock/src/main/java/feign/mock/MockClient.java
@@ -13,267 +13,261 @@
  */
 package feign.mock;
 
-import static feign.Util.UTF_8;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 import feign.Client;
 import feign.Request;
 import feign.Response;
 import feign.Util;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.util.*;
+
+import static feign.Util.UTF_8;
+
 public class MockClient implements Client {
 
-  class RequestResponse {
+    class RequestResponse {
 
-    private final RequestKey requestKey;
+        private final RequestKey requestKey;
 
-    private final Response.Builder responseBuilder;
+        private final Response.Builder responseBuilder;
 
-    public RequestResponse(RequestKey requestKey, Response.Builder responseBuilder) {
-      this.requestKey = requestKey;
-      this.responseBuilder = responseBuilder;
+        public RequestResponse(RequestKey requestKey, Response.Builder responseBuilder) {
+            this.requestKey = requestKey;
+            this.responseBuilder = responseBuilder;
+        }
+
     }
 
-  }
+    private final List<RequestResponse> responses = new ArrayList<RequestResponse>();
 
-  public static final Map<String, Collection<String>> EMPTY_HEADERS = Collections.emptyMap();
+    private final Map<RequestKey, List<Request>> requests = new HashMap<RequestKey, List<Request>>();
 
-  private final List<RequestResponse> responses = new ArrayList<RequestResponse>();
+    private boolean sequential;
 
-  private final Map<RequestKey, List<Request>> requests = new HashMap<RequestKey, List<Request>>();
+    private Iterator<RequestResponse> responseIterator;
 
-  private boolean sequential;
-
-  private Iterator<RequestResponse> responseIterator;
-
-  public MockClient() {}
-
-  public MockClient(boolean sequential) {
-    this.sequential = sequential;
-  }
-
-  @Override
-  public synchronized Response execute(Request request, Request.Options options)
-      throws IOException {
-    RequestKey requestKey = RequestKey.create(request);
-    Response.Builder responseBuilder;
-    if (sequential) {
-      responseBuilder = executeSequential(requestKey);
-    } else {
-      responseBuilder = executeAny(request, requestKey);
+    public MockClient() {
     }
 
-    return responseBuilder.request(request).build();
-  }
-
-  private Response.Builder executeSequential(RequestKey requestKey) {
-    Response.Builder responseBuilder;
-    if (responseIterator == null) {
-      responseIterator = responses.iterator();
-    }
-    if (!responseIterator.hasNext()) {
-      throw new VerificationAssertionError("Received excessive request %s", requestKey);
+    public MockClient(boolean sequential) {
+        this.sequential = sequential;
     }
 
-    RequestResponse expectedRequestResponse = responseIterator.next();
-    if (!expectedRequestResponse.requestKey.equalsExtended(requestKey)) {
-      throw new VerificationAssertionError("Expected %s, but was %s",
-          expectedRequestResponse.requestKey,
-          requestKey);
+    @Override
+    public synchronized Response execute(Request request, Request.Options options)
+            throws IOException {
+        RequestKey requestKey = RequestKey.create(request);
+        Response.Builder responseBuilder;
+        if (sequential) {
+            responseBuilder = executeSequential(requestKey);
+        } else {
+            responseBuilder = executeAny(request, requestKey);
+        }
+
+        return responseBuilder.request(request).build();
     }
 
-    responseBuilder = expectedRequestResponse.responseBuilder;
-    return responseBuilder;
-  }
+    private Response.Builder executeSequential(RequestKey requestKey) {
+        Response.Builder responseBuilder;
+        if (responseIterator == null) {
+            responseIterator = responses.iterator();
+        }
+        if (!responseIterator.hasNext()) {
+            throw new VerificationAssertionError("Received excessive request %s", requestKey);
+        }
 
-  private Response.Builder executeAny(Request request, RequestKey requestKey) {
-    Response.Builder responseBuilder;
-    if (requests.containsKey(requestKey)) {
-      requests.get(requestKey).add(request);
-    } else {
-      requests.put(requestKey, new ArrayList<Request>(Arrays.asList(request)));
+        RequestResponse expectedRequestResponse = responseIterator.next();
+        if (!expectedRequestResponse.requestKey.equalsExtended(requestKey)) {
+            throw new VerificationAssertionError("Expected %s, but was %s",
+                    expectedRequestResponse.requestKey,
+                    requestKey);
+        }
+
+        responseBuilder = expectedRequestResponse.responseBuilder;
+        return responseBuilder;
     }
 
-    responseBuilder = getResponseBuilder(request, requestKey);
-    return responseBuilder;
-  }
+    private Response.Builder executeAny(Request request, RequestKey requestKey) {
+        Response.Builder responseBuilder;
+        if (requests.containsKey(requestKey)) {
+            requests.get(requestKey).add(request);
+        } else {
+            requests.put(requestKey, new ArrayList<Request>(Arrays.asList(request)));
+        }
 
-  private Response.Builder getResponseBuilder(Request request, RequestKey requestKey) {
-    Response.Builder responseBuilder = null;
-    for (RequestResponse requestResponse : responses) {
-      if (requestResponse.requestKey.equalsExtended(requestKey)) {
-        responseBuilder = requestResponse.responseBuilder;
-        // Don't break here, last one should win to be compatible with
-        // previous
-        // releases of this library!
-      }
-    }
-    if (responseBuilder == null) {
-      responseBuilder =
-          Response.builder().status(HttpURLConnection.HTTP_NOT_FOUND).reason("Not mocker")
-              .headers(request.headers());
-    }
-    return responseBuilder;
-  }
-
-  public MockClient ok(HttpMethod method, String url, InputStream responseBody) throws IOException {
-    return ok(RequestKey.builder(method, url).build(), responseBody);
-  }
-
-  public MockClient ok(HttpMethod method, String url, String responseBody) {
-    return ok(RequestKey.builder(method, url).build(), responseBody);
-  }
-
-  public MockClient ok(HttpMethod method, String url, byte[] responseBody) {
-    return ok(RequestKey.builder(method, url).build(), responseBody);
-  }
-
-  public MockClient ok(HttpMethod method, String url) {
-    return ok(RequestKey.builder(method, url).build());
-  }
-
-  public MockClient ok(RequestKey requestKey, InputStream responseBody) throws IOException {
-    return ok(requestKey, Util.toByteArray(responseBody));
-  }
-
-  public MockClient ok(RequestKey requestKey, String responseBody) {
-    return ok(requestKey, responseBody.getBytes(UTF_8));
-  }
-
-  public MockClient ok(RequestKey requestKey, byte[] responseBody) {
-    return add(requestKey, HttpURLConnection.HTTP_OK, responseBody);
-  }
-
-  public MockClient ok(RequestKey requestKey) {
-    return ok(requestKey, (byte[]) null);
-  }
-
-  public MockClient add(HttpMethod method, String url, int status, InputStream responseBody)
-      throws IOException {
-    return add(RequestKey.builder(method, url).build(), status, responseBody);
-  }
-
-  public MockClient add(HttpMethod method, String url, int status, String responseBody) {
-    return add(RequestKey.builder(method, url).build(), status, responseBody);
-  }
-
-  public MockClient add(HttpMethod method, String url, int status, byte[] responseBody) {
-    return add(RequestKey.builder(method, url).build(), status, responseBody);
-  }
-
-  public MockClient add(HttpMethod method, String url, int status) {
-    return add(RequestKey.builder(method, url).build(), status);
-  }
-
-  /**
-   * @param response
-   *        <ul>
-   *        <li>the status defaults to 0, not 200!</li>
-   *        <li>the internal feign-code requires the headers to be set</li>
-   *        </ul>
-   */
-  public MockClient add(HttpMethod method, String url, Response.Builder response) {
-    return add(RequestKey.builder(method, url).build(), response);
-  }
-
-  public MockClient add(RequestKey requestKey, int status, InputStream responseBody)
-      throws IOException {
-    return add(requestKey, status, Util.toByteArray(responseBody));
-  }
-
-  public MockClient add(RequestKey requestKey, int status, String responseBody) {
-    return add(requestKey, status, responseBody.getBytes(UTF_8));
-  }
-
-  public MockClient add(RequestKey requestKey, int status, byte[] responseBody) {
-    return add(requestKey,
-        Response.builder().status(status).reason("Mocked").headers(EMPTY_HEADERS)
-            .body(responseBody));
-  }
-
-  public MockClient add(RequestKey requestKey, int status) {
-    return add(requestKey, status, (byte[]) null);
-  }
-
-  public MockClient add(RequestKey requestKey, Response.Builder response) {
-    responses.add(new RequestResponse(requestKey, response));
-    return this;
-  }
-
-  public MockClient add(HttpMethod method, String url, Response response) {
-    return this.add(method, url, response.toBuilder());
-  }
-
-  public MockClient noContent(HttpMethod method, String url) {
-    return add(method, url, HttpURLConnection.HTTP_NO_CONTENT);
-  }
-
-  public Request verifyOne(HttpMethod method, String url) {
-    return verifyTimes(method, url, 1).get(0);
-  }
-
-  public List<Request> verifyTimes(final HttpMethod method, final String url, final int times) {
-    if (times < 0) {
-      throw new IllegalArgumentException("times must be a non negative number");
+        responseBuilder = getResponseBuilder(request, requestKey);
+        return responseBuilder;
     }
 
-    if (times == 0) {
-      verifyNever(method, url);
-      return Collections.emptyList();
+    private Response.Builder getResponseBuilder(Request request, RequestKey requestKey) {
+        Response.Builder responseBuilder = null;
+        for (RequestResponse requestResponse : responses) {
+            if (requestResponse.requestKey.equalsExtended(requestKey)) {
+                responseBuilder = requestResponse.responseBuilder;
+                // Don't break here, last one should win to be compatible with
+                // previous
+                // releases of this library!
+            }
+        }
+        if (responseBuilder == null) {
+            responseBuilder =
+                    Response.builder().status(HttpURLConnection.HTTP_NOT_FOUND).reason("Not mocker")
+                            .headers(request.headers());
+        }
+        return responseBuilder;
     }
 
-    RequestKey requestKey = RequestKey.builder(method, url).build();
-    if (!requests.containsKey(requestKey)) {
-      throw new VerificationAssertionError("Wanted: '%s' but never invoked!", requestKey);
+    public MockClient ok(HttpMethod method, String url, InputStream responseBody) throws IOException {
+        return ok(RequestKey.builder(method, url).build(), responseBody);
     }
 
-    List<Request> result = requests.get(requestKey);
-    if (result.size() != times) {
-      throw new VerificationAssertionError("Wanted: '%s' to be invoked: '%s' times but got: '%s'!",
-          requestKey,
-          times, result.size());
+    public MockClient ok(HttpMethod method, String url, String responseBody) {
+        return ok(RequestKey.builder(method, url).build(), responseBody);
     }
 
-    return result;
-  }
-
-  public void verifyNever(HttpMethod method, String url) {
-    RequestKey requestKey = RequestKey.builder(method, url).build();
-    if (requests.containsKey(requestKey)) {
-      throw new VerificationAssertionError("Do not wanted: '%s' but was invoked!", requestKey);
+    public MockClient ok(HttpMethod method, String url, byte[] responseBody) {
+        return ok(RequestKey.builder(method, url).build(), responseBody);
     }
-  }
 
-  /**
-   * To be called in an &#64;After method:
-   * 
-   * <pre>
-   * &#64;After
-   * public void tearDown() {
-   *   mockClient.verifyStatus();
-   * }
-   * </pre>
-   */
-  public void verifyStatus() {
-    if (sequential) {
-      boolean unopenedIterator = responseIterator == null && !responses.isEmpty();
-      if (unopenedIterator || responseIterator.hasNext()) {
-        throw new VerificationAssertionError("More executions were expected");
-      }
+    public MockClient ok(HttpMethod method, String url) {
+        return ok(RequestKey.builder(method, url).build());
     }
-  }
 
-  public void resetRequests() {
-    requests.clear();
-  }
+    public MockClient ok(RequestKey requestKey, InputStream responseBody) throws IOException {
+        return ok(requestKey, Util.toByteArray(responseBody));
+    }
+
+    public MockClient ok(RequestKey requestKey, String responseBody) {
+        return ok(requestKey, responseBody.getBytes(UTF_8));
+    }
+
+    public MockClient ok(RequestKey requestKey, byte[] responseBody) {
+        return add(requestKey, HttpURLConnection.HTTP_OK, responseBody);
+    }
+
+    public MockClient ok(RequestKey requestKey) {
+        return ok(requestKey, (byte[]) null);
+    }
+
+    public MockClient add(HttpMethod method, String url, int status, InputStream responseBody)
+            throws IOException {
+        return add(RequestKey.builder(method, url).build(), status, responseBody);
+    }
+
+    public MockClient add(HttpMethod method, String url, int status, String responseBody) {
+        return add(RequestKey.builder(method, url).build(), status, responseBody);
+    }
+
+    public MockClient add(HttpMethod method, String url, int status, byte[] responseBody) {
+        return add(RequestKey.builder(method, url).build(), status, responseBody);
+    }
+
+    public MockClient add(HttpMethod method, String url, int status) {
+        return add(RequestKey.builder(method, url).build(), status);
+    }
+
+    /**
+     * @param response
+     *        <ul>
+     *        <li>the status defaults to 0, not 200!</li>
+     *        <li>the internal feign-code requires the headers to be set</li>
+     *        </ul>
+     */
+    public MockClient add(HttpMethod method, String url, Response.Builder response) {
+        return add(RequestKey.builder(method, url).build(), response);
+    }
+
+    public MockClient add(RequestKey requestKey, int status, InputStream responseBody)
+            throws IOException {
+        return add(requestKey, status, Util.toByteArray(responseBody));
+    }
+
+    public MockClient add(RequestKey requestKey, int status, String responseBody) {
+        return add(requestKey, status, responseBody.getBytes(UTF_8));
+    }
+
+    public MockClient add(RequestKey requestKey, int status, byte[] responseBody) {
+        return add(requestKey,
+                Response.builder().status(status).reason("Mocked").headers(RequestHeaders.EMPTY)
+                        .body(responseBody));
+    }
+
+    public MockClient add(RequestKey requestKey, int status) {
+        return add(requestKey, status, (byte[]) null);
+    }
+
+    public MockClient add(RequestKey requestKey, Response.Builder response) {
+        responses.add(new RequestResponse(requestKey, response));
+        return this;
+    }
+
+    public MockClient add(HttpMethod method, String url, Response response) {
+        return this.add(method, url, response.toBuilder());
+    }
+
+    public MockClient noContent(HttpMethod method, String url) {
+        return add(method, url, HttpURLConnection.HTTP_NO_CONTENT);
+    }
+
+    public Request verifyOne(HttpMethod method, String url) {
+        return verifyTimes(method, url, 1).get(0);
+    }
+
+    public List<Request> verifyTimes(final HttpMethod method, final String url, final int times) {
+        if (times < 0) {
+            throw new IllegalArgumentException("times must be a non negative number");
+        }
+
+        if (times == 0) {
+            verifyNever(method, url);
+            return Collections.emptyList();
+        }
+
+        RequestKey requestKey = RequestKey.builder(method, url).build();
+        if (!requests.containsKey(requestKey)) {
+            throw new VerificationAssertionError("Wanted: '%s' but never invoked!", requestKey);
+        }
+
+        List<Request> result = requests.get(requestKey);
+        if (result.size() != times) {
+            throw new VerificationAssertionError("Wanted: '%s' to be invoked: '%s' times but got: '%s'!",
+                    requestKey,
+                    times, result.size());
+        }
+
+        return result;
+    }
+
+    public void verifyNever(HttpMethod method, String url) {
+        RequestKey requestKey = RequestKey.builder(method, url).build();
+        if (requests.containsKey(requestKey)) {
+            throw new VerificationAssertionError("Do not wanted: '%s' but was invoked!", requestKey);
+        }
+    }
+
+    /**
+     * To be called in an &#64;After method:
+     *
+     * <pre>
+     * &#64;After
+     * public void tearDown() {
+     *   mockClient.verifyStatus();
+     * }
+     * </pre>
+     */
+    public void verifyStatus() {
+        if (sequential) {
+            boolean unopenedIterator = responseIterator == null && !responses.isEmpty();
+            if (unopenedIterator || responseIterator.hasNext()) {
+                throw new VerificationAssertionError("More executions were expected");
+            }
+        }
+    }
+
+    public void resetRequests() {
+        requests.clear();
+    }
 
 }

--- a/mock/src/main/java/feign/mock/RequestHeaders.java
+++ b/mock/src/main/java/feign/mock/RequestHeaders.java
@@ -13,102 +13,110 @@
  */
 package feign.mock;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 public class RequestHeaders {
 
-    public static class Builder {
+  public static class Builder {
 
-        private Map<String, Collection<String>> headers = new HashMap<String, Collection<String>>();
+    private Map<String, Collection<String>> headers = new HashMap<String, Collection<String>>();
 
-        private Builder() {
-        }
-
-        public Builder add(String key, Collection<String> values) {
-            if (!headers.containsKey(key)) {
-                headers.put(key, values);
-            } else {
-                Collection<String> previousValues = headers.get(key);
-                previousValues.addAll(values);
-                headers.put(key, previousValues);
-            }
-            return this;
-        }
-
-        public Builder add(String key, String value) {
-            if (!headers.containsKey(key)) {
-                headers.put(key, new ArrayList<String>(Arrays.asList(value)));
-            } else {
-                final Collection<String> values = headers.get(key);
-                values.add(value);
-                headers.put(key, values);
-            }
-            return this;
-        }
-
-        public RequestHeaders build() {
-            return new RequestHeaders(this);
-        }
-
+    private Builder() {
     }
 
-    public static Builder builder() {
-        return new Builder();
+    public Builder add(String key, Collection<String> values) {
+      if (!headers.containsKey(key)) {
+        headers.put(key, values);
+      } else {
+        Collection<String> previousValues = headers.get(key);
+        previousValues.addAll(values);
+        headers.put(key, previousValues);
+      }
+      return this;
     }
 
-    public static final Map<String, Collection<String>> EMPTY = Collections.emptyMap();
-
-    public static RequestHeaders of(Map<String, Collection<String>> headers) {
-        return new RequestHeaders(headers);
+    public Builder add(String key, String value) {
+      if (!headers.containsKey(key)) {
+        headers.put(key, new ArrayList<String>(Arrays.asList(value)));
+      } else {
+        final Collection<String> values = headers.get(key);
+        values.add(value);
+        headers.put(key, values);
+      }
+      return this;
     }
 
-    private Map<String, Collection<String>> headers;
-
-    private RequestHeaders(Builder builder) {
-        this.headers = builder.headers;
+    public RequestHeaders build() {
+      return new RequestHeaders(this);
     }
 
-    private RequestHeaders(Map<String, Collection<String>> headers) {
-        this.headers = headers;
-    }
+  }
 
-    public int size() {
-        return headers.size();
-    }
+  public static Builder builder() {
+    return new Builder();
+  }
 
-    public int sizeOf(String key) {
-        if (!headers.containsKey(key)) {
-            return 0;
-        }
-        return headers.get(key).size();
-    }
+  public static final Map<String, Collection<String>> EMPTY = Collections.emptyMap();
 
-    public Collection<String> fetch(String key) {
-        return headers.get(key);
+  public static RequestHeaders of(Map<String, Collection<String>> headers) {
+    return new RequestHeaders(headers);
+  }
+
+  private Map<String, Collection<String>> headers;
+
+  private RequestHeaders(Builder builder) {
+    this.headers = builder.headers;
+  }
+
+  private RequestHeaders(Map<String, Collection<String>> headers) {
+    this.headers = headers;
+  }
+
+  public int size() {
+    return headers.size();
+  }
+
+  public int sizeOf(String key) {
+    if (!headers.containsKey(key)) {
+      return 0;
     }
+    return headers.get(key).size();
+  }
+
+  public Collection<String> fetch(String key) {
+    return headers.get(key);
+  }
 
 
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        final RequestHeaders other = (RequestHeaders) obj;
-        return this.headers.equals(other.headers);
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
     }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    final RequestHeaders other = (RequestHeaders) obj;
+    return this.headers.equals(other.headers);
+  }
 
-    @Override
-    public String toString() {
-        StringBuilder builder = new StringBuilder();
-        for (Map.Entry<String, Collection<String>> entry : headers.entrySet()) {
-            builder.append(entry).append(',').append(' ');
-        }
-        if (builder.length() > 0) {
-            return builder.substring(0, builder.length() - 2);
-        }
-        return "no";
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    for (Map.Entry<String, Collection<String>> entry : headers.entrySet()) {
+      builder.append(entry).append(',').append(' ');
     }
+    if (builder.length() > 0) {
+      return builder.substring(0, builder.length() - 2);
+    }
+    return "no";
+  }
 }

--- a/mock/src/main/java/feign/mock/RequestHeaders.java
+++ b/mock/src/main/java/feign/mock/RequestHeaders.java
@@ -26,8 +26,7 @@ public class RequestHeaders {
 
     private Map<String, Collection<String>> headers = new HashMap<String, Collection<String>>();
 
-    private Builder() {
-    }
+    private Builder() {}
 
     public Builder add(String key, Collection<String> values) {
       if (!headers.containsKey(key)) {
@@ -57,11 +56,11 @@ public class RequestHeaders {
 
   }
 
+  public static final Map<String, Collection<String>> EMPTY = Collections.emptyMap();
+
   public static Builder builder() {
     return new Builder();
   }
-
-  public static final Map<String, Collection<String>> EMPTY = Collections.emptyMap();
 
   public static RequestHeaders of(Map<String, Collection<String>> headers) {
     return new RequestHeaders(headers);
@@ -92,7 +91,6 @@ public class RequestHeaders {
     return headers.get(key);
   }
 
-
   @Override
   public boolean equals(Object obj) {
     if (this == obj) {
@@ -119,4 +117,5 @@ public class RequestHeaders {
     }
     return "no";
   }
+
 }

--- a/mock/src/main/java/feign/mock/RequestHeaders.java
+++ b/mock/src/main/java/feign/mock/RequestHeaders.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2012-2018 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.mock;
+
+import java.util.*;
+
+public class RequestHeaders {
+
+    public static class Builder {
+
+        private Map<String, Collection<String>> headers = new HashMap<String, Collection<String>>();
+
+        private Builder() {
+        }
+
+        public Builder add(String key, Collection<String> values) {
+            if (!headers.containsKey(key)) {
+                headers.put(key, values);
+            } else {
+                Collection<String> previousValues = headers.get(key);
+                previousValues.addAll(values);
+                headers.put(key, previousValues);
+            }
+            return this;
+        }
+
+        public Builder add(String key, String value) {
+            if (!headers.containsKey(key)) {
+                headers.put(key, new ArrayList<String>(Arrays.asList(value)));
+            } else {
+                final Collection<String> values = headers.get(key);
+                values.add(value);
+                headers.put(key, values);
+            }
+            return this;
+        }
+
+        public RequestHeaders build() {
+            return new RequestHeaders(this);
+        }
+
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final Map<String, Collection<String>> EMPTY = Collections.emptyMap();
+
+    public static RequestHeaders of(Map<String, Collection<String>> headers) {
+        return new RequestHeaders(headers);
+    }
+
+    private Map<String, Collection<String>> headers;
+
+    private RequestHeaders(Builder builder) {
+        this.headers = builder.headers;
+    }
+
+    private RequestHeaders(Map<String, Collection<String>> headers) {
+        this.headers = headers;
+    }
+
+    public int size() {
+        return headers.size();
+    }
+
+    public int sizeOf(String key) {
+        if (!headers.containsKey(key)) {
+            return 0;
+        }
+        return headers.get(key).size();
+    }
+
+    public Collection<String> fetch(String key) {
+        return headers.get(key);
+    }
+
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        final RequestHeaders other = (RequestHeaders) obj;
+        return this.headers.equals(other.headers);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        for (Map.Entry<String, Collection<String>> entry : headers.entrySet()) {
+            builder.append(entry).append(',').append(' ');
+        }
+        if (builder.length() > 0) {
+            return builder.substring(0, builder.length() - 2);
+        }
+        return "no";
+    }
+}

--- a/mock/src/main/java/feign/mock/RequestKey.java
+++ b/mock/src/main/java/feign/mock/RequestKey.java
@@ -13,168 +13,173 @@
  */
 package feign.mock;
 
+import static feign.Util.UTF_8;
+
 import feign.Request;
 import feign.Util;
-
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 
-import static feign.Util.UTF_8;
-
 public class RequestKey {
 
-    public static class Builder {
-
-        private final HttpMethod method;
-
-        private final String url;
-
-        private RequestHeaders headers;
-
-        private Charset charset;
-
-        private byte[] body;
-
-        private Builder(HttpMethod method, String url) {
-            this.method = method;
-            this.url = url;
-        }
-
-        public Builder headers(RequestHeaders headers) {
-            this.headers = headers;
-            return this;
-        }
-
-        public Builder charset(Charset charset) {
-            this.charset = charset;
-            return this;
-        }
-
-        public Builder body(String body) {
-            return body(body.getBytes(UTF_8));
-        }
-
-        public Builder body(byte[] body) {
-            this.body = body;
-            return this;
-        }
-
-        public RequestKey build() {
-            return new RequestKey(this);
-        }
-
-    }
-
-    public static Builder builder(HttpMethod method, String url) {
-        return new Builder(method, url);
-    }
-
-    public static RequestKey create(Request request) {
-        return new RequestKey(request);
-    }
-
-    private static String buildUrl(Request request) {
-        try {
-            return URLDecoder.decode(request.url(), Util.UTF_8.name());
-        } catch (final UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
-    }
+  public static class Builder {
 
     private final HttpMethod method;
 
     private final String url;
 
-    private final RequestHeaders headers;
+    private RequestHeaders headers;
 
-    private final Charset charset;
+    private Charset charset;
 
-    private final byte[] body;
+    private byte[] body;
 
-    private RequestKey(Builder builder) {
-        this.method = builder.method;
-        this.url = builder.url;
-        this.headers = builder.headers;
-        this.charset = builder.charset;
-        this.body = builder.body;
+    private Builder(HttpMethod method, String url) {
+      this.method = method;
+      this.url = url;
     }
 
-    private RequestKey(Request request) {
-        this.method = HttpMethod.valueOf(request.method());
-        this.url = buildUrl(request);
-        this.headers = RequestHeaders.of(request.headers());
-        this.charset = request.charset();
-        this.body = request.body();
+    public Builder headers(RequestHeaders headers) {
+      this.headers = headers;
+      return this;
     }
 
-    public HttpMethod getMethod() {
-        return method;
+    public Builder charset(Charset charset) {
+      this.charset = charset;
+      return this;
     }
 
-    public String getUrl() {
-        return url;
+    public Builder body(String body) {
+      return body(body.getBytes(UTF_8));
     }
 
-    public RequestHeaders getHeaders() {
-        return headers;
+    public Builder body(byte[] body) {
+      this.body = body;
+      return this;
     }
 
-    public Charset getCharset() {
-        return charset;
+    public RequestKey build() {
+      return new RequestKey(this);
     }
 
-    public byte[] getBody() {
-        return body;
-    }
+  }
 
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((method == null) ? 0 : method.hashCode());
-        result = prime * result + ((url == null) ? 0 : url.hashCode());
-        return result;
-    }
+  public static Builder builder(HttpMethod method, String url) {
+    return new Builder(method, url);
+  }
 
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        final RequestKey other = (RequestKey) obj;
-        if (method != other.method)
-            return false;
-        if (url == null) {
-            if (other.url != null)
-                return false;
-        } else if (!url.equals(other.url))
-            return false;
-        return true;
-    }
+  public static RequestKey create(Request request) {
+    return new RequestKey(request);
+  }
 
-    public boolean equalsExtended(Object obj) {
-        if (equals(obj)) {
-            RequestKey other = (RequestKey) obj;
-            boolean headersEqual =
-                    other.headers == null || headers == null || headers.equals(other.headers);
-            boolean charsetEqual =
-                    other.charset == null || charset == null || charset.equals(other.charset);
-            boolean bodyEqual = other.body == null || body == null || Arrays.equals(other.body, body);
-            return headersEqual && charsetEqual && bodyEqual;
-        }
+  private static String buildUrl(Request request) {
+    try {
+      return URLDecoder.decode(request.url(), Util.UTF_8.name());
+    } catch (final UnsupportedEncodingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private final HttpMethod method;
+
+  private final String url;
+
+  private final RequestHeaders headers;
+
+  private final Charset charset;
+
+  private final byte[] body;
+
+  private RequestKey(Builder builder) {
+    this.method = builder.method;
+    this.url = builder.url;
+    this.headers = builder.headers;
+    this.charset = builder.charset;
+    this.body = builder.body;
+  }
+
+  private RequestKey(Request request) {
+    this.method = HttpMethod.valueOf(request.method());
+    this.url = buildUrl(request);
+    this.headers = RequestHeaders.of(request.headers());
+    this.charset = request.charset();
+    this.body = request.body();
+  }
+
+  public HttpMethod getMethod() {
+    return method;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public RequestHeaders getHeaders() {
+    return headers;
+  }
+
+  public Charset getCharset() {
+    return charset;
+  }
+
+  public byte[] getBody() {
+    return body;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((method == null) ? 0 : method.hashCode());
+    result = prime * result + ((url == null) ? 0 : url.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    final RequestKey other = (RequestKey) obj;
+    if (method != other.method) {
+      return false;
+    }
+    if (url == null) {
+      if (other.url != null) {
         return false;
+      }
+    } else if (!url.equals(other.url)) {
+      return false;
     }
+    return true;
+  }
 
-    @Override
-    public String toString() {
-        return String.format("Request [%s %s: %s headers and %s]", method, url,
-                headers == null ? "without" : "with " + headers,
-                charset == null ? "no charset" : "charset " + charset);
+  public boolean equalsExtended(Object obj) {
+    if (equals(obj)) {
+      RequestKey other = (RequestKey) obj;
+      boolean headersEqual =
+        other.headers == null || headers == null || headers.equals(other.headers);
+      boolean charsetEqual =
+        other.charset == null || charset == null || charset.equals(other.charset);
+      boolean bodyEqual = other.body == null || body == null || Arrays.equals(other.body, body);
+      return headersEqual && charsetEqual && bodyEqual;
     }
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("Request [%s %s: %s headers and %s]", method, url,
+      headers == null ? "without" : "with " + headers,
+      charset == null ? "no charset" : "charset " + charset);
+  }
 
 }

--- a/mock/src/main/java/feign/mock/RequestKey.java
+++ b/mock/src/main/java/feign/mock/RequestKey.java
@@ -14,13 +14,14 @@
 package feign.mock;
 
 import static feign.Util.UTF_8;
-
-import feign.Request;
-import feign.Util;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import feign.Request;
+import feign.Util;
 
 public class RequestKey {
 
@@ -39,6 +40,12 @@ public class RequestKey {
     private Builder(HttpMethod method, String url) {
       this.method = method;
       this.url = url;
+    }
+
+    @Deprecated
+    public Builder headers(Map<String, Collection<String>> headers) {
+      this.headers = RequestHeaders.of(headers);
+      return this;
     }
 
     public Builder headers(RequestHeaders headers) {
@@ -153,22 +160,18 @@ public class RequestKey {
       return false;
     }
     if (url == null) {
-      if (other.url != null) {
-        return false;
-      }
-    } else if (!url.equals(other.url)) {
-      return false;
-    }
-    return true;
+      return other.url == null;
+    } else
+      return url.equals(other.url);
   }
 
   public boolean equalsExtended(Object obj) {
     if (equals(obj)) {
       RequestKey other = (RequestKey) obj;
       boolean headersEqual =
-        other.headers == null || headers == null || headers.equals(other.headers);
+          other.headers == null || headers == null || headers.equals(other.headers);
       boolean charsetEqual =
-        other.charset == null || charset == null || charset.equals(other.charset);
+          other.charset == null || charset == null || charset.equals(other.charset);
       boolean bodyEqual = other.body == null || body == null || Arrays.equals(other.body, body);
       return headersEqual && charsetEqual && bodyEqual;
     }
@@ -178,8 +181,8 @@ public class RequestKey {
   @Override
   public String toString() {
     return String.format("Request [%s %s: %s headers and %s]", method, url,
-      headers == null ? "without" : "with " + headers,
-      charset == null ? "no charset" : "charset " + charset);
+        headers == null ? "without" : "with " + headers,
+        charset == null ? "no charset" : "charset " + charset);
   }
 
 }

--- a/mock/src/main/java/feign/mock/RequestKey.java
+++ b/mock/src/main/java/feign/mock/RequestKey.java
@@ -13,168 +13,168 @@
  */
 package feign.mock;
 
-import static feign.Util.UTF_8;
+import feign.Request;
+import feign.Util;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Map;
-import feign.Request;
-import feign.Util;
+
+import static feign.Util.UTF_8;
 
 public class RequestKey {
 
-  public static class Builder {
+    public static class Builder {
+
+        private final HttpMethod method;
+
+        private final String url;
+
+        private RequestHeaders headers;
+
+        private Charset charset;
+
+        private byte[] body;
+
+        private Builder(HttpMethod method, String url) {
+            this.method = method;
+            this.url = url;
+        }
+
+        public Builder headers(RequestHeaders headers) {
+            this.headers = headers;
+            return this;
+        }
+
+        public Builder charset(Charset charset) {
+            this.charset = charset;
+            return this;
+        }
+
+        public Builder body(String body) {
+            return body(body.getBytes(UTF_8));
+        }
+
+        public Builder body(byte[] body) {
+            this.body = body;
+            return this;
+        }
+
+        public RequestKey build() {
+            return new RequestKey(this);
+        }
+
+    }
+
+    public static Builder builder(HttpMethod method, String url) {
+        return new Builder(method, url);
+    }
+
+    public static RequestKey create(Request request) {
+        return new RequestKey(request);
+    }
+
+    private static String buildUrl(Request request) {
+        try {
+            return URLDecoder.decode(request.url(), Util.UTF_8.name());
+        } catch (final UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     private final HttpMethod method;
 
     private final String url;
 
-    private Map<String, Collection<String>> headers;
+    private final RequestHeaders headers;
 
-    private Charset charset;
+    private final Charset charset;
 
-    private byte[] body;
+    private final byte[] body;
 
-    private Builder(HttpMethod method, String url) {
-      this.method = method;
-      this.url = url;
+    private RequestKey(Builder builder) {
+        this.method = builder.method;
+        this.url = builder.url;
+        this.headers = builder.headers;
+        this.charset = builder.charset;
+        this.body = builder.body;
     }
 
-    public Builder headers(Map<String, Collection<String>> headers) {
-      this.headers = headers;
-      return this;
+    private RequestKey(Request request) {
+        this.method = HttpMethod.valueOf(request.method());
+        this.url = buildUrl(request);
+        this.headers = RequestHeaders.of(request.headers());
+        this.charset = request.charset();
+        this.body = request.body();
     }
 
-    public Builder charset(Charset charset) {
-      this.charset = charset;
-      return this;
+    public HttpMethod getMethod() {
+        return method;
     }
 
-    public Builder body(String body) {
-      return body(body.getBytes(UTF_8));
+    public String getUrl() {
+        return url;
     }
 
-    public Builder body(byte[] body) {
-      this.body = body;
-      return this;
+    public RequestHeaders getHeaders() {
+        return headers;
     }
 
-    public RequestKey build() {
-      return new RequestKey(this);
+    public Charset getCharset() {
+        return charset;
     }
 
-  }
-
-  public static Builder builder(HttpMethod method, String url) {
-    return new Builder(method, url);
-  }
-
-  public static RequestKey create(Request request) {
-    return new RequestKey(request);
-  }
-
-  private static String buildUrl(Request request) {
-    try {
-      return URLDecoder.decode(request.url(), Util.UTF_8.name());
-    } catch (final UnsupportedEncodingException e) {
-      throw new RuntimeException(e);
+    public byte[] getBody() {
+        return body;
     }
-  }
 
-  private final HttpMethod method;
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((method == null) ? 0 : method.hashCode());
+        result = prime * result + ((url == null) ? 0 : url.hashCode());
+        return result;
+    }
 
-  private final String url;
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        final RequestKey other = (RequestKey) obj;
+        if (method != other.method)
+            return false;
+        if (url == null) {
+            if (other.url != null)
+                return false;
+        } else if (!url.equals(other.url))
+            return false;
+        return true;
+    }
 
-  private final Map<String, Collection<String>> headers;
-
-  private final Charset charset;
-
-  private final byte[] body;
-
-  private RequestKey(Builder builder) {
-    this.method = builder.method;
-    this.url = builder.url;
-    this.headers = builder.headers;
-    this.charset = builder.charset;
-    this.body = builder.body;
-  }
-
-  private RequestKey(Request request) {
-    this.method = HttpMethod.valueOf(request.method());
-    this.url = buildUrl(request);
-    this.headers = request.headers();
-    this.charset = request.charset();
-    this.body = request.body();
-  }
-
-  public HttpMethod getMethod() {
-    return method;
-  }
-
-  public String getUrl() {
-    return url;
-  }
-
-  public Map<String, Collection<String>> getHeaders() {
-    return headers;
-  }
-
-  public Charset getCharset() {
-    return charset;
-  }
-
-  public byte[] getBody() {
-    return body;
-  }
-
-  @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((method == null) ? 0 : method.hashCode());
-    result = prime * result + ((url == null) ? 0 : url.hashCode());
-    return result;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj)
-      return true;
-    if (obj == null)
-      return false;
-    if (getClass() != obj.getClass())
-      return false;
-    final RequestKey other = (RequestKey) obj;
-    if (method != other.method)
-      return false;
-    if (url == null) {
-      if (other.url != null)
+    public boolean equalsExtended(Object obj) {
+        if (equals(obj)) {
+            RequestKey other = (RequestKey) obj;
+            boolean headersEqual =
+                    other.headers == null || headers == null || headers.equals(other.headers);
+            boolean charsetEqual =
+                    other.charset == null || charset == null || charset.equals(other.charset);
+            boolean bodyEqual = other.body == null || body == null || Arrays.equals(other.body, body);
+            return headersEqual && charsetEqual && bodyEqual;
+        }
         return false;
-    } else if (!url.equals(other.url))
-      return false;
-    return true;
-  }
-
-  public boolean equalsExtended(Object obj) {
-    if (equals(obj)) {
-      RequestKey other = (RequestKey) obj;
-      boolean headersEqual =
-          other.headers == null || headers == null || headers.equals(other.headers);
-      boolean charsetEqual =
-          other.charset == null || charset == null || charset.equals(other.charset);
-      boolean bodyEqual = other.body == null || body == null || Arrays.equals(other.body, body);
-      return headersEqual && charsetEqual && bodyEqual;
     }
-    return false;
-  }
 
-  @Override
-  public String toString() {
-    return String.format("Request [%s %s: %s headers and %s]", method, url,
-        headers == null ? "without" : "with " + headers.size(),
-        charset == null ? "no charset" : "charset " + charset);
-  }
+    @Override
+    public String toString() {
+        return String.format("Request [%s %s: %s headers and %s]", method, url,
+                headers == null ? "without" : "with " + headers,
+                charset == null ? "no charset" : "charset " + charset);
+    }
 
 }

--- a/mock/src/test/java/feign/mock/MockClientSequentialTest.java
+++ b/mock/src/test/java/feign/mock/MockClientSequentialTest.java
@@ -172,7 +172,6 @@ public class MockClientSequentialTest {
       githubSequential.contributors("7 7", "netflix", "feign");
       fail();
     } catch (VerificationAssertionError e) {
-      System.out.println(e.getMessage());
       assertThat(e.getMessage(), startsWith("Expected Request ["));
     }
   }

--- a/mock/src/test/java/feign/mock/MockClientSequentialTest.java
+++ b/mock/src/test/java/feign/mock/MockClientSequentialTest.java
@@ -95,8 +95,7 @@ public class MockClientSequentialTest {
 
   @Before
   public void setup() throws IOException {
-    InputStream input = getClass().getResourceAsStream("/fixtures/contributors.json");
-    try {
+    try (InputStream input = getClass().getResourceAsStream("/fixtures/contributors.json")) {
       byte[] data = toByteArray(input);
       RequestHeaders headers = RequestHeaders
           .builder()
@@ -115,9 +114,7 @@ public class MockClientSequentialTest {
               .add(HttpMethod.GET, "/repos/netflix/feign/contributors",
                   Response.builder().status(HttpsURLConnection.HTTP_OK)
                       .headers(RequestHeaders.EMPTY).body(data)))
-          .target(new MockTarget<GitHub>(GitHub.class));
-    } finally {
-      input.close();
+          .target(new MockTarget<>(GitHub.class));
     }
   }
 

--- a/mock/src/test/java/feign/mock/MockClientSequentialTest.java
+++ b/mock/src/test/java/feign/mock/MockClientSequentialTest.java
@@ -20,7 +20,14 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.fail;
-
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+import java.util.List;
+import javax.net.ssl.HttpsURLConnection;
+import org.junit.Before;
+import org.junit.Test;
 import feign.Body;
 import feign.Feign;
 import feign.FeignException;
@@ -31,14 +38,6 @@ import feign.Response;
 import feign.codec.DecodeException;
 import feign.codec.Decoder;
 import feign.gson.GsonDecoder;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.reflect.Type;
-import java.util.List;
-import javax.net.ssl.HttpsURLConnection;
-import org.junit.Before;
-import org.junit.Test;
 
 public class MockClientSequentialTest {
 
@@ -50,8 +49,8 @@ public class MockClientSequentialTest {
 
     @RequestLine("GET /repos/{owner}/{repo}/contributors?client_id={client_id}")
     List<Contributor> contributors(@Param("client_id") String clientId,
-      @Param("owner") String owner,
-      @Param("repo") String repo);
+                                   @Param("owner") String owner,
+                                   @Param("repo") String repo);
 
     @RequestLine("PATCH /repos/{owner}/{repo}/contributors")
     List<Contributor> patchContributors(@Param("owner") String owner, @Param("repo") String repo);
@@ -59,9 +58,9 @@ public class MockClientSequentialTest {
     @RequestLine("POST /repos/{owner}/{repo}/contributors")
     @Body("%7B\"login\":\"{login}\",\"type\":\"{type}\"%7D")
     Contributor create(@Param("owner") String owner,
-      @Param("repo") String repo,
-      @Param("login") String login,
-      @Param("type") String type);
+                       @Param("repo") String repo,
+                       @Param("login") String login,
+                       @Param("type") String type);
 
   }
 
@@ -83,7 +82,7 @@ public class MockClientSequentialTest {
 
     @Override
     public Object decode(Response response, Type type)
-      throws IOException, DecodeException, FeignException {
+        throws IOException, DecodeException, FeignException {
       assertThat(response.request(), notNullValue());
 
       return delegate.decode(response, type);
@@ -92,7 +91,6 @@ public class MockClientSequentialTest {
   }
 
   private GitHub githubSequential;
-
   private MockClient mockClientSequential;
 
   @Before
@@ -101,23 +99,23 @@ public class MockClientSequentialTest {
     try {
       byte[] data = toByteArray(input);
       RequestHeaders headers = RequestHeaders
-        .builder()
-        .add("Name", "netflix")
-        .build();
+          .builder()
+          .add("Name", "netflix")
+          .build();
       mockClientSequential = new MockClient(true);
       githubSequential = Feign.builder().decoder(new AssertionDecoder(new GsonDecoder()))
-        .client(mockClientSequential
-          .add(RequestKey
-            .builder(HttpMethod.GET, "/repos/netflix/feign/contributors")
-            .headers(headers).build(), HttpsURLConnection.HTTP_OK, data)
-          .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=55",
-            HttpsURLConnection.HTTP_NOT_FOUND)
-          .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=7 7",
-            HttpsURLConnection.HTTP_INTERNAL_ERROR, new ByteArrayInputStream(data))
-          .add(HttpMethod.GET, "/repos/netflix/feign/contributors",
-            Response.builder().status(HttpsURLConnection.HTTP_OK)
-              .headers(RequestHeaders.EMPTY).body(data)))
-        .target(new MockTarget<GitHub>(GitHub.class));
+          .client(mockClientSequential
+              .add(RequestKey
+                  .builder(HttpMethod.GET, "/repos/netflix/feign/contributors")
+                  .headers(headers).build(), HttpsURLConnection.HTTP_OK, data)
+              .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=55",
+                  HttpsURLConnection.HTTP_NOT_FOUND)
+              .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=7 7",
+                  HttpsURLConnection.HTTP_INTERNAL_ERROR, new ByteArrayInputStream(data))
+              .add(HttpMethod.GET, "/repos/netflix/feign/contributors",
+                  Response.builder().status(HttpsURLConnection.HTTP_OK)
+                      .headers(RequestHeaders.EMPTY).body(data)))
+          .target(new MockTarget<GitHub>(GitHub.class));
     } finally {
       input.close();
     }

--- a/mock/src/test/java/feign/mock/MockClientSequentialTest.java
+++ b/mock/src/test/java/feign/mock/MockClientSequentialTest.java
@@ -20,150 +20,156 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.fail;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Type;
-import java.util.List;
+import java.util.*;
 import javax.net.ssl.HttpsURLConnection;
+
+import feign.*;
 import org.junit.Before;
 import org.junit.Test;
-import feign.Body;
-import feign.Feign;
-import feign.FeignException;
-import feign.Param;
-import feign.RequestLine;
-import feign.Response;
 import feign.codec.DecodeException;
 import feign.codec.Decoder;
 import feign.gson.GsonDecoder;
 
 public class MockClientSequentialTest {
 
-  interface GitHub {
+    interface GitHub {
 
-    @RequestLine("GET /repos/{owner}/{repo}/contributors")
-    List<Contributor> contributors(@Param("owner") String owner, @Param("repo") String repo);
+        @Headers({"Name: {owner}"})
+        @RequestLine("GET /repos/{owner}/{repo}/contributors")
+        List<Contributor> contributors(@Param("owner") String owner, @Param("repo") String repo);
 
-    @RequestLine("GET /repos/{owner}/{repo}/contributors?client_id={client_id}")
-    List<Contributor> contributors(@Param("client_id") String clientId,
-                                   @Param("owner") String owner,
-                                   @Param("repo") String repo);
+        @RequestLine("GET /repos/{owner}/{repo}/contributors?client_id={client_id}")
+        List<Contributor> contributors(@Param("client_id") String clientId,
+                                       @Param("owner") String owner,
+                                       @Param("repo") String repo);
 
-    @RequestLine("PATCH /repos/{owner}/{repo}/contributors")
-    List<Contributor> patchContributors(@Param("owner") String owner, @Param("repo") String repo);
+        @RequestLine("PATCH /repos/{owner}/{repo}/contributors")
+        List<Contributor> patchContributors(@Param("owner") String owner, @Param("repo") String repo);
 
-    @RequestLine("POST /repos/{owner}/{repo}/contributors")
-    @Body("%7B\"login\":\"{login}\",\"type\":\"{type}\"%7D")
-    Contributor create(@Param("owner") String owner,
-                       @Param("repo") String repo,
-                       @Param("login") String login,
-                       @Param("type") String type);
+        @RequestLine("POST /repos/{owner}/{repo}/contributors")
+        @Body("%7B\"login\":\"{login}\",\"type\":\"{type}\"%7D")
+        Contributor create(@Param("owner") String owner,
+                           @Param("repo") String repo,
+                           @Param("login") String login,
+                           @Param("type") String type);
 
-  }
-
-  static class Contributor {
-
-    String login;
-
-    int contributions;
-
-  }
-
-  class AssertionDecoder implements Decoder {
-
-    private final Decoder delegate;
-
-    public AssertionDecoder(Decoder delegate) {
-      this.delegate = delegate;
     }
 
-    @Override
-    public Object decode(Response response, Type type)
-        throws IOException, DecodeException, FeignException {
-      assertThat(response.request(), notNullValue());
+    static class Contributor {
 
-      return delegate.decode(response, type);
+        String login;
+
+        int contributions;
+
     }
 
-  }
+    class AssertionDecoder implements Decoder {
 
-  private GitHub githubSequential;
+        private final Decoder delegate;
 
-  private MockClient mockClientSequential;
+        public AssertionDecoder(Decoder delegate) {
+            this.delegate = delegate;
+        }
 
-  @Before
-  public void setup() throws IOException {
-    try (InputStream input = getClass().getResourceAsStream("/fixtures/contributors.json")) {
-      byte[] data = toByteArray(input);
+        @Override
+        public Object decode(Response response, Type type)
+                throws IOException, DecodeException, FeignException {
+            assertThat(response.request(), notNullValue());
 
-      mockClientSequential = new MockClient(true);
-      githubSequential = Feign.builder().decoder(new AssertionDecoder(new GsonDecoder()))
-          .client(mockClientSequential
-              .add(HttpMethod.GET, "/repos/netflix/feign/contributors", HttpsURLConnection.HTTP_OK,
-                  data)
-              .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=55",
-                  HttpsURLConnection.HTTP_NOT_FOUND)
-              .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=7 7",
-                  HttpsURLConnection.HTTP_INTERNAL_ERROR, new ByteArrayInputStream(data))
-              .add(HttpMethod.GET, "/repos/netflix/feign/contributors",
-                  Response.builder().status(HttpsURLConnection.HTTP_OK)
-                      .headers(MockClient.EMPTY_HEADERS).body(data)))
-          .target(new MockTarget<>(GitHub.class));
+            return delegate.decode(response, type);
+        }
+
     }
-  }
 
-  @Test
-  public void sequentialRequests() throws Exception {
-    githubSequential.contributors("netflix", "feign");
-    try {
-      githubSequential.contributors("55", "netflix", "feign");
-      fail();
-    } catch (FeignException e) {
-      assertThat(e.status(), equalTo(HttpsURLConnection.HTTP_NOT_FOUND));
+    private GitHub githubSequential;
+
+    private MockClient mockClientSequential;
+
+    @Before
+    public void setup() throws IOException {
+        InputStream input = getClass().getResourceAsStream("/fixtures/contributors.json");
+        try {
+            byte[] data = toByteArray(input);
+            RequestHeaders headers = RequestHeaders
+                    .builder()
+                    .add("Name", "netflix")
+                    .build();
+            mockClientSequential = new MockClient(true);
+            githubSequential = Feign.builder().decoder(new AssertionDecoder(new GsonDecoder()))
+                    .client(mockClientSequential
+                            .add(RequestKey
+                                    .builder(HttpMethod.GET, "/repos/netflix/feign/contributors")
+                                    .headers(headers).build(), HttpsURLConnection.HTTP_OK, data)
+                            .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=55",
+                                    HttpsURLConnection.HTTP_NOT_FOUND)
+                            .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=7 7",
+                                    HttpsURLConnection.HTTP_INTERNAL_ERROR, new ByteArrayInputStream(data))
+                            .add(HttpMethod.GET, "/repos/netflix/feign/contributors",
+                                    Response.builder().status(HttpsURLConnection.HTTP_OK)
+                                            .headers(RequestHeaders.EMPTY).body(data)))
+                    .target(new MockTarget<GitHub>(GitHub.class));
+        } finally {
+            input.close();
+        }
     }
-    try {
-      githubSequential.contributors("7 7", "netflix", "feign");
-      fail();
-    } catch (FeignException e) {
-      assertThat(e.status(), equalTo(HttpsURLConnection.HTTP_INTERNAL_ERROR));
+
+    @Test
+    public void sequentialRequests() throws Exception {
+        githubSequential.contributors("netflix", "feign");
+        try {
+            githubSequential.contributors("55", "netflix", "feign");
+            fail();
+        } catch (FeignException e) {
+            assertThat(e.status(), equalTo(HttpsURLConnection.HTTP_NOT_FOUND));
+        }
+        try {
+            githubSequential.contributors("7 7", "netflix", "feign");
+            fail();
+        } catch (FeignException e) {
+            assertThat(e.status(), equalTo(HttpsURLConnection.HTTP_INTERNAL_ERROR));
+        }
+        githubSequential.contributors("netflix", "feign");
+
+        mockClientSequential.verifyStatus();
     }
-    githubSequential.contributors("netflix", "feign");
 
-    mockClientSequential.verifyStatus();
-  }
-
-  @Test
-  public void sequentialRequestsCalledTooLess() throws Exception {
-    githubSequential.contributors("netflix", "feign");
-    try {
-      mockClientSequential.verifyStatus();
-      fail();
-    } catch (VerificationAssertionError e) {
-      assertThat(e.getMessage(), startsWith("More executions"));
+    @Test
+    public void sequentialRequestsCalledTooLess() throws Exception {
+        githubSequential.contributors("netflix", "feign");
+        try {
+            mockClientSequential.verifyStatus();
+            fail();
+        } catch (VerificationAssertionError e) {
+            assertThat(e.getMessage(), startsWith("More executions"));
+        }
     }
-  }
 
-  @Test
-  public void sequentialRequestsCalledTooMany() throws Exception {
-    sequentialRequests();
+    @Test
+    public void sequentialRequestsCalledTooMany() throws Exception {
+        sequentialRequests();
 
-    try {
-      githubSequential.contributors("netflix", "feign");
-      fail();
-    } catch (VerificationAssertionError e) {
-      assertThat(e.getMessage(), containsString("excessive"));
+        try {
+            githubSequential.contributors("netflix", "feign");
+            fail();
+        } catch (VerificationAssertionError e) {
+            assertThat(e.getMessage(), containsString("excessive"));
+        }
     }
-  }
 
-  @Test
-  public void sequentialRequestsInWrongOrder() throws Exception {
-    try {
-      githubSequential.contributors("7 7", "netflix", "feign");
-      fail();
-    } catch (VerificationAssertionError e) {
-      assertThat(e.getMessage(), startsWith("Expected Request ["));
+    @Test
+    public void sequentialRequestsInWrongOrder() throws Exception {
+        try {
+            githubSequential.contributors("7 7", "netflix", "feign");
+            fail();
+        } catch (VerificationAssertionError e) {
+            System.out.println(e.getMessage());
+            assertThat(e.getMessage(), startsWith("Expected Request ["));
+        }
     }
-  }
 
 }

--- a/mock/src/test/java/feign/mock/MockClientTest.java
+++ b/mock/src/test/java/feign/mock/MockClientTest.java
@@ -95,8 +95,7 @@ public class MockClientTest {
 
   @Before
   public void setup() throws IOException {
-    InputStream input = getClass().getResourceAsStream("/fixtures/contributors.json");
-    try {
+    try (InputStream input = getClass().getResourceAsStream("/fixtures/contributors.json")) {
       byte[] data = toByteArray(input);
       mockClient = new MockClient();
       github = Feign.builder().decoder(new AssertionDecoder(new GsonDecoder()))
@@ -115,9 +114,7 @@ public class MockClientTest {
                   HttpsURLConnection.HTTP_INTERNAL_ERROR, "")
               .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=123456789",
                   HttpsURLConnection.HTTP_INTERNAL_ERROR, data))
-          .target(new MockTarget<GitHub>(GitHub.class));
-    } finally {
-      input.close();
+          .target(new MockTarget<>(GitHub.class));
     }
   }
 

--- a/mock/src/test/java/feign/mock/MockClientTest.java
+++ b/mock/src/test/java/feign/mock/MockClientTest.java
@@ -13,249 +13,257 @@
  */
 package feign.mock;
 
-import feign.*;
+import static feign.Util.toByteArray;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.fail;
+
+import feign.Body;
+import feign.Feign;
+import feign.FeignException;
+import feign.Param;
+import feign.Request;
+import feign.RequestLine;
+import feign.Response;
 import feign.codec.DecodeException;
 import feign.codec.Decoder;
 import feign.gson.GsonDecoder;
-import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
-
-import javax.net.ssl.HttpsURLConnection;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Type;
 import java.util.List;
-
-import static feign.Util.toByteArray;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.fail;
+import javax.net.ssl.HttpsURLConnection;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
 
 public class MockClientTest {
 
-    interface GitHub {
+  interface GitHub {
 
-        @RequestLine("GET /repos/{owner}/{repo}/contributors")
-        List<Contributor> contributors(@Param("owner") String owner, @Param("repo") String repo);
+    @RequestLine("GET /repos/{owner}/{repo}/contributors")
+    List<Contributor> contributors(@Param("owner") String owner, @Param("repo") String repo);
 
-        @RequestLine("GET /repos/{owner}/{repo}/contributors?client_id={client_id}")
-        List<Contributor> contributors(@Param("client_id") String clientId,
-                                       @Param("owner") String owner,
-                                       @Param("repo") String repo);
+    @RequestLine("GET /repos/{owner}/{repo}/contributors?client_id={client_id}")
+    List<Contributor> contributors(@Param("client_id") String clientId,
+      @Param("owner") String owner,
+      @Param("repo") String repo);
 
-        @RequestLine("PATCH /repos/{owner}/{repo}/contributors")
-        List<Contributor> patchContributors(@Param("owner") String owner, @Param("repo") String repo);
+    @RequestLine("PATCH /repos/{owner}/{repo}/contributors")
+    List<Contributor> patchContributors(@Param("owner") String owner, @Param("repo") String repo);
 
-        @RequestLine("POST /repos/{owner}/{repo}/contributors")
-        @Body("%7B\"login\":\"{login}\",\"type\":\"{type}\"%7D")
-        Contributor create(@Param("owner") String owner,
-                           @Param("repo") String repo,
-                           @Param("login") String login,
-                           @Param("type") String type);
+    @RequestLine("POST /repos/{owner}/{repo}/contributors")
+    @Body("%7B\"login\":\"{login}\",\"type\":\"{type}\"%7D")
+    Contributor create(@Param("owner") String owner,
+      @Param("repo") String repo,
+      @Param("login") String login,
+      @Param("type") String type);
 
+  }
+
+  static class Contributor {
+
+    String login;
+
+    int contributions;
+
+  }
+
+  class AssertionDecoder implements Decoder {
+
+    private final Decoder delegate;
+
+    public AssertionDecoder(Decoder delegate) {
+      this.delegate = delegate;
     }
 
-    static class Contributor {
+    @Override
+    public Object decode(Response response, Type type)
+      throws IOException, DecodeException, FeignException {
+      assertThat(response.request(), notNullValue());
 
-        String login;
-
-        int contributions;
-
+      return delegate.decode(response, type);
     }
 
-    class AssertionDecoder implements Decoder {
+  }
 
-        private final Decoder delegate;
+  private GitHub github;
 
-        public AssertionDecoder(Decoder delegate) {
-            this.delegate = delegate;
-        }
+  private MockClient mockClient;
 
-        @Override
-        public Object decode(Response response, Type type)
-                throws IOException, DecodeException, FeignException {
-            assertThat(response.request(), notNullValue());
+  @Before
+  public void setup() throws IOException {
+    InputStream input = getClass().getResourceAsStream("/fixtures/contributors.json");
+    try {
+      byte[] data = toByteArray(input);
+      mockClient = new MockClient();
+      github = Feign.builder().decoder(new AssertionDecoder(new GsonDecoder()))
+        .client(mockClient.ok(HttpMethod.GET, "/repos/netflix/feign/contributors", data)
+          .ok(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=55")
+          .ok(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=7 7",
+            new ByteArrayInputStream(data))
+          .ok(HttpMethod.POST, "/repos/netflix/feign/contributors",
+            "{\"login\":\"velo\",\"contributions\":0}")
+          .noContent(HttpMethod.PATCH, "/repos/velo/feign-mock/contributors")
+          .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=1234567890",
+            HttpsURLConnection.HTTP_NOT_FOUND)
+          .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=123456789",
+            HttpsURLConnection.HTTP_INTERNAL_ERROR, new ByteArrayInputStream(data))
+          .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=123456789",
+            HttpsURLConnection.HTTP_INTERNAL_ERROR, "")
+          .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=123456789",
+            HttpsURLConnection.HTTP_INTERNAL_ERROR, data))
+        .target(new MockTarget<GitHub>(GitHub.class));
+    } finally {
+      input.close();
+    }
+  }
 
-            return delegate.decode(response, type);
-        }
+  @Test
+  public void hitMock() {
+    List<Contributor> contributors = github.contributors("netflix", "feign");
+    assertThat(contributors, hasSize(30));
+    mockClient.verifyStatus();
+  }
 
+  @Test
+  public void missMock() {
+    try {
+      github.contributors("velo", "feign-mock");
+      fail();
+    } catch (FeignException e) {
+      assertThat(e.getMessage(), Matchers.containsString("404"));
+    }
+  }
+
+  @Test
+  public void missHttpMethod() {
+    try {
+      github.patchContributors("netflix", "feign");
+      fail();
+    } catch (FeignException e) {
+      assertThat(e.getMessage(), Matchers.containsString("404"));
+    }
+  }
+
+  @Test
+  public void paramsEncoding() {
+    List<Contributor> contributors = github.contributors("7 7", "netflix", "feign");
+    assertThat(contributors, hasSize(30));
+    mockClient.verifyStatus();
+  }
+
+  @Test
+  public void verifyInvocation() {
+    Contributor contribution =
+      github.create("netflix", "feign", "velo_at_github", "preposterous hacker");
+    // making sure it received a proper response
+    assertThat(contribution, notNullValue());
+    assertThat(contribution.login, equalTo("velo"));
+    assertThat(contribution.contributions, equalTo(0));
+
+    List<Request> results =
+      mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 1);
+    assertThat(results, hasSize(1));
+
+    byte[] body = mockClient.verifyOne(HttpMethod.POST, "/repos/netflix/feign/contributors").body();
+    assertThat(body, notNullValue());
+
+    String message = new String(body);
+    assertThat(message, containsString("velo_at_github"));
+    assertThat(message, containsString("preposterous hacker"));
+
+    mockClient.verifyStatus();
+  }
+
+  @Test
+  public void verifyNone() {
+    github.create("netflix", "feign", "velo_at_github", "preposterous hacker");
+    mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 1);
+
+    try {
+      mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 0);
+      fail();
+    } catch (VerificationAssertionError e) {
+      assertThat(e.getMessage(), containsString("Do not wanted"));
+      assertThat(e.getMessage(), containsString("POST"));
+      assertThat(e.getMessage(), containsString("/repos/netflix/feign/contributors"));
     }
 
-    private GitHub github;
-
-    private MockClient mockClient;
-
-    @Before
-    public void setup() throws IOException {
-        InputStream input = getClass().getResourceAsStream("/fixtures/contributors.json");
-        try {
-            byte[] data = toByteArray(input);
-            mockClient = new MockClient();
-            github = Feign.builder().decoder(new AssertionDecoder(new GsonDecoder()))
-                    .client(mockClient.ok(HttpMethod.GET, "/repos/netflix/feign/contributors", data)
-                            .ok(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=55")
-                            .ok(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=7 7",
-                                    new ByteArrayInputStream(data))
-                            .ok(HttpMethod.POST, "/repos/netflix/feign/contributors",
-                                    "{\"login\":\"velo\",\"contributions\":0}")
-                            .noContent(HttpMethod.PATCH, "/repos/velo/feign-mock/contributors")
-                            .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=1234567890",
-                                    HttpsURLConnection.HTTP_NOT_FOUND)
-                            .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=123456789",
-                                    HttpsURLConnection.HTTP_INTERNAL_ERROR, new ByteArrayInputStream(data))
-                            .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=123456789",
-                                    HttpsURLConnection.HTTP_INTERNAL_ERROR, "")
-                            .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=123456789",
-                                    HttpsURLConnection.HTTP_INTERNAL_ERROR, data))
-                    .target(new MockTarget<GitHub>(GitHub.class));
-        } finally {
-            input.close();
-        }
+    try {
+      mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 3);
+      fail();
+    } catch (VerificationAssertionError e) {
+      assertThat(e.getMessage(), containsString("Wanted"));
+      assertThat(e.getMessage(), containsString("POST"));
+      assertThat(e.getMessage(), containsString("/repos/netflix/feign/contributors"));
+      assertThat(e.getMessage(), containsString("'3'"));
+      assertThat(e.getMessage(), containsString("'1'"));
     }
+  }
 
-    @Test
-    public void hitMock() {
-        List<Contributor> contributors = github.contributors("netflix", "feign");
-        assertThat(contributors, hasSize(30));
-        mockClient.verifyStatus();
+  @Test
+  public void verifyNotInvoked() {
+    mockClient.verifyNever(HttpMethod.POST, "/repos/netflix/feign/contributors");
+    List<Request> results =
+      mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 0);
+    assertThat(results, hasSize(0));
+    try {
+      mockClient.verifyOne(HttpMethod.POST, "/repos/netflix/feign/contributors");
+      fail();
+    } catch (VerificationAssertionError e) {
+      assertThat(e.getMessage(), containsString("Wanted"));
+      assertThat(e.getMessage(), containsString("POST"));
+      assertThat(e.getMessage(), containsString("/repos/netflix/feign/contributors"));
+      assertThat(e.getMessage(), containsString("never invoked"));
     }
+  }
 
-    @Test
-    public void missMock() {
-        try {
-            github.contributors("velo", "feign-mock");
-            fail();
-        } catch (FeignException e) {
-            assertThat(e.getMessage(), Matchers.containsString("404"));
-        }
+  @Test
+  public void verifyNegative() {
+    try {
+      mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", -1);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage(), containsString("non negative"));
     }
+  }
 
-    @Test
-    public void missHttpMethod() {
-        try {
-            github.patchContributors("netflix", "feign");
-            fail();
-        } catch (FeignException e) {
-            assertThat(e.getMessage(), Matchers.containsString("404"));
-        }
-    }
+  @Test
+  public void verifyMultipleRequests() {
+    mockClient.verifyNever(HttpMethod.POST, "/repos/netflix/feign/contributors");
 
-    @Test
-    public void paramsEncoding() {
-        List<Contributor> contributors = github.contributors("7 7", "netflix", "feign");
-        assertThat(contributors, hasSize(30));
-        mockClient.verifyStatus();
-    }
+    github.create("netflix", "feign", "velo_at_github", "preposterous hacker");
+    Request result = mockClient.verifyOne(HttpMethod.POST, "/repos/netflix/feign/contributors");
+    assertThat(result, notNullValue());
 
-    @Test
-    public void verifyInvocation() {
-        Contributor contribution =
-                github.create("netflix", "feign", "velo_at_github", "preposterous hacker");
-        // making sure it received a proper response
-        assertThat(contribution, notNullValue());
-        assertThat(contribution.login, equalTo("velo"));
-        assertThat(contribution.contributions, equalTo(0));
+    github.create("netflix", "feign", "velo_at_github", "preposterous hacker");
+    List<Request> results =
+      mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 2);
+    assertThat(results, hasSize(2));
 
-        List<Request> results =
-                mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 1);
-        assertThat(results, hasSize(1));
+    github.create("netflix", "feign", "velo_at_github", "preposterous hacker");
+    results = mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 3);
+    assertThat(results, hasSize(3));
 
-        byte[] body = mockClient.verifyOne(HttpMethod.POST, "/repos/netflix/feign/contributors").body();
-        assertThat(body, notNullValue());
+    mockClient.verifyStatus();
+  }
 
-        String message = new String(body);
-        assertThat(message, containsString("velo_at_github"));
-        assertThat(message, containsString("preposterous hacker"));
+  @Test
+  public void resetRequests() {
+    mockClient.verifyNever(HttpMethod.POST, "/repos/netflix/feign/contributors");
 
-        mockClient.verifyStatus();
-    }
+    github.create("netflix", "feign", "velo_at_github", "preposterous hacker");
+    Request result = mockClient.verifyOne(HttpMethod.POST, "/repos/netflix/feign/contributors");
+    assertThat(result, notNullValue());
 
-    @Test
-    public void verifyNone() {
-        github.create("netflix", "feign", "velo_at_github", "preposterous hacker");
-        mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 1);
+    mockClient.resetRequests();
 
-        try {
-            mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 0);
-            fail();
-        } catch (VerificationAssertionError e) {
-            assertThat(e.getMessage(), containsString("Do not wanted"));
-            assertThat(e.getMessage(), containsString("POST"));
-            assertThat(e.getMessage(), containsString("/repos/netflix/feign/contributors"));
-        }
-
-        try {
-            mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 3);
-            fail();
-        } catch (VerificationAssertionError e) {
-            assertThat(e.getMessage(), containsString("Wanted"));
-            assertThat(e.getMessage(), containsString("POST"));
-            assertThat(e.getMessage(), containsString("/repos/netflix/feign/contributors"));
-            assertThat(e.getMessage(), containsString("'3'"));
-            assertThat(e.getMessage(), containsString("'1'"));
-        }
-    }
-
-    @Test
-    public void verifyNotInvoked() {
-        mockClient.verifyNever(HttpMethod.POST, "/repos/netflix/feign/contributors");
-        List<Request> results =
-                mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 0);
-        assertThat(results, hasSize(0));
-        try {
-            mockClient.verifyOne(HttpMethod.POST, "/repos/netflix/feign/contributors");
-            fail();
-        } catch (VerificationAssertionError e) {
-            assertThat(e.getMessage(), containsString("Wanted"));
-            assertThat(e.getMessage(), containsString("POST"));
-            assertThat(e.getMessage(), containsString("/repos/netflix/feign/contributors"));
-            assertThat(e.getMessage(), containsString("never invoked"));
-        }
-    }
-
-    @Test
-    public void verifyNegative() {
-        try {
-            mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", -1);
-            fail();
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), containsString("non negative"));
-        }
-    }
-
-    @Test
-    public void verifyMultipleRequests() {
-        mockClient.verifyNever(HttpMethod.POST, "/repos/netflix/feign/contributors");
-
-        github.create("netflix", "feign", "velo_at_github", "preposterous hacker");
-        Request result = mockClient.verifyOne(HttpMethod.POST, "/repos/netflix/feign/contributors");
-        assertThat(result, notNullValue());
-
-        github.create("netflix", "feign", "velo_at_github", "preposterous hacker");
-        List<Request> results =
-                mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 2);
-        assertThat(results, hasSize(2));
-
-        github.create("netflix", "feign", "velo_at_github", "preposterous hacker");
-        results = mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 3);
-        assertThat(results, hasSize(3));
-
-        mockClient.verifyStatus();
-    }
-
-    @Test
-    public void resetRequests() {
-        mockClient.verifyNever(HttpMethod.POST, "/repos/netflix/feign/contributors");
-
-        github.create("netflix", "feign", "velo_at_github", "preposterous hacker");
-        Request result = mockClient.verifyOne(HttpMethod.POST, "/repos/netflix/feign/contributors");
-        assertThat(result, notNullValue());
-
-        mockClient.resetRequests();
-
-        mockClient.verifyNever(HttpMethod.POST, "/repos/netflix/feign/contributors");
-    }
+    mockClient.verifyNever(HttpMethod.POST, "/repos/netflix/feign/contributors");
+  }
 
 }

--- a/mock/src/test/java/feign/mock/MockClientTest.java
+++ b/mock/src/test/java/feign/mock/MockClientTest.java
@@ -20,7 +20,15 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.fail;
-
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+import java.util.List;
+import javax.net.ssl.HttpsURLConnection;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
 import feign.Body;
 import feign.Feign;
 import feign.FeignException;
@@ -31,15 +39,6 @@ import feign.Response;
 import feign.codec.DecodeException;
 import feign.codec.Decoder;
 import feign.gson.GsonDecoder;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.reflect.Type;
-import java.util.List;
-import javax.net.ssl.HttpsURLConnection;
-import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
 
 public class MockClientTest {
 
@@ -50,8 +49,8 @@ public class MockClientTest {
 
     @RequestLine("GET /repos/{owner}/{repo}/contributors?client_id={client_id}")
     List<Contributor> contributors(@Param("client_id") String clientId,
-      @Param("owner") String owner,
-      @Param("repo") String repo);
+                                   @Param("owner") String owner,
+                                   @Param("repo") String repo);
 
     @RequestLine("PATCH /repos/{owner}/{repo}/contributors")
     List<Contributor> patchContributors(@Param("owner") String owner, @Param("repo") String repo);
@@ -59,9 +58,9 @@ public class MockClientTest {
     @RequestLine("POST /repos/{owner}/{repo}/contributors")
     @Body("%7B\"login\":\"{login}\",\"type\":\"{type}\"%7D")
     Contributor create(@Param("owner") String owner,
-      @Param("repo") String repo,
-      @Param("login") String login,
-      @Param("type") String type);
+                       @Param("repo") String repo,
+                       @Param("login") String login,
+                       @Param("type") String type);
 
   }
 
@@ -83,7 +82,7 @@ public class MockClientTest {
 
     @Override
     public Object decode(Response response, Type type)
-      throws IOException, DecodeException, FeignException {
+        throws IOException, DecodeException, FeignException {
       assertThat(response.request(), notNullValue());
 
       return delegate.decode(response, type);
@@ -92,7 +91,6 @@ public class MockClientTest {
   }
 
   private GitHub github;
-
   private MockClient mockClient;
 
   @Before
@@ -102,22 +100,22 @@ public class MockClientTest {
       byte[] data = toByteArray(input);
       mockClient = new MockClient();
       github = Feign.builder().decoder(new AssertionDecoder(new GsonDecoder()))
-        .client(mockClient.ok(HttpMethod.GET, "/repos/netflix/feign/contributors", data)
-          .ok(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=55")
-          .ok(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=7 7",
-            new ByteArrayInputStream(data))
-          .ok(HttpMethod.POST, "/repos/netflix/feign/contributors",
-            "{\"login\":\"velo\",\"contributions\":0}")
-          .noContent(HttpMethod.PATCH, "/repos/velo/feign-mock/contributors")
-          .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=1234567890",
-            HttpsURLConnection.HTTP_NOT_FOUND)
-          .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=123456789",
-            HttpsURLConnection.HTTP_INTERNAL_ERROR, new ByteArrayInputStream(data))
-          .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=123456789",
-            HttpsURLConnection.HTTP_INTERNAL_ERROR, "")
-          .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=123456789",
-            HttpsURLConnection.HTTP_INTERNAL_ERROR, data))
-        .target(new MockTarget<GitHub>(GitHub.class));
+          .client(mockClient.ok(HttpMethod.GET, "/repos/netflix/feign/contributors", data)
+              .ok(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=55")
+              .ok(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=7 7",
+                  new ByteArrayInputStream(data))
+              .ok(HttpMethod.POST, "/repos/netflix/feign/contributors",
+                  "{\"login\":\"velo\",\"contributions\":0}")
+              .noContent(HttpMethod.PATCH, "/repos/velo/feign-mock/contributors")
+              .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=1234567890",
+                  HttpsURLConnection.HTTP_NOT_FOUND)
+              .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=123456789",
+                  HttpsURLConnection.HTTP_INTERNAL_ERROR, new ByteArrayInputStream(data))
+              .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=123456789",
+                  HttpsURLConnection.HTTP_INTERNAL_ERROR, "")
+              .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=123456789",
+                  HttpsURLConnection.HTTP_INTERNAL_ERROR, data))
+          .target(new MockTarget<GitHub>(GitHub.class));
     } finally {
       input.close();
     }
@@ -160,14 +158,14 @@ public class MockClientTest {
   @Test
   public void verifyInvocation() {
     Contributor contribution =
-      github.create("netflix", "feign", "velo_at_github", "preposterous hacker");
+        github.create("netflix", "feign", "velo_at_github", "preposterous hacker");
     // making sure it received a proper response
     assertThat(contribution, notNullValue());
     assertThat(contribution.login, equalTo("velo"));
     assertThat(contribution.contributions, equalTo(0));
 
     List<Request> results =
-      mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 1);
+        mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 1);
     assertThat(results, hasSize(1));
 
     byte[] body = mockClient.verifyOne(HttpMethod.POST, "/repos/netflix/feign/contributors").body();
@@ -210,7 +208,7 @@ public class MockClientTest {
   public void verifyNotInvoked() {
     mockClient.verifyNever(HttpMethod.POST, "/repos/netflix/feign/contributors");
     List<Request> results =
-      mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 0);
+        mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 0);
     assertThat(results, hasSize(0));
     try {
       mockClient.verifyOne(HttpMethod.POST, "/repos/netflix/feign/contributors");
@@ -243,7 +241,7 @@ public class MockClientTest {
 
     github.create("netflix", "feign", "velo_at_github", "preposterous hacker");
     List<Request> results =
-      mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 2);
+        mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 2);
     assertThat(results, hasSize(2));
 
     github.create("netflix", "feign", "velo_at_github", "preposterous hacker");

--- a/mock/src/test/java/feign/mock/MockClientTest.java
+++ b/mock/src/test/java/feign/mock/MockClientTest.java
@@ -13,253 +13,249 @@
  */
 package feign.mock;
 
-import static feign.Util.toByteArray;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.fail;
+import feign.*;
+import feign.codec.DecodeException;
+import feign.codec.Decoder;
+import feign.gson.GsonDecoder;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.net.ssl.HttpsURLConnection;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Type;
 import java.util.List;
-import javax.net.ssl.HttpsURLConnection;
-import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
-import feign.Body;
-import feign.Feign;
-import feign.FeignException;
-import feign.Param;
-import feign.Request;
-import feign.RequestLine;
-import feign.Response;
-import feign.codec.DecodeException;
-import feign.codec.Decoder;
-import feign.gson.GsonDecoder;
+
+import static feign.Util.toByteArray;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.fail;
 
 public class MockClientTest {
 
-  interface GitHub {
+    interface GitHub {
 
-    @RequestLine("GET /repos/{owner}/{repo}/contributors")
-    List<Contributor> contributors(@Param("owner") String owner, @Param("repo") String repo);
+        @RequestLine("GET /repos/{owner}/{repo}/contributors")
+        List<Contributor> contributors(@Param("owner") String owner, @Param("repo") String repo);
 
-    @RequestLine("GET /repos/{owner}/{repo}/contributors?client_id={client_id}")
-    List<Contributor> contributors(@Param("client_id") String clientId,
-                                   @Param("owner") String owner,
-                                   @Param("repo") String repo);
+        @RequestLine("GET /repos/{owner}/{repo}/contributors?client_id={client_id}")
+        List<Contributor> contributors(@Param("client_id") String clientId,
+                                       @Param("owner") String owner,
+                                       @Param("repo") String repo);
 
-    @RequestLine("PATCH /repos/{owner}/{repo}/contributors")
-    List<Contributor> patchContributors(@Param("owner") String owner, @Param("repo") String repo);
+        @RequestLine("PATCH /repos/{owner}/{repo}/contributors")
+        List<Contributor> patchContributors(@Param("owner") String owner, @Param("repo") String repo);
 
-    @RequestLine("POST /repos/{owner}/{repo}/contributors")
-    @Body("%7B\"login\":\"{login}\",\"type\":\"{type}\"%7D")
-    Contributor create(@Param("owner") String owner,
-                       @Param("repo") String repo,
-                       @Param("login") String login,
-                       @Param("type") String type);
+        @RequestLine("POST /repos/{owner}/{repo}/contributors")
+        @Body("%7B\"login\":\"{login}\",\"type\":\"{type}\"%7D")
+        Contributor create(@Param("owner") String owner,
+                           @Param("repo") String repo,
+                           @Param("login") String login,
+                           @Param("type") String type);
 
-  }
-
-  static class Contributor {
-
-    String login;
-
-    int contributions;
-
-  }
-
-  class AssertionDecoder implements Decoder {
-
-    private final Decoder delegate;
-
-    public AssertionDecoder(Decoder delegate) {
-      this.delegate = delegate;
     }
 
-    @Override
-    public Object decode(Response response, Type type)
-        throws IOException, DecodeException, FeignException {
-      assertThat(response.request(), notNullValue());
+    static class Contributor {
 
-      return delegate.decode(response, type);
+        String login;
+
+        int contributions;
+
     }
 
-  }
+    class AssertionDecoder implements Decoder {
 
-  private GitHub github;
+        private final Decoder delegate;
 
-  private MockClient mockClient;
+        public AssertionDecoder(Decoder delegate) {
+            this.delegate = delegate;
+        }
 
-  @Before
-  public void setup() throws IOException {
-    try (InputStream input = getClass().getResourceAsStream("/fixtures/contributors.json")) {
-      byte[] data = toByteArray(input);
-      mockClient = new MockClient();
-      github = Feign.builder().decoder(new AssertionDecoder(new GsonDecoder()))
-          .client(mockClient.ok(HttpMethod.GET, "/repos/netflix/feign/contributors", data)
-              .ok(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=55")
-              .ok(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=7 7",
-                  new ByteArrayInputStream(data))
-              .ok(HttpMethod.POST, "/repos/netflix/feign/contributors",
-                  "{\"login\":\"velo\",\"contributions\":0}")
-              .noContent(HttpMethod.PATCH, "/repos/velo/feign-mock/contributors")
-              .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=1234567890",
-                  HttpsURLConnection.HTTP_NOT_FOUND)
-              .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=123456789",
-                  HttpsURLConnection.HTTP_INTERNAL_ERROR, new ByteArrayInputStream(data))
-              .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=123456789",
-                  HttpsURLConnection.HTTP_INTERNAL_ERROR, "")
-              .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=123456789",
-                  HttpsURLConnection.HTTP_INTERNAL_ERROR, data))
-          .target(new MockTarget<>(GitHub.class));
+        @Override
+        public Object decode(Response response, Type type)
+                throws IOException, DecodeException, FeignException {
+            assertThat(response.request(), notNullValue());
+
+            return delegate.decode(response, type);
+        }
+
     }
-  }
 
-  @Test
-  public void hitMock() {
-    List<Contributor> contributors = github.contributors("netflix", "feign");
-    assertThat(contributors, hasSize(30));
-    mockClient.verifyStatus();
-  }
+    private GitHub github;
 
-  @Test
-  public void missMock() {
-    try {
-      github.contributors("velo", "feign-mock");
-      fail();
-    } catch (FeignException e) {
-      assertThat(e.getMessage(), Matchers.containsString("404"));
+    private MockClient mockClient;
+
+    @Before
+    public void setup() throws IOException {
+        InputStream input = getClass().getResourceAsStream("/fixtures/contributors.json");
+        try {
+            byte[] data = toByteArray(input);
+            mockClient = new MockClient();
+            github = Feign.builder().decoder(new AssertionDecoder(new GsonDecoder()))
+                    .client(mockClient.ok(HttpMethod.GET, "/repos/netflix/feign/contributors", data)
+                            .ok(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=55")
+                            .ok(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=7 7",
+                                    new ByteArrayInputStream(data))
+                            .ok(HttpMethod.POST, "/repos/netflix/feign/contributors",
+                                    "{\"login\":\"velo\",\"contributions\":0}")
+                            .noContent(HttpMethod.PATCH, "/repos/velo/feign-mock/contributors")
+                            .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=1234567890",
+                                    HttpsURLConnection.HTTP_NOT_FOUND)
+                            .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=123456789",
+                                    HttpsURLConnection.HTTP_INTERNAL_ERROR, new ByteArrayInputStream(data))
+                            .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=123456789",
+                                    HttpsURLConnection.HTTP_INTERNAL_ERROR, "")
+                            .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=123456789",
+                                    HttpsURLConnection.HTTP_INTERNAL_ERROR, data))
+                    .target(new MockTarget<GitHub>(GitHub.class));
+        } finally {
+            input.close();
+        }
     }
-  }
 
-  @Test
-  public void missHttpMethod() {
-    try {
-      github.patchContributors("netflix", "feign");
-      fail();
-    } catch (FeignException e) {
-      assertThat(e.getMessage(), Matchers.containsString("404"));
+    @Test
+    public void hitMock() {
+        List<Contributor> contributors = github.contributors("netflix", "feign");
+        assertThat(contributors, hasSize(30));
+        mockClient.verifyStatus();
     }
-  }
 
-  @Test
-  public void paramsEncoding() {
-    List<Contributor> contributors = github.contributors("7 7", "netflix", "feign");
-    assertThat(contributors, hasSize(30));
-    mockClient.verifyStatus();
-  }
+    @Test
+    public void missMock() {
+        try {
+            github.contributors("velo", "feign-mock");
+            fail();
+        } catch (FeignException e) {
+            assertThat(e.getMessage(), Matchers.containsString("404"));
+        }
+    }
 
-  @Test
-  public void verifyInvocation() {
-    Contributor contribution =
+    @Test
+    public void missHttpMethod() {
+        try {
+            github.patchContributors("netflix", "feign");
+            fail();
+        } catch (FeignException e) {
+            assertThat(e.getMessage(), Matchers.containsString("404"));
+        }
+    }
+
+    @Test
+    public void paramsEncoding() {
+        List<Contributor> contributors = github.contributors("7 7", "netflix", "feign");
+        assertThat(contributors, hasSize(30));
+        mockClient.verifyStatus();
+    }
+
+    @Test
+    public void verifyInvocation() {
+        Contributor contribution =
+                github.create("netflix", "feign", "velo_at_github", "preposterous hacker");
+        // making sure it received a proper response
+        assertThat(contribution, notNullValue());
+        assertThat(contribution.login, equalTo("velo"));
+        assertThat(contribution.contributions, equalTo(0));
+
+        List<Request> results =
+                mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 1);
+        assertThat(results, hasSize(1));
+
+        byte[] body = mockClient.verifyOne(HttpMethod.POST, "/repos/netflix/feign/contributors").body();
+        assertThat(body, notNullValue());
+
+        String message = new String(body);
+        assertThat(message, containsString("velo_at_github"));
+        assertThat(message, containsString("preposterous hacker"));
+
+        mockClient.verifyStatus();
+    }
+
+    @Test
+    public void verifyNone() {
         github.create("netflix", "feign", "velo_at_github", "preposterous hacker");
-    // making sure it received a proper response
-    assertThat(contribution, notNullValue());
-    assertThat(contribution.login, equalTo("velo"));
-    assertThat(contribution.contributions, equalTo(0));
-
-    List<Request> results =
         mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 1);
-    assertThat(results, hasSize(1));
 
-    byte[] body = mockClient.verifyOne(HttpMethod.POST, "/repos/netflix/feign/contributors").body();
-    assertThat(body, notNullValue());
+        try {
+            mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 0);
+            fail();
+        } catch (VerificationAssertionError e) {
+            assertThat(e.getMessage(), containsString("Do not wanted"));
+            assertThat(e.getMessage(), containsString("POST"));
+            assertThat(e.getMessage(), containsString("/repos/netflix/feign/contributors"));
+        }
 
-    String message = new String(body);
-    assertThat(message, containsString("velo_at_github"));
-    assertThat(message, containsString("preposterous hacker"));
-
-    mockClient.verifyStatus();
-  }
-
-  @Test
-  public void verifyNone() {
-    github.create("netflix", "feign", "velo_at_github", "preposterous hacker");
-    mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 1);
-
-    try {
-      mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 0);
-      fail();
-    } catch (VerificationAssertionError e) {
-      assertThat(e.getMessage(), containsString("Do not wanted"));
-      assertThat(e.getMessage(), containsString("POST"));
-      assertThat(e.getMessage(), containsString("/repos/netflix/feign/contributors"));
+        try {
+            mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 3);
+            fail();
+        } catch (VerificationAssertionError e) {
+            assertThat(e.getMessage(), containsString("Wanted"));
+            assertThat(e.getMessage(), containsString("POST"));
+            assertThat(e.getMessage(), containsString("/repos/netflix/feign/contributors"));
+            assertThat(e.getMessage(), containsString("'3'"));
+            assertThat(e.getMessage(), containsString("'1'"));
+        }
     }
 
-    try {
-      mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 3);
-      fail();
-    } catch (VerificationAssertionError e) {
-      assertThat(e.getMessage(), containsString("Wanted"));
-      assertThat(e.getMessage(), containsString("POST"));
-      assertThat(e.getMessage(), containsString("/repos/netflix/feign/contributors"));
-      assertThat(e.getMessage(), containsString("'3'"));
-      assertThat(e.getMessage(), containsString("'1'"));
+    @Test
+    public void verifyNotInvoked() {
+        mockClient.verifyNever(HttpMethod.POST, "/repos/netflix/feign/contributors");
+        List<Request> results =
+                mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 0);
+        assertThat(results, hasSize(0));
+        try {
+            mockClient.verifyOne(HttpMethod.POST, "/repos/netflix/feign/contributors");
+            fail();
+        } catch (VerificationAssertionError e) {
+            assertThat(e.getMessage(), containsString("Wanted"));
+            assertThat(e.getMessage(), containsString("POST"));
+            assertThat(e.getMessage(), containsString("/repos/netflix/feign/contributors"));
+            assertThat(e.getMessage(), containsString("never invoked"));
+        }
     }
-  }
 
-  @Test
-  public void verifyNotInvoked() {
-    mockClient.verifyNever(HttpMethod.POST, "/repos/netflix/feign/contributors");
-    List<Request> results =
-        mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 0);
-    assertThat(results, hasSize(0));
-    try {
-      mockClient.verifyOne(HttpMethod.POST, "/repos/netflix/feign/contributors");
-      fail();
-    } catch (VerificationAssertionError e) {
-      assertThat(e.getMessage(), containsString("Wanted"));
-      assertThat(e.getMessage(), containsString("POST"));
-      assertThat(e.getMessage(), containsString("/repos/netflix/feign/contributors"));
-      assertThat(e.getMessage(), containsString("never invoked"));
+    @Test
+    public void verifyNegative() {
+        try {
+            mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", -1);
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), containsString("non negative"));
+        }
     }
-  }
 
-  @Test
-  public void verifyNegative() {
-    try {
-      mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", -1);
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertThat(e.getMessage(), containsString("non negative"));
+    @Test
+    public void verifyMultipleRequests() {
+        mockClient.verifyNever(HttpMethod.POST, "/repos/netflix/feign/contributors");
+
+        github.create("netflix", "feign", "velo_at_github", "preposterous hacker");
+        Request result = mockClient.verifyOne(HttpMethod.POST, "/repos/netflix/feign/contributors");
+        assertThat(result, notNullValue());
+
+        github.create("netflix", "feign", "velo_at_github", "preposterous hacker");
+        List<Request> results =
+                mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 2);
+        assertThat(results, hasSize(2));
+
+        github.create("netflix", "feign", "velo_at_github", "preposterous hacker");
+        results = mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 3);
+        assertThat(results, hasSize(3));
+
+        mockClient.verifyStatus();
     }
-  }
 
-  @Test
-  public void verifyMultipleRequests() {
-    mockClient.verifyNever(HttpMethod.POST, "/repos/netflix/feign/contributors");
+    @Test
+    public void resetRequests() {
+        mockClient.verifyNever(HttpMethod.POST, "/repos/netflix/feign/contributors");
 
-    github.create("netflix", "feign", "velo_at_github", "preposterous hacker");
-    Request result = mockClient.verifyOne(HttpMethod.POST, "/repos/netflix/feign/contributors");
-    assertThat(result, notNullValue());
+        github.create("netflix", "feign", "velo_at_github", "preposterous hacker");
+        Request result = mockClient.verifyOne(HttpMethod.POST, "/repos/netflix/feign/contributors");
+        assertThat(result, notNullValue());
 
-    github.create("netflix", "feign", "velo_at_github", "preposterous hacker");
-    List<Request> results =
-        mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 2);
-    assertThat(results, hasSize(2));
+        mockClient.resetRequests();
 
-    github.create("netflix", "feign", "velo_at_github", "preposterous hacker");
-    results = mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 3);
-    assertThat(results, hasSize(3));
-
-    mockClient.verifyStatus();
-  }
-
-  @Test
-  public void resetRequests() {
-    mockClient.verifyNever(HttpMethod.POST, "/repos/netflix/feign/contributors");
-
-    github.create("netflix", "feign", "velo_at_github", "preposterous hacker");
-    Request result = mockClient.verifyOne(HttpMethod.POST, "/repos/netflix/feign/contributors");
-    assertThat(result, notNullValue());
-
-    mockClient.resetRequests();
-
-    mockClient.verifyNever(HttpMethod.POST, "/repos/netflix/feign/contributors");
-  }
+        mockClient.verifyNever(HttpMethod.POST, "/repos/netflix/feign/contributors");
+    }
 
 }

--- a/mock/src/test/java/feign/mock/MockTargetTest.java
+++ b/mock/src/test/java/feign/mock/MockTargetTest.java
@@ -14,23 +14,23 @@
 package feign.mock;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 
 import org.junit.Before;
 import org.junit.Test;
 
 public class MockTargetTest {
 
-    private MockTarget<MockTargetTest> target;
+  private MockTarget<MockTargetTest> target;
 
-    @Before
-    public void setup() {
-        target = new MockTarget<MockTargetTest>(MockTargetTest.class);
-    }
+  @Before
+  public void setup() {
+    target = new MockTarget<MockTargetTest>(MockTargetTest.class);
+  }
 
-    @Test
-    public void test() {
-        assertThat(target.name(), equalTo("MockTargetTest"));
-    }
+  @Test
+  public void test() {
+    assertThat(target.name(), equalTo("MockTargetTest"));
+  }
 
 }

--- a/mock/src/test/java/feign/mock/MockTargetTest.java
+++ b/mock/src/test/java/feign/mock/MockTargetTest.java
@@ -24,7 +24,7 @@ public class MockTargetTest {
 
   @Before
   public void setup() {
-    target = new MockTarget<MockTargetTest>(MockTargetTest.class);
+    target = new MockTarget<>(MockTargetTest.class);
   }
 
   @Test

--- a/mock/src/test/java/feign/mock/MockTargetTest.java
+++ b/mock/src/test/java/feign/mock/MockTargetTest.java
@@ -15,7 +15,6 @@ package feign.mock;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
-
 import org.junit.Before;
 import org.junit.Test;
 

--- a/mock/src/test/java/feign/mock/MockTargetTest.java
+++ b/mock/src/test/java/feign/mock/MockTargetTest.java
@@ -15,21 +15,22 @@ package feign.mock;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.*;
+
 import org.junit.Before;
 import org.junit.Test;
 
 public class MockTargetTest {
 
-  private MockTarget<MockTargetTest> target;
+    private MockTarget<MockTargetTest> target;
 
-  @Before
-  public void setup() {
-    target = new MockTarget<>(MockTargetTest.class);
-  }
+    @Before
+    public void setup() {
+        target = new MockTarget<MockTargetTest>(MockTargetTest.class);
+    }
 
-  @Test
-  public void test() {
-    assertThat(target.name(), equalTo("MockTargetTest"));
-  }
+    @Test
+    public void test() {
+        assertThat(target.name(), equalTo("MockTargetTest"));
+    }
 
 }

--- a/mock/src/test/java/feign/mock/RequestHeadersTest.java
+++ b/mock/src/test/java/feign/mock/RequestHeadersTest.java
@@ -13,78 +13,77 @@
  */
 package feign.mock;
 
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Test;
 
 public class RequestHeadersTest {
 
-    @Test
-    public void shouldCreateEmptyRequestHeaders() {
-        RequestHeaders headers = RequestHeaders
-                .builder()
-                .build();
-        assertThat(headers.size()).isEqualTo(0);
-    }
+  @Test
+  public void shouldCreateEmptyRequestHeaders() {
+    RequestHeaders headers = RequestHeaders
+      .builder()
+      .build();
+    assertThat(headers.size()).isEqualTo(0);
+  }
 
-    @Test
-    public void shouldReturnZeroSizeForUnknownKey() {
-        RequestHeaders headers = RequestHeaders
-                .builder()
-                .build();
-        assertThat(headers.sizeOf("unknown")).isEqualTo(0);
-    }
+  @Test
+  public void shouldReturnZeroSizeForUnknownKey() {
+    RequestHeaders headers = RequestHeaders
+      .builder()
+      .build();
+    assertThat(headers.sizeOf("unknown")).isEqualTo(0);
+  }
 
-    @Test
-    public void shouldCreateRequestHeadersFromSingleValue() {
-        RequestHeaders headers = RequestHeaders
-                .builder()
-                .add("header", "val")
-                .add("other header", "val2")
-                .build();
+  @Test
+  public void shouldCreateRequestHeadersFromSingleValue() {
+    RequestHeaders headers = RequestHeaders
+      .builder()
+      .add("header", "val")
+      .add("other header", "val2")
+      .build();
 
-        assertThat(headers.fetch("header")).contains("val");
-        assertThat(headers.sizeOf("header")).isEqualTo(1);
-        assertThat(headers.fetch("other header")).contains("val2");
-        assertThat(headers.sizeOf("other header")).isEqualTo(1);
-    }
+    assertThat(headers.fetch("header")).contains("val");
+    assertThat(headers.sizeOf("header")).isEqualTo(1);
+    assertThat(headers.fetch("other header")).contains("val2");
+    assertThat(headers.sizeOf("other header")).isEqualTo(1);
+  }
 
-    @Test
-    public void shouldCreateRequestHeadersFromSingleValueAndCollection() {
-        RequestHeaders headers = RequestHeaders
-                .builder()
-                .add("header", "val")
-                .add("other header", "val2")
-                .add("header", Arrays.asList("val3", "val4"))
-                .build();
+  @Test
+  public void shouldCreateRequestHeadersFromSingleValueAndCollection() {
+    RequestHeaders headers = RequestHeaders
+      .builder()
+      .add("header", "val")
+      .add("other header", "val2")
+      .add("header", Arrays.asList("val3", "val4"))
+      .build();
 
-        assertThat(headers.fetch("header")).contains("val", "val3", "val4");
-        assertThat(headers.sizeOf("header")).isEqualTo(3);
-        assertThat(headers.fetch("other header")).contains("val2");
-        assertThat(headers.sizeOf("other header")).isEqualTo(1);
-    }
+    assertThat(headers.fetch("header")).contains("val", "val3", "val4");
+    assertThat(headers.sizeOf("header")).isEqualTo(3);
+    assertThat(headers.fetch("other header")).contains("val2");
+    assertThat(headers.sizeOf("other header")).isEqualTo(1);
+  }
 
-    @Test
-    public void shouldCreateRequestHeadersFromHeadersMap() {
-        Map<String, Collection<String>> map = new HashMap<String, Collection<String>>();
-        map.put("header", Arrays.asList("val", "val2"));
-        RequestHeaders headers = RequestHeaders.of(map);
-        assertThat(headers.size()).isEqualTo(1);
-    }
+  @Test
+  public void shouldCreateRequestHeadersFromHeadersMap() {
+    Map<String, Collection<String>> map = new HashMap<String, Collection<String>>();
+    map.put("header", Arrays.asList("val", "val2"));
+    RequestHeaders headers = RequestHeaders.of(map);
+    assertThat(headers.size()).isEqualTo(1);
+  }
 
-    @Test
-    public void shouldPrintHeaders() {
-        RequestHeaders headers = RequestHeaders
-                .builder()
-                .add("header", "val")
-                .add("other header", "val2")
-                .add("header", Arrays.asList("val3", "val4"))
-                .build();
-        assertThat(headers.toString()).isEqualTo("other header=[val2], header=[val, val3, val4]");
-    }
+  @Test
+  public void shouldPrintHeaders() {
+    RequestHeaders headers = RequestHeaders
+      .builder()
+      .add("header", "val")
+      .add("other header", "val2")
+      .add("header", Arrays.asList("val3", "val4"))
+      .build();
+    assertThat(headers.toString()).isEqualTo("other header=[val2], header=[val, val3, val4]");
+  }
 }

--- a/mock/src/test/java/feign/mock/RequestHeadersTest.java
+++ b/mock/src/test/java/feign/mock/RequestHeadersTest.java
@@ -14,7 +14,6 @@
 package feign.mock;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -26,26 +25,26 @@ public class RequestHeadersTest {
   @Test
   public void shouldCreateEmptyRequestHeaders() {
     RequestHeaders headers = RequestHeaders
-      .builder()
-      .build();
+        .builder()
+        .build();
     assertThat(headers.size()).isEqualTo(0);
   }
 
   @Test
   public void shouldReturnZeroSizeForUnknownKey() {
     RequestHeaders headers = RequestHeaders
-      .builder()
-      .build();
+        .builder()
+        .build();
     assertThat(headers.sizeOf("unknown")).isEqualTo(0);
   }
 
   @Test
   public void shouldCreateRequestHeadersFromSingleValue() {
     RequestHeaders headers = RequestHeaders
-      .builder()
-      .add("header", "val")
-      .add("other header", "val2")
-      .build();
+        .builder()
+        .add("header", "val")
+        .add("other header", "val2")
+        .build();
 
     assertThat(headers.fetch("header")).contains("val");
     assertThat(headers.sizeOf("header")).isEqualTo(1);
@@ -56,11 +55,11 @@ public class RequestHeadersTest {
   @Test
   public void shouldCreateRequestHeadersFromSingleValueAndCollection() {
     RequestHeaders headers = RequestHeaders
-      .builder()
-      .add("header", "val")
-      .add("other header", "val2")
-      .add("header", Arrays.asList("val3", "val4"))
-      .build();
+        .builder()
+        .add("header", "val")
+        .add("other header", "val2")
+        .add("header", Arrays.asList("val3", "val4"))
+        .build();
 
     assertThat(headers.fetch("header")).contains("val", "val3", "val4");
     assertThat(headers.sizeOf("header")).isEqualTo(3);
@@ -79,11 +78,11 @@ public class RequestHeadersTest {
   @Test
   public void shouldPrintHeaders() {
     RequestHeaders headers = RequestHeaders
-      .builder()
-      .add("header", "val")
-      .add("other header", "val2")
-      .add("header", Arrays.asList("val3", "val4"))
-      .build();
+        .builder()
+        .add("header", "val")
+        .add("other header", "val2")
+        .add("header", Arrays.asList("val3", "val4"))
+        .build();
     assertThat(headers.toString()).isEqualTo("other header=[val2], header=[val, val3, val4]");
   }
 }

--- a/mock/src/test/java/feign/mock/RequestHeadersTest.java
+++ b/mock/src/test/java/feign/mock/RequestHeadersTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2012-2018 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.mock;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RequestHeadersTest {
+
+    @Test
+    public void shouldCreateEmptyRequestHeaders() {
+        RequestHeaders headers = RequestHeaders
+                .builder()
+                .build();
+        assertThat(headers.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldReturnZeroSizeForUnknownKey() {
+        RequestHeaders headers = RequestHeaders
+                .builder()
+                .build();
+        assertThat(headers.sizeOf("unknown")).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldCreateRequestHeadersFromSingleValue() {
+        RequestHeaders headers = RequestHeaders
+                .builder()
+                .add("header", "val")
+                .add("other header", "val2")
+                .build();
+
+        assertThat(headers.fetch("header")).contains("val");
+        assertThat(headers.sizeOf("header")).isEqualTo(1);
+        assertThat(headers.fetch("other header")).contains("val2");
+        assertThat(headers.sizeOf("other header")).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldCreateRequestHeadersFromSingleValueAndCollection() {
+        RequestHeaders headers = RequestHeaders
+                .builder()
+                .add("header", "val")
+                .add("other header", "val2")
+                .add("header", Arrays.asList("val3", "val4"))
+                .build();
+
+        assertThat(headers.fetch("header")).contains("val", "val3", "val4");
+        assertThat(headers.sizeOf("header")).isEqualTo(3);
+        assertThat(headers.fetch("other header")).contains("val2");
+        assertThat(headers.sizeOf("other header")).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldCreateRequestHeadersFromHeadersMap() {
+        Map<String, Collection<String>> map = new HashMap<String, Collection<String>>();
+        map.put("header", Arrays.asList("val", "val2"));
+        RequestHeaders headers = RequestHeaders.of(map);
+        assertThat(headers.size()).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldPrintHeaders() {
+        RequestHeaders headers = RequestHeaders
+                .builder()
+                .add("header", "val")
+                .add("other header", "val2")
+                .add("header", Arrays.asList("val3", "val4"))
+                .build();
+        assertThat(headers.toString()).isEqualTo("other header=[val2], header=[val, val3, val4]");
+    }
+}

--- a/mock/src/test/java/feign/mock/RequestKeyTest.java
+++ b/mock/src/test/java/feign/mock/RequestKeyTest.java
@@ -13,149 +13,146 @@
  */
 package feign.mock;
 
-import static org.hamcrest.Matchers.both;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
+
+import java.nio.charset.Charset;
+import java.util.*;
+
 import org.junit.Before;
 import org.junit.Test;
 import feign.Request;
 
 public class RequestKeyTest {
 
-  private RequestKey requestKey;
+    private RequestKey requestKey;
 
-  @Before
-  public void setUp() {
-    Map<String, Collection<String>> map = new HashMap<>();
-    map.put("my-header", Arrays.asList("val"));
-    requestKey =
-        RequestKey.builder(HttpMethod.GET, "a").headers(map).charset(StandardCharsets.UTF_16)
-            .body("content").build();
-  }
+    @Before
+    public void setUp() {
+        RequestHeaders headers = RequestHeaders
+                .builder()
+                .add("my-header", "val").build();
+        requestKey =
+                RequestKey.builder(HttpMethod.GET, "a").headers(headers).charset(Charset.forName("UTF-16"))
+                        .body("content").build();
+    }
 
-  @Test
-  public void builder() throws Exception {
-    assertThat(requestKey.getMethod(), equalTo(HttpMethod.GET));
-    assertThat(requestKey.getUrl(), equalTo("a"));
-    assertThat(requestKey.getHeaders().entrySet(), hasSize(1));
-    assertThat(requestKey.getHeaders().get("my-header"),
-        equalTo((Collection<String>) Arrays.asList("val")));
-    assertThat(requestKey.getCharset(), equalTo(StandardCharsets.UTF_16));
-  }
+    @Test
+    public void builder() throws Exception {
+        assertThat(requestKey.getMethod(), equalTo(HttpMethod.GET));
+        assertThat(requestKey.getUrl(), equalTo("a"));
+        assertThat(requestKey.getHeaders().size(), is(1));
+        assertThat(requestKey.getHeaders().fetch("my-header"),
+                equalTo((Collection<String>) Arrays.asList("val")));
+        assertThat(requestKey.getCharset(), equalTo(Charset.forName("UTF-16")));
+    }
 
-  @Test
-  public void create() throws Exception {
-    Map<String, Collection<String>> map = new HashMap<>();
-    map.put("my-header", Arrays.asList("val"));
-    Request request = Request.create("GET", "a", map, "content".getBytes(StandardCharsets.UTF_8),
-        StandardCharsets.UTF_16);
-    requestKey = RequestKey.create(request);
+    @Test
+    public void create() throws Exception {
+        Map<String, Collection<String>> map = new HashMap<String, Collection<String>>();
+        map.put("my-header", Arrays.asList("val"));
+        Request request = Request.create("GET", "a", map, "content".getBytes(Charset.forName("UTF-8")),
+                Charset.forName("UTF-16"));
+        requestKey = RequestKey.create(request);
 
-    assertThat(requestKey.getMethod(), equalTo(HttpMethod.GET));
-    assertThat(requestKey.getUrl(), equalTo("a"));
-    assertThat(requestKey.getHeaders().entrySet(), hasSize(1));
-    assertThat(requestKey.getHeaders().get("my-header"),
-        equalTo((Collection<String>) Arrays.asList("val")));
-    assertThat(requestKey.getCharset(), equalTo(StandardCharsets.UTF_16));
-    assertThat(requestKey.getBody(), equalTo("content".getBytes(StandardCharsets.UTF_8)));
-  }
+        assertThat(requestKey.getMethod(), equalTo(HttpMethod.GET));
+        assertThat(requestKey.getUrl(), equalTo("a"));
+        assertThat(requestKey.getHeaders().size(), is(1));
+        assertThat(requestKey.getHeaders().fetch("my-header"),
+                equalTo((Collection<String>) Arrays.asList("val")));
+        assertThat(requestKey.getCharset(), equalTo(Charset.forName("UTF-16")));
+        assertThat(requestKey.getBody(), equalTo("content".getBytes(Charset.forName("UTF-8"))));
+    }
 
-  @Test
-  public void checkHashes() {
-    RequestKey requestKey1 = RequestKey.builder(HttpMethod.GET, "a").build();
-    RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "b").build();
+    @Test
+    public void checkHashes() {
+        RequestKey requestKey1 = RequestKey.builder(HttpMethod.GET, "a").build();
+        RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "b").build();
 
-    assertThat(requestKey1.hashCode(), not(equalTo(requestKey2.hashCode())));
-    assertThat(requestKey1, not(equalTo(requestKey2)));
-  }
+        assertThat(requestKey1.hashCode(), not(equalTo(requestKey2.hashCode())));
+        assertThat(requestKey1, not(equalTo(requestKey2)));
+    }
 
-  @Test
-  public void equalObject() {
-    assertThat(requestKey, not(equalTo(new Object())));
-  }
+    @Test
+    public void equalObject() {
+        assertThat(requestKey, not(equalTo(new Object())));
+    }
 
-  @Test
-  public void equalNull() {
-    assertThat(requestKey, not(equalTo(null)));
-  }
+    @Test
+    public void equalNull() {
+        assertThat(requestKey, not(equalTo(null)));
+    }
 
-  @Test
-  public void equalPost() {
-    RequestKey requestKey1 = RequestKey.builder(HttpMethod.GET, "a").build();
-    RequestKey requestKey2 = RequestKey.builder(HttpMethod.POST, "a").build();
+    @Test
+    public void equalPost() {
+        RequestKey requestKey1 = RequestKey.builder(HttpMethod.GET, "a").build();
+        RequestKey requestKey2 = RequestKey.builder(HttpMethod.POST, "a").build();
 
-    assertThat(requestKey1.hashCode(), not(equalTo(requestKey2.hashCode())));
-    assertThat(requestKey1, not(equalTo(requestKey2)));
-  }
+        assertThat(requestKey1.hashCode(), not(equalTo(requestKey2.hashCode())));
+        assertThat(requestKey1, not(equalTo(requestKey2)));
+    }
 
-  @Test
-  public void equalSelf() {
-    assertThat(requestKey.hashCode(), equalTo(requestKey.hashCode()));
-    assertThat(requestKey, equalTo(requestKey));
-  }
+    @Test
+    public void equalSelf() {
+        assertThat(requestKey.hashCode(), equalTo(requestKey.hashCode()));
+        assertThat(requestKey, equalTo(requestKey));
+    }
 
-  @Test
-  public void equalMinimum() {
-    RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").build();
+    @Test
+    public void equalMinimum() {
+        RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").build();
 
-    assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
-    assertThat(requestKey, equalTo(requestKey2));
-  }
+        assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
+        assertThat(requestKey, equalTo(requestKey2));
+    }
 
-  @Test
-  public void equalExtra() {
-    Map<String, Collection<String>> map = new HashMap<>();
-    map.put("my-other-header", Arrays.asList("other value"));
-    RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").headers(map)
-        .charset(StandardCharsets.ISO_8859_1).build();
+    @Test
+    public void equalExtra() {
+        RequestHeaders headers = RequestHeaders
+                .builder()
+                .add("my-other-header", "other value").build();
+        RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").headers(headers)
+                .charset(Charset.forName("ISO-8859-1")).build();
 
-    assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
-    assertThat(requestKey, equalTo(requestKey2));
-  }
+        assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
+        assertThat(requestKey, equalTo(requestKey2));
+    }
 
-  @Test
-  public void equalsExtended() {
-    RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").build();
+    @Test
+    public void equalsExtended() {
+        RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").build();
 
-    assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
-    assertThat(requestKey.equalsExtended(requestKey2), equalTo(true));
-  }
+        assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
+        assertThat(requestKey.equalsExtended(requestKey2), equalTo(true));
+    }
 
-  @Test
-  public void equalsExtendedExtra() {
-    Map<String, Collection<String>> map = new HashMap<>();
-    map.put("my-other-header", Arrays.asList("other value"));
-    RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").headers(map)
-        .charset(StandardCharsets.ISO_8859_1).build();
+    @Test
+    public void equalsExtendedExtra() {
+        RequestHeaders headers = RequestHeaders
+                .builder()
+                .add("my-other-header", "other value").build();
+        RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").headers(headers)
+                .charset(Charset.forName("ISO-8859-1")).build();
 
-    assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
-    assertThat(requestKey.equalsExtended(requestKey2), equalTo(false));
-  }
+        assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
+        assertThat(requestKey.equalsExtended(requestKey2), equalTo(false));
+    }
 
-  @Test
-  public void testToString() throws Exception {
-    assertThat(requestKey.toString(), startsWith("Request [GET a: "));
-    assertThat(requestKey.toString(),
-        both(containsString(" with 1 ")).and(containsString(" UTF-16]")));
-  }
+    @Test
+    public void testToString() throws Exception {
+        assertThat(requestKey.toString(), startsWith("Request [GET a: "));
+        assertThat(requestKey.toString(),
+                both(containsString(" with my-header=[val] ")).and(containsString(" UTF-16]")));
+    }
 
-  @Test
-  public void testToStringSimple() throws Exception {
-    requestKey = RequestKey.builder(HttpMethod.GET, "a").build();
+    @Test
+    public void testToStringSimple() throws Exception {
+        requestKey = RequestKey.builder(HttpMethod.GET, "a").build();
 
-    assertThat(requestKey.toString(), startsWith("Request [GET a: "));
-    assertThat(requestKey.toString(),
-        both(containsString(" without ")).and(containsString(" no charset")));
-  }
+        assertThat(requestKey.toString(), startsWith("Request [GET a: "));
+        assertThat(requestKey.toString(),
+                both(containsString(" without ")).and(containsString(" no charset")));
+    }
 
 }
 //

--- a/mock/src/test/java/feign/mock/RequestKeyTest.java
+++ b/mock/src/test/java/feign/mock/RequestKeyTest.java
@@ -20,8 +20,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
-
-import feign.Request;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collection;
@@ -29,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
+import feign.Request;
 
 public class RequestKeyTest {
 
@@ -37,11 +36,11 @@ public class RequestKeyTest {
   @Before
   public void setUp() {
     RequestHeaders headers = RequestHeaders
-      .builder()
-      .add("my-header", "val").build();
+        .builder()
+        .add("my-header", "val").build();
     requestKey =
-      RequestKey.builder(HttpMethod.GET, "a").headers(headers).charset(Charset.forName("UTF-16"))
-        .body("content").build();
+        RequestKey.builder(HttpMethod.GET, "a").headers(headers).charset(Charset.forName("UTF-16"))
+            .body("content").build();
   }
 
   @Test
@@ -50,7 +49,7 @@ public class RequestKeyTest {
     assertThat(requestKey.getUrl(), equalTo("a"));
     assertThat(requestKey.getHeaders().size(), is(1));
     assertThat(requestKey.getHeaders().fetch("my-header"),
-      equalTo((Collection<String>) Arrays.asList("val")));
+        equalTo((Collection<String>) Arrays.asList("val")));
     assertThat(requestKey.getCharset(), equalTo(Charset.forName("UTF-16")));
   }
 
@@ -59,14 +58,14 @@ public class RequestKeyTest {
     Map<String, Collection<String>> map = new HashMap<String, Collection<String>>();
     map.put("my-header", Arrays.asList("val"));
     Request request = Request.create("GET", "a", map, "content".getBytes(Charset.forName("UTF-8")),
-      Charset.forName("UTF-16"));
+        Charset.forName("UTF-16"));
     requestKey = RequestKey.create(request);
 
     assertThat(requestKey.getMethod(), equalTo(HttpMethod.GET));
     assertThat(requestKey.getUrl(), equalTo("a"));
     assertThat(requestKey.getHeaders().size(), is(1));
     assertThat(requestKey.getHeaders().fetch("my-header"),
-      equalTo((Collection<String>) Arrays.asList("val")));
+        equalTo((Collection<String>) Arrays.asList("val")));
     assertThat(requestKey.getCharset(), equalTo(Charset.forName("UTF-16")));
     assertThat(requestKey.getBody(), equalTo("content".getBytes(Charset.forName("UTF-8"))));
   }
@@ -116,10 +115,10 @@ public class RequestKeyTest {
   @Test
   public void equalExtra() {
     RequestHeaders headers = RequestHeaders
-      .builder()
-      .add("my-other-header", "other value").build();
+        .builder()
+        .add("my-other-header", "other value").build();
     RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").headers(headers)
-      .charset(Charset.forName("ISO-8859-1")).build();
+        .charset(Charset.forName("ISO-8859-1")).build();
 
     assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
     assertThat(requestKey, equalTo(requestKey2));
@@ -136,10 +135,10 @@ public class RequestKeyTest {
   @Test
   public void equalsExtendedExtra() {
     RequestHeaders headers = RequestHeaders
-      .builder()
-      .add("my-other-header", "other value").build();
+        .builder()
+        .add("my-other-header", "other value").build();
     RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").headers(headers)
-      .charset(Charset.forName("ISO-8859-1")).build();
+        .charset(Charset.forName("ISO-8859-1")).build();
 
     assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
     assertThat(requestKey.equalsExtended(requestKey2), equalTo(false));
@@ -149,7 +148,7 @@ public class RequestKeyTest {
   public void testToString() throws Exception {
     assertThat(requestKey.toString(), startsWith("Request [GET a: "));
     assertThat(requestKey.toString(),
-      both(containsString(" with my-header=[val] ")).and(containsString(" UTF-16]")));
+        both(containsString(" with my-header=[val] ")).and(containsString(" UTF-16]")));
   }
 
   @Test
@@ -158,7 +157,7 @@ public class RequestKeyTest {
 
     assertThat(requestKey.toString(), startsWith("Request [GET a: "));
     assertThat(requestKey.toString(),
-      both(containsString(" without ")).and(containsString(" no charset")));
+        both(containsString(" without ")).and(containsString(" no charset")));
   }
 
 }

--- a/mock/src/test/java/feign/mock/RequestKeyTest.java
+++ b/mock/src/test/java/feign/mock/RequestKeyTest.java
@@ -20,7 +20,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -39,7 +39,7 @@ public class RequestKeyTest {
         .builder()
         .add("my-header", "val").build();
     requestKey =
-        RequestKey.builder(HttpMethod.GET, "a").headers(headers).charset(Charset.forName("UTF-16"))
+        RequestKey.builder(HttpMethod.GET, "a").headers(headers).charset(StandardCharsets.UTF_16)
             .body("content").build();
   }
 
@@ -50,15 +50,15 @@ public class RequestKeyTest {
     assertThat(requestKey.getHeaders().size(), is(1));
     assertThat(requestKey.getHeaders().fetch("my-header"),
         equalTo((Collection<String>) Arrays.asList("val")));
-    assertThat(requestKey.getCharset(), equalTo(Charset.forName("UTF-16")));
+    assertThat(requestKey.getCharset(), equalTo(StandardCharsets.UTF_16));
   }
 
   @Test
   public void create() throws Exception {
     Map<String, Collection<String>> map = new HashMap<String, Collection<String>>();
     map.put("my-header", Arrays.asList("val"));
-    Request request = Request.create("GET", "a", map, "content".getBytes(Charset.forName("UTF-8")),
-        Charset.forName("UTF-16"));
+    Request request = Request.create("GET", "a", map, "content".getBytes(StandardCharsets.UTF_8),
+        StandardCharsets.UTF_16);
     requestKey = RequestKey.create(request);
 
     assertThat(requestKey.getMethod(), equalTo(HttpMethod.GET));
@@ -66,8 +66,8 @@ public class RequestKeyTest {
     assertThat(requestKey.getHeaders().size(), is(1));
     assertThat(requestKey.getHeaders().fetch("my-header"),
         equalTo((Collection<String>) Arrays.asList("val")));
-    assertThat(requestKey.getCharset(), equalTo(Charset.forName("UTF-16")));
-    assertThat(requestKey.getBody(), equalTo("content".getBytes(Charset.forName("UTF-8"))));
+    assertThat(requestKey.getCharset(), equalTo(StandardCharsets.UTF_16));
+    assertThat(requestKey.getBody(), equalTo("content".getBytes(StandardCharsets.UTF_8)));
   }
 
   @Test
@@ -118,7 +118,7 @@ public class RequestKeyTest {
         .builder()
         .add("my-other-header", "other value").build();
     RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").headers(headers)
-        .charset(Charset.forName("ISO-8859-1")).build();
+        .charset(StandardCharsets.ISO_8859_1).build();
 
     assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
     assertThat(requestKey, equalTo(requestKey2));
@@ -138,7 +138,7 @@ public class RequestKeyTest {
         .builder()
         .add("my-other-header", "other value").build();
     RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").headers(headers)
-        .charset(Charset.forName("ISO-8859-1")).build();
+        .charset(StandardCharsets.ISO_8859_1).build();
 
     assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
     assertThat(requestKey.equalsExtended(requestKey2), equalTo(false));

--- a/mock/src/test/java/feign/mock/RequestKeyTest.java
+++ b/mock/src/test/java/feign/mock/RequestKeyTest.java
@@ -13,146 +13,153 @@
  */
 package feign.mock;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
 
+import feign.Request;
 import java.nio.charset.Charset;
-import java.util.*;
-
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
-import feign.Request;
 
 public class RequestKeyTest {
 
-    private RequestKey requestKey;
+  private RequestKey requestKey;
 
-    @Before
-    public void setUp() {
-        RequestHeaders headers = RequestHeaders
-                .builder()
-                .add("my-header", "val").build();
-        requestKey =
-                RequestKey.builder(HttpMethod.GET, "a").headers(headers).charset(Charset.forName("UTF-16"))
-                        .body("content").build();
-    }
+  @Before
+  public void setUp() {
+    RequestHeaders headers = RequestHeaders
+      .builder()
+      .add("my-header", "val").build();
+    requestKey =
+      RequestKey.builder(HttpMethod.GET, "a").headers(headers).charset(Charset.forName("UTF-16"))
+        .body("content").build();
+  }
 
-    @Test
-    public void builder() throws Exception {
-        assertThat(requestKey.getMethod(), equalTo(HttpMethod.GET));
-        assertThat(requestKey.getUrl(), equalTo("a"));
-        assertThat(requestKey.getHeaders().size(), is(1));
-        assertThat(requestKey.getHeaders().fetch("my-header"),
-                equalTo((Collection<String>) Arrays.asList("val")));
-        assertThat(requestKey.getCharset(), equalTo(Charset.forName("UTF-16")));
-    }
+  @Test
+  public void builder() throws Exception {
+    assertThat(requestKey.getMethod(), equalTo(HttpMethod.GET));
+    assertThat(requestKey.getUrl(), equalTo("a"));
+    assertThat(requestKey.getHeaders().size(), is(1));
+    assertThat(requestKey.getHeaders().fetch("my-header"),
+      equalTo((Collection<String>) Arrays.asList("val")));
+    assertThat(requestKey.getCharset(), equalTo(Charset.forName("UTF-16")));
+  }
 
-    @Test
-    public void create() throws Exception {
-        Map<String, Collection<String>> map = new HashMap<String, Collection<String>>();
-        map.put("my-header", Arrays.asList("val"));
-        Request request = Request.create("GET", "a", map, "content".getBytes(Charset.forName("UTF-8")),
-                Charset.forName("UTF-16"));
-        requestKey = RequestKey.create(request);
+  @Test
+  public void create() throws Exception {
+    Map<String, Collection<String>> map = new HashMap<String, Collection<String>>();
+    map.put("my-header", Arrays.asList("val"));
+    Request request = Request.create("GET", "a", map, "content".getBytes(Charset.forName("UTF-8")),
+      Charset.forName("UTF-16"));
+    requestKey = RequestKey.create(request);
 
-        assertThat(requestKey.getMethod(), equalTo(HttpMethod.GET));
-        assertThat(requestKey.getUrl(), equalTo("a"));
-        assertThat(requestKey.getHeaders().size(), is(1));
-        assertThat(requestKey.getHeaders().fetch("my-header"),
-                equalTo((Collection<String>) Arrays.asList("val")));
-        assertThat(requestKey.getCharset(), equalTo(Charset.forName("UTF-16")));
-        assertThat(requestKey.getBody(), equalTo("content".getBytes(Charset.forName("UTF-8"))));
-    }
+    assertThat(requestKey.getMethod(), equalTo(HttpMethod.GET));
+    assertThat(requestKey.getUrl(), equalTo("a"));
+    assertThat(requestKey.getHeaders().size(), is(1));
+    assertThat(requestKey.getHeaders().fetch("my-header"),
+      equalTo((Collection<String>) Arrays.asList("val")));
+    assertThat(requestKey.getCharset(), equalTo(Charset.forName("UTF-16")));
+    assertThat(requestKey.getBody(), equalTo("content".getBytes(Charset.forName("UTF-8"))));
+  }
 
-    @Test
-    public void checkHashes() {
-        RequestKey requestKey1 = RequestKey.builder(HttpMethod.GET, "a").build();
-        RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "b").build();
+  @Test
+  public void checkHashes() {
+    RequestKey requestKey1 = RequestKey.builder(HttpMethod.GET, "a").build();
+    RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "b").build();
 
-        assertThat(requestKey1.hashCode(), not(equalTo(requestKey2.hashCode())));
-        assertThat(requestKey1, not(equalTo(requestKey2)));
-    }
+    assertThat(requestKey1.hashCode(), not(equalTo(requestKey2.hashCode())));
+    assertThat(requestKey1, not(equalTo(requestKey2)));
+  }
 
-    @Test
-    public void equalObject() {
-        assertThat(requestKey, not(equalTo(new Object())));
-    }
+  @Test
+  public void equalObject() {
+    assertThat(requestKey, not(equalTo(new Object())));
+  }
 
-    @Test
-    public void equalNull() {
-        assertThat(requestKey, not(equalTo(null)));
-    }
+  @Test
+  public void equalNull() {
+    assertThat(requestKey, not(equalTo(null)));
+  }
 
-    @Test
-    public void equalPost() {
-        RequestKey requestKey1 = RequestKey.builder(HttpMethod.GET, "a").build();
-        RequestKey requestKey2 = RequestKey.builder(HttpMethod.POST, "a").build();
+  @Test
+  public void equalPost() {
+    RequestKey requestKey1 = RequestKey.builder(HttpMethod.GET, "a").build();
+    RequestKey requestKey2 = RequestKey.builder(HttpMethod.POST, "a").build();
 
-        assertThat(requestKey1.hashCode(), not(equalTo(requestKey2.hashCode())));
-        assertThat(requestKey1, not(equalTo(requestKey2)));
-    }
+    assertThat(requestKey1.hashCode(), not(equalTo(requestKey2.hashCode())));
+    assertThat(requestKey1, not(equalTo(requestKey2)));
+  }
 
-    @Test
-    public void equalSelf() {
-        assertThat(requestKey.hashCode(), equalTo(requestKey.hashCode()));
-        assertThat(requestKey, equalTo(requestKey));
-    }
+  @Test
+  public void equalSelf() {
+    assertThat(requestKey.hashCode(), equalTo(requestKey.hashCode()));
+    assertThat(requestKey, equalTo(requestKey));
+  }
 
-    @Test
-    public void equalMinimum() {
-        RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").build();
+  @Test
+  public void equalMinimum() {
+    RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").build();
 
-        assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
-        assertThat(requestKey, equalTo(requestKey2));
-    }
+    assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
+    assertThat(requestKey, equalTo(requestKey2));
+  }
 
-    @Test
-    public void equalExtra() {
-        RequestHeaders headers = RequestHeaders
-                .builder()
-                .add("my-other-header", "other value").build();
-        RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").headers(headers)
-                .charset(Charset.forName("ISO-8859-1")).build();
+  @Test
+  public void equalExtra() {
+    RequestHeaders headers = RequestHeaders
+      .builder()
+      .add("my-other-header", "other value").build();
+    RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").headers(headers)
+      .charset(Charset.forName("ISO-8859-1")).build();
 
-        assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
-        assertThat(requestKey, equalTo(requestKey2));
-    }
+    assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
+    assertThat(requestKey, equalTo(requestKey2));
+  }
 
-    @Test
-    public void equalsExtended() {
-        RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").build();
+  @Test
+  public void equalsExtended() {
+    RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").build();
 
-        assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
-        assertThat(requestKey.equalsExtended(requestKey2), equalTo(true));
-    }
+    assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
+    assertThat(requestKey.equalsExtended(requestKey2), equalTo(true));
+  }
 
-    @Test
-    public void equalsExtendedExtra() {
-        RequestHeaders headers = RequestHeaders
-                .builder()
-                .add("my-other-header", "other value").build();
-        RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").headers(headers)
-                .charset(Charset.forName("ISO-8859-1")).build();
+  @Test
+  public void equalsExtendedExtra() {
+    RequestHeaders headers = RequestHeaders
+      .builder()
+      .add("my-other-header", "other value").build();
+    RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").headers(headers)
+      .charset(Charset.forName("ISO-8859-1")).build();
 
-        assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
-        assertThat(requestKey.equalsExtended(requestKey2), equalTo(false));
-    }
+    assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
+    assertThat(requestKey.equalsExtended(requestKey2), equalTo(false));
+  }
 
-    @Test
-    public void testToString() throws Exception {
-        assertThat(requestKey.toString(), startsWith("Request [GET a: "));
-        assertThat(requestKey.toString(),
-                both(containsString(" with my-header=[val] ")).and(containsString(" UTF-16]")));
-    }
+  @Test
+  public void testToString() throws Exception {
+    assertThat(requestKey.toString(), startsWith("Request [GET a: "));
+    assertThat(requestKey.toString(),
+      both(containsString(" with my-header=[val] ")).and(containsString(" UTF-16]")));
+  }
 
-    @Test
-    public void testToStringSimple() throws Exception {
-        requestKey = RequestKey.builder(HttpMethod.GET, "a").build();
+  @Test
+  public void testToStringSimple() throws Exception {
+    requestKey = RequestKey.builder(HttpMethod.GET, "a").build();
 
-        assertThat(requestKey.toString(), startsWith("Request [GET a: "));
-        assertThat(requestKey.toString(),
-                both(containsString(" without ")).and(containsString(" no charset")));
-    }
+    assertThat(requestKey.toString(), startsWith("Request [GET a: "));
+    assertThat(requestKey.toString(),
+      both(containsString(" without ")).and(containsString(" no charset")));
+  }
 
 }
 //


### PR DESCRIPTION
Add the new class `RequestHeaders` in order to improve management of request headers when testing.

So instead of doing this:
```java
    Map<String, Collection<String>> headers = new HashMap<>();
    headers.put("my-header", Arrays.asList("val"));
    headers.put("my-header-2", Arrays.asList("val2", "val3"));
```
we can do :
```java
    RequestHeaders headers = RequestHeaders.builder()
      .add("my-header", "val")
      .add("my-header-2", Arrays.asList("val2", "val3"))
      .build();
```
or 

```java
    RequestHeaders headers = RequestHeaders.builder()
      .add("my-header", "val")
      .add("my-header-2", "val2")
      .add("my-header-2", "val3")
      .build();
```

Moreover, when a request do not match, we will now print the expected headers instead of the numbers of headers.

Before:
`Expected Request [GET /myrequest: with 2 headers and no charset], but was Request [GET /myrequest: with 0 headers and no charset]`

After:
`Expected Request [GET /myrequest: with my-header=[val], my-header-2=[val2,val3] headers and no charset], but was Request [GET /myrequest: with no headers and no charset]`