### PR TITLE
modify Feign's connectTimeout and readTimeout props' priority while use Ribbon

### DIFF
--- a/core/src/main/java/feign/Feign.java
+++ b/core/src/main/java/feign/Feign.java
@@ -13,11 +13,6 @@
  */
 package feign;
 
-import java.io.IOException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.List;
 import feign.Logger.NoOpLogger;
 import feign.ReflectiveFeign.ParseHandlersByName;
 import feign.Request.Options;
@@ -25,6 +20,12 @@ import feign.Target.HardCodedTarget;
 import feign.codec.Decoder;
 import feign.codec.Encoder;
 import feign.codec.ErrorDecoder;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Feign's purpose is to ease development against http apis that feign restfulness. <br>
@@ -104,7 +105,7 @@ public abstract class Feign {
     private Decoder decoder = new Decoder.Default();
     private QueryMapEncoder queryMapEncoder = new QueryMapEncoder.Default();
     private ErrorDecoder errorDecoder = new ErrorDecoder.Default();
-    private Options options = new Options();
+    private Options options = Options.DEFAULT;
     private InvocationHandlerFactory invocationHandlerFactory =
         new InvocationHandlerFactory.Default();
     private boolean decode404;

--- a/core/src/main/java/feign/Request.java
+++ b/core/src/main/java/feign/Request.java
@@ -107,6 +107,8 @@ public final class Request {
    */
   public static class Options {
 
+    public static final Options DEFAULT = new Options();
+
     private final int connectTimeoutMillis;
     private final int readTimeoutMillis;
     private final boolean followRedirects;


### PR DESCRIPTION
while use Feign-Ribbon, the conf for ribbon's readTimeout and connectTimeout prop will be override by Feign's Request.Options which is fixed from Feign.Builder. After the commit, if use the Feign's Request.Options' DEFAULT, readTimeout and connectTimeout will use Ribbon's readTimeout and connectTimeout prop which is Dynamic.