### PR TITLE
Unwrap RetryableException and throw cause

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,7 +727,9 @@ public class Example {
 `Retryer`s are responsible for determining if a retry should occur by returning either a `true` or
 `false` from the method `continueOrPropagate(RetryableException e);`  A `Retryer` instance will be 
 created for each `Client` execution, allowing you to maintain state bewteen each request if desired.
-If the retry is determined to be unsucessful, the last `RetryException` will be thrown.
+
+If the retry is determined to be unsuccessful, the last `RetryException` will be thrown.  To throw the original
+cause that led to the unsuccessful retry, build your Feign client with the `propagateExceptions()` option.
 
 #### Static and Default Methods
 Interfaces targeted by Feign may have static or default methods (if using Java 8+).

--- a/README.md
+++ b/README.md
@@ -729,7 +729,7 @@ public class Example {
 created for each `Client` execution, allowing you to maintain state bewteen each request if desired.
 
 If the retry is determined to be unsuccessful, the last `RetryException` will be thrown.  To throw the original
-cause that led to the unsuccessful retry, build your Feign client with the `propagateExceptions()` option.
+cause that led to the unsuccessful retry, build your Feign client with the `exceptionPropagationPolicy()` option.
 
 #### Static and Default Methods
 Interfaces targeted by Feign may have static or default methods (if using Java 8+).

--- a/core/src/main/java/feign/ExceptionPropagationPolicy.java
+++ b/core/src/main/java/feign/ExceptionPropagationPolicy.java
@@ -14,5 +14,5 @@
 package feign;
 
 public enum ExceptionPropagationPolicy {
-    NONE, UNWRAP
+  NONE, UNWRAP
 }

--- a/core/src/main/java/feign/ExceptionPropagationPolicy.java
+++ b/core/src/main/java/feign/ExceptionPropagationPolicy.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2012-2018 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package feign;
 
 public enum ExceptionPropagationPolicy {

--- a/core/src/main/java/feign/ExceptionPropagationPolicy.java
+++ b/core/src/main/java/feign/ExceptionPropagationPolicy.java
@@ -1,0 +1,5 @@
+package feign;
+
+public enum ExceptionPropagationPolicy {
+    NONE, UNWRAP
+}

--- a/core/src/main/java/feign/Feign.java
+++ b/core/src/main/java/feign/Feign.java
@@ -26,6 +26,8 @@ import feign.codec.Decoder;
 import feign.codec.Encoder;
 import feign.codec.ErrorDecoder;
 
+import static feign.ExceptionPropagationPolicy.NONE;
+
 /**
  * Feign's purpose is to ease development against http apis that feign restfulness. <br>
  * In implementation, Feign is a {@link Feign#newInstance factory} for generating {@link Target
@@ -109,7 +111,7 @@ public abstract class Feign {
         new InvocationHandlerFactory.Default();
     private boolean decode404;
     private boolean closeAfterDecode = true;
-    private boolean propagateExceptions = false;
+    private ExceptionPropagationPolicy propagationPolicy = NONE;
 
     public Builder logLevel(Logger.Level logLevel) {
       this.logLevel = logLevel;
@@ -237,8 +239,8 @@ public abstract class Feign {
       return this;
     }
 
-    public Builder propagateExceptions() {
-      this.propagateExceptions = true;
+    public Builder exceptionPropagationPolicy(ExceptionPropagationPolicy propagationPolicy) {
+      this.propagationPolicy = propagationPolicy;
       return this;
     }
 
@@ -253,7 +255,7 @@ public abstract class Feign {
     public Feign build() {
       SynchronousMethodHandler.Factory synchronousMethodHandlerFactory =
           new SynchronousMethodHandler.Factory(client, retryer, requestInterceptors, logger,
-              logLevel, decode404, closeAfterDecode, propagateExceptions);
+              logLevel, decode404, closeAfterDecode, propagationPolicy);
       ParseHandlersByName handlersByName =
           new ParseHandlersByName(contract, options, encoder, decoder, queryMapEncoder,
               errorDecoder, synchronousMethodHandlerFactory);

--- a/core/src/main/java/feign/Feign.java
+++ b/core/src/main/java/feign/Feign.java
@@ -25,7 +25,6 @@ import feign.Target.HardCodedTarget;
 import feign.codec.Decoder;
 import feign.codec.Encoder;
 import feign.codec.ErrorDecoder;
-
 import static feign.ExceptionPropagationPolicy.NONE;
 
 /**

--- a/core/src/main/java/feign/Feign.java
+++ b/core/src/main/java/feign/Feign.java
@@ -109,6 +109,7 @@ public abstract class Feign {
         new InvocationHandlerFactory.Default();
     private boolean decode404;
     private boolean closeAfterDecode = true;
+    private boolean propagateExceptions = false;
 
     public Builder logLevel(Logger.Level logLevel) {
       this.logLevel = logLevel;
@@ -236,6 +237,11 @@ public abstract class Feign {
       return this;
     }
 
+    public Builder propagateExceptions() {
+      this.propagateExceptions = true;
+      return this;
+    }
+
     public <T> T target(Class<T> apiType, String url) {
       return target(new HardCodedTarget<T>(apiType, url));
     }
@@ -247,7 +253,7 @@ public abstract class Feign {
     public Feign build() {
       SynchronousMethodHandler.Factory synchronousMethodHandlerFactory =
           new SynchronousMethodHandler.Factory(client, retryer, requestInterceptors, logger,
-              logLevel, decode404, closeAfterDecode);
+              logLevel, decode404, closeAfterDecode, propagateExceptions);
       ParseHandlersByName handlersByName =
           new ParseHandlersByName(contract, options, encoder, decoder, queryMapEncoder,
               errorDecoder, synchronousMethodHandlerFactory);

--- a/core/src/main/java/feign/ReflectiveFeign.java
+++ b/core/src/main/java/feign/ReflectiveFeign.java
@@ -100,15 +100,7 @@ public class ReflectiveFeign extends Feign {
         return toString();
       }
 
-      try {
-          return dispatch.get(method).invoke(args);
-      } catch (Throwable th) {
-        Throwable cause = th.getCause();
-        if (th instanceof RetryableException && cause != null) {
-          throw cause;
-        }
-        throw th;
-      }
+      return dispatch.get(method).invoke(args);
     }
 
     @Override

--- a/core/src/main/java/feign/ReflectiveFeign.java
+++ b/core/src/main/java/feign/ReflectiveFeign.java
@@ -98,7 +98,16 @@ public class ReflectiveFeign extends Feign {
       } else if ("toString".equals(method.getName())) {
         return toString();
       }
-      return dispatch.get(method).invoke(args);
+
+      try {
+          return dispatch.get(method).invoke(args);
+      } catch (Throwable th) {
+        Throwable cause = th.getCause();
+        if (th instanceof RetryableException && cause != null) {
+          throw cause;
+        }
+        throw th;
+      }
     }
 
     @Override

--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -43,13 +43,14 @@ final class SynchronousMethodHandler implements MethodHandler {
   private final ErrorDecoder errorDecoder;
   private final boolean decode404;
   private final boolean closeAfterDecode;
+  private final boolean propagateExceptions;
 
   private SynchronousMethodHandler(Target<?> target, Client client, Retryer retryer,
-      List<RequestInterceptor> requestInterceptors, Logger logger,
-      Logger.Level logLevel, MethodMetadata metadata,
-      RequestTemplate.Factory buildTemplateFromArgs, Options options,
-      Decoder decoder, ErrorDecoder errorDecoder, boolean decode404,
-      boolean closeAfterDecode) {
+                                   List<RequestInterceptor> requestInterceptors, Logger logger,
+                                   Logger.Level logLevel, MethodMetadata metadata,
+                                   RequestTemplate.Factory buildTemplateFromArgs, Options options,
+                                   Decoder decoder, ErrorDecoder errorDecoder, boolean decode404,
+                                   boolean closeAfterDecode, boolean propagateExceptions) {
     this.target = checkNotNull(target, "target");
     this.client = checkNotNull(client, "client for %s", target);
     this.retryer = checkNotNull(retryer, "retryer for %s", target);
@@ -64,6 +65,7 @@ final class SynchronousMethodHandler implements MethodHandler {
     this.decoder = checkNotNull(decoder, "decoder for %s", target);
     this.decode404 = decode404;
     this.closeAfterDecode = closeAfterDecode;
+    this.propagateExceptions = propagateExceptions;
   }
 
   @Override
@@ -74,7 +76,16 @@ final class SynchronousMethodHandler implements MethodHandler {
       try {
         return executeAndDecode(template);
       } catch (RetryableException e) {
-        retryer.continueOrPropagate(e);
+        try {
+          retryer.continueOrPropagate(e);
+        } catch (RetryableException th) {
+          Throwable cause = th.getCause();
+          if (propagateExceptions && cause != null) {
+            throw cause;
+          } else {
+            throw th;
+          }
+        }
         if (logLevel != Logger.Level.NONE) {
           logger.logRetry(metadata.configKey(), logLevel);
         }
@@ -178,9 +189,11 @@ final class SynchronousMethodHandler implements MethodHandler {
     private final Logger.Level logLevel;
     private final boolean decode404;
     private final boolean closeAfterDecode;
+    private final boolean propagateExceptions;
 
     Factory(Client client, Retryer retryer, List<RequestInterceptor> requestInterceptors,
-        Logger logger, Logger.Level logLevel, boolean decode404, boolean closeAfterDecode) {
+            Logger logger, Logger.Level logLevel, boolean decode404, boolean closeAfterDecode,
+            boolean propagateExceptions) {
       this.client = checkNotNull(client, "client");
       this.retryer = checkNotNull(retryer, "retryer");
       this.requestInterceptors = checkNotNull(requestInterceptors, "requestInterceptors");
@@ -188,6 +201,7 @@ final class SynchronousMethodHandler implements MethodHandler {
       this.logLevel = checkNotNull(logLevel, "logLevel");
       this.decode404 = decode404;
       this.closeAfterDecode = closeAfterDecode;
+      this.propagateExceptions = propagateExceptions;
     }
 
     public MethodHandler create(Target<?> target,
@@ -198,7 +212,7 @@ final class SynchronousMethodHandler implements MethodHandler {
                                 ErrorDecoder errorDecoder) {
       return new SynchronousMethodHandler(target, client, retryer, requestInterceptors, logger,
           logLevel, md, buildTemplateFromArgs, options, decoder,
-          errorDecoder, decode404, closeAfterDecode);
+          errorDecoder, decode404, closeAfterDecode, propagateExceptions);
     }
   }
 }

--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -46,11 +46,11 @@ final class SynchronousMethodHandler implements MethodHandler {
   private final boolean propagateExceptions;
 
   private SynchronousMethodHandler(Target<?> target, Client client, Retryer retryer,
-                                   List<RequestInterceptor> requestInterceptors, Logger logger,
-                                   Logger.Level logLevel, MethodMetadata metadata,
-                                   RequestTemplate.Factory buildTemplateFromArgs, Options options,
-                                   Decoder decoder, ErrorDecoder errorDecoder, boolean decode404,
-                                   boolean closeAfterDecode, boolean propagateExceptions) {
+      List<RequestInterceptor> requestInterceptors, Logger logger,
+      Logger.Level logLevel, MethodMetadata metadata,
+      RequestTemplate.Factory buildTemplateFromArgs, Options options,
+      Decoder decoder, ErrorDecoder errorDecoder, boolean decode404,
+      boolean closeAfterDecode, boolean propagateExceptions) {
     this.target = checkNotNull(target, "target");
     this.client = checkNotNull(client, "client for %s", target);
     this.retryer = checkNotNull(retryer, "retryer for %s", target);

--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -21,7 +21,6 @@ import feign.Request.Options;
 import feign.codec.DecodeException;
 import feign.codec.Decoder;
 import feign.codec.ErrorDecoder;
-
 import static feign.ExceptionPropagationPolicy.UNWRAP;
 import static feign.FeignException.errorExecuting;
 import static feign.FeignException.errorReading;
@@ -194,8 +193,8 @@ final class SynchronousMethodHandler implements MethodHandler {
     private final ExceptionPropagationPolicy propagationPolicy;
 
     Factory(Client client, Retryer retryer, List<RequestInterceptor> requestInterceptors,
-            Logger logger, Logger.Level logLevel, boolean decode404, boolean closeAfterDecode,
-            ExceptionPropagationPolicy propagationPolicy) {
+        Logger logger, Logger.Level logLevel, boolean decode404, boolean closeAfterDecode,
+        ExceptionPropagationPolicy propagationPolicy) {
       this.client = checkNotNull(client, "client");
       this.retryer = checkNotNull(retryer, "retryer");
       this.requestInterceptors = checkNotNull(requestInterceptors, "requestInterceptors");

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -37,7 +37,6 @@ import feign.codec.EncodeException;
 import feign.codec.Encoder;
 import feign.codec.ErrorDecoder;
 import feign.codec.StringDecoder;
-
 import static feign.ExceptionPropagationPolicy.UNWRAP;
 import static feign.Util.UTF_8;
 import static feign.assertj.MockWebServerAssertions.assertThat;
@@ -560,15 +559,15 @@ public class FeignTest {
     thrown.expectMessage(message);
 
     TestInterface api = Feign.builder()
-            .exceptionPropagationPolicy(UNWRAP)
-            .retryer(new Retryer.Default(1, 1, 2))
-            .errorDecoder(new ErrorDecoder() {
-              @Override
-              public Exception decode(String methodKey, Response response) {
-                return new RetryableException("play it again sam!", HttpMethod.POST,
-                        new TestInterfaceException(message), null);
-              }
-            }).target(TestInterface.class, "http://localhost:" + server.getPort());
+        .exceptionPropagationPolicy(UNWRAP)
+        .retryer(new Retryer.Default(1, 1, 2))
+        .errorDecoder(new ErrorDecoder() {
+          @Override
+          public Exception decode(String methodKey, Response response) {
+            return new RetryableException("play it again sam!", HttpMethod.POST,
+                new TestInterfaceException(message), null);
+          }
+        }).target(TestInterface.class, "http://localhost:" + server.getPort());
 
     api.post();
   }
@@ -583,14 +582,14 @@ public class FeignTest {
     thrown.expectMessage(message);
 
     TestInterface api = Feign.builder()
-            .exceptionPropagationPolicy(UNWRAP)
-            .retryer(new Retryer.Default(1, 1, 2))
-            .errorDecoder(new ErrorDecoder() {
-              @Override
-              public Exception decode(String methodKey, Response response) {
-                return new RetryableException(message, HttpMethod.POST, null);
-              }
-            }).target(TestInterface.class, "http://localhost:" + server.getPort());
+        .exceptionPropagationPolicy(UNWRAP)
+        .retryer(new Retryer.Default(1, 1, 2))
+        .errorDecoder(new ErrorDecoder() {
+          @Override
+          public Exception decode(String methodKey, Response response) {
+            return new RetryableException(message, HttpMethod.POST, null);
+          }
+        }).target(TestInterface.class, "http://localhost:" + server.getPort());
 
     api.post();
   }

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -567,11 +567,12 @@ public class FeignTest {
     thrown.expectMessage(message);
 
     TestInterface api = Feign.builder()
+            .propagateExceptions()
             .retryer(new Retryer.Default(1, 1, 2))
             .errorDecoder(new ErrorDecoder() {
               @Override
               public Exception decode(String methodKey, Response response) {
-                return new RetryableException("play it again sam!",
+                return new RetryableException("play it again sam!", HttpMethod.POST,
                         new TestInterfaceException(message), null);
               }
             }).target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -589,11 +590,12 @@ public class FeignTest {
     thrown.expectMessage(message);
 
     TestInterface api = Feign.builder()
+            .propagateExceptions()
             .retryer(new Retryer.Default(1, 1, 2))
             .errorDecoder(new ErrorDecoder() {
               @Override
               public Exception decode(String methodKey, Response response) {
-                return new RetryableException(message, null);
+                return new RetryableException(message, HttpMethod.POST, null);
               }
             }).target(TestInterface.class, "http://localhost:" + server.getPort());
 

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -46,6 +46,8 @@ import feign.codec.Encoder;
 import feign.codec.ErrorDecoder;
 import feign.codec.StringDecoder;
 import feign.Feign.ResponseMappingDecoder;
+
+import static feign.ExceptionPropagationPolicy.UNWRAP;
 import static feign.Util.UTF_8;
 import static feign.assertj.MockWebServerAssertions.assertThat;
 import static org.assertj.core.data.MapEntry.entry;
@@ -567,7 +569,7 @@ public class FeignTest {
     thrown.expectMessage(message);
 
     TestInterface api = Feign.builder()
-            .propagateExceptions()
+            .exceptionPropagationPolicy(UNWRAP)
             .retryer(new Retryer.Default(1, 1, 2))
             .errorDecoder(new ErrorDecoder() {
               @Override
@@ -590,7 +592,7 @@ public class FeignTest {
     thrown.expectMessage(message);
 
     TestInterface api = Feign.builder()
-            .propagateExceptions()
+            .exceptionPropagationPolicy(UNWRAP)
             .retryer(new Retryer.Default(1, 1, 2))
             .errorDecoder(new ErrorDecoder() {
               @Override


### PR DESCRIPTION
As described in #709, this changes Feign to unwrap `RetryableException`s to throw the underlying cause in the event retrying fails.

This will require documentation updates, but I wanted to make a PR to show the changes for discussion first.