### PR TITLE
Fixed NPE in RequestTemplate.java. Updated TrustingSSLSocketFactory.java to use cipher from master.

### DIFF
--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -670,7 +670,10 @@ public final class RequestTemplate implements Serializable {
       }
       Collection<String> values = new ArrayList<String>();
       for (String value : entry.getValue()) {
-        if (value.indexOf('{') == 0 && value.indexOf('}') == value.length() - 1) {
+        // Allow a pure param to be represented, e.g. /path/resource?wsdl
+        if (null == value) {
+          values.add(null);
+        } else if (value.indexOf('{') == 0 && value.indexOf('}') == value.length() - 1) {
           Object variableValue = unencoded.get(value.substring(1, value.length() - 1));
           // only add non-null expressions
           if (variableValue == null) {

--- a/core/src/test/java/feign/client/AbstractClientTest.java
+++ b/core/src/test/java/feign/client/AbstractClientTest.java
@@ -332,6 +332,9 @@ public abstract class AbstractClientTest {
     @RequestLine("POST /?foo=bar&foo=baz&qux=")
     @Headers({"Foo: Bar", "Foo: Baz", "Qux: ", "Content-Type: {contentType}"})
     Response postWithContentType(String body, @Param("contentType") String contentType);
+
+    @RequestLine("GET /wsdl/testcase?wsdl")
+    Response getWsdl();
   }
 
 }

--- a/core/src/test/java/feign/client/DefaultClientTest.java
+++ b/core/src/test/java/feign/client/DefaultClientTest.java
@@ -17,6 +17,8 @@ import java.io.IOException;
 import java.net.ProtocolException;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSession;
+import feign.Response;
+import feign.assertj.MockWebServerAssertions;
 import org.junit.Test;
 import feign.Client;
 import feign.Feign;
@@ -24,6 +26,7 @@ import feign.Feign.Builder;
 import feign.RetryableException;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.SocketPolicy;
+import static feign.assertj.FeignAssertions.assertThat;
 import static org.hamcrest.core.Is.isA;
 import static org.junit.Assert.assertEquals;
 
@@ -94,6 +97,22 @@ public class DefaultClientTest extends AbstractClientTest {
         .target(TestInterface.class, "https://localhost:" + server.getPort());
 
     api.post("foo");
+  }
+
+  @Test
+  public void testWsdlApi() throws InterruptedException {
+    server.enqueue(new MockResponse().setResponseCode(200).setBody(""));
+
+    TestInterface api = newBuilder()
+        .target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    Response response = api.getWsdl();
+
+    assertThat(response.status()).isEqualTo(200);
+    assertThat(response.reason()).isEqualTo("OK");
+
+    MockWebServerAssertions.assertThat(server.takeRequest()).hasMethod("GET")
+        .hasPath("/wsdl/testcase?wsdl");
   }
 
 }

--- a/core/src/test/java/feign/client/TrustingSSLSocketFactory.java
+++ b/core/src/test/java/feign/client/TrustingSSLSocketFactory.java
@@ -43,7 +43,7 @@ public final class TrustingSSLSocketFactory extends SSLSocketFactory
   private static final Map<String, SSLSocketFactory> sslSocketFactories =
       new LinkedHashMap<String, SSLSocketFactory>();
   private static final char[] KEYSTORE_PASSWORD = "password".toCharArray();
-  private final static String[] ENABLED_CIPHER_SUITES = {"SSL_RSA_WITH_3DES_EDE_CBC_SHA"};
+  private final static String[] ENABLED_CIPHER_SUITES = {"TLS_RSA_WITH_AES_256_CBC_SHA"};
   private final SSLSocketFactory delegate;
   private final String serverAlias;
   private final PrivateKey privateKey;


### PR DESCRIPTION
This PR fixes the NPE in RequestTemplate.java described in this open issue: https://github.com/OpenFeign/feign/issues/693#issuecomment-386323127
Included, there is also a simple unit test to check for the NPE and an update to TrustingSSLSocketFactory.java to use the cipher from master.