### PR TITLE
Update pom.xml for formatter-maven-plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -443,9 +443,9 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>com.marvinformatics.formatter</groupId>
+        <groupId>net.revelc.code.formatter</groupId>
         <artifactId>formatter-maven-plugin</artifactId>
-        <version>2.2.0</version>
+        <version>2.7.3</version>
         <configuration>
           <lineEnding>LF</lineEnding>
           <configFile>${main.basedir}/src/config/eclipse-java-style.xml</configFile>


### PR DESCRIPTION
Update formatter-maven-plugin to groupId net.revelc.code.formatter and version 2.7.3 because current one causes Java version problems on Eclipse-STS for windows.