### PR TITLE
Adding Multiple Values for Consumes and Produces

### DIFF
--- a/core/src/main/java/feign/Util.java
+++ b/core/src/main/java/feign/Util.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.function.Predicate;
 import static java.lang.String.format;
 
 /**
@@ -146,6 +147,21 @@ public class Util {
    */
   public static String emptyToNull(String string) {
     return string == null || string.isEmpty() ? null : string;
+  }
+
+  /**
+   * Removes values from the array that meet the criteria for removal via the supplied {@link Predicate} value
+   */
+  @SuppressWarnings("unchecked")
+  public static <T> T[] removeValues(T[] values, Predicate<T> shouldRemove, Class<T> type) {
+    Collection<T> collection = new ArrayList<>(values.length);
+    for (T value : values) {
+      if (shouldRemove.negate().test(value)) {
+        collection.add(value);
+      }
+    }
+    T[] array = (T[]) Array.newInstance(type, collection.size());
+    return collection.toArray(array);
   }
 
   /**

--- a/core/src/test/java/feign/UtilTest.java
+++ b/core/src/test/java/feign/UtilTest.java
@@ -23,11 +23,27 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import feign.codec.Decoder;
+import static feign.Util.emptyToNull;
+import static feign.Util.removeValues;
 import static feign.Util.resolveLastTypeParameter;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 public class UtilTest {
+
+  @Test
+  public void removesEmptyStrings() {
+    String[] values = new String[] {"", null};
+    assertThat(removeValues(values, (value) -> emptyToNull(value) == null, String.class))
+        .isEmpty();
+  }
+
+  @Test
+  public void removesEvenNumbers() {
+    Integer[] values = new Integer[] {22, 23};
+    assertThat(removeValues(values, (number) -> number % 2 == 0, Integer.class))
+        .containsExactly(23);
+  }
 
   @Test
   public void emptyValueOf() throws Exception {

--- a/jaxrs/README.md
+++ b/jaxrs/README.md
@@ -21,9 +21,9 @@ Sets the request method.
 #### `@Path`
 Appends the value to `Target.url()`.  Can have tokens corresponding to `@PathParam` annotations.
 #### `@Produces`
-Adds the first value as the `Accept` header.
+Adds all values into the `Accept` header.
 #### `@Consumes`
-Adds the first value as the `Content-Type` header.
+Adds all values into the `Content-Type` header.
 ### Parameter Annotations
 #### `@PathParam`
 Links the value of the corresponding parameter to a template variable declared in the path.

--- a/jaxrs/src/main/java/feign/jaxrs/JAXRSContract.java
+++ b/jaxrs/src/main/java/feign/jaxrs/JAXRSContract.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import static feign.Util.checkState;
 import static feign.Util.emptyToNull;
+import static feign.Util.removeValues;
 
 /**
  * Please refer to the <a href="https://github.com/Netflix/feign/tree/master/feign-jaxrs">Feign
@@ -99,19 +100,19 @@ public class JAXRSContract extends Contract.BaseContract {
   }
 
   private void handleProducesAnnotation(MethodMetadata data, Produces produces, String name) {
-    String[] serverProduces = produces.value();
-    String clientAccepts = serverProduces.length == 0 ? null : emptyToNull(serverProduces[0]);
-    checkState(clientAccepts != null, "Produces.value() was empty on %s", name);
+    String[] serverProduces =
+        removeValues(produces.value(), (mediaType) -> emptyToNull(mediaType) == null, String.class);
+    checkState(serverProduces.length > 0, "Produces.value() was empty on %s", name);
     data.template().header(ACCEPT, (String) null); // remove any previous produces
-    data.template().header(ACCEPT, clientAccepts);
+    data.template().header(ACCEPT, serverProduces);
   }
 
   private void handleConsumesAnnotation(MethodMetadata data, Consumes consumes, String name) {
-    String[] serverConsumes = consumes.value();
-    String clientProduces = serverConsumes.length == 0 ? null : emptyToNull(serverConsumes[0]);
-    checkState(clientProduces != null, "Consumes.value() was empty on %s", name);
+    String[] serverConsumes =
+        removeValues(consumes.value(), (mediaType) -> emptyToNull(mediaType) == null, String.class);
+    checkState(serverConsumes.length > 0, "Consumes.value() was empty on %s", name);
     data.template().header(CONTENT_TYPE, (String) null); // remove any previous consumes
-    data.template().header(CONTENT_TYPE, clientProduces);
+    data.template().header(CONTENT_TYPE, serverConsumes);
   }
 
   /**

--- a/jaxrs/src/test/java/feign/jaxrs/JAXRSContractTest.java
+++ b/jaxrs/src/test/java/feign/jaxrs/JAXRSContractTest.java
@@ -121,6 +121,16 @@ public class JAXRSContractTest {
   }
 
   @Test
+  public void producesMultipleAddsAcceptHeader() throws Exception {
+    MethodMetadata md = parseAndValidateMetadata(ProducesAndConsumes.class, "producesMultiple");
+
+    assertThat(md.template())
+        .hasHeaders(
+            entry("Content-Type", asList("application/json")),
+            entry("Accept", asList("application/xml", "text/plain")));
+  }
+
+  @Test
   public void producesNada() throws Exception {
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("Produces.value() was empty on method producesNada");
@@ -143,6 +153,15 @@ public class JAXRSContractTest {
     assertThat(md.template())
         .hasHeaders(entry("Accept", asList("text/html")),
             entry("Content-Type", asList("application/xml")));
+  }
+
+  @Test
+  public void consumesMultipleAddsContentTypeHeader() throws Exception {
+    MethodMetadata md = parseAndValidateMetadata(ProducesAndConsumes.class, "consumesMultiple");
+
+    assertThat(md.template())
+        .hasHeaders(entry("Accept", asList("text/html")),
+            entry("Content-Type", asList("application/xml", "application/json")));
   }
 
   @Test
@@ -425,6 +444,10 @@ public class JAXRSContractTest {
     Response produces();
 
     @GET
+    @Produces({"application/xml", "text/plain"})
+    Response producesMultiple();
+
+    @GET
     @Produces({})
     Response producesNada();
 
@@ -435,6 +458,10 @@ public class JAXRSContractTest {
     @POST
     @Consumes("application/xml")
     Response consumes();
+
+    @POST
+    @Consumes({"application/xml", "application/json"})
+    Response consumesMultiple();
 
     @POST
     @Consumes({})


### PR DESCRIPTION
Addresses Issue #763

This PR adds the support for having multiple values in the `@Produces` and `@Consumes` annotations when using the `JAXRSContract`. Empty or `null` values are removed if present, and at least one non-empty or non-null value must be present. 

To facilitate, I created a new method in `Util` that allows for removing values from an array that meet a `Predicate` criteria for removal. 