### PR TITLE
Disabling JDK 11 Builds in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 # Run `travis lint` when changing this file to avoid breaking the build.
 # Default JDK is really old: 1.8.0_31; Trusty's is less old: 1.8.0_51
 # https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments
-sudo: required
 dist: trusty
 sudo: false
 language: java
+jdk: oraclejdk8
 before_install:
   # Parameters used during release
   - git config user.name "$GH_USER"
@@ -24,16 +24,16 @@ cache:
   directories:
   - $HOME/.m2
 
-matrix:
-  include:
-    - os: linux
-      jdk: oraclejdk8
-      addons:
-        apt:
-          packages:
-            - oracle-java8-installer
-    - os: linux
-      jdk: openjdk11
+#matrix:
+#  include:
+#    - os: linux
+#      jdk: oraclejdk8
+#      addons:
+#        apt:
+#          packages:
+#            - oracle-java8-installer
+#     - os: linux
+#      jdk: openjdk11
 
 # Don't build release tags. This avoids publish conflicts because the version commit exists both on master and the release tag.
 # See https://github.com/travis-ci/travis-ci/issues/1532


### PR DESCRIPTION
Releasing when more than one JDK is specified attempts to create the tag
twice.  This change removes the JDK 11 build profile.