### PR TITLE
Added testing only fixes Windows newlines.

### DIFF
--- a/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
+++ b/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
@@ -46,15 +46,15 @@ import static org.junit.Assert.assertTrue;
 public class JacksonCodecTest {
 
   private String zonesJson = ""//
-      + "[\n"//
-      + "  {\n"//
-      + "    \"name\": \"denominator.io.\"\n"//
-      + "  },\n"//
-      + "  {\n"//
-      + "    \"name\": \"denominator.io.\",\n"//
-      + "    \"id\": \"ABCD\"\n"//
-      + "  }\n"//
-      + "]\n";
+      + "[" + System.lineSeparator() //
+      + "  {" + System.lineSeparator() //
+      + "    \"name\": \"denominator.io.\"" + System.lineSeparator()//
+      + "  }," + System.lineSeparator()//
+      + "  {" + System.lineSeparator()//
+      + "    \"name\": \"denominator.io.\"," + System.lineSeparator()//
+      + "    \"id\": \"ABCD\"" + System.lineSeparator()//
+      + "  }" + System.lineSeparator()//
+      + "]" + System.lineSeparator();
 
   @Test
   public void encodesMapObjectNumericalValuesAsInteger() throws Exception {
@@ -65,8 +65,8 @@ public class JacksonCodecTest {
     new JacksonEncoder().encode(map, map.getClass(), template);
 
     assertThat(template).hasBody(""//
-        + "{\n" //
-        + "  \"foo\" : 1\n" //
+        + "{" + System.lineSeparator() //
+        + "  \"foo\" : 1" + System.lineSeparator() //
         + "}");
   }
 
@@ -80,9 +80,9 @@ public class JacksonCodecTest {
     new JacksonEncoder().encode(form, new TypeReference<Map<String, ?>>() {}.getType(), template);
 
     assertThat(template).hasBody(""//
-        + "{\n" //
-        + "  \"foo\" : 1,\n" //
-        + "  \"bar\" : [ 2, 3 ]\n" //
+        + "{" + System.lineSeparator() //
+        + "  \"foo\" : 1," + System.lineSeparator() //
+        + "  \"bar\" : [ 2, 3 ]" + System.lineSeparator() //
         + "}");
   }
 
@@ -155,11 +155,11 @@ public class JacksonCodecTest {
     encoder.encode(zones, new TypeReference<List<Zone>>() {}.getType(), template);
 
     assertThat(template).hasBody("" //
-        + "[ {\n"
-        + "  \"name\" : \"DENOMINATOR.IO.\"\n"
-        + "}, {\n"
-        + "  \"name\" : \"DENOMINATOR.IO.\",\n"
-        + "  \"id\" : \"ABCD\"\n"
+        + "[ {" + System.lineSeparator() 
+        + "  \"name\" : \"DENOMINATOR.IO.\"" + System.lineSeparator()
+        + "}, {" + System.lineSeparator()
+        + "  \"name\" : \"DENOMINATOR.IO.\"," + System.lineSeparator()
+        + "  \"id\" : \"ABCD\"" + System.lineSeparator()
         + "} ]");
   }
 

--- a/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
+++ b/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
@@ -140,17 +140,16 @@ public class JAXBCodecTest {
     RequestTemplate template = new RequestTemplate();
     encoder.encode(mock, MockObject.class, template);
 
-    String NEWLINE = System.getProperty("line.separator");
-
+    // RequestTemplate always expects a UNIX style newline.
     assertThat(template).hasBody(
         new StringBuilder().append("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>")
-            .append(NEWLINE)
+            .append("\n")
             .append("<mockObject>")
-            .append(NEWLINE)
+            .append("\n")
             .append("    <value>Test</value>")
-            .append(NEWLINE)
+            .append("\n")
             .append("</mockObject>")
-            .append(NEWLINE)
+            .append("\n")
             .toString());
   }
 

--- a/slf4j/src/test/java/feign/slf4j/Slf4jLoggerTest.java
+++ b/slf4j/src/test/java/feign/slf4j/Slf4jLoggerTest.java
@@ -43,7 +43,7 @@ public class Slf4jLoggerTest {
   @Test
   public void useFeignLoggerByDefault() throws Exception {
     slf4j.logLevel("debug");
-    slf4j.expectMessages("DEBUG feign.Logger - [someMethod] This is my message\n");
+    slf4j.expectMessages("DEBUG feign.Logger - [someMethod] This is my message" + System.lineSeparator());
 
     logger = new Slf4jLogger();
     logger.log(CONFIG_KEY, "This is my message");
@@ -52,7 +52,7 @@ public class Slf4jLoggerTest {
   @Test
   public void useLoggerByNameIfRequested() throws Exception {
     slf4j.logLevel("debug");
-    slf4j.expectMessages("DEBUG named.logger - [someMethod] This is my message\n");
+    slf4j.expectMessages("DEBUG named.logger - [someMethod] This is my message" + System.lineSeparator());
 
     logger = new Slf4jLogger("named.logger");
     logger.log(CONFIG_KEY, "This is my message");
@@ -61,7 +61,7 @@ public class Slf4jLoggerTest {
   @Test
   public void useLoggerByClassIfRequested() throws Exception {
     slf4j.logLevel("debug");
-    slf4j.expectMessages("DEBUG feign.Feign - [someMethod] This is my message\n");
+    slf4j.expectMessages("DEBUG feign.Feign - [someMethod] This is my message" + System.lineSeparator());
 
     logger = new Slf4jLogger(Feign.class);
     logger.log(CONFIG_KEY, "This is my message");
@@ -70,7 +70,7 @@ public class Slf4jLoggerTest {
   @Test
   public void useSpecifiedLoggerIfRequested() throws Exception {
     slf4j.logLevel("debug");
-    slf4j.expectMessages("DEBUG specified.logger - [someMethod] This is my message\n");
+    slf4j.expectMessages("DEBUG specified.logger - [someMethod] This is my message" + System.lineSeparator());
 
     logger = new Slf4jLogger(LoggerFactory.getLogger("specified.logger"));
     logger.log(CONFIG_KEY, "This is my message");
@@ -89,10 +89,12 @@ public class Slf4jLoggerTest {
   @Test
   public void logRequestsAndResponses() throws Exception {
     slf4j.logLevel("debug");
-    slf4j.expectMessages("DEBUG feign.Logger - [someMethod] A message with 2 formatting tokens.\n" +
-        "DEBUG feign.Logger - [someMethod] ---> GET http://api.example.com HTTP/1.1\n"
-        +
-        "DEBUG feign.Logger - [someMethod] <--- HTTP/1.1 200 OK (273ms)\n");
+    slf4j.expectMessages("DEBUG feign.Logger - [someMethod] A message with 2 formatting tokens." 
+        + System.lineSeparator() + 
+        "DEBUG feign.Logger - [someMethod] ---> GET http://api.example.com HTTP/1.1"
+        + System.lineSeparator() +
+        "DEBUG feign.Logger - [someMethod] <--- HTTP/1.1 200 OK (273ms)"
+        + System.lineSeparator());
 
     logger = new Slf4jLogger();
     logger.log(CONFIG_KEY, "A message with %d formatting %s.", 2, "tokens");


### PR DESCRIPTION
Added fixes to junit only tests for Windows platform newlines. Pretty much just put System.lineSeparator() everywhere except in jaxb where feign returns only UNIX specific newlines.