### PR TITLE
Make Feign's MethodHandlerFactory configurable

### DIFF
--- a/core/src/main/java/feign/MethodHandlerFactory.java
+++ b/core/src/main/java/feign/MethodHandlerFactory.java
@@ -1,0 +1,15 @@
+package feign;
+
+import feign.codec.Decoder;
+import feign.codec.ErrorDecoder;
+
+import static feign.InvocationHandlerFactory.*;
+
+public interface MethodHandlerFactory {
+    MethodHandler create(Target<?> target,
+                                                  MethodMetadata md,
+                                                  RequestTemplate.Factory buildTemplateFromArgs,
+                                                  Request.Options options,
+                                                  Decoder decoder,
+                                                  ErrorDecoder errorDecoder);
+}

--- a/core/src/main/java/feign/ReflectiveFeign.java
+++ b/core/src/main/java/feign/ReflectiveFeign.java
@@ -129,7 +129,7 @@ public class ReflectiveFeign extends Feign {
     private final Decoder decoder;
     private final ErrorDecoder errorDecoder;
     private final QueryMapEncoder queryMapEncoder;
-    private final SynchronousMethodHandler.Factory factory;
+    private final MethodHandlerFactory factory;
 
     ParseHandlersByName(
         Contract contract,
@@ -138,7 +138,7 @@ public class ReflectiveFeign extends Feign {
         Decoder decoder,
         QueryMapEncoder queryMapEncoder,
         ErrorDecoder errorDecoder,
-        SynchronousMethodHandler.Factory factory) {
+        MethodHandlerFactory factory) {
       this.contract = contract;
       this.options = options;
       this.factory = factory;

--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -173,7 +173,7 @@ final class SynchronousMethodHandler implements MethodHandler {
     }
   }
 
-  static class Factory {
+  static class Factory implements MethodHandlerFactory {
 
     private final Client client;
     private final Retryer retryer;
@@ -194,6 +194,7 @@ final class SynchronousMethodHandler implements MethodHandler {
       this.closeAfterDecode = closeAfterDecode;
     }
 
+    @Override
     public MethodHandler create(Target<?> target,
                                 MethodMetadata md,
                                 RequestTemplate.Factory buildTemplateFromArgs,


### PR DESCRIPTION
I want to be able to provide my own `MethodHandler` factory as a way to change the way retries work[1].  Currently the factory for `MethodHandler`s is always [`SynchronousMethodHandler`'s internal `Factory`](https://github.com/OpenFeign/feign/blob/master/core/src/main/java/feign/Feign.java#L248).

This PR pulls an interface out of `SynchronousMethodHandler.Factory` (`MethodHandlerFactory`), adds a `methodHandlerFactory()` to `Feign.builder` to allow setting this, and initializes the method handler to `SynchronousMethodHandler.Factory` in `Feign.Builder.build()` if it isn't set by the caller.


[1]: Specifically, I want to be able to throw checked exceptions from my `ErrorDecoder`s (see also: #709) so that users of the client can know what exceptions might be emitted.  Providing my own `MHF` will allow me to provide my own `MethodHandler` that, along with my `Retryer`, handles checked exceptions from my `ErrorDecoders`.