### PR TITLE
Allow decoding of parameterizedTypes (generics) Fixes #759

### DIFF
--- a/jaxb/src/main/java/feign/jaxb/JAXBDecoder.java
+++ b/jaxb/src/main/java/feign/jaxb/JAXBDecoder.java
@@ -15,6 +15,7 @@ package feign.jaxb;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.lang.reflect.ParameterizedType;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.parsers.ParserConfigurationException;
@@ -36,13 +37,13 @@ import org.xml.sax.SAXException;
  * 
  * <pre>
  * JAXBContextFactory jaxbFactory = new JAXBContextFactory.Builder()
- *     .withMarshallerJAXBEncoding("UTF-8")
- *     .withMarshallerSchemaLocation("http://apihost http://apihost/schema.xsd")
+ *     .withMarshallerJAXBEncoding(&quot;UTF-8&quot;)
+ *     .withMarshallerSchemaLocation(&quot;http://apihost http://apihost/schema.xsd&quot;)
  *     .build();
- *
+ * 
  * api = Feign.builder()
  *     .decoder(new JAXBDecoder(jaxbFactory))
- *     .target(MyApi.class, "http://api");
+ *     .target(MyApi.class, &quot;http://api&quot;);
  * </pre>
  * <p>
  * The JAXBContextFactory should be reused across requests as it caches the created JAXB contexts.
@@ -69,7 +70,7 @@ public class JAXBDecoder implements Decoder {
       return Util.emptyValueOf(type);
     if (response.body() == null)
       return null;
-    if (type instanceof ParameterizedType) {
+    while (type instanceof ParameterizedType) {
       ParameterizedType ptype = (ParameterizedType) type;
       type = ptype.getRawType();
     }

--- a/jaxb/src/main/java/feign/jaxb/JAXBDecoder.java
+++ b/jaxb/src/main/java/feign/jaxb/JAXBDecoder.java
@@ -69,6 +69,10 @@ public class JAXBDecoder implements Decoder {
       return Util.emptyValueOf(type);
     if (response.body() == null)
       return null;
+    if (type instanceof ParameterizedType) {
+      ParameterizedType ptype = (ParameterizedType) type;
+      type = ptype.getRawType();
+    }
     if (!(type instanceof Class)) {
       throw new UnsupportedOperationException(
           "JAXB only supports decoding raw types. Found " + type);

--- a/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
+++ b/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
@@ -47,8 +47,9 @@ public class JAXBCodecTest {
     new JAXBEncoder(new JAXBContextFactory.Builder().build())
         .encode(mock, MockObject.class, template);
 
-    assertThat(template).hasBody(
-        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><mockObject><value>Test</value></mockObject>");
+    assertThat(template)
+        .hasBody(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><mockObject><value>Test</value></mockObject>");
   }
 
   @Test
@@ -101,10 +102,8 @@ public class JAXBCodecTest {
     encoder.encode(mock, MockObject.class, template);
 
     assertThat(template).hasBody("<?xml version=\"1.0\" encoding=\"UTF-8\" " +
-        "standalone=\"yes\"?><mockObject xsi:schemaLocation=\"http://apihost "
-        +
-        "http://apihost/schema.xsd\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">"
-        +
+        "standalone=\"yes\"?><mockObject xsi:schemaLocation=\"http://apihost " +
+        "http://apihost/schema.xsd\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" +
         "<value>Test</value></mockObject>");
   }
 
@@ -122,11 +121,12 @@ public class JAXBCodecTest {
     RequestTemplate template = new RequestTemplate();
     encoder.encode(mock, MockObject.class, template);
 
-    assertThat(template).hasBody("<?xml version=\"1.0\" encoding=\"UTF-8\" " +
-        "standalone=\"yes\"?><mockObject xsi:noNamespaceSchemaLocation=\"http://apihost/schema.xsd\" "
-        +
-        "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" +
-        "<value>Test</value></mockObject>");
+    assertThat(template)
+        .hasBody(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" " +
+                "standalone=\"yes\"?><mockObject xsi:noNamespaceSchemaLocation=\"http://apihost/schema.xsd\" " +
+                "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" +
+                "<value>Test</value></mockObject>");
   }
 
   @Test
@@ -178,9 +178,11 @@ public class JAXBCodecTest {
 
   @Test
   public void doesntDecodeParameterizedTypes() throws Exception {
-    thrown.expect(UnsupportedOperationException.class);
+    thrown.expect(feign.codec.DecodeException.class);
     thrown.expectMessage(
-        "JAXB only supports decoding raw types. Found java.util.Map<java.lang.String, ?>");
+        "java.util.Map is an interface, and JAXB can't handle interfaces.\n"+
+            "\tthis problem is related to the following location:\n"+
+            "\t\tat java.util.Map");
 
     class ParameterizedHolder {
 
@@ -197,6 +199,44 @@ public class JAXBCodecTest {
         .build();
 
     new JAXBDecoder(new JAXBContextFactory.Builder().build()).decode(response, parameterized);
+  }
+
+  @XmlRootElement
+  static class Box<T> {
+
+    @XmlElement
+    private T t;
+
+    public void set(T t) {
+      this.t = t;
+    }
+
+  }
+
+  @Test
+  public void decodeAnnotatedParameterizedTypes() throws Exception {
+    JAXBContextFactory jaxbContextFactory =
+        new JAXBContextFactory.Builder().withMarshallerFormattedOutput(true).build();
+
+    Encoder encoder = new JAXBEncoder(jaxbContextFactory);
+
+    Box<String> boxStr = new Box<>();
+    boxStr.set("hello");
+    Box<Box<String>> boxBoxStr = new Box<>();
+    boxBoxStr.set(boxStr);
+    RequestTemplate template = new RequestTemplate();
+    encoder.encode(boxBoxStr, Box.class, template);
+
+    Response response = Response.builder()
+        .status(200)
+        .reason("OK")
+        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.<String, Collection<String>>emptyMap())
+        .body(template.body())
+        .build();
+
+    new JAXBDecoder(new JAXBContextFactory.Builder().build()).decode(response, Box.class);
+
   }
 
   /** Enabled via {@link feign.Feign.Builder#decode404()} */


### PR DESCRIPTION
If type is a parameterizedType then extract rawType before proceeding with decoding instead of Trowing an exception