### PR TITLE
Create relocation pom for the deprecated 'feign-java8'

### DIFF
--- a/java8/pom.xml
+++ b/java8/pom.xml
@@ -22,33 +22,19 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <!-- remove after feign 10.0 release -->
     <artifactId>feign-java8</artifactId>
     <name>Feign Java 8</name>
     <description>Feign Java 8</description>
 
     <properties>
-        <!-- override default bytecode version for src/main from parent pom -->
-        <main.java.version>1.8</main.java.version>
-        <main.signature.artifact>java18</main.signature.artifact>
         <main.basedir>${project.basedir}/..</main.basedir>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
-    <dependencies>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>feign-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>feign-jackson</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>mockwebserver</artifactId>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+  <distributionManagement>
+    <relocation>
+      <artifactId>feign-core</artifactId>
+    </relocation>
+  </distributionManagement>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,8 @@
     <module>ribbon</module>
     <module>sax</module>
     <module>slf4j</module>
+    <!-- remove after feign 10.0 release -->
+    <module>java8</module>
     <module>mock</module>
     <module>benchmark</module>
   </modules>


### PR DESCRIPTION
https://maven.apache.org/guides/mini/guide-relocation.html

I think this is a nice to have for 10.0 and we must delete soon after