### PR TITLE
Validate code format when building on travis

### DIFF
--- a/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
+++ b/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
@@ -123,10 +123,10 @@ public class JAXBCodecTest {
 
     assertThat(template)
         .hasBody(
-            "<?xml version=\"1.0\" encoding=\"UTF-8\" " +
-                "standalone=\"yes\"?><mockObject xsi:noNamespaceSchemaLocation=\"http://apihost/schema.xsd\" " +
-                "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" +
-                "<value>Test</value></mockObject>");
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" "
+                + "standalone=\"yes\"?><mockObject xsi:noNamespaceSchemaLocation=\"http://apihost/schema.xsd\" "
+                + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">"
+                + "<value>Test</value></mockObject>");
   }
 
   @Test
@@ -180,9 +180,9 @@ public class JAXBCodecTest {
   public void doesntDecodeParameterizedTypes() throws Exception {
     thrown.expect(feign.codec.DecodeException.class);
     thrown.expectMessage(
-        "java.util.Map is an interface, and JAXB can't handle interfaces.\n"+
-            "\tthis problem is related to the following location:\n"+
-            "\t\tat java.util.Map");
+        "java.util.Map is an interface, and JAXB can't handle interfaces.\n"
+            + "\tthis problem is related to the following location:\n"
+            + "\t\tat java.util.Map");
 
     class ParameterizedHolder {
 

--- a/pom.xml
+++ b/pom.xml
@@ -472,6 +472,39 @@
         <module>jaxb</module>
       </modules>
     </profile>
+
+    <profile>
+      <id>validateCodeFormat</id>
+      <activation>
+        <property>
+          <name>validateFormat</name>
+        </property>
+      </activation>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.marvinformatics.formatter</groupId>
+            <artifactId>formatter-maven-plugin</artifactId>
+            <version>2.2.0</version>
+            <configuration>
+              <lineEnding>LF</lineEnding>
+              <configFile>${main.basedir}/src/config/eclipse-java-style.xml</configFile>
+            </configuration>
+            <executions>
+              <execution>
+                <id>validate-only</id>
+                <goals>
+                  <goal>validate</goal>
+                </goals>
+                <phase>initialize</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <profile>
       <id>release</id>
       <build>

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -159,7 +159,7 @@ if ! is_pull_request && build_started_by_tag; then
 fi
 
 # skip license on travis due to #1512
-./mvnw install -nsu -Dlicense.skip=true
+./mvnw install -nsu -Dlicense.skip=true -DvalidateFormat
 
 # If we are on a pull request, our only job is to run tests, which happened above via ./mvnw install
 if is_pull_request; then


### PR DESCRIPTION
Code format deviated from settings, again.

To prevent this recurring issue, change build to fail if code format mismatch