### PR TITLE
Refactoring RequestTemplate to RFC6570

### DIFF
--- a/benchmark/src/main/java/feign/benchmark/DecoderIteratorsBenchmark.java
+++ b/benchmark/src/main/java/feign/benchmark/DecoderIteratorsBenchmark.java
@@ -15,6 +15,7 @@ package feign.benchmark;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import feign.Request;
+import feign.Request.HttpMethod;
 import feign.Response;
 import feign.Util;
 import feign.codec.Decoder;
@@ -79,7 +80,7 @@ public class DecoderIteratorsBenchmark {
     response = Response.builder()
         .status(200)
         .reason("OK")
-        .request(Request.create("GET", "/", Collections.emptyMap(), null, Util.UTF_8))
+        .request(Request.create(HttpMethod.GET, "/", Collections.emptyMap(), null, Util.UTF_8))
         .headers(Collections.emptyMap())
         .body(carsJson(Integer.valueOf(size)), Util.UTF_8)
         .build();

--- a/core/src/main/java/feign/CollectionFormat.java
+++ b/core/src/main/java/feign/CollectionFormat.java
@@ -13,6 +13,8 @@
  */
 package feign;
 
+import feign.template.UriUtils;
+import java.nio.charset.Charset;
 import java.util.Collection;
 
 /**
@@ -61,31 +63,32 @@ public enum CollectionFormat {
    *
    * @param field The field name corresponding to these values.
    * @param values A collection of value strings for the given field.
+   * @param charset to encode the sequence
    * @return The formatted char sequence of the field and joined values. If the value collection is
    *         empty, an empty char sequence will be returned.
    */
-  CharSequence join(String field, Collection<String> values) {
+  public CharSequence join(String field, Collection<String> values, Charset charset) {
     StringBuilder builder = new StringBuilder();
     int valueCount = 0;
     for (String value : values) {
       if (separator == null) {
         // exploded
         builder.append(valueCount++ == 0 ? "" : "&");
-        builder.append(field);
+        builder.append(UriUtils.queryEncode(field, charset));
         if (value != null) {
           builder.append('=');
-          builder.append(value);
+          builder.append(UriUtils.queryEncode(value, charset));
         }
       } else {
         // delimited with a separator character
         if (builder.length() == 0) {
-          builder.append(field);
+          builder.append(UriUtils.queryEncode(field, charset));
         }
         if (value == null) {
           continue;
         }
         builder.append(valueCount++ == 0 ? "=" : separator);
-        builder.append(value);
+        builder.append(UriUtils.queryEncode(value, charset));
       }
     }
     return builder;

--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -15,7 +15,6 @@ package feign;
 
 import static feign.Util.checkState;
 import static feign.Util.emptyToNull;
-
 import feign.Request.HttpMethod;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;

--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -13,6 +13,10 @@
  */
 package feign;
 
+import static feign.Util.checkState;
+import static feign.Util.emptyToNull;
+
+import feign.Request.HttpMethod;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -24,8 +28,8 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import static feign.Util.checkState;
-import static feign.Util.emptyToNull;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Defines what annotations and values are valid on interfaces.
@@ -65,7 +69,7 @@ public interface Contract {
             metadata.configKey());
         result.put(metadata.configKey(), metadata);
       }
-      return new ArrayList<MethodMetadata>(result.values());
+      return new ArrayList<>(result.values());
     }
 
     /**
@@ -209,6 +213,9 @@ public interface Contract {
   }
 
   class Default extends BaseContract {
+
+    static final Pattern REQUEST_LINE_PATTERN = Pattern.compile("^([A-Z]+)[ ]*(.+)*");
+
     @Override
     protected void processAnnotationOnClass(MethodMetadata data, Class<?> targetType) {
       if (targetType.isAnnotationPresent(Headers.class)) {
@@ -231,23 +238,16 @@ public interface Contract {
         String requestLine = RequestLine.class.cast(methodAnnotation).value();
         checkState(emptyToNull(requestLine) != null,
             "RequestLine annotation was empty on method %s.", method.getName());
-        if (requestLine.indexOf(' ') == -1) {
-          checkState(requestLine.indexOf('/') == -1,
-              "RequestLine annotation didn't start with an HTTP verb on method %s.",
-              method.getName());
-          data.template().method(requestLine);
-          return;
-        }
-        data.template().method(requestLine.substring(0, requestLine.indexOf(' ')));
-        if (requestLine.indexOf(' ') == requestLine.lastIndexOf(' ')) {
-          // no HTTP version is ok
-          data.template().append(requestLine.substring(requestLine.indexOf(' ') + 1));
-        } else {
-          // skip HTTP version
-          data.template().append(
-              requestLine.substring(requestLine.indexOf(' ') + 1, requestLine.lastIndexOf(' ')));
-        }
 
+        Matcher requestLineMatcher = REQUEST_LINE_PATTERN.matcher(requestLine);
+        if (!requestLineMatcher.find()) {
+          throw new IllegalStateException(String.format(
+              "RequestLine annotation didn't start with an HTTP verb on method %s",
+              method.getName()));
+        } else {
+          data.template().method(HttpMethod.valueOf(requestLineMatcher.group(1)));
+          data.template().uri(requestLineMatcher.group(2));
+        }
         data.template().decodeSlash(RequestLine.class.cast(methodAnnotation).decodeSlash());
         data.template()
             .collectionFormat(RequestLine.class.cast(methodAnnotation).collectionFormat());
@@ -288,10 +288,7 @@ public interface Contract {
           }
           data.indexToEncoded().put(paramIndex, paramAnnotation.encoded());
           isHttpAnnotation = true;
-          String varName = '{' + name + '}';
-          if (!data.template().url().contains(varName) &&
-              !searchMapValuesContainsSubstring(data.template().queries(), varName) &&
-              !searchMapValuesContainsSubstring(data.template().headers(), varName)) {
+          if (!data.template().hasRequestVariable(name)) {
             data.formParams().add(name);
           }
         } else if (annotationType == QueryMap.class) {
@@ -308,24 +305,6 @@ public interface Contract {
         }
       }
       return isHttpAnnotation;
-    }
-
-    private static <K, V> boolean searchMapValuesContainsSubstring(Map<K, Collection<String>> map,
-                                                                   String search) {
-      Collection<Collection<String>> values = map.values();
-      if (values == null) {
-        return false;
-      }
-
-      for (Collection<String> entry : values) {
-        for (String value : entry) {
-          if (value.contains(search)) {
-            return true;
-          }
-        }
-      }
-
-      return false;
     }
 
     private static Map<String, Collection<String>> toMap(String[] input) {

--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -213,7 +213,7 @@ public interface Contract {
 
   class Default extends BaseContract {
 
-    static final Pattern REQUEST_LINE_PATTERN = Pattern.compile("^([A-Z]+)[ ]*(.+)*");
+    static final Pattern REQUEST_LINE_PATTERN = Pattern.compile("^([A-Z]+)[ ]*(.*)$");
 
     @Override
     protected void processAnnotationOnClass(MethodMetadata data, Class<?> targetType) {

--- a/core/src/main/java/feign/ReflectiveFeign.java
+++ b/core/src/main/java/feign/ReflectiveFeign.java
@@ -13,6 +13,7 @@
  */
 package feign;
 
+import feign.template.UriUtils;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -199,11 +200,11 @@ public class ReflectiveFeign extends Feign {
 
     @Override
     public RequestTemplate create(Object[] argv) {
-      RequestTemplate mutable = new RequestTemplate(metadata.template());
+      RequestTemplate mutable = RequestTemplate.from(metadata.template());
       if (metadata.urlIndex() != null) {
         int urlIndex = metadata.urlIndex();
         checkArgument(argv[urlIndex] != null, "URI parameter %s was null", urlIndex);
-        mutable.insert(0, String.valueOf(argv[urlIndex]));
+        mutable.target(String.valueOf(argv[urlIndex]));
       }
       Map<String, Object> varBuilder = new LinkedHashMap<String, Object>();
       for (Entry<Integer, Collection<String>> entry : metadata.indexToName().entrySet()) {
@@ -300,15 +301,14 @@ public class ReflectiveFeign extends Feign {
             Object nextObject = iter.next();
             values.add(nextObject == null ? null
                 : encoded ? nextObject.toString()
-                    : RequestTemplate.urlEncode(nextObject.toString()));
+                    : UriUtils.encode(nextObject.toString()));
           }
         } else {
           values.add(currValue == null ? null
-              : encoded ? currValue.toString() : RequestTemplate.urlEncode(currValue.toString()));
+              : encoded ? currValue.toString() : UriUtils.encode(currValue.toString()));
         }
 
-        mutable.query(true,
-            encoded ? currEntry.getKey() : RequestTemplate.urlEncode(currEntry.getKey()), values);
+        mutable.query(encoded ? currEntry.getKey() : UriUtils.encode(currEntry.getKey()), values);
       }
       return mutable;
     }
@@ -316,15 +316,7 @@ public class ReflectiveFeign extends Feign {
     protected RequestTemplate resolve(Object[] argv,
                                       RequestTemplate mutable,
                                       Map<String, Object> variables) {
-      // Resolving which variable names are already encoded using their indices
-      Map<String, Boolean> variableToEncoded = new LinkedHashMap<String, Boolean>();
-      for (Entry<Integer, Boolean> entry : metadata.indexToEncoded().entrySet()) {
-        Collection<String> names = metadata.indexToName().get(entry.getKey());
-        for (String name : names) {
-          variableToEncoded.put(name, entry.getValue());
-        }
-      }
-      return mutable.resolve(variables, variableToEncoded);
+      return mutable.resolve(variables);
     }
   }
 

--- a/core/src/main/java/feign/RequestLine.java
+++ b/core/src/main/java/feign/RequestLine.java
@@ -18,54 +18,10 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Expands the request-line supplied in the {@code value}, permitting path and query variables, or
- * just the http method. <br>
- * 
- * <pre>
- * ...
- * &#64;RequestLine("POST /servers")
- * ...
- *
- * &#64;RequestLine("GET /servers/{serverId}?count={count}")
- * void get(&#64;Param("serverId") String serverId, &#64;Param("count") int count);
- * ...
- *
- * &#64;RequestLine("GET")
- * Response getNext(URI nextLink);
- * ...
- * </pre>
- * 
- * HTTP version suffix is optional, but permitted. There are no guarantees this version will impact
- * that sent by the client. <br>
- * 
- * <pre>
- * &#64;RequestLine("POST /servers HTTP/1.1")
- * ...
- * </pre>
- * 
- * <br>
- * <strong>Note:</strong> Query params do not overwrite each other. All queries with the same name
- * will be included in the request. <br>
- * <br>
- * <b>Relationship to JAXRS</b><br>
- * <br>
- * The following two forms are identical. <br>
- * Feign:
- * 
- * <pre>
- * &#64;RequestLine("GET /servers/{serverId}?count={count}")
- * void get(&#64;Param("serverId") String serverId, &#64;Param("count") int count);
- * ...
- * </pre>
- * 
- * <br>
- * JAX-RS:
- * 
- * <pre>
- * &#64;GET &#64;Path("/servers/{serverId}")
- * void get(&#64;PathParam("serverId") String serverId, &#64;QueryParam("count") int count);
- * ...
- * </pre>
+ * Expands the uri template supplied in the {@code value}, permitting path and query variables, or
+ * just the http method. Templates should conform to
+ * <a href="https://tools.ietf.org/html/rfc6570">RFC 6570</a>. Support is limited to Simple String
+ * expansion and Reserved Expansion (Level 1 and Level 2) expressions.
  */
 @java.lang.annotation.Target(METHOD)
 @Retention(RUNTIME)

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -13,561 +13,707 @@
  */
 package feign;
 
+import static feign.Util.CONTENT_LENGTH;
+import static feign.Util.UTF_8;
+import static feign.Util.checkNotNull;
+
+import feign.Request.HttpMethod;
+import feign.template.BodyTemplate;
+import feign.template.HeaderTemplate;
+import feign.template.QueryTemplate;
+import feign.template.UriTemplate;
+import feign.template.UriUtils;
 import java.io.Serializable;
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.net.URLEncoder;
 import java.nio.charset.Charset;
+import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import static feign.Util.CONTENT_LENGTH;
-import static feign.Util.UTF_8;
-import static feign.Util.checkArgument;
-import static feign.Util.checkNotNull;
-import static feign.Util.emptyToNull;
-import static feign.Util.toArray;
-import static feign.Util.valuesOrEmpty;
-import static java.util.stream.Collectors.toMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
- * Builds a request to an http target. Not thread safe. <br>
- * <br>
- * <br>
- * <b>relationship to JAXRS 2.0</b><br>
- * <br>
- * A combination of {@code javax.ws.rs.client.WebTarget} and {@code
- * javax.ws.rs.client.Invocation.Builder}, ensuring you can modify any part of the request. However,
- * this object is mutable, so needs to be guarded with the copy constructor.
+ * Request Builder for an HTTP Target.
+ * <p>
+ * This class is a variation on a UriTemplate, where, in addition to the uri, Headers and Query
+ * information also support template expressions.
+ * </p>
  */
+@SuppressWarnings({"WeakerAccess", "UnusedReturnValue"})
 public final class RequestTemplate implements Serializable {
 
-  private static final long serialVersionUID = 1L;
-  private final Map<String, Collection<String>> queries =
-      new LinkedHashMap<String, Collection<String>>();
-  private final Map<String, Collection<String>> headers =
-      new LinkedHashMap<String, Collection<String>>();
-  private String method;
-  /* final to encourage mutable use vs replacing the object. */
-  private StringBuilder url = new StringBuilder();
-  private transient Charset charset;
+  private static final Pattern QUERY_STRING_PATTERN = Pattern.compile("(?<!\\{)\\?");
+  private final Map<String, QueryTemplate> queries = new LinkedHashMap<>();
+  private final Map<String, HeaderTemplate> headers = new LinkedHashMap<>();
+  private String target;
+  private boolean resolved = false;
+  private UriTemplate uriTemplate;
+  private BodyTemplate bodyTemplate;
+  private HttpMethod method;
+  private transient Charset charset = Util.UTF_8;
   private byte[] body;
-  private String bodyTemplate;
   private boolean decodeSlash = true;
   private CollectionFormat collectionFormat = CollectionFormat.EXPLODED;
 
-  public RequestTemplate() {}
+  /**
+   * Create a new Request Template.
+   */
+  public RequestTemplate() {
+    super();
+  }
 
-  /* Copy constructor. Use this when making templates. */
+  /**
+   * Create a new Request Template.
+   *
+   * @param target for the template.
+   * @param uriTemplate for the template.
+   * @param bodyTemplate for the template.
+   * @param method of the request.
+   * @param charset for the request.
+   * @param body of the request, may be null
+   * @param decodeSlash if the request uri should encode slash characters.
+   * @param collectionFormat when expanding collection based variables.
+   */
+  private RequestTemplate(String target,
+      UriTemplate uriTemplate,
+      BodyTemplate bodyTemplate,
+      HttpMethod method,
+      Charset charset,
+      byte[] body,
+      boolean decodeSlash,
+      CollectionFormat collectionFormat) {
+    this.target = target;
+    this.uriTemplate = uriTemplate;
+    this.bodyTemplate = bodyTemplate;
+    this.method = method;
+    this.charset = charset;
+    this.body = body;
+    this.decodeSlash = decodeSlash;
+    this.collectionFormat =
+        (collectionFormat != null) ? collectionFormat : CollectionFormat.EXPLODED;
+  }
+
+  /**
+   * Create a Request Template from an existing Request Template.
+   *
+   * @param requestTemplate to copy from.
+   * @return a new Request Template.
+   */
+  public static RequestTemplate from(RequestTemplate requestTemplate) {
+    return new RequestTemplate(requestTemplate.target, requestTemplate.uriTemplate,
+        requestTemplate.bodyTemplate, requestTemplate.method, requestTemplate.charset,
+        requestTemplate.body, requestTemplate.decodeSlash, requestTemplate.collectionFormat);
+  }
+
+  /**
+   * Create a Request Template from an existing Request Template.
+   *
+   * @param toCopy template.
+   * @deprecated replaced by {@link RequestTemplate#from(RequestTemplate)}
+   */
+  @Deprecated
   public RequestTemplate(RequestTemplate toCopy) {
     checkNotNull(toCopy, "toCopy");
+    this.target = toCopy.target;
     this.method = toCopy.method;
-    this.url.append(toCopy.url);
     this.queries.putAll(toCopy.queries);
     this.headers.putAll(toCopy.headers);
     this.charset = toCopy.charset;
     this.body = toCopy.body;
     this.bodyTemplate = toCopy.bodyTemplate;
     this.decodeSlash = toCopy.decodeSlash;
-    this.collectionFormat = toCopy.collectionFormat;
-  }
-
-  private static String urlDecode(String arg) {
-    try {
-      return URLDecoder.decode(arg, UTF_8.name());
-    } catch (UnsupportedEncodingException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  static String urlEncode(Object arg) {
-    try {
-      return URLEncoder.encode(String.valueOf(arg), UTF_8.name());
-    } catch (UnsupportedEncodingException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  private static boolean isHttpUrl(CharSequence value) {
-    return value.length() >= 4 && value.subSequence(0, 3).equals("http".substring(0, 3));
-  }
-
-  private static CharSequence removeTrailingSlash(CharSequence charSequence) {
-    if (charSequence != null && charSequence.length() > 0
-        && charSequence.charAt(charSequence.length() - 1) == '/') {
-      return charSequence.subSequence(0, charSequence.length() - 1);
-    } else {
-      return charSequence;
-    }
+    this.collectionFormat =
+        (toCopy.collectionFormat != null) ? toCopy.collectionFormat : CollectionFormat.EXPLODED;
+    this.uriTemplate = toCopy.uriTemplate;
+    this.resolved = false;
   }
 
   /**
-   * Expands a {@code template}, such as {@code username}, using the {@code variables} supplied. Any
-   * unresolved parameters will remain. <br>
-   * Note that if you'd like curly braces literally in the {@code template}, urlencode them first.
+   * Resolve all expressions using the variable value substitutions provided. Variable values will
+   * be pct-encoded, if they are not already.
    *
-   * @param template URI template that can be in level 1
-   *        <a href="http://tools.ietf.org/html/rfc6570">RFC6570</a> form.
-   * @param variables to the URI template
-   * @return expanded template, leaving any unresolved parameters literal
+   * @param variables containing the variable values to use when resolving expressions.
+   * @return a new Request Template with all of the variables resolved.
    */
-  public static String expand(String template, Map<String, ?> variables) {
-    // skip expansion if there's no valid variables set. ex. {a} is the
-    // first valid
-    if (checkNotNull(template, "template").length() < 3) {
-      return template;
-    }
-    checkNotNull(variables, "variables for %s", template);
+  public RequestTemplate resolve(Map<String, ?> variables) {
 
-    boolean inVar = false;
-    StringBuilder var = new StringBuilder();
-    StringBuilder builder = new StringBuilder();
-    for (char c : template.toCharArray()) {
-      switch (c) {
-        case '{':
-          if (inVar) {
-            // '{{' is an escape: write the brace and don't interpret as a variable
-            builder.append("{");
-            inVar = false;
-            break;
-          }
-          inVar = true;
-          break;
-        case '}':
-          if (!inVar) { // then write the brace literally
-            builder.append('}');
-            break;
-          }
-          inVar = false;
-          String key = var.toString();
-          Object value = variables.get(var.toString());
-          if (value != null) {
-            builder.append(value);
-          } else {
-            builder.append('{').append(key).append('}');
-          }
-          var = new StringBuilder();
-          break;
-        default:
-          if (inVar) {
-            var.append(c);
-          } else {
-            builder.append(c);
-          }
-      }
-    }
-    return builder.toString();
-  }
+    StringBuilder uri = new StringBuilder();
 
-  private static Map<String, Collection<String>> parseAndDecodeQueries(String queryLine) {
-    Map<String, Collection<String>> map = new LinkedHashMap<>();
-    if (emptyToNull(queryLine) == null) {
-      return map;
+    /* create a new template form this one, but explicitly */
+    RequestTemplate resolved = RequestTemplate.from(this);
+
+    if (this.uriTemplate == null) {
+      /* create a new uri template using the default root */
+      this.uriTemplate = UriTemplate.create("", !this.decodeSlash, this.charset);
     }
-    if (queryLine.indexOf('&') == -1) {
-      putKV(queryLine, map);
-    } else {
-      char[] chars = queryLine.toCharArray();
-      int start = 0;
-      int i = 0;
-      for (; i < chars.length; i++) {
-        if (chars[i] == '&') {
-          putKV(queryLine.substring(start, i), map);
-          start = i + 1;
+
+    uri.append(this.uriTemplate.expand(variables));
+
+    /*
+     * for simplicity, combine the queries into the uri and use the resulting uri to seed the
+     * resolved template.
+     */
+    if (!this.queries.isEmpty()) {
+      /* resolve the queries, appending them to the uri */
+      StringBuilder query = new StringBuilder();
+      Iterator<QueryTemplate> queryTemplates = this.queries.values().iterator();
+
+      while (queryTemplates.hasNext()) {
+        QueryTemplate queryTemplate = queryTemplates.next();
+        String queryExpanded = queryTemplate.expand(variables);
+        if (Util.isNotBlank(queryExpanded)) {
+          query.append(queryTemplate.expand(variables));
+          if (queryTemplates.hasNext()) {
+            query.append("&");
+          }
         }
       }
-      putKV(queryLine.substring(start, i), map);
-    }
-    return map;
-  }
 
-  private static void putKV(String stringToParse, Map<String, Collection<String>> map) {
-    String key;
-    String value;
-    // note that '=' can be a valid part of the value
-    int firstEq = stringToParse.indexOf('=');
-    if (firstEq == -1) {
-      key = urlDecode(stringToParse);
-      value = null;
-    } else {
-      key = urlDecode(stringToParse.substring(0, firstEq));
-      value = urlDecode(stringToParse.substring(firstEq + 1));
+      String queryString = query.toString();
+      if (!queryString.isEmpty()) {
+        Matcher queryMatcher = QUERY_STRING_PATTERN.matcher(uri);
+        if (queryMatcher.find()) {
+          /* the uri already has a query, so any additional queries should be appended */
+          uri.append("&");
+        } else {
+          uri.append("?");
+        }
+        uri.append(queryString);
+      }
     }
-    Collection<String> values = map.containsKey(key) ? map.get(key) : new ArrayList<String>();
-    values.add(value);
-    map.put(key, values);
-  }
 
-  /** {@link #resolve(Map, Map)}, which assumes no parameter is encoded */
-  public RequestTemplate resolve(Map<String, ?> unencoded) {
-    return resolve(unencoded, Collections.<String, Boolean>emptyMap());
+    /* add the uri to result */
+    resolved.uri(uri.toString());
+
+    /* headers */
+    if (!this.headers.isEmpty()) {
+      for (HeaderTemplate headerTemplate : this.headers.values()) {
+        /* resolve the header */
+        String header = headerTemplate.expand(variables);
+        if (!header.isEmpty()) {
+          /* split off the header values and add it to the resolved template */
+          String headerValues = header.substring(header.indexOf(" ") + 1);
+          if (!headerValues.isEmpty()) {
+            resolved.header(headerTemplate.getName(), headerValues);
+          }
+        }
+      }
+    }
+
+    if (this.bodyTemplate != null) {
+      resolved.body(this.bodyTemplate.expand(variables));
+    }
+
+    /* mark the new template resolved */
+    resolved.resolved = true;
+    return resolved;
   }
 
   /**
-   * Resolves any template parameters in the requests path, query, or headers against the supplied
-   * unencoded arguments. <br>
-   * <br>
-   * <br>
-   * <b>relationship to JAXRS 2.0</b><br>
-   * <br>
-   * This call is similar to
-   * {@code javax.ws.rs.client.WebTarget.resolveTemplates(templateValues, true)} , except that the
-   * template values apply to any part of the request, not just the URL
+   * Resolves all expressions, using the variables provided. Values not present in the {@code
+   * alreadyEncoded} map are pct-encoded.
+   *
+   * @param unencoded variable values to substitute.
+   * @param alreadyEncoded variable names.
+   * @return a resolved Request Template
+   * @deprecated use {@link RequestTemplate#resolve(Map)}. Values already encoded are recognized as
+   *             such and skipped.
    */
+  @SuppressWarnings("unused")
+  @Deprecated
   RequestTemplate resolve(Map<String, ?> unencoded, Map<String, Boolean> alreadyEncoded) {
-    replaceQueryValues(unencoded, alreadyEncoded);
-    Map<String, String> encoded = new LinkedHashMap<String, String>();
-    for (Entry<String, ?> entry : unencoded.entrySet()) {
-      final String key = entry.getKey();
-      final Object objectValue = entry.getValue();
-      String encodedValue = encodeValueIfNotEncoded(key, objectValue, alreadyEncoded);
-      encoded.put(key, encodedValue);
-    }
-    String resolvedUrl = expand(url.toString(), encoded).replace("+", "%20");
-    if (decodeSlash) {
-      resolvedUrl = resolvedUrl.replace("%2F", "/");
-    }
-    url = new StringBuilder(resolvedUrl);
-
-    Map<String, Collection<String>> resolvedHeaders =
-        new LinkedHashMap<String, Collection<String>>();
-    for (String field : headers.keySet()) {
-      Collection<String> resolvedValues = new ArrayList<String>();
-      for (String value : valuesOrEmpty(headers, field)) {
-        String resolved = expand(value, unencoded);
-        resolvedValues.add(resolved);
-      }
-      resolvedHeaders.put(field, resolvedValues);
-    }
-    headers.clear();
-    headers.putAll(resolvedHeaders);
-    if (bodyTemplate != null) {
-      body(urlDecode(expand(bodyTemplate, encoded)));
-    }
-    return this;
+    return this.resolve(unencoded);
   }
 
-  private String encodeValueIfNotEncoded(String key,
-                                         Object objectValue,
-                                         Map<String, Boolean> alreadyEncoded) {
-    String value = String.valueOf(objectValue);
-    final Boolean isEncoded = alreadyEncoded.get(key);
-    if (isEncoded == null || !isEncoded) {
-      value = urlEncode(value);
-    }
-    return value;
-  }
-
-  /* roughly analogous to {@code javax.ws.rs.client.Target.request()}. */
+  /**
+   * Creates a {@link Request} from this template. The template must be resolved before calling this
+   * method, or an {@link IllegalStateException} will be thrown.
+   *
+   * @return a new Request instance.
+   * @throws IllegalStateException if this template has not been resolved.
+   */
   public Request request() {
-    Map<String, Collection<String>> safeCopy = new LinkedHashMap<String, Collection<String>>();
-    safeCopy.putAll(headers());
-    return Request.create(
-        method, url + queryLine(),
-        Collections.unmodifiableMap(safeCopy),
-        body, charset);
+    if (!this.resolved) {
+      throw new IllegalStateException("template has not been resolved.");
+    }
+    return Request.create(this.method, this.url(), this.headers(), this.body(), this.charset);
   }
 
-  /* @see Request#method() */
+  /**
+   * Set the Http Method.
+   *
+   * @param method to use.
+   * @return a RequestTemplate for chaining.
+   * @deprecated see {@link RequestTemplate#method(HttpMethod)}
+   */
+  @Deprecated
   public RequestTemplate method(String method) {
-    this.method = checkNotNull(method, "method");
-    checkArgument(method.matches("^[A-Z]+$"), "Invalid HTTP Method: %s", method);
+    checkNotNull(method, "method");
+    try {
+      this.method = HttpMethod.valueOf(method);
+    } catch (IllegalArgumentException iae) {
+      throw new IllegalArgumentException("Invalid HTTP Method: " + method);
+    }
     return this;
   }
 
-  /* @see Request#method() */
-  public String method() {
-    return method;
+  /**
+   * Set the Http Method.
+   *
+   * @param method to use.
+   * @return a RequestTemplate for chaining.
+   */
+  public RequestTemplate method(HttpMethod method) {
+    checkNotNull(method, "method");
+    this.method = method;
+    return this;
   }
 
+  /**
+   * The Request Http Method.
+   *
+   * @return Http Method.
+   */
+  public String method() {
+    return (method != null) ? method.name() : null;
+  }
+
+  /**
+   * Set whether do encode slash {@literal /} characters when resolving this template.
+   *
+   * @param decodeSlash if slash literals should not be encoded.
+   * @return a RequestTemplate for chaining.
+   */
   public RequestTemplate decodeSlash(boolean decodeSlash) {
     this.decodeSlash = decodeSlash;
+    this.uriTemplate =
+        UriTemplate.create(this.uriTemplate.toString(), !this.decodeSlash, this.charset);
     return this;
   }
 
+  /**
+   * If slash {@literal /} characters are not encoded when resolving.
+   *
+   * @return true if slash literals are not encoded, false otherwise.
+   */
   public boolean decodeSlash() {
     return decodeSlash;
   }
 
+  /**
+   * The Collection Format to use when resolving variables that represent {@link Iterable}s or
+   * {@link Collection}s
+   *
+   * @param collectionFormat to use.
+   * @return a RequestTemplate for chaining.
+   */
   public RequestTemplate collectionFormat(CollectionFormat collectionFormat) {
     this.collectionFormat = collectionFormat;
     return this;
   }
 
+  /**
+   * The Collection Format that will be used when resolving {@link Iterable} and {@link Collection}
+   * variables.
+   *
+   * @return the collection format set
+   */
+  @SuppressWarnings("unused")
   public CollectionFormat collectionFormat() {
     return collectionFormat;
   }
 
-  /* @see #url() */
+  /**
+   * Append the value to the template.
+   * <p>
+   * This method is poorly named and is used primarily to store the relative uri for the request. It
+   * has been replaced by {@link RequestTemplate#uri(String)} and will be removed in a future
+   * release.
+   * </p>
+   *
+   * @param value to append.
+   * @return a RequestTemplate for chaining.
+   * @deprecated see {@link RequestTemplate#uri(String, boolean)}
+   */
+  @Deprecated
   public RequestTemplate append(CharSequence value) {
-    url.append(value);
-    url = pullAnyQueriesOutOfUrl(url);
-    return this;
-  }
-
-  /* @see #url() */
-  public RequestTemplate insert(int pos, CharSequence value) {
-    if (isHttpUrl(value)) {
-      value = removeTrailingSlash(value);
-      if (url.length() > 0 && url.charAt(0) != '/') {
-        url.insert(0, '/');
-      }
+    /* proxy to url */
+    if (this.uriTemplate != null) {
+      return this.uri(value.toString(), true);
     }
-    url.insert(pos, pullAnyQueriesOutOfUrl(new StringBuilder(value)));
+    return this.uri(value.toString());
+  }
+
+  /**
+   * Insert the value at the specified point in the template uri.
+   * <p>
+   * This method is poorly named has undocumented behavior. When the value contains a fully
+   * qualified http request url, the value is always inserted at the beginning of the uri.
+   * </p>
+   * <p>
+   * Due to this, use of this method is not recommended and remains for backward compatibility. It
+   * has been replaced by {@link RequestTemplate#target(String)} and will be removed in a future
+   * release.
+   * </p>
+   *
+   * @param pos in the uri to place the value.
+   * @param value to insert.
+   * @return a RequestTemplate for chaining.
+   * @deprecated see {@link RequestTemplate#target(String)}
+   */
+  @SuppressWarnings("unused")
+  @Deprecated
+  public RequestTemplate insert(int pos, CharSequence value) {
+    return target(value.toString());
+  }
+
+  /**
+   * Set the Uri for the request, replacing the existing uri if set.
+   *
+   * @param uri to use, must be a relative uri.
+   * @return a RequestTemplate for chaining.
+   */
+  public RequestTemplate uri(String uri) {
+    return this.uri(uri, false);
+  }
+
+  /**
+   * Set the uri for the request.
+   *
+   * @param uri to use, must be a relative uri.
+   * @param append if the uri should be appended, if the uri is already set.
+   * @return a RequestTemplate for chaining.
+   */
+  public RequestTemplate uri(String uri, boolean append) {
+    /* validate and ensure that the url is always a relative one */
+    if (UriUtils.isAbsolute(uri)) {
+      throw new IllegalArgumentException("url values must be not be absolute.");
+    }
+
+    if (uri == null) {
+      uri = "/";
+    } else if ((!uri.isEmpty() && !uri.startsWith("/") && !uri.startsWith("{"))) {
+      /* if the start of the url is a literal, it must begin with a slash. */
+      uri = "/" + uri;
+    }
+
+    /*
+     * templates may provide query parameters. since we want to manage those explicity, we will need
+     * to extract those out, leaving the uriTemplate with only the path to deal with.
+     */
+    Matcher queryMatcher = QUERY_STRING_PATTERN.matcher(uri);
+    if (queryMatcher.find()) {
+      String queryString = uri.substring(queryMatcher.start() + 1);
+
+      /* parse the query string */
+      this.extractQueryTemplates(queryString);
+
+      /* reduce the uri to the path */
+      uri = uri.substring(0, queryMatcher.start());
+    }
+
+    /* replace the uri template */
+    if (append && this.uriTemplate != null) {
+      this.uriTemplate = UriTemplate.append(this.uriTemplate, uri);
+    } else {
+      this.uriTemplate = UriTemplate.create(uri, !this.decodeSlash, this.charset);
+    }
     return this;
   }
 
+  /**
+   * Set the target host for this request.
+   *
+   * @param target host for this request. Must be an absolute target.
+   * @return a RequestTemplate for chaining.
+   */
+  public RequestTemplate target(String target) {
+    /* target can be empty */
+    if (Util.isBlank(target)) {
+      return this;
+    }
+
+    /* verify that the target contains the scheme, host and port */
+    if (!UriUtils.isAbsolute(target)) {
+      throw new IllegalArgumentException("target values must be absolute.");
+    }
+    if (target.endsWith("/")) {
+      target = target.substring(0, target.length() - 1);
+    }
+
+    /* no query strings allowed */
+    Matcher queryStringMatcher = QUERY_STRING_PATTERN.matcher(target);
+    if (queryStringMatcher.find()) {
+      /*
+       * target has a query string, we need to make sure that they are recorded as queries
+       */
+      int queryStart = queryStringMatcher.start();
+      this.extractQueryTemplates(target.substring(queryStart + 1));
+
+      /* strip the query string */
+      target = target.substring(0, queryStart);
+    }
+    this.target = target;
+    return this;
+  }
+
+  /**
+   * The URL for the request. If the template has not been resolved, the url will represent a uri
+   * template.
+   *
+   * @return the url
+   */
   public String url() {
+
+    /* build the fully qualified url with all query parameters */
+    StringBuilder url = new StringBuilder(this.path());
+    if (!this.queries.isEmpty()) {
+      url.append(this.queryLine());
+    }
+
     return url.toString();
   }
 
   /**
-   * Replaces queries with the specified {@code name} with the {@code values} supplied. <br>
-   * Values can be passed in decoded or in url-encoded form depending on the value of the
-   * {@code encoded} parameter. <br>
-   * When the {@code value} is {@code null}, all queries with the {@code configKey} are removed.
-   * <br>
-   * <br>
-   * <br>
-   * <b>relationship to JAXRS 2.0</b><br>
-   * <br>
-   * Like {@code WebTarget.query}, except the values can be templatized. <br>
-   * ex. <br>
-   * 
-   * <pre>
-   * template.query(&quot;Signature&quot;, &quot;{signature}&quot;);
-   * </pre>
-   * 
-   * <br>
-   * <b>Note:</b> behavior of RequestTemplate is not consistent if a query parameter with unsafe
-   * characters is passed as both encoded and unencoded, although no validation is performed. <br>
-   * ex. <br>
-   * 
-   * <pre>
-   * template.query(true, &quot;param[]&quot;, &quot;value&quot;);
-   * template.query(false, &quot;param[]&quot;, &quot;value&quot;);
-   * </pre>
+   * The Uri Path.
    *
-   * @param encoded whether name and values are already url-encoded
-   * @param name the name of the query
-   * @param values can be a single null to imply removing all values. Else no values are expected to
-   *        be null.
-   * @see #queries()
+   * @return the uri path.
    */
-  public RequestTemplate query(boolean encoded, String name, String... values) {
-    return doQuery(encoded, name, values);
-  }
+  public String path() {
+    /* build the fully qualified url with all query parameters */
+    StringBuilder path = new StringBuilder();
+    if (this.target != null) {
+      path.append(this.target);
+    }
+    if (this.uriTemplate != null) {
+      path.append(this.uriTemplate.toString());
+    }
+    return path.toString();
 
-  /* @see #query(boolean, String, String...) */
-  public RequestTemplate query(boolean encoded, String name, Iterable<String> values) {
-    return doQuery(encoded, name, values);
   }
 
   /**
-   * Shortcut for {@code query(false, String, String...)}
-   * 
-   * @see #query(boolean, String, String...)
+   * List all of the template variable expressions for this template.
+   *
+   * @return a list of template variable names
+   */
+  public List<String> variables() {
+    /* combine the variables from the uri, query, header, and body templates */
+    List<String> variables = new ArrayList<>(this.uriTemplate.getVariables());
+
+    /* queries */
+    for (QueryTemplate queryTemplate : this.queries.values()) {
+      variables.addAll(queryTemplate.getVariables());
+    }
+
+    /* headers */
+    for (HeaderTemplate headerTemplate : this.headers.values()) {
+      variables.addAll(headerTemplate.getVariables());
+    }
+
+    /* body */
+    if (this.bodyTemplate != null) {
+      variables.addAll(this.bodyTemplate.getVariables());
+    }
+
+    return variables;
+  }
+
+  /**
+   * @see RequestTemplate#query(String, Iterable)
    */
   public RequestTemplate query(String name, String... values) {
-    return doQuery(false, name, values);
+    if (values == null) {
+      return query(name, Collections.emptyList());
+    }
+    return query(name, Arrays.asList(values));
   }
 
   /**
-   * Shortcut for {@code query(false, String, Iterable<String>)}
-   * 
-   * @see #query(boolean, String, String...)
+   * Specify a Query String parameter, with the specified values. Values can be literals or template
+   * expressions.
+   *
+   * @param name of the parameter.
+   * @param values for this parameter.
+   * @return a RequestTemplate for chaining.
    */
   public RequestTemplate query(String name, Iterable<String> values) {
-    return doQuery(false, name, values);
+    return appendQuery(name, values);
   }
 
-  private RequestTemplate doQuery(boolean encoded, String name, String... values) {
-    checkNotNull(name, "name");
-    String paramName = encoded ? name : encodeIfNotVariable(name);
-    queries.remove(paramName);
-    if (values != null && values.length > 0 && values[0] != null) {
-      ArrayList<String> paramValues = new ArrayList<String>();
-      for (String value : values) {
-        paramValues.add(encoded ? value : encodeIfNotVariable(value));
-      }
-      this.queries.put(paramName, paramValues);
+  /**
+   * Appends the query name and values.
+   *
+   * @param name of the parameter.
+   * @param values for the parameter, may be expressions.
+   * @return a RequestTemplate for chaining.
+   */
+  private RequestTemplate appendQuery(String name, Iterable<String> values) {
+    if (!values.iterator().hasNext()) {
+      /* empty value, clear the existing values */
+      this.queries.remove(name);
+      return this;
     }
+
+    /* create a new query template out of the information here */
+    this.queries.compute(name, (key, queryTemplate) -> {
+      if (queryTemplate == null) {
+        return QueryTemplate.create(name, values, this.charset, this.collectionFormat);
+      } else {
+        return QueryTemplate.append(queryTemplate, values, this.collectionFormat);
+      }
+    });
+    // this.queries.put(name, QueryTemplate.create(name, values));
     return this;
   }
 
-  private RequestTemplate doQuery(boolean encoded, String name, Iterable<String> values) {
-    if (values != null) {
-      return doQuery(encoded, name, toArray(values, String.class));
-    }
-    return doQuery(encoded, name, (String[]) null);
-  }
-
-  private static String encodeIfNotVariable(String in) {
-    if (in == null || in.indexOf('{') == 0) {
-      return in;
-    }
-    return urlEncode(in);
-  }
-
   /**
-   * Replaces all existing queries with the newly supplied url decoded queries. <br>
-   * <br>
-   * <br>
-   * <b>relationship to JAXRS 2.0</b><br>
-   * <br>
-   * Like {@code WebTarget.queries}, except the values can be templatized. <br>
-   * ex. <br>
-   * 
-   * <pre>
-   * template.queries(ImmutableMultimap.of(&quot;Signature&quot;, &quot;{signature}&quot;));
-   * </pre>
+   * Sets the Query Parameters.
    *
-   * @param queries if null, remove all queries. else value to replace all queries with.
-   * @see #queries()
+   * @param queries to use for this request.
+   * @return a RequestTemplate for chaining.
    */
+  @SuppressWarnings("unused")
   public RequestTemplate queries(Map<String, Collection<String>> queries) {
     if (queries == null || queries.isEmpty()) {
       this.queries.clear();
     } else {
-      for (Entry<String, Collection<String>> entry : queries.entrySet()) {
-        query(entry.getKey(), toArray(entry.getValue(), String.class));
-      }
+      queries.forEach(this::query);
     }
     return this;
   }
 
+
   /**
-   * Returns an immutable copy of the url decoded queries.
+   * Return an immutable Map of all Query Parameters and their values.
    *
-   * @see Request#url()
+   * @return registered Query Parameters.
    */
   public Map<String, Collection<String>> queries() {
-    Map<String, Collection<String>> decoded = new LinkedHashMap<String, Collection<String>>();
-    for (String field : queries.keySet()) {
-      Collection<String> decodedValues = new ArrayList<String>();
-      for (String value : valuesOrEmpty(queries, field)) {
-        if (value != null) {
-          decodedValues.add(urlDecode(value));
-        } else {
-          decodedValues.add(null);
-        }
-      }
-      decoded.put(urlDecode(field), decodedValues);
-    }
-    return Collections.unmodifiableMap(decoded);
+    Map<String, Collection<String>> queryMap = new LinkedHashMap<>();
+    this.queries.forEach((key, queryTemplate) -> {
+      List<String> values = new ArrayList<>(queryTemplate.getValues());
+
+      /* add the expanded collection, but lock it */
+      queryMap.put(key, Collections.unmodifiableList(values));
+    });
+
+    return Collections.unmodifiableMap(queryMap);
   }
 
   /**
-   * Replaces headers with the specified {@code configKey} with the {@code values} supplied. <br>
-   * When the {@code value} is {@code null}, all headers with the {@code configKey} are removed.
-   * <br>
-   * <br>
-   * <br>
-   * <b>relationship to JAXRS 2.0</b><br>
-   * <br>
-   * Like {@code WebTarget.queries} and {@code javax.ws.rs.client.Invocation.Builder.header}, except
-   * the values can be templatized. <br>
-   * ex. <br>
-   * 
-   * <pre>
-   * template.query(&quot;X-Application-Version&quot;, &quot;{version}&quot;);
-   * </pre>
-   *
-   * @param name the name of the header
-   * @param values can be a single null to imply removing all values. Else no values are expected to
-   *        be null.
-   * @see #headers()
+   * @see RequestTemplate#header(String, Iterable)
    */
   public RequestTemplate header(String name, String... values) {
-    checkNotNull(name, "header name");
-    if (values == null || (values.length == 1 && values[0] == null)) {
-      headers.remove(name);
-    } else {
-      List<String> headers = new ArrayList<String>();
-      headers.addAll(Arrays.asList(values));
-      this.headers.put(name, headers);
-    }
-    return this;
-  }
-
-  /* @see #header(String, String...) */
-  public RequestTemplate header(String name, Iterable<String> values) {
-    if (values != null) {
-      return header(name, toArray(values, String.class));
-    }
-    return header(name, (String[]) null);
+    return header(name, Arrays.asList(values));
   }
 
   /**
-   * Replaces all existing headers with the newly supplied headers. <br>
-   * <br>
-   * <br>
-   * <b>relationship to JAXRS 2.0</b><br>
-   * <br>
-   * Like {@code Invocation.Builder.headers(MultivaluedMap)}, except the values can be templatized.
-   * <br>
-   * ex. <br>
-   * 
-   * <pre>
-   * template.headers(mapOf(&quot;X-Application-Version&quot;, asList(&quot;{version}&quot;)));
-   * </pre>
+   * Specify a Header, with the specified values. Values can be literals or template expressions.
    *
-   * @param headers if null, remove all headers. else value to replace all headers with.
-   * @see #headers()
+   * @param name of the header.
+   * @param values for this header.
+   * @return a RequestTemplate for chaining.
+   */
+  public RequestTemplate header(String name, Iterable<String> values) {
+    if (name == null || name.isEmpty()) {
+      throw new IllegalArgumentException("name is required.");
+    }
+    if (values == null) {
+      values = Collections.emptyList();
+    }
+
+    return appendHeader(name, values);
+  }
+
+  /**
+   * Create a Header Template.
+   *
+   * @param name of the header
+   * @param values for the header, may be expressions.
+   * @return a RequestTemplate for chaining.
+   */
+  private RequestTemplate appendHeader(String name, Iterable<String> values) {
+    this.headers.compute(name, (headerName, headerTemplate) -> {
+      if (headerTemplate == null) {
+        return HeaderTemplate.create(headerName, values);
+      } else {
+        return HeaderTemplate.append(headerTemplate, values);
+      }
+    });
+    return this;
+  }
+
+  /**
+   * Headers for this Request.
+   *
+   * @param headers to use.
+   * @return a RequestTemplate for chaining.
    */
   public RequestTemplate headers(Map<String, Collection<String>> headers) {
-    if (headers == null || headers.isEmpty()) {
-      this.headers.clear();
+    if (headers != null && !headers.isEmpty()) {
+      headers.forEach(this::header);
     } else {
-      this.headers.putAll(headers);
+      this.headers.clear();
     }
     return this;
   }
 
   /**
-   * Returns an immutable copy of the current headers.
+   * Returns an immutable copy of the Headers for this request.
    *
-   * @see Request#headers()
+   * @return the currently applied headers.
    */
   public Map<String, Collection<String>> headers() {
+    Map<String, Collection<String>> headerMap = new LinkedHashMap<>();
+    this.headers.forEach((key, headerTemplate) -> {
+      List<String> values = new ArrayList<>(headerTemplate.getValues());
 
-    return Collections.unmodifiableMap(
-        headers.entrySet().stream().filter(h -> h.getValue() != null && !h.getValue().isEmpty())
-            .collect(toMap(
-                Entry::getKey,
-                Entry::getValue,
-                (e1, e2) -> {
-                  throw new IllegalStateException("headers should not have duplicated keys");
-                },
-                LinkedHashMap::new)));
+      /* add the expanded collection, but only if it has values */
+      if (!values.isEmpty()) {
+        headerMap.put(key, Collections.unmodifiableList(values));
+      }
+    });
+    return Collections.unmodifiableMap(headerMap);
   }
 
   /**
-   * replaces the {@link feign.Util#CONTENT_LENGTH} header. <br>
-   * Usually populated by an {@link feign.codec.Encoder}.
+   * Sets the Body and Charset for this request.
    *
-   * @see Request#body()
+   * @param bodyData to send, can be null.
+   * @param charset of the encoded data.
+   * @return a RequestTemplate for chaining.
    */
   public RequestTemplate body(byte[] bodyData, Charset charset) {
+
+    /*
+     * since the body is being set directly, we need to clear out any existing body template
+     * information to prevent unintended side effects.
+     */
     this.bodyTemplate = null;
     this.charset = charset;
     this.body = bodyData;
+
+    /* calculate the content length based on the data provided */
     int bodyLength = bodyData != null ? bodyData.length : 0;
     header(CONTENT_LENGTH, String.valueOf(bodyLength));
+
     return this;
   }
 
   /**
-   * replaces the {@link feign.Util#CONTENT_LENGTH} header. <br>
-   * Usually populated by an {@link feign.codec.Encoder}.
+   * Set the Body for this request. Charset is assumed to be UTF_8. Data must be encoded.
    *
-   * @see Request#body()
+   * @param bodyText to send.
+   * @return a RequestTemplate for chaining.
    */
   public RequestTemplate body(String bodyText) {
     byte[] bodyData = bodyText != null ? bodyText.getBytes(UTF_8) : null;
@@ -575,86 +721,44 @@ public final class RequestTemplate implements Serializable {
   }
 
   /**
-   * The character set with which the body is encoded, or null if unknown or not applicable. When
-   * this is present, you can use {@code new String(req.body(), req.charset())} to access the body
-   * as a String.
+   * Charset of the Request Body, if known.
+   *
+   * @return the currently applied Charset.
    */
   public Charset charset() {
     return charset;
   }
 
   /**
-   * @see Request#body()
+   * The Request Body.
+   *
+   * @return the request body.
    */
   public byte[] body() {
     return body;
   }
 
+
   /**
-   * populated by {@link Body}
+   * Specify the Body Template to use. Can contain literals and expressions.
    *
-   * @see Request#body()
+   * @param bodyTemplate to use.
+   * @return a RequestTemplate for chaining.
    */
   public RequestTemplate bodyTemplate(String bodyTemplate) {
-    this.bodyTemplate = bodyTemplate;
-    this.charset = null;
+    this.bodyTemplate = BodyTemplate.create(bodyTemplate);
+    this.charset = Util.UTF_8;
     this.body = null;
     return this;
   }
 
   /**
-   * @see Request#body()
-   * @see #expand(String, Map)
+   * Body Template to resolve.
+   *
+   * @return the unresolved body template.
    */
   public String bodyTemplate() {
-    return bodyTemplate;
-  }
-
-  /**
-   * if there are any query params in the URL, this will extract them out.
-   */
-  private StringBuilder pullAnyQueriesOutOfUrl(StringBuilder url) {
-    // parse out queries
-    int queryIndex = url.indexOf("?");
-    if (queryIndex != -1) {
-      String queryLine = url.substring(queryIndex + 1);
-      Map<String, Collection<String>> firstQueries = parseAndDecodeQueries(queryLine);
-      if (!queries.isEmpty()) {
-        firstQueries.putAll(queries);
-        queries.clear();
-      }
-      // Since we decode all queries, we want to use the
-      // query()-method to re-add them to ensure that all
-      // logic (such as url-encoding) are executed, giving
-      // a valid queryLine()
-      for (String key : firstQueries.keySet()) {
-        Collection<String> values = firstQueries.get(key);
-        if (allValuesAreNull(values)) {
-          // Queries where all values are null will
-          // be ignored by the query(key, value)-method
-          // So we manually avoid this case here, to ensure that
-          // we still fulfill the contract (ex. parameters without values)
-          queries.put(urlEncode(key), values);
-        } else {
-          query(key, values);
-        }
-
-      }
-      return new StringBuilder(url.substring(0, queryIndex));
-    }
-    return url;
-  }
-
-  private boolean allValuesAreNull(Collection<String> values) {
-    if (values == null || values.isEmpty()) {
-      return true;
-    }
-    for (String val : values) {
-      if (val != null) {
-        return false;
-      }
-    }
-    return true;
+    return (bodyTemplate != null) ? bodyTemplate.toString() : null;
   }
 
   @Override
@@ -662,66 +766,97 @@ public final class RequestTemplate implements Serializable {
     return request().toString();
   }
 
-  /** {@link #replaceQueryValues(Map, Map)}, which assumes no parameter is encoded */
-  public void replaceQueryValues(Map<String, ?> unencoded) {
-    replaceQueryValues(unencoded, Collections.<String, Boolean>emptyMap());
+  /**
+   * Return if the variable exists on the uri, query, or headers, in this template.
+   *
+   * @param variable to look for.
+   * @return true if the variable exists, false otherwise.
+   */
+  public boolean hasRequestVariable(String variable) {
+    return this.getRequestVariables().contains(variable);
   }
 
   /**
-   * Replaces query values which are templated with corresponding values from the {@code unencoded}
-   * map. Any unresolved queries are removed.
+   * Retrieve all uri, header, and query template variables.
+   *
+   * @return a List of all the variable names.
    */
-  void replaceQueryValues(Map<String, ?> unencoded, Map<String, Boolean> alreadyEncoded) {
-    Iterator<Entry<String, Collection<String>>> iterator = queries.entrySet().iterator();
-    while (iterator.hasNext()) {
-      Entry<String, Collection<String>> entry = iterator.next();
-      if (entry.getValue() == null) {
-        continue;
-      }
-      Collection<String> values = new ArrayList<String>();
-      for (String value : entry.getValue()) {
-        if (value.indexOf('{') == 0 && value.indexOf('}') == value.length() - 1) {
-          Object variableValue = unencoded.get(value.substring(1, value.length() - 1));
-          // only add non-null expressions
-          if (variableValue == null) {
-            continue;
+  public Collection<String> getRequestVariables() {
+    final Collection<String> variables = new LinkedHashSet<>(this.uriTemplate.getVariables());
+    this.queries.values().forEach(queryTemplate -> variables.addAll(queryTemplate.getVariables()));
+    this.headers.values()
+        .forEach(headerTemplate -> variables.addAll(headerTemplate.getVariables()));
+    return variables;
+  }
+
+  /**
+   * If this template has been resolved.
+   *
+   * @return true if the template has been resolved, false otherwise.
+   */
+  @SuppressWarnings("unused")
+  public boolean resolved() {
+    return this.resolved;
+  }
+
+  /**
+   * The Query String for the template. Expressions are not resolved.
+   *
+   * @return the Query String.
+   */
+  public String queryLine() {
+    StringBuilder queryString = new StringBuilder();
+
+    if (!this.queries.isEmpty()) {
+      Iterator<QueryTemplate> iterator = this.queries.values().iterator();
+      while (iterator.hasNext()) {
+        QueryTemplate queryTemplate = iterator.next();
+        String query = queryTemplate.toString();
+        if (query != null && !query.isEmpty()) {
+          queryString.append(queryTemplate.toString());
+          if (iterator.hasNext()) {
+            queryString.append("&");
           }
-          if (variableValue instanceof Iterable) {
-            for (Object val : Iterable.class.cast(variableValue)) {
-              String encodedValue = encodeValueIfNotEncoded(entry.getKey(), val, alreadyEncoded);
-              values.add(encodedValue);
-            }
-          } else {
-            String encodedValue =
-                encodeValueIfNotEncoded(entry.getKey(), variableValue, alreadyEncoded);
-            values.add(encodedValue);
-          }
-        } else {
-          values.add(value);
         }
       }
-      if (values.isEmpty()) {
-        iterator.remove();
-      } else {
-        entry.setValue(values);
-      }
     }
+    /* remove any trailing ampersands */
+    String result = queryString.toString();
+    if (result.endsWith("&")) {
+      result = result.substring(0, result.length() - 1);
+    }
+
+    if (!result.isEmpty()) {
+      result = "?" + result;
+    }
+
+    return result;
   }
 
-  public String queryLine() {
-    if (queries.isEmpty()) {
-      return "";
-    }
-    StringBuilder queryBuilder = new StringBuilder("?");
-    for (String field : queries.keySet()) {
-      Collection<String> values = valuesOrEmpty(queries, field);
-      CharSequence fieldAndValues = collectionFormat.join(field, values);
-      queryBuilder.append(queryBuilder.length() == 1 || fieldAndValues.length() == 0 ? "" : "&");
-      queryBuilder.append(fieldAndValues);
-    }
-    return queryBuilder.toString();
+  private void extractQueryTemplates(String queryString) {
+    /* split the query string up into name value pairs */
+    Map<String, List<String>> queryParameters =
+        Arrays.stream(queryString.split("&"))
+            .map(this::splitQueryParameter)
+            .collect(Collectors.groupingBy(
+                SimpleImmutableEntry::getKey,
+                LinkedHashMap::new,
+                Collectors.mapping(Entry::getValue, Collectors.toList())));
+
+    /* add them to this template */
+    queryParameters.forEach(this::query);
   }
 
+  private SimpleImmutableEntry<String, String> splitQueryParameter(String pair) {
+    int eq = pair.indexOf("=");
+    final String name = (eq > 0) ? pair.substring(0, eq) : pair;
+    final String value = (eq > 0 && eq < pair.length()) ? pair.substring(eq + 1) : null;
+    return new SimpleImmutableEntry<>(name, value);
+  }
+
+  /**
+   * Factory for creating RequestTemplate.
+   */
   interface Factory {
 
     /**

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -513,6 +513,10 @@ public final class RequestTemplate implements Serializable {
     if (this.uriTemplate != null) {
       path.append(this.uriTemplate.toString());
     }
+    if (path.length() == 0) {
+      /* no path indicates the root uri */
+      path.append("/");
+    }
     return path.toString();
 
   }

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -834,7 +834,7 @@ public final class RequestTemplate implements Serializable {
         QueryTemplate queryTemplate = iterator.next();
         String query = queryTemplate.toString();
         if (query != null && !query.isEmpty()) {
-          queryString.append(queryTemplate.toString());
+          queryString.append(query);
           if (iterator.hasNext()) {
             queryString.append("&");
           }

--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -156,7 +156,7 @@ final class SynchronousMethodHandler implements MethodHandler {
     for (RequestInterceptor interceptor : requestInterceptors) {
       interceptor.apply(template);
     }
-    return target.apply(new RequestTemplate(template));
+    return target.apply(template);
   }
 
   Object decode(Response response) throws Throwable {

--- a/core/src/main/java/feign/Target.java
+++ b/core/src/main/java/feign/Target.java
@@ -98,7 +98,7 @@ public interface Target<T> {
     @Override
     public Request apply(RequestTemplate input) {
       if (input.url().indexOf("http") != 0) {
-        input.insert(0, url());
+        input.target(url());
       }
       return input.request();
     }

--- a/core/src/main/java/feign/Util.java
+++ b/core/src/main/java/feign/Util.java
@@ -344,4 +344,24 @@ public class Util {
       return defaultValue;
     }
   }
+
+  /**
+   * If the provided String is not null or empty.
+   *
+   * @param value to evaluate.
+   * @return true of the value is not null and not empty.
+   */
+  public static boolean isNotBlank(String value) {
+    return value != null && !value.isEmpty();
+  }
+
+  /**
+   * If the provided String is null or empty.
+   *
+   * @param value to evaluate.
+   * @return true if the value is null or empty.
+   */
+  public static boolean isBlank(String value) {
+    return value == null || value.isEmpty();
+  }
 }

--- a/core/src/main/java/feign/template/BodyTemplate.java
+++ b/core/src/main/java/feign/template/BodyTemplate.java
@@ -22,7 +22,7 @@ import java.util.Map;
  * Template for @{@link feign.Body} annotated Templates. Unresolved expressions are preserved as
  * literals and literals are not URI encoded.
  */
-public class BodyTemplate extends Template {
+public final class BodyTemplate extends Template {
 
   /**
    * Create a new Body Template.

--- a/core/src/main/java/feign/template/BodyTemplate.java
+++ b/core/src/main/java/feign/template/BodyTemplate.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2012-2018 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package feign.template;
+
+import feign.Util;
+import java.nio.charset.Charset;
+import java.util.Map;
+
+/**
+ * Template for @{@link feign.Body} annotated Templates. Unresolved expressions are preserved as
+ * literals and literals are not URI encoded.
+ */
+public class BodyTemplate extends Template {
+
+  /**
+   * Create a new Body Template.
+   *
+   * @param template to parse.
+   * @return a Body Template instance.
+   */
+  public static BodyTemplate create(String template) {
+    return new BodyTemplate(template, Util.UTF_8);
+  }
+
+  private BodyTemplate(String value, Charset charset) {
+    super(value, false, false, false, charset);
+  }
+
+  @Override
+  public String expand(Map<String, ?> variables) {
+    return UriUtils.decode(super.expand(variables), Util.UTF_8);
+  }
+}

--- a/core/src/main/java/feign/template/Expression.java
+++ b/core/src/main/java/feign/template/Expression.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2012-2018 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package feign.template;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * URI Template Expression.
+ */
+abstract class Expression extends TemplateChunk {
+
+  private String name;
+  private Pattern pattern;
+
+  /**
+   * Create a new Expression.
+   *
+   * @param name of the variable
+   * @param pattern the resolved variable must adhere to, optional.
+   */
+  Expression(String name, String pattern) {
+    this.name = name;
+    Optional.ofNullable(pattern).ifPresent(s -> this.pattern = Pattern.compile(s));
+  }
+
+  abstract String expand(Object variable, boolean encode);
+
+  public String getName() {
+    return this.name;
+  }
+
+  Pattern getPattern() {
+    return pattern;
+  }
+
+  /**
+   * Checks if the provided value matches the variable pattern, if one is defined. Always true if no
+   * pattern is defined.
+   *
+   * @param value to check.
+   * @return true if it matches.
+   */
+  boolean matches(String value) {
+    if (pattern == null) {
+      return true;
+    }
+    return pattern.matcher(value).matches();
+  }
+
+  @Override
+  public String getValue() {
+    if (this.pattern != null) {
+      return "{" + this.name + ":" + this.pattern + "}";
+    }
+    return "{" + this.name + "}";
+  }
+}

--- a/core/src/main/java/feign/template/Expression.java
+++ b/core/src/main/java/feign/template/Expression.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
 /**
  * URI Template Expression.
  */
-abstract class Expression extends TemplateChunk {
+abstract class Expression implements TemplateChunk {
 
   private String name;
   private Pattern pattern;

--- a/core/src/main/java/feign/template/Expressions.java
+++ b/core/src/main/java/feign/template/Expressions.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class Expressions {
+public final class Expressions {
   private static Map<Pattern, Class<? extends Expression>> expressions;
 
   static {

--- a/core/src/main/java/feign/template/Expressions.java
+++ b/core/src/main/java/feign/template/Expressions.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2012-2018 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package feign.template;
+
+import feign.Util;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class Expressions {
+  private static Map<Pattern, Class<? extends Expression>> expressions;
+
+  static {
+    expressions = new LinkedHashMap<>();
+    expressions.put(Pattern.compile("\\+(\\w[-\\w.]*[ ]*)(:(.+))?"), ReservedExpression.class);
+    expressions.put(Pattern.compile("(\\w[-\\w.]*[ ]*)(:(.+))?"), SimpleExpression.class);
+  }
+
+  public static Expression create(final String value) {
+
+    /* remove the start and end braces */
+    final String expression = stripBraces(value);
+    if (expression == null || expression.isEmpty()) {
+      throw new IllegalArgumentException("an expression is required.");
+    }
+
+    Optional<Entry<Pattern, Class<? extends Expression>>> matchedExpressionEntry =
+        expressions.entrySet()
+            .stream()
+            .filter(entry -> entry.getKey().matcher(expression).matches())
+            .findFirst();
+
+    if (!matchedExpressionEntry.isPresent()) {
+      /* not a valid expression */
+      return null;
+    }
+
+    Entry<Pattern, Class<? extends Expression>> matchedExpression = matchedExpressionEntry.get();
+    Pattern expressionPattern = matchedExpression.getKey();
+    Class<? extends Expression> expressionType = matchedExpression.getValue();
+
+    /* create a new regular expression matcher for the expression */
+    String variableName = null;
+    String variablePattern = null;
+    Matcher matcher = expressionPattern.matcher(expression);
+    if (matcher.matches()) {
+      /* we have a valid variable expression, extract the name from the first group */
+      variableName = matcher.group(1).trim();
+      if (matcher.group(2) != null && matcher.group(3) != null) {
+        /* this variable contains an optional pattern */
+        variablePattern = matcher.group(3);
+      }
+    }
+
+    return new SimpleExpression(variableName, variablePattern);
+  }
+
+  private static String stripBraces(String expression) {
+    if (expression == null) {
+      return null;
+    }
+    if (expression.startsWith("{") && expression.endsWith("}")) {
+      return expression.substring(1, expression.length() - 1);
+    }
+    return expression;
+  }
+
+  /**
+   * Expression that does not encode reserved characters. This expression adheres to RFC 6570
+   * <a href="https://tools.ietf.org/html/rfc6570#section-3.2.3">Reserved Expansion (Level 2)</a>
+   * specification.
+   */
+  public static class ReservedExpression extends SimpleExpression {
+    private final String RESERVED_CHARACTERS = ":/?#[]@!$&\'()*+,;=";
+
+    ReservedExpression(String expression, String pattern) {
+      super(expression, pattern);
+    }
+
+    @Override
+    String encode(Object value) {
+      return UriUtils.encodeReserved(value.toString(), RESERVED_CHARACTERS, Util.UTF_8);
+    }
+  }
+
+  /**
+   * Expression that adheres to Simple String Expansion as outlined in <a
+   * href="https://tools.ietf.org/html/rfc6570#section-3.2.2>Simple String Expansion (Level 1)</a>
+   */
+  static class SimpleExpression extends Expression {
+
+    SimpleExpression(String expression, String pattern) {
+      super(expression, pattern);
+    }
+
+    String encode(Object value) {
+      return UriUtils.encode(value.toString(), Util.UTF_8);
+    }
+
+    @Override
+    String expand(Object variable, boolean encode) {
+      StringBuilder expanded = new StringBuilder();
+      if (Iterable.class.isAssignableFrom(variable.getClass())) {
+        List<String> items = new ArrayList<>();
+        for (Object item : ((Iterable) variable)) {
+          items.add((encode) ? encode(item) : item.toString());
+        }
+        expanded.append(String.join(",", items));
+      } else {
+        expanded.append((encode) ? encode(variable) : variable);
+      }
+
+      /* return the string value of the variable */
+      String result = expanded.toString();
+      if (!this.matches(result)) {
+        throw new IllegalArgumentException("Value " + expanded
+            + " does not match the expression pattern: " + this.getPattern());
+      }
+      return result;
+    }
+  }
+}

--- a/core/src/main/java/feign/template/HeaderTemplate.java
+++ b/core/src/main/java/feign/template/HeaderTemplate.java
@@ -27,7 +27,7 @@ import java.util.stream.StreamSupport;
  * Template for HTTP Headers. Variables that are unresolved are ignored and Literals are not
  * encoded.
  */
-public class HeaderTemplate extends Template {
+public final class HeaderTemplate extends Template {
 
   /* cache a copy of the variables for lookup later */
   private Set<String> values;

--- a/core/src/main/java/feign/template/HeaderTemplate.java
+++ b/core/src/main/java/feign/template/HeaderTemplate.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2012-2018 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.template;
+
+import feign.Util;
+import java.nio.charset.Charset;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Template for HTTP Headers. Variables that are unresolved are ignored and Literals are not
+ * encoded.
+ */
+public class HeaderTemplate extends Template {
+
+  /* cache a copy of the variables for lookup later */
+  private Set<String> values;
+  private String name;
+
+  public static HeaderTemplate create(String name, Iterable<String> values) {
+    if (name == null || name.isEmpty()) {
+      throw new IllegalArgumentException("name is required.");
+    }
+
+    if (values == null) {
+      throw new IllegalArgumentException("values are required");
+    }
+
+    /* construct a uri template from the name and values */
+    StringBuilder template = new StringBuilder();
+    template.append(name)
+        .append(" ");
+
+    /* create a comma separated template for the header values */
+    Iterator<String> iterator = values.iterator();
+    while (iterator.hasNext()) {
+      template.append(iterator.next());
+      if (iterator.hasNext()) {
+        template.append(", ");
+      }
+    }
+    return new HeaderTemplate(template.toString(), name, values, Util.UTF_8);
+  }
+
+  /**
+   * Append values to a Header Template.
+   *
+   * @param headerTemplate to append to.
+   * @param values to append.
+   * @return a new Header Template with the values added.
+   */
+  public static HeaderTemplate append(HeaderTemplate headerTemplate, Iterable<String> values) {
+    Set<String> headerValues = new LinkedHashSet<>(headerTemplate.getValues());
+    headerValues.addAll(StreamSupport.stream(values.spliterator(), false)
+        .filter(Util::isNotBlank)
+        .collect(Collectors.toList()));
+    return create(headerTemplate.getName(), headerValues);
+  }
+
+  /**
+   * Creates a new Header Template.
+   *
+   * @param template to parse.
+   */
+  private HeaderTemplate(String template, String name, Iterable<String> values, Charset charset) {
+    super(template, false, false, false, charset);
+    this.values = StreamSupport.stream(values.spliterator(), false)
+        .filter(Util::isNotBlank)
+        .collect(Collectors.toSet());
+    this.name = name;
+  }
+
+  public Collection<String> getValues() {
+    return Collections.unmodifiableCollection(values);
+  }
+
+  public String getName() {
+    return name;
+  }
+}

--- a/core/src/main/java/feign/template/HeaderTemplate.java
+++ b/core/src/main/java/feign/template/HeaderTemplate.java
@@ -69,7 +69,7 @@ public class HeaderTemplate extends Template {
     Set<String> headerValues = new LinkedHashSet<>(headerTemplate.getValues());
     headerValues.addAll(StreamSupport.stream(values.spliterator(), false)
         .filter(Util::isNotBlank)
-        .collect(Collectors.toList()));
+        .collect(Collectors.toSet()));
     return create(headerTemplate.getName(), headerValues);
   }
 

--- a/core/src/main/java/feign/template/Literal.java
+++ b/core/src/main/java/feign/template/Literal.java
@@ -11,39 +11,39 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package feign.mock;
+package feign.template;
 
-import feign.Request;
-import feign.RequestTemplate;
-import feign.Target;
+/**
+ * URI Template Literal.
+ */
+class Literal extends TemplateChunk {
 
-public class MockTarget<E> implements Target<E> {
+  private final String value;
 
-  private final Class<E> type;
+  /**
+   * Create a new Literal.
+   *
+   * @param value of the literal.
+   * @return the new Literal.
+   */
+  public static Literal create(String value) {
+    return new Literal(value);
+  }
 
-  public MockTarget(Class<E> type) {
-    this.type = type;
+  /**
+   * Create a new Literal.
+   *
+   * @param value of the literal.
+   */
+  Literal(String value) {
+    if (value == null || value.isEmpty()) {
+      throw new IllegalArgumentException("a value is required.");
+    }
+    this.value = value;
   }
 
   @Override
-  public Class<E> type() {
-    return type;
+  public String getValue() {
+    return this.value;
   }
-
-  @Override
-  public String name() {
-    return type.getSimpleName();
-  }
-
-  @Override
-  public String url() {
-    return "";
-  }
-
-  @Override
-  public Request apply(RequestTemplate input) {
-    input.target(url());
-    return input.request();
-  }
-
 }

--- a/core/src/main/java/feign/template/Literal.java
+++ b/core/src/main/java/feign/template/Literal.java
@@ -16,7 +16,7 @@ package feign.template;
 /**
  * URI Template Literal.
  */
-class Literal extends TemplateChunk {
+class Literal implements TemplateChunk {
 
   private final String value;
 

--- a/core/src/main/java/feign/template/QueryTemplate.java
+++ b/core/src/main/java/feign/template/QueryTemplate.java
@@ -1,0 +1,164 @@
+/**
+ * Copyright 2012-2018 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.template;
+
+import feign.CollectionFormat;
+import feign.Util;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+public class QueryTemplate extends Template {
+
+  /* cache a copy of the variables for lookup later */
+  private List<String> values;
+  private final String name;
+  private final CollectionFormat collectionFormat;
+
+  /**
+   * Create a new Query Template.
+   *
+   * @param name of the query parameter.
+   * @param values in the template.
+   * @param charset for the template.
+   * @return a QueryTemplate.
+   */
+  public static QueryTemplate create(String name, Iterable<String> values, Charset charset) {
+    return create(name, values, charset, CollectionFormat.EXPLODED);
+  }
+
+  /**
+   * Create a new Query Template.
+   *
+   * @param name of the query parameter.
+   * @param values in the template.
+   * @param charset for the template.
+   * @param collectionFormat to use.
+   * @return a QueryTemplate
+   */
+  public static QueryTemplate create(String name,
+                                     Iterable<String> values,
+                                     Charset charset,
+                                     CollectionFormat collectionFormat) {
+    if (name == null || name.isEmpty()) {
+      throw new IllegalArgumentException("name is required.");
+    }
+
+    if (values == null) {
+      throw new IllegalArgumentException("values are required");
+    }
+
+    /* remove all empty values from the array */
+    Collection<String> remaining = StreamSupport.stream(values.spliterator(), false)
+        .filter(Util::isNotBlank)
+        .collect(Collectors.toList());
+
+    StringBuilder template = new StringBuilder();
+    Iterator<String> iterator = remaining.iterator();
+    while (iterator.hasNext()) {
+      template.append(iterator.next());
+      if (iterator.hasNext()) {
+        template.append(",");
+      }
+    }
+
+    return new QueryTemplate(template.toString(), name, remaining, charset, collectionFormat);
+  }
+
+  /**
+   * Append a value to the Query Template.
+   *
+   * @param queryTemplate to append to.
+   * @param values to append.
+   * @return a new QueryTemplate with value appended.
+   */
+  public static QueryTemplate append(QueryTemplate queryTemplate,
+                                     Iterable<String> values,
+                                     CollectionFormat collectionFormat) {
+    List<String> queryValues = new ArrayList<>(queryTemplate.getValues());
+    queryValues.addAll(StreamSupport.stream(values.spliterator(), false)
+        .filter(Util::isNotBlank)
+        .collect(Collectors.toList()));
+    return create(queryTemplate.getName(), queryValues, queryTemplate.getCharset(),
+        collectionFormat);
+  }
+
+  /**
+   * Create a new Query Template.
+   *
+   * @param template for the Query String.
+   * @param name of the query parameter.
+   * @param values for the parameter.
+   * @param collectionFormat to use.
+   */
+  private QueryTemplate(
+      String template,
+      String name,
+      Iterable<String> values,
+      Charset charset,
+      CollectionFormat collectionFormat) {
+    super(template, false, true, true, charset);
+    this.name = name;
+    this.collectionFormat = collectionFormat;
+    this.values = StreamSupport.stream(values.spliterator(), false)
+        .filter(Util::isNotBlank)
+        .collect(Collectors.toList());
+  }
+
+  public List<String> getValues() {
+    return values;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String toString() {
+    return this.queryString(super.toString());
+  }
+
+  /**
+   * Expand this template. Unresolved variables are removed. If all values remain unresolved, the
+   * result is an empty string.
+   *
+   * @param variables containing the values for expansion.
+   * @return the expanded template.
+   */
+  @Override
+  public String expand(Map<String, ?> variables) {
+    return this.queryString(super.expand(variables));
+  }
+
+  private String queryString(String values) {
+    /* covert the comma separated values into a value query string */
+    List<String> resolved = Arrays.stream(values.split(","))
+        .filter(Util::isNotBlank)
+        .collect(Collectors.toList());
+
+    if (!resolved.isEmpty()) {
+      return this.collectionFormat.join(this.name, resolved, this.getCharset()).toString();
+    }
+
+    /* nothing to return, all values are unresolved */
+    return null;
+  }
+
+}

--- a/core/src/main/java/feign/template/QueryTemplate.java
+++ b/core/src/main/java/feign/template/QueryTemplate.java
@@ -34,6 +34,7 @@ public final class QueryTemplate extends Template {
   private List<String> values;
   private final String name;
   private final CollectionFormat collectionFormat;
+  private boolean pure = false;
 
   /**
    * Create a new Query Template.
@@ -123,6 +124,11 @@ public final class QueryTemplate extends Template {
     this.values = StreamSupport.stream(values.spliterator(), false)
         .filter(Util::isNotBlank)
         .collect(Collectors.toList());
+    if (this.values.isEmpty()) {
+      /* in this case, we have a pure parameter */
+      this.pure = true;
+
+    }
   }
 
   public List<String> getValues() {
@@ -151,6 +157,10 @@ public final class QueryTemplate extends Template {
   }
 
   private String queryString(String values) {
+    if (this.pure) {
+      return this.name;
+    }
+
     /* covert the comma separated values into a value query string */
     List<String> resolved = Arrays.stream(values.split(","))
         .filter(Util::isNotBlank)

--- a/core/src/main/java/feign/template/QueryTemplate.java
+++ b/core/src/main/java/feign/template/QueryTemplate.java
@@ -25,7 +25,10 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-public class QueryTemplate extends Template {
+/**
+ * Template for a Query String parameter.
+ */
+public final class QueryTemplate extends Template {
 
   /* cache a copy of the variables for lookup later */
   private List<String> values;

--- a/core/src/main/java/feign/template/Template.java
+++ b/core/src/main/java/feign/template/Template.java
@@ -1,0 +1,309 @@
+/**
+ * Copyright 2012-2018 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.template;
+
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * A Generic representation of a Template Expression as defined by
+ * <a href="https://tools.ietf.org/html/rfc6570">RFC 6570</a>, with some relaxed rules, allowing the
+ * concept to be used in areas outside of the uri.
+ */
+public abstract class Template {
+
+  private static final Logger logger = Logger.getLogger(Template.class.getName());
+  private static final Pattern QUERY_STRING_PATTERN = Pattern.compile("(?<!\\{)(\\?)");
+  private final String template;
+  private final boolean allowUnresolved;
+  private final boolean encode;
+  private final boolean encodeSlash;
+  private final Charset charset;
+  private final List<TemplateChunk> templateChunks = new ArrayList<>();
+
+  /**
+   * Create a new Template.
+   *
+   * @param value of the template.
+   * @param allowUnresolved if unresolved expressions should remain.
+   * @param encode all values.
+   * @param encodeSlash if slash characters should be encoded.
+   */
+  Template(
+      String value, boolean allowUnresolved, boolean encode, boolean encodeSlash, Charset charset) {
+    if (value == null) {
+      throw new IllegalArgumentException("template is required.");
+    }
+    this.template = value;
+    this.allowUnresolved = allowUnresolved;
+    this.encode = encode;
+    this.encodeSlash = encodeSlash;
+    this.charset = charset;
+    this.parseTemplate();
+  }
+
+  /**
+   * Expand the template.
+   *
+   * @param variables containing the values for expansion.
+   * @return a fully qualified URI with the variables expanded.
+   */
+  public String expand(Map<String, ?> variables) {
+    if (variables == null) {
+      throw new IllegalArgumentException("variable map is required.");
+    }
+
+    /* resolve all expressions within the template */
+    StringBuilder resolved = new StringBuilder();
+    for (TemplateChunk chunk : this.templateChunks) {
+      if (chunk instanceof Expression) {
+        Expression expression = (Expression) chunk;
+        Object value = variables.get(expression.getName());
+        if (value != null) {
+          String expanded = expression.expand(value, this.encode);
+          if (!this.encodeSlash) {
+            logger.fine("Explicit slash decoding specified, decoding all slashes in uri");
+            expanded = expanded.replaceAll("\\%2F", "/");
+          }
+          resolved.append(expanded);
+        } else {
+          if (this.allowUnresolved) {
+            /* unresolved variables are treated as literals */
+            resolved.append(encode(expression.toString()));
+          }
+        }
+      } else {
+        /* chunk is a literal value */
+        resolved.append(chunk.getValue());
+      }
+    }
+    return resolved.toString();
+  }
+
+  /**
+   * Uri Encode the value.
+   *
+   * @param value to encode.
+   * @return the encoded value.
+   */
+  private String encode(String value) {
+    return this.encode ? UriUtils.encode(value, this.charset) : value;
+  }
+
+  /**
+   * Uri Encode the value.
+   *
+   * @param value to encode
+   * @param query indicating this value is on a query string.
+   * @return the encoded value
+   */
+  private String encode(String value, boolean query) {
+    if (this.encode) {
+      return query ? UriUtils.queryEncode(value, this.charset)
+          : UriUtils.pathEncode(value, this.charset);
+    } else {
+      return value;
+    }
+  }
+
+  /**
+   * Variable names contained in the template.
+   *
+   * @return a List of Variable Names.
+   */
+  public List<String> getVariables() {
+    return this.templateChunks.stream()
+        .filter(templateChunk -> Expression.class.isAssignableFrom(templateChunk.getClass()))
+        .map(templateChunk -> ((Expression) templateChunk).getName())
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * List of all Literals in the Template.
+   *
+   * @return list of Literal values.
+   */
+  public List<String> getLiterals() {
+    return this.templateChunks.stream()
+        .filter(templateChunk -> Literal.class.isAssignableFrom(templateChunk.getClass()))
+        .map(TemplateChunk::toString)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Parse the template into {@link TemplateChunk}s.
+   */
+  private void parseTemplate() {
+    /*
+     * query string and path literals have different reserved characters and different encoding
+     * requirements. to ensure compliance with RFC 6570, we'll need to encode query literals
+     * differently from path literals. let's look at the template to see if it contains a query
+     * string and if so, keep track of where it starts.
+     */
+    Matcher queryStringMatcher = QUERY_STRING_PATTERN.matcher(this.template);
+    if (queryStringMatcher.find()) {
+      /*
+       * the template contains a query string, split the template into two parts, the path and query
+       */
+      String path = this.template.substring(0, queryStringMatcher.start());
+      String query = this.template.substring(queryStringMatcher.end() - 1);
+      this.parseFragment(path, false);
+      this.parseFragment(query, true);
+    } else {
+      /* parse the entire template */
+      this.parseFragment(this.template, false);
+    }
+  }
+
+  /**
+   * Parse a template fragment.
+   *
+   * @param fragment to parse
+   * @param query if the fragment is part of a query string.
+   */
+  private void parseFragment(String fragment, boolean query) {
+    ChunkTokenizer tokenizer = new ChunkTokenizer(fragment);
+
+    while (tokenizer.hasNext()) {
+      /* check to see if we have an expression or a literal */
+      String chunk = tokenizer.next();
+
+      if (chunk.startsWith("{")) {
+        /* it's an expression, defer encoding until resolution */
+        Expression expression = Expressions.create(chunk);
+        if (expression == null) {
+          this.templateChunks.add(Literal.create(encode(chunk, query)));
+        } else {
+          this.templateChunks.add(expression);
+        }
+      } else {
+        /* it's a literal, pct-encode it */
+        this.templateChunks.add(Literal.create(encode(chunk, query)));
+      }
+    }
+  }
+
+  @Override
+  public String toString() {
+    return this.templateChunks.stream()
+        .map(TemplateChunk::toString).collect(Collectors.joining());
+  }
+
+  public boolean allowUnresolved() {
+    return allowUnresolved;
+  }
+
+  public boolean encode() {
+    return encode;
+  }
+
+  public boolean encodeSlash() {
+    return encodeSlash;
+  }
+
+  /**
+   * The Charset for the template.
+   *
+   * @return the Charset, if set. Defaults to UTF-8
+   */
+  public Charset getCharset() {
+    return this.charset;
+  }
+
+  /**
+   * Splits a Uri into Chunks that exists inside and outside of an expression, delimited by curly
+   * braces "{}". Nested expressions are treated as literals, for example "foo{bar{baz}}" will be
+   * treated as "foo, {bar{baz}}". Inspired by Apache CXF Jax-RS.
+   */
+  static class ChunkTokenizer {
+
+    private List<String> tokens = new ArrayList<>();
+    private int index;
+
+    ChunkTokenizer(String template) {
+      boolean outside = true;
+      int level = 0;
+      int lastIndex = 0;
+      int idx;
+
+      /* loop through the template, character by character */
+      for (idx = 0; idx < template.length(); idx++) {
+        if (template.charAt(idx) == '{') {
+          /* start of an expression */
+          if (outside) {
+            /* outside of an expression */
+            if (lastIndex < idx) {
+              /* this is the start of a new token */
+              tokens.add(template.substring(lastIndex, idx));
+            }
+            lastIndex = idx;
+
+            /*
+             * no longer outside of an expression, additional characters will be treated as in an
+             * expression
+             */
+            outside = false;
+          } else {
+            /* nested braces, increase our nesting level */
+            level++;
+          }
+        } else if (template.charAt(idx) == '}' && !outside) {
+          /* the end of an expression */
+          if (level > 0) {
+            /*
+             * sometimes we see nested expressions, we only want the outer most expression
+             * boundaries.
+             */
+            level--;
+          } else {
+            /* outermost boundary */
+            if (lastIndex < idx) {
+              /* this is the end of an expression token */
+              tokens.add(template.substring(lastIndex, idx + 1));
+            }
+            lastIndex = idx + 1;
+
+            /* outside an expression */
+            outside = true;
+          }
+        }
+      }
+      if (lastIndex < idx) {
+        /* grab the remaining chunk */
+        tokens.add(template.substring(lastIndex, idx));
+      }
+    }
+
+    public boolean hasNext() {
+      return this.tokens.size() > this.index;
+    }
+
+    public String next() {
+      if (hasNext()) {
+        return this.tokens.get(this.index++);
+      }
+      throw new IllegalStateException("No More Elements");
+    }
+  }
+
+}

--- a/core/src/main/java/feign/template/Template.java
+++ b/core/src/main/java/feign/template/Template.java
@@ -151,6 +151,15 @@ public abstract class Template {
   }
 
   /**
+   * Flag to indicate that this template is a literal string, with no variable expressions.
+   *
+   * @return true if this template is made up entirely of literal strings.
+   */
+  public boolean isLiteral() {
+    return this.getVariables().isEmpty();
+  }
+
+  /**
    * Parse the template into {@link TemplateChunk}s.
    */
   private void parseTemplate() {

--- a/core/src/main/java/feign/template/Template.java
+++ b/core/src/main/java/feign/template/Template.java
@@ -206,7 +206,7 @@ public abstract class Template {
   @Override
   public String toString() {
     return this.templateChunks.stream()
-        .map(TemplateChunk::toString).collect(Collectors.joining());
+        .map(TemplateChunk::getValue).collect(Collectors.joining());
   }
 
   public boolean allowUnresolved() {

--- a/core/src/main/java/feign/template/TemplateChunk.java
+++ b/core/src/main/java/feign/template/TemplateChunk.java
@@ -11,39 +11,17 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package feign.mock;
+package feign.template;
 
-import feign.Request;
-import feign.RequestTemplate;
-import feign.Target;
+/**
+ * Represents the parts of a URI Template.
+ */
+abstract class TemplateChunk {
 
-public class MockTarget<E> implements Target<E> {
-
-  private final Class<E> type;
-
-  public MockTarget(Class<E> type) {
-    this.type = type;
-  }
+  public abstract String getValue();
 
   @Override
-  public Class<E> type() {
-    return type;
+  public String toString() {
+    return getValue();
   }
-
-  @Override
-  public String name() {
-    return type.getSimpleName();
-  }
-
-  @Override
-  public String url() {
-    return "";
-  }
-
-  @Override
-  public Request apply(RequestTemplate input) {
-    input.target(url());
-    return input.request();
-  }
-
 }

--- a/core/src/main/java/feign/template/TemplateChunk.java
+++ b/core/src/main/java/feign/template/TemplateChunk.java
@@ -16,12 +16,9 @@ package feign.template;
 /**
  * Represents the parts of a URI Template.
  */
-abstract class TemplateChunk {
+@FunctionalInterface
+interface TemplateChunk {
 
-  public abstract String getValue();
+  String getValue();
 
-  @Override
-  public String toString() {
-    return getValue();
-  }
 }

--- a/core/src/main/java/feign/template/UriTemplate.java
+++ b/core/src/main/java/feign/template/UriTemplate.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2012-2018 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.template;
+
+import java.nio.charset.Charset;
+
+/**
+ * URI Template, as defined by <a href="https://tools.ietf.org/html/rfc6570">RFC 6570</a>,
+ * supporting <a href="https://tools.ietf.org/html/rfc6570#section-3.2.2">Level 1</a> expressions,
+ * with the following differences:
+ *
+ * <ol>
+ * <li>unresolved variables are preserved as literals</li>
+ * <li>all literals are pct-encoded</li>
+ * </ol>
+ */
+public class UriTemplate extends Template {
+
+  /**
+   * Create a Uri Template.
+   *
+   * @param template representing the uri.
+   * @param charset for encoding.
+   * @return a new Uri Template instance.
+   */
+  public static UriTemplate create(String template, Charset charset) {
+    return new UriTemplate(template, true, charset);
+  }
+
+  /**
+   * Create a Uri Template.
+   *
+   * @param template representing the uri
+   * @param encodeSlash flag if slash characters should be encoded.
+   * @param charset for the template.
+   * @return a new Uri Template instance.
+   */
+  public static UriTemplate create(String template, boolean encodeSlash, Charset charset) {
+    return new UriTemplate(template, encodeSlash, charset);
+  }
+
+  /**
+   * Append a uri fragment to the template.
+   *
+   * @param uriTemplate to append to.
+   * @param fragment to append.
+   * @return a new UriTemplate with the fragment appended.
+   */
+  public static UriTemplate append(UriTemplate uriTemplate, String fragment) {
+    return new UriTemplate(uriTemplate.toString() + fragment, uriTemplate.encodeSlash(),
+        uriTemplate.getCharset());
+  }
+
+  /**
+   * Create a new Uri Template.
+   *
+   * @param template for the uri.
+   * @param encodeSlash flag for encoding slash characters.
+   * @param charset to use when encoding.
+   */
+  private UriTemplate(String template, boolean encodeSlash, Charset charset) {
+    super(template, false, true, encodeSlash, charset);
+  }
+}

--- a/core/src/main/java/feign/template/UriUtils.java
+++ b/core/src/main/java/feign/template/UriUtils.java
@@ -1,0 +1,222 @@
+/**
+ * Copyright 2012-2018 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.template;
+
+import feign.Util;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class UriUtils {
+
+  private static final String QUERY_RESERVED_CHARACTERS = "?/,=";
+  private static final String PATH_RESERVED_CHARACTERS = "/=@:!$&\'(),;~";
+  private static final Pattern PCT_ENCODED_PATTERN = Pattern.compile("%[0-9A-Fa-f][0-9A-Fa-f]");
+
+  /**
+   * Determines if the value is already pct-encoded.
+   *
+   * @param value to check.
+   * @return {@literal true} if the value is already pct-encoded
+   */
+  public static boolean isEncoded(String value) {
+    return PCT_ENCODED_PATTERN.matcher(value).matches();
+  }
+
+  /**
+   * Uri Encode the value, using the default Charset. Already encoded values are skipped.
+   *
+   * @param value to encode.
+   * @return the encoded value.
+   */
+  public static String encode(String value) {
+    return encodeReserved(value, "", Util.UTF_8);
+  }
+
+  /**
+   * Uri Encode the value. Already encoded values are skipped.
+   *
+   * @param value to encode.
+   * @param charset to use.
+   * @return the encoded value.
+   */
+  public static String encode(String value, Charset charset) {
+    return encodeReserved(value, "", charset);
+  }
+
+  /**
+   * Uri Decode the value.
+   *
+   * @param value to decode
+   * @param charset to use.
+   * @return the decoded value.
+   */
+  public static String decode(String value, Charset charset) {
+    try {
+      /* there is nothing special between uri and url decoding */
+      return URLDecoder.decode(value, charset.name());
+    } catch (UnsupportedEncodingException uee) {
+      /* since the encoding is not supported, return the original value */
+      return value;
+    }
+  }
+
+  /**
+   * Uri Encode a Path Fragment.
+   *
+   * @param path containing the path fragment.
+   * @param charset to use.
+   * @return the encoded path fragment.
+   */
+  public static String pathEncode(String path, Charset charset) {
+    return encodeReserved(path, PATH_RESERVED_CHARACTERS, charset);
+  }
+
+  /**
+   * Uri Encode a Query Fragment.
+   *
+   * @param query containing the query fragment
+   * @param charset to use.
+   * @return the encoded query fragment.
+   */
+  public static String queryEncode(String query, Charset charset) {
+    return encodeReserved(query, QUERY_RESERVED_CHARACTERS, charset);
+  }
+
+  /**
+   * Determines if the provided uri is an absolute uri.
+   *
+   * @param uri to evaluate.
+   * @return true if the uri is absolute.
+   */
+  public static boolean isAbsolute(String uri) {
+    return uri != null && !uri.isEmpty() && uri.startsWith("http");
+  }
+
+  /**
+   * Uri Encode a String using the provided charset.
+   *
+   * @param value to encode.
+   * @param charset to use.
+   * @return the encoded value.
+   */
+  private static String urlEncode(String value, Charset charset) {
+    try {
+      String encoded = URLEncoder.encode(value, charset.toString());
+
+      /*
+       * url encoding is not equivalent to URI encoding, there are few differences, namely dealing
+       * with spaces, !, ', (, ), and ~ characters. we will need to manually process those values.
+       */
+      return encoded.replaceAll("\\+", "%20")
+          .replaceAll("\\%21", "!")
+          .replaceAll("\\%27", "'")
+          .replaceAll("\\%28", "(")
+          .replaceAll("\\%29", ")")
+          .replaceAll("\\%7E", "~")
+          .replaceAll("\\%2B", "+");
+
+    } catch (UnsupportedEncodingException uee) {
+      /* since the encoding is not supported, return the original value */
+      return value;
+    }
+  }
+
+
+  /**
+   * Encodes the value, preserving all reserved characters.. Values that are already pct-encoded are
+   * ignored.
+   *
+   * @param value inspect.
+   * @param reserved characters to preserve.
+   * @param charset to use.
+   * @return a new String with the reserved characters preserved.
+   */
+  public static String encodeReserved(String value, String reserved, Charset charset) {
+    /* value is encoded, we need to split it up and skip the parts that are already encoded */
+    Matcher matcher = PCT_ENCODED_PATTERN.matcher(value);
+
+    if (!matcher.find()) {
+      return encodeChunk(value, reserved, charset);
+    }
+
+    int length = value.length();
+    StringBuilder encoded = new StringBuilder(length + 8);
+    int index = 0;
+    do {
+      /* split out the value before the encoded value */
+      String before = value.substring(index, matcher.start());
+
+      /* encode it */
+      encoded.append(encodeChunk(before, reserved, charset));
+
+      /* append the encoded value */
+      encoded.append(matcher.group());
+
+      /* update the string search index */
+      index = matcher.end();
+    } while (matcher.find());
+
+    /* append the rest of the string */
+    String tail = value.substring(index, length);
+    encoded.append(encodeChunk(tail, reserved, charset));
+    return encoded.toString();
+  }
+
+  /**
+   * Encode a Uri Chunk, ensuring that all reserved characters are also encoded.
+   *
+   * @param value to encode.
+   * @param reserved characters to evaluate.
+   * @param charset to use.
+   * @return an encoded uri chunk.
+   */
+  private static String encodeChunk(String value, String reserved, Charset charset) {
+    StringBuilder encoded = null;
+    int length = value.length();
+    int index = 0;
+    for (int i = 0; i < length; i++) {
+      char character = value.charAt(i);
+      if (reserved.indexOf(character) != -1) {
+        if (encoded == null) {
+          encoded = new StringBuilder(length + 8);
+        }
+
+        if (i != index) {
+          /* we are in the middle of the value, so we need to encode mid string */
+          encoded.append(urlEncode(value.substring(index, i), charset));
+        }
+        encoded.append(character);
+        index = i + 1;
+      }
+    }
+
+    /* if there are no reserved characters, encode the original value */
+    if (encoded == null) {
+      return urlEncode(value, charset);
+    }
+
+    /* encode the rest of the string */
+    if (index < length) {
+      encoded.append(urlEncode(value.substring(index, length), charset));
+    }
+    return encoded.toString();
+
+  }
+}

--- a/core/src/test/java/feign/DefaultContractTest.java
+++ b/core/src/test/java/feign/DefaultContractTest.java
@@ -14,6 +14,7 @@
 package feign;
 
 import com.google.gson.reflect.TypeToken;
+import java.util.ArrayList;
 import org.assertj.core.api.Fail;
 import org.junit.Rule;
 import org.junit.Test;
@@ -85,7 +86,7 @@ public class DefaultContractTest {
   public void customMethodWithoutPath() throws Exception {
     assertThat(parseAndValidateMetadata(CustomMethod.class, "patch").template())
         .hasMethod("PATCH")
-        .hasUrl("");
+        .hasUrl("/");
   }
 
   @Test
@@ -95,40 +96,40 @@ public class DefaultContractTest {
         .hasQueries();
 
     assertThat(parseAndValidateMetadata(WithQueryParamsInPath.class, "one").template())
-        .hasUrl("/")
+        .hasPath("/")
         .hasQueries(
             entry("Action", asList("GetUser")));
 
     assertThat(parseAndValidateMetadata(WithQueryParamsInPath.class, "two").template())
-        .hasUrl("/")
+        .hasPath("/")
         .hasQueries(
             entry("Action", asList("GetUser")),
             entry("Version", asList("2010-05-08")));
 
     assertThat(parseAndValidateMetadata(WithQueryParamsInPath.class, "three").template())
-        .hasUrl("/")
+        .hasPath("/")
         .hasQueries(
             entry("Action", asList("GetUser")),
             entry("Version", asList("2010-05-08")),
             entry("limit", asList("1")));
 
     assertThat(parseAndValidateMetadata(WithQueryParamsInPath.class, "twoAndOneEmpty").template())
-        .hasUrl("/")
+        .hasPath("/")
         .hasQueries(
-            entry("flag", asList(new String[] {null})),
+            entry("flag", new ArrayList<>()),
             entry("Action", asList("GetUser")),
             entry("Version", asList("2010-05-08")));
 
     assertThat(parseAndValidateMetadata(WithQueryParamsInPath.class, "oneEmpty").template())
         .hasUrl("/")
         .hasQueries(
-            entry("flag", asList(new String[] {null})));
+            entry("flag", new ArrayList<>()));
 
     assertThat(parseAndValidateMetadata(WithQueryParamsInPath.class, "twoEmpty").template())
-        .hasUrl("/")
+        .hasPath("/")
         .hasQueries(
-            entry("flag", asList(new String[] {null})),
-            entry("NoErrors", asList(new String[] {null})));
+            entry("flag", new ArrayList<>()),
+            entry("NoErrors", new ArrayList<>()));
   }
 
   @Test
@@ -544,7 +545,7 @@ public class DefaultContractTest {
     @RequestLine(value = "GET /api/queues/{vhost}", decodeSlash = false)
     String getQueues(@Param("vhost") String vhost);
 
-    @RequestLine("GET /api/{zoneId}")
+    @RequestLine(value = "GET /api/{zoneId}")
     String getZone(@Param("ZoneId") String vhost);
   }
 

--- a/core/src/test/java/feign/DefaultContractTest.java
+++ b/core/src/test/java/feign/DefaultContractTest.java
@@ -121,7 +121,7 @@ public class DefaultContractTest {
             entry("Version", asList("2010-05-08")));
 
     assertThat(parseAndValidateMetadata(WithQueryParamsInPath.class, "oneEmpty").template())
-        .hasUrl("/")
+        .hasPath("/")
         .hasQueries(
             entry("flag", new ArrayList<>()));
 

--- a/core/src/test/java/feign/EmptyTargetTest.java
+++ b/core/src/test/java/feign/EmptyTargetTest.java
@@ -13,6 +13,7 @@
  */
 package feign;
 
+import feign.Request.HttpMethod;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -49,7 +50,7 @@ public class EmptyTargetTest {
     thrown.expectMessage("Request with non-absolute URL not supported with empty target");
 
     EmptyTarget.create(UriInterface.class)
-        .apply(new RequestTemplate().method("GET").append("/relative"));
+        .apply(new RequestTemplate().method(HttpMethod.GET).uri("/relative"));
   }
 
   interface UriInterface {

--- a/core/src/test/java/feign/FeignBuilderTest.java
+++ b/core/src/test/java/feign/FeignBuilderTest.java
@@ -230,7 +230,7 @@ public class FeignBuilderTest {
     assertEquals(Util.toString(response.body().asReader()), "response data");
 
     assertThat(server.takeRequest())
-        .hasHeaders(MapEntry.entry("Content-Type", "text/plain"))
+        .hasHeaders(MapEntry.entry("Content-Type", Collections.singletonList("text/plain")))
         .hasBody("request data");
   }
 

--- a/core/src/test/java/feign/FeignBuilderTest.java
+++ b/core/src/test/java/feign/FeignBuilderTest.java
@@ -16,6 +16,7 @@ package feign;
 import java.util.HashMap;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+import org.assertj.core.data.MapEntry;
 import org.junit.Rule;
 import org.junit.Test;
 import java.io.IOException;
@@ -229,7 +230,7 @@ public class FeignBuilderTest {
     assertEquals(Util.toString(response.body().asReader()), "response data");
 
     assertThat(server.takeRequest())
-        .hasHeaders("Content-Type: text/plain")
+        .hasHeaders(MapEntry.entry("Content-Type", "text/plain"))
         .hasBody("request data");
   }
 

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -118,7 +118,7 @@ public class FeignTest {
     api.body(Arrays.asList("netflix", "denominator", "password"));
 
     assertThat(server.takeRequest())
-        .hasHeaders(entry("Content-Length", "32"))
+        .hasHeaders(entry("Content-Length", Collections.singletonList("32")))
         .hasBody("[netflix, denominator, password]");
   }
 
@@ -184,7 +184,7 @@ public class FeignTest {
     api.post();
 
     assertThat(server.takeRequest())
-        .hasHeaders(entry("X-Forwarded-For", "origin.host.com"));
+        .hasHeaders(entry("X-Forwarded-For", Collections.singletonList("origin.host.com")));
   }
 
   @Test
@@ -198,8 +198,9 @@ public class FeignTest {
 
     api.post();
 
-    assertThat(server.takeRequest()).hasHeaders(entry("X-Forwarded-For","origin.host.com"),
-        entry("User-Agent", "Feign"));
+    assertThat(server.takeRequest())
+        .hasHeaders(entry("X-Forwarded-For", Collections.singletonList("origin.host.com")),
+            entry("User-Agent", Collections.singletonList("Feign")));
   }
 
   @Test
@@ -860,6 +861,7 @@ public class FeignTest {
     }
   }
 
+
   interface OtherTestInterface {
 
     @RequestLine("POST /")
@@ -872,6 +874,7 @@ public class FeignTest {
     void binaryRequestBody(byte[] contents);
   }
 
+
   static class ForwardedForInterceptor implements RequestInterceptor {
 
     @Override
@@ -880,6 +883,7 @@ public class FeignTest {
     }
   }
 
+
   static class UserAgentInterceptor implements RequestInterceptor {
 
     @Override
@@ -887,6 +891,7 @@ public class FeignTest {
       template.header("User-Agent", "Feign");
     }
   }
+
 
   static class IllegalArgumentExceptionOn400 extends ErrorDecoder.Default {
 
@@ -899,6 +904,7 @@ public class FeignTest {
     }
   }
 
+
   static class IllegalArgumentExceptionOn404 extends ErrorDecoder.Default {
 
     @Override
@@ -909,6 +915,7 @@ public class FeignTest {
       return super.decode(methodKey, response);
     }
   }
+
 
   static final class TestInterfaceBuilder {
 

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -316,7 +316,7 @@ public class FeignTest {
     api.queryMap(queryMap);
 
     assertThat(server.takeRequest())
-        .hasPath("/?name=Alice&name=Bob&fooKey=fooValue");
+        .hasPath("/?name=Alice&name=Bob&fooKey=fooValue&emptyStringKey");
   }
 
   @Test

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -48,6 +48,7 @@ import feign.codec.StringDecoder;
 import feign.Feign.ResponseMappingDecoder;
 import static feign.Util.UTF_8;
 import static feign.assertj.MockWebServerAssertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
 import static org.hamcrest.CoreMatchers.isA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -117,7 +118,7 @@ public class FeignTest {
     api.body(Arrays.asList("netflix", "denominator", "password"));
 
     assertThat(server.takeRequest())
-        .hasHeaders("Content-Length: 32")
+        .hasHeaders(entry("Content-Length", "32"))
         .hasBody("[netflix, denominator, password]");
   }
 
@@ -183,7 +184,7 @@ public class FeignTest {
     api.post();
 
     assertThat(server.takeRequest())
-        .hasHeaders("X-Forwarded-For: origin.host.com");
+        .hasHeaders(entry("X-Forwarded-For", "origin.host.com"));
   }
 
   @Test
@@ -197,8 +198,8 @@ public class FeignTest {
 
     api.post();
 
-    assertThat(server.takeRequest()).hasHeaders("X-Forwarded-For: origin.host.com",
-        "User-Agent: Feign");
+    assertThat(server.takeRequest()).hasHeaders(entry("X-Forwarded-For","origin.host.com"),
+        entry("User-Agent", "Feign"));
   }
 
   @Test
@@ -250,8 +251,8 @@ public class FeignTest {
 
     assertThat(server.takeRequest())
         .hasHeaders(
-            MapEntry.entry("Content-Type", Arrays.asList("myContent")),
-            MapEntry.entry("Custom-Header", Arrays.asList("fooValue")));
+            entry("Content-Type", Arrays.asList("myContent")),
+            entry("Custom-Header", Arrays.asList("fooValue")));
   }
 
   @Test
@@ -267,20 +268,22 @@ public class FeignTest {
     // header map should be additive for headers provided by annotations
     assertThat(server.takeRequest())
         .hasHeaders(
-            MapEntry.entry("Content-Encoding", Arrays.asList("deflate")),
-            MapEntry.entry("Custom-Header", Arrays.asList("fooValue")));
+            entry("Content-Encoding", Arrays.asList("deflate")),
+            entry("Custom-Header", Arrays.asList("fooValue")));
 
     server.enqueue(new MockResponse());
     headerMap.put("Content-Encoding", "overrideFromMap");
 
     api.headerMapWithHeaderAnnotations(headerMap);
 
-    // if header map has entry that collides with annotation, value specified
-    // by header map should be used
+    /*
+     * @HeaderMap map values no longer override @Header parameters. This caused confusion as it is
+     * valid to have more than one value for a header.
+     */
     assertThat(server.takeRequest())
         .hasHeaders(
-            MapEntry.entry("Content-Encoding", Arrays.asList("overrideFromMap")),
-            MapEntry.entry("Custom-Header", Arrays.asList("fooValue")));
+            entry("Content-Encoding", Arrays.asList("deflate", "overrideFromMap")),
+            entry("Custom-Header", Arrays.asList("fooValue")));
   }
 
   @Test
@@ -308,11 +311,11 @@ public class FeignTest {
     queryMap.put("name", Arrays.asList("Alice", "Bob"));
     queryMap.put("fooKey", "fooValue");
     queryMap.put("emptyListKey", new ArrayList<String>());
-    queryMap.put("emptyStringKey", "");
+    queryMap.put("emptyStringKey", ""); // empty values are ignored.
     api.queryMap(queryMap);
 
     assertThat(server.takeRequest())
-        .hasPath("/?name=Alice&name=Bob&fooKey=fooValue&emptyStringKey=");
+        .hasPath("/?name=Alice&name=Bob&fooKey=fooValue");
   }
 
   @Test
@@ -332,9 +335,9 @@ public class FeignTest {
     queryMap = new LinkedHashMap<String, Object>();
     queryMap.put("name", "bob");
     api.queryMapWithQueryParams("alice", queryMap);
-    // query map keys take precedence over built-in parameters
+    // queries are additive
     assertThat(server.takeRequest())
-        .hasPath("/?name=bob");
+        .hasPath("/?name=alice&name=bob");
 
     server.enqueue(new MockResponse());
     queryMap = new LinkedHashMap<String, Object>();
@@ -342,7 +345,7 @@ public class FeignTest {
     api.queryMapWithQueryParams("alice", queryMap);
     // null value for a query map key removes query parameter
     assertThat(server.takeRequest())
-        .hasPath("/");
+        .hasPath("/?name=alice");
   }
 
   @Test
@@ -417,9 +420,9 @@ public class FeignTest {
   @Test
   public void configKeyFormatsAsExpected() throws Exception {
     assertEquals("TestInterface#post()",
-        Feign.configKey(TestInterface.class.getDeclaredMethod("post")));
+        Feign.configKey(TestInterface.class, TestInterface.class.getDeclaredMethod("post")));
     assertEquals("TestInterface#uriParam(String,URI,String)",
-        Feign.configKey(TestInterface.class
+        Feign.configKey(TestInterface.class, TestInterface.class
             .getDeclaredMethod("uriParam", String.class, URI.class,
                 String.class)));
   }
@@ -561,19 +564,17 @@ public class FeignTest {
         .status(302)
         .reason("Found")
         .headers(headers)
-        .request(Request.create("GET", "/", Collections.emptyMap(), null, Util.UTF_8))
+        .request(Request.create(HttpMethod.GET, "/", Collections.emptyMap(), null, Util.UTF_8))
         .body(new byte[0])
         .build();
 
+    // fake client as Client.Default follows redirects.
     TestInterface api = Feign.builder()
-        .client(new Client() { // fake client as Client.Default follows redirects.
-          public Response execute(Request request, Request.Options options) {
-            return response;
-          }
-        })
+        .client((request, options) -> response)
         .target(TestInterface.class, "http://localhost:" + server.getPort());
 
-    assertEquals(api.response().headers().get("Location"), Arrays.asList("http://bar.com"));
+    assertEquals(api.response().headers().get("Location"),
+        Collections.singletonList("http://bar.com"));
   }
 
   private static class MockRetryer implements Retryer {
@@ -761,8 +762,8 @@ public class FeignTest {
     return Response.builder()
         .body(text, Util.UTF_8)
         .status(200)
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
-        .headers(new HashMap<String, Collection<String>>())
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(new HashMap<>())
         .build();
   }
 

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -108,6 +108,16 @@ public class RequestTemplateTest {
   }
 
   @Test
+  public void resolveTemplateWithRelativeUriWithQuery() {
+    RequestTemplate template = new RequestTemplate()
+        .method(HttpMethod.GET)
+        .uri("/wsdl/testcase?wsdl")
+        .target("https://api.example.com");
+
+    assertThat(template).hasUrl("https://api.example.com/wsdl/testcase?wsdl");
+  }
+
+  @Test
   public void resolveTemplateWithBaseAndParameterizedQuery() {
     RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)
         .uri("/?Action=DescribeRegions").query("RegionName.1", "{region}");

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -13,19 +13,20 @@
  */
 package feign;
 
-import org.assertj.core.api.Assertions;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import static feign.assertj.FeignAssertions.assertThat;
+import static java.util.Arrays.asList;
+import static org.assertj.core.data.MapEntry.entry;
+
+import feign.Request.HttpMethod;
+import feign.template.UriUtils;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import static feign.RequestTemplate.expand;
-import static feign.assertj.FeignAssertions.assertThat;
-import static java.util.Arrays.asList;
-import static org.assertj.core.data.MapEntry.entry;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class RequestTemplateTest {
 
@@ -36,7 +37,7 @@ public class RequestTemplateTest {
    * Avoid depending on guava solely for map literals.
    */
   private static <K, V> Map<K, V> mapOf(K key, V val) {
-    Map<K, V> result = new LinkedHashMap<K, V>();
+    Map<K, V> result = new LinkedHashMap<>();
     result.put(key, val);
     return result;
   }
@@ -53,18 +54,24 @@ public class RequestTemplateTest {
     return result;
   }
 
+  private static String expand(String template, Map<String, Object> variables) {
+    RequestTemplate requestTemplate = new RequestTemplate();
+    requestTemplate.uri(template);
+    return requestTemplate.resolve(variables).url();
+  }
+
   @Test
-  public void expandNotUrlEncoded() {
+  public void expandUrlEncoded() {
     for (String val : Arrays.asList("apples", "sp ace", "unic???de", "qu?stion")) {
       assertThat(expand("/users/{user}", mapOf("user", val)))
-          .isEqualTo("/users/" + val);
+          .isEqualTo("/users/" + UriUtils.encode(val, Util.UTF_8));
     }
   }
 
   @Test
   public void expandMultipleParams() {
     assertThat(expand("/users/{user}/{repo}", mapOf("user", "unic???de", "repo", "foo")))
-        .isEqualTo("/users/unic???de/foo");
+        .isEqualTo("/users/unic%3F%3F%3Fde/foo");
   }
 
   @Test
@@ -76,15 +83,15 @@ public class RequestTemplateTest {
   @Test
   public void expandMissingParamProceeds() {
     assertThat(expand("/{user-dir}", mapOf("user_dir", "foo")))
-        .isEqualTo("/{user-dir}");
+        .isEqualTo("/");
   }
 
   @Test
   public void resolveTemplateWithParameterizedPathSkipsEncodingSlash() {
-    RequestTemplate template = new RequestTemplate().method("GET")
-        .append("{zoneId}");
+    RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)
+        .uri("{zoneId}");
 
-    template.resolve(mapOf("zoneId", "/hostedzone/Z1PA6795UKMFR9"));
+    template = template.resolve(mapOf("zoneId", "/hostedzone/Z1PA6795UKMFR9"));
 
     assertThat(template)
         .hasUrl("/hostedzone/Z1PA6795UKMFR9");
@@ -92,10 +99,10 @@ public class RequestTemplateTest {
 
   @Test
   public void canInsertAbsoluteHref() {
-    RequestTemplate template = new RequestTemplate().method("GET")
-        .append("/hostedzone/Z1PA6795UKMFR9");
+    RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)
+        .uri("/hostedzone/Z1PA6795UKMFR9");
 
-    template.insert(0, "https://route53.amazonaws.com/2012-12-12");
+    template.target("https://route53.amazonaws.com/2012-12-12");
 
     assertThat(template)
         .hasUrl("https://route53.amazonaws.com/2012-12-12/hostedzone/Z1PA6795UKMFR9");
@@ -103,90 +110,90 @@ public class RequestTemplateTest {
 
   @Test
   public void resolveTemplateWithBaseAndParameterizedQuery() {
-    RequestTemplate template = new RequestTemplate().method("GET")
-        .append("/?Action=DescribeRegions").query("RegionName.1", "{region}");
+    RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)
+        .uri("/?Action=DescribeRegions").query("RegionName.1", "{region}");
 
-    template.resolve(mapOf("region", "eu-west-1"));
+    template = template.resolve(mapOf("region", "eu-west-1"));
 
     assertThat(template)
         .hasQueries(
-            entry("Action", asList("DescribeRegions")),
-            entry("RegionName.1", asList("eu-west-1")));
+            entry("Action", Collections.singletonList("DescribeRegions")),
+            entry("RegionName.1", Collections.singletonList("eu-west-1")));
   }
 
   @Test
   public void resolveTemplateWithBaseAndParameterizedIterableQuery() {
-    RequestTemplate template = new RequestTemplate().method("GET")
-        .append("/?Query=one").query("Queries", "{queries}");
+    RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)
+        .uri("/?Query=one").query("Queries", "{queries}");
 
-    template.resolve(mapOf("queries", Arrays.asList("us-east-1", "eu-west-1")));
+    template = template.resolve(mapOf("queries", Arrays.asList("us-east-1", "eu-west-1")));
 
     assertThat(template)
         .hasQueries(
-            entry("Query", asList("one")),
+            entry("Query", Collections.singletonList("one")),
             entry("Queries", asList("us-east-1", "eu-west-1")));
   }
 
   @Test
   public void resolveTemplateWithHeaderSubstitutions() {
-    RequestTemplate template = new RequestTemplate().method("GET")
+    RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)
         .header("Auth-Token", "{authToken}");
 
-    template.resolve(mapOf("authToken", "1234"));
+    template = template.resolve(mapOf("authToken", "1234"));
 
     assertThat(template)
-        .hasHeaders(entry("Auth-Token", asList("1234")));
+        .hasHeaders(entry("Auth-Token", Collections.singletonList("1234")));
   }
 
   @Test
   public void resolveTemplateWithHeaderSubstitutionsNotAtStart() {
-    RequestTemplate template = new RequestTemplate().method("GET")
+    RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)
         .header("Authorization", "Bearer {token}");
 
-    template.resolve(mapOf("token", "1234"));
+    template = template.resolve(mapOf("token", "1234"));
 
     assertThat(template)
-        .hasHeaders(entry("Authorization", asList("Bearer 1234")));
+        .hasHeaders(entry("Authorization", Collections.singletonList("Bearer 1234")));
   }
 
   @Test
   public void resolveTemplateWithHeaderWithEscapedCurlyBrace() {
-    RequestTemplate template = new RequestTemplate().method("GET")
+    RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)
         .header("Encoded", "{{{{dont_expand_me}}");
 
     template.resolve(mapOf("dont_expand_me", "1234"));
 
     assertThat(template)
-        .hasHeaders(entry("Encoded", asList("{{dont_expand_me}}")));
+        .hasHeaders(entry("Encoded", Collections.singletonList("{{{{dont_expand_me}}")));
   }
 
   /** This ensures we don't mess up vnd types */
   @Test
   public void resolveTemplateWithHeaderIncludingSpecialCharacters() {
-    RequestTemplate template = new RequestTemplate().method("GET")
+    RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)
         .header("Accept", "application/vnd.github.v3+{type}");
 
-    template.resolve(mapOf("type", "json"));
+    template = template.resolve(mapOf("type", "json"));
 
     assertThat(template)
-        .hasHeaders(entry("Accept", asList("application/vnd.github.v3+json")));
+        .hasHeaders(entry("Accept", Collections.singletonList("application/vnd.github.v3+json")));
   }
 
   @Test
   public void resolveTemplateWithHeaderEmptyResult() {
-    RequestTemplate template = new RequestTemplate().method("GET")
+    RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)
         .header("Encoded", "{var}");
 
-    template.resolve(mapOf("var", ""));
+    template = template.resolve(mapOf("var", ""));
 
     assertThat(template)
-        .hasHeaders(entry("Encoded", asList("")));
+        .hasNoHeader("Encoded");
   }
 
   @Test
-  public void resolveTemplateWithMixedRequestLineParams() throws Exception {
-    RequestTemplate template = new RequestTemplate().method("GET")//
-        .append("/domains/{domainId}/records")//
+  public void resolveTemplateWithMixedRequestLineParams() {
+    RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)//
+        .uri("/domains/{domainId}/records")//
         .query("name", "{name}")//
         .query("type", "{type}");
 
@@ -194,32 +201,31 @@ public class RequestTemplateTest {
         mapOf("domainId", 1001, "name", "denominator.io", "type", "CNAME"));
 
     assertThat(template)
-        .hasUrl("/domains/1001/records")
         .hasQueries(
-            entry("name", asList("denominator.io")),
-            entry("type", asList("CNAME")));
+            entry("name", Collections.singletonList("denominator.io")),
+            entry("type", Collections.singletonList("CNAME")));
   }
 
   @Test
-  public void insertHasQueryParams() throws Exception {
-    RequestTemplate template = new RequestTemplate().method("GET")//
-        .append("/domains/1001/records")//
+  public void insertHasQueryParams() {
+    RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)//
+        .uri("/domains/1001/records")//
         .query("name", "denominator.io")//
         .query("type", "CNAME");
 
-    template.insert(0, "https://host/v1.0/1234?provider=foo");
+    template.target("https://host/v1.0/1234?provider=foo");
 
     assertThat(template)
-        .hasUrl("https://host/v1.0/1234/domains/1001/records")
+        .hasPath("https://host/v1.0/1234/domains/1001/records")
         .hasQueries(
-            entry("provider", asList("foo")),
-            entry("name", asList("denominator.io")),
-            entry("type", asList("CNAME")));
+            entry("name", Collections.singletonList("denominator.io")),
+            entry("type", Collections.singletonList("CNAME")),
+            entry("provider", Collections.singletonList("foo")));
   }
 
   @Test
   public void resolveTemplateWithBodyTemplateSetsBodyAndContentLength() {
-    RequestTemplate template = new RequestTemplate().method("POST")
+    RequestTemplate template = new RequestTemplate().method(HttpMethod.POST)
         .bodyTemplate(
             "%7B\"customer_name\": \"{customer_name}\", \"user_name\": \"{user_name}\", " +
                 "\"password\": \"{password}\"%7D");
@@ -234,12 +240,13 @@ public class RequestTemplateTest {
         .hasBody(
             "{\"customer_name\": \"netflix\", \"user_name\": \"denominator\", \"password\": \"password\"}")
         .hasHeaders(
-            entry("Content-Length", asList(String.valueOf(template.body().length))));
+            entry("Content-Length",
+                Collections.singletonList(String.valueOf(template.body().length))));
   }
 
   @Test
   public void resolveTemplateWithBodyTemplateDoesNotDoubleDecode() {
-    RequestTemplate template = new RequestTemplate().method("POST")
+    RequestTemplate template = new RequestTemplate().method(HttpMethod.POST)
         .bodyTemplate(
             "%7B\"customer_name\": \"{customer_name}\", \"user_name\": \"{user_name}\", \"password\": \"{password}\"%7D");
 
@@ -251,13 +258,13 @@ public class RequestTemplateTest {
 
     assertThat(template)
         .hasBody(
-            "{\"customer_name\": \"netflix\", \"user_name\": \"denominator\", \"password\": \"abc+123%25d8\"}");
+            "{\"customer_name\": \"netflix\", \"user_name\": \"denominator\", \"password\": \"abc 123%d8\"}");
   }
 
   @Test
-  public void skipUnresolvedQueries() throws Exception {
-    RequestTemplate template = new RequestTemplate().method("GET")//
-        .append("/domains/{domainId}/records")//
+  public void skipUnresolvedQueries() {
+    RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)
+        .uri("/domains/{domainId}/records")//
         .query("optional", "{optional}")//
         .query("name", "{nameVariable}");
 
@@ -266,15 +273,14 @@ public class RequestTemplateTest {
         "nameVariable", "denominator.io"));
 
     assertThat(template)
-        .hasUrl("/domains/1001/records")
         .hasQueries(
-            entry("name", asList("denominator.io")));
+            entry("name", Collections.singletonList("denominator.io")));
   }
 
   @Test
-  public void allQueriesUnresolvable() throws Exception {
-    RequestTemplate template = new RequestTemplate().method("GET")//
-        .append("/domains/{domainId}/records")//
+  public void allQueriesUnresolvable() {
+    RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)//
+        .uri("/domains/{domainId}/records")//
         .query("optional", "{optional}")//
         .query("optional2", "{optional2}");
 
@@ -287,67 +293,67 @@ public class RequestTemplateTest {
 
   @Test
   public void spaceEncodingInUrlParam() {
-    RequestTemplate template = new RequestTemplate().method("GET")//
-        .append("/api/{value1}?key={value2}");
+    RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)//
+        .uri("/api/{value1}?key={value2}");
 
     template = template.resolve(mapOf("value1", "ABC 123", "value2", "XYZ 123"));
 
     assertThat(template.request().url())
-        .isEqualTo("/api/ABC%20123?key=XYZ+123");
+        .isEqualTo("/api/ABC%20123?key=XYZ%20123");
   }
 
   @Test
-  public void encodeSlashTest() throws Exception {
-    RequestTemplate template = new RequestTemplate().method("GET")
-        .append("/api/{vhost}")
+  public void encodeSlashTest() {
+    RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)
+        .uri("/api/{vhost}")
         .decodeSlash(false);
 
-    template.resolve(mapOf("vhost", "/"));
+    template = template.resolve(mapOf("vhost", "/"));
 
     assertThat(template)
         .hasUrl("/api/%2F");
   }
 
   /** Implementations have a bug if they pass junk as the http method. */
+  @SuppressWarnings("deprecation")
   @Test
-  public void uriStuffedIntoMethod() throws Exception {
+  public void uriStuffedIntoMethod() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Invalid HTTP Method: /path?queryParam={queryParam}");
-
     new RequestTemplate().method("/path?queryParam={queryParam}");
   }
 
   @Test
-  public void encodedQueryClearedOnNull() throws Exception {
+  public void encodedQueryClearedOnNull() {
     RequestTemplate template = new RequestTemplate();
 
     template.query("param[]", "value");
-    assertThat(template).hasQueries(entry("param[]", asList("value")));
+    assertThat(template).hasQueries(entry("param[]", Collections.singletonList("value")));
 
     template.query("param[]", (String[]) null);
     assertThat(template.queries()).isEmpty();
   }
 
   @Test
-  public void encodedQuery() throws Exception {
-    RequestTemplate template = new RequestTemplate().query(true, "params[]", "foo%20bar");
-
-    assertThat(template.queryLine()).isEqualTo("?params[]=foo%20bar");
-    assertThat(template).hasQueries(entry("params[]", asList("foo bar")));
+  public void encodedQuery() {
+    RequestTemplate template = new RequestTemplate().query("params[]", "foo%20bar");
+    assertThat(template.queryLine()).isEqualTo("?params%5B%5D=foo%20bar");
+    assertThat(template).hasQueries(entry("params[]", Collections.singletonList("foo%20bar")));
   }
 
   @Test
-  public void encodedQueryWithUnsafeCharactersMixedWithUnencoded() throws Exception {
+  public void encodedQueryWithUnsafeCharactersMixedWithUnencoded() {
     RequestTemplate template = new RequestTemplate()
-        .query(false, "params[]", "not encoded") // stored as "param%5D%5B"
-        .query(true, "params[]", "encoded"); // stored as "param[]"
+        .query("params[]", "not encoded") // stored as "param%5D%5B"
+        .query("params[]", "encoded"); // stored as "param[]"
 
-    // We can't ensure consistent behavior, because decode("param[]") == decode("param%5B%5D")
-    assertThat(template.queryLine()).isEqualTo("?params%5B%5D=not+encoded&params[]=encoded");
-    assertThat(template.queries()).doesNotContain(entry("params[]", asList("not encoded")));
-    assertThat(template.queries()).contains(entry("params[]", asList("encoded")));
+    assertThat(template.queryLine()).isEqualTo("?params%5B%5D=not%20encoded&params%5B%5D=encoded");
+    Map<String, Collection<String>> queries = template.queries();
+    assertThat(queries).containsKey("params[]");
+    assertThat(queries.get("params[]")).contains("encoded").contains("not encoded");
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void shouldRetrieveHeadersWithoutNull() {
     RequestTemplate template = new RequestTemplate()
@@ -364,6 +370,7 @@ public class RequestTemplateTest {
 
   }
 
+  @SuppressWarnings("ConstantConditions")
   @Test(expected = UnsupportedOperationException.class)
   public void shouldNotInsertHeadersImmutableMap() {
     RequestTemplate template = new RequestTemplate()
@@ -372,6 +379,6 @@ public class RequestTemplateTest {
     assertThat(template.headers()).hasSize(1);
     assertThat(template.headers().keySet()).containsExactly("key1");
 
-    template.headers().put("key2", asList("other value"));
+    template.headers().put("key2", Collections.singletonList("other value"));
   }
 }

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -16,7 +16,6 @@ package feign;
 import static feign.assertj.FeignAssertions.assertThat;
 import static java.util.Arrays.asList;
 import static org.assertj.core.data.MapEntry.entry;
-
 import feign.Request.HttpMethod;
 import feign.template.UriUtils;
 import java.util.Arrays;

--- a/core/src/test/java/feign/ResponseTest.java
+++ b/core/src/test/java/feign/ResponseTest.java
@@ -13,6 +13,7 @@
  */
 package feign;
 
+import feign.Request.HttpMethod;
 import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collection;
@@ -30,7 +31,7 @@ public class ResponseTest {
     Response response = Response.builder()
         .status(200)
         .headers(Collections.<String, Collection<String>>emptyMap())
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .body(new byte[0])
         .build();
 
@@ -46,7 +47,7 @@ public class ResponseTest {
     Response response = Response.builder()
         .status(200)
         .headers(headersMap)
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .body(new byte[0])
         .build();
     assertThat(response.headers().get("content-type")).isEqualTo(valueList);
@@ -62,7 +63,7 @@ public class ResponseTest {
     Response response = Response.builder()
         .status(200)
         .headers(headersMap)
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .body(new byte[0])
         .build();
 

--- a/core/src/test/java/feign/TargetTest.java
+++ b/core/src/test/java/feign/TargetTest.java
@@ -57,7 +57,7 @@ public class TargetTest {
       public Request apply(RequestTemplate input) {
         Request urlEncoded = super.apply(input);
         return Request.create(
-            urlEncoded.method(),
+            urlEncoded.httpMethod(),
             urlEncoded.url().replace("%2F", "/"),
             urlEncoded.headers(),
             urlEncoded.body(), urlEncoded.charset());

--- a/core/src/test/java/feign/assertj/RequestTemplateAssert.java
+++ b/core/src/test/java/feign/assertj/RequestTemplateAssert.java
@@ -44,6 +44,12 @@ public final class RequestTemplateAssert
     return this;
   }
 
+  public RequestTemplateAssert hasPath(String expected) {
+    isNotNull();
+    objects.assertEqual(info, actual.path(), expected);
+    return this;
+  }
+
   public RequestTemplateAssert hasBody(String utf8Expected) {
     isNotNull();
     if (actual.bodyTemplate() != null) {

--- a/core/src/test/java/feign/client/AbstractClientTest.java
+++ b/core/src/test/java/feign/client/AbstractClientTest.java
@@ -13,13 +13,11 @@
  */
 package feign.client;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import static feign.Util.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.junit.Assert.assertEquals;
+
 import feign.Client;
 import feign.CollectionFormat;
 import feign.Feign.Builder;
@@ -31,13 +29,17 @@ import feign.RequestLine;
 import feign.Response;
 import feign.Util;
 import feign.assertj.MockWebServerAssertions;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
-import static java.util.Arrays.asList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.entry;
-import static org.junit.Assert.assertEquals;
-import static feign.Util.UTF_8;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 /**
  * {@link AbstractClientTest} can be extended to run a set of tests against any {@link Client}
@@ -70,7 +72,7 @@ public abstract class AbstractClientTest {
     assertEquals("foo", api.patch(""));
 
     MockWebServerAssertions.assertThat(server.takeRequest())
-        .hasHeaders("Accept: text/plain", "Content-Length: 0") // Note: OkHttp adds content length.
+        .hasHeaders(entry("Accept", "text/plain"), entry("Content-Length", "0"))
         .hasNoHeaderNamed("Content-Type")
         .hasMethod("PATCH");
   }
@@ -87,15 +89,17 @@ public abstract class AbstractClientTest {
     assertThat(response.status()).isEqualTo(200);
     assertThat(response.reason()).isEqualTo("OK");
     assertThat(response.headers())
-        .containsEntry("Content-Length", asList("3"))
-        .containsEntry("Foo", asList("Bar"));
+        .containsEntry("Content-Length", Collections.singletonList("3"))
+        .containsEntry("Foo", Collections.singletonList("Bar"));
     assertThat(response.body().asInputStream())
         .hasContentEqualTo(new ByteArrayInputStream("foo".getBytes(UTF_8)));
 
-    MockWebServerAssertions.assertThat(server.takeRequest()).hasMethod("POST")
-        .hasPath("/?foo=bar&foo=baz&qux=")
-        .hasHeaders("Foo: Bar", "Foo: Baz", "Accept: */*", "Content-Length: 3")
-        .hasBody("foo");
+    RecordedRequest recordedRequest = server.takeRequest();
+    assertThat(recordedRequest.getMethod()).isEqualToIgnoringCase("POST");
+    assertThat(recordedRequest.getHeader("Foo")).isEqualToIgnoringCase("Bar, Baz");
+    assertThat(recordedRequest.getHeader("Accept")).isEqualToIgnoringCase("*/*");
+    assertThat(recordedRequest.getHeader("Content-Length")).isEqualToIgnoringCase("3");
+    assertThat(recordedRequest.getBody().readUtf8()).isEqualToIgnoringCase("foo");
   }
 
   @Test
@@ -112,7 +116,7 @@ public abstract class AbstractClientTest {
   }
 
   @Test
-  public void parsesErrorResponse() throws IOException, InterruptedException {
+  public void parsesErrorResponse() {
     thrown.expect(FeignException.class);
     thrown.expectMessage("status 500 reading TestInterface#get()");
 
@@ -141,7 +145,7 @@ public abstract class AbstractClientTest {
   }
 
   @Test
-  public void safeRebuffering() throws IOException, InterruptedException {
+  public void safeRebuffering() {
     server.enqueue(new MockResponse().setBody("foo"));
 
     TestInterface api = newBuilder()
@@ -157,7 +161,7 @@ public abstract class AbstractClientTest {
 
   /** This shows that is a no-op or otherwise doesn't cause an NPE when there's no content. */
   @Test
-  public void safeRebuffering_noContent() throws IOException, InterruptedException {
+  public void safeRebuffering_noContent() {
     server.enqueue(new MockResponse().setResponseCode(204));
 
     TestInterface api = newBuilder()
@@ -192,7 +196,7 @@ public abstract class AbstractClientTest {
   }
 
   @Test
-  public void parsesResponseMissingLength() throws IOException, InterruptedException {
+  public void parsesResponseMissingLength() throws IOException {
     server.enqueue(new MockResponse().setChunkedBody("foo", 1));
 
     TestInterface api = newBuilder()
@@ -207,13 +211,12 @@ public abstract class AbstractClientTest {
   }
 
   @Test
-  public void postWithSpacesInPath() throws IOException, InterruptedException {
+  public void postWithSpacesInPath() throws InterruptedException {
     server.enqueue(new MockResponse().setBody("foo"));
 
     TestInterface api = newBuilder()
         .target(TestInterface.class, "http://localhost:" + server.getPort());
-
-    Response response = api.post("current documents", "foo");
+    api.post("current documents", "foo");
 
     MockWebServerAssertions.assertThat(server.takeRequest()).hasMethod("POST")
         .hasPath("/path/current%20documents/resource")
@@ -221,7 +224,7 @@ public abstract class AbstractClientTest {
   }
 
   @Test
-  public void testVeryLongResponseNullLength() throws Exception {
+  public void testVeryLongResponseNullLength() {
     server.enqueue(new MockResponse()
         .setBody("AAAAAAAA")
         .addHeader("Content-Length", Long.MAX_VALUE));
@@ -234,7 +237,7 @@ public abstract class AbstractClientTest {
   }
 
   @Test
-  public void testResponseLength() throws Exception {
+  public void testResponseLength() {
     server.enqueue(new MockResponse()
         .setBody("test"));
     TestInterface api = newBuilder()
@@ -290,7 +293,7 @@ public abstract class AbstractClientTest {
     TestInterface api = newBuilder()
         .target(TestInterface.class, "http://localhost:" + server.getPort());
 
-    Response response = api.get(Arrays.asList(new String[] {"bar", "baz"}));
+    Response response = api.get(Arrays.asList("bar", "baz"));
 
     assertThat(response.status()).isEqualTo(200);
     assertThat(response.reason()).isEqualTo("OK");
@@ -328,7 +331,7 @@ public abstract class AbstractClientTest {
     assertThat(response.reason()).isEqualTo("OK");
 
     MockWebServerAssertions.assertThat(server.takeRequest()).hasMethod("GET")
-        .hasPath("/").hasHeaders(entry("authorization", asList("token")));
+        .hasPath("/").hasHeaders(entry("authorization", Collections.singletonList("token")));
   }
 
   @Test
@@ -338,7 +341,7 @@ public abstract class AbstractClientTest {
     TestInterface api = newBuilder()
         .target(TestInterface.class, "http://localhost:" + server.getPort());
 
-    Response response = api.getCSV(Arrays.asList(new String[] {"bar", "baz"}));
+    Response response = api.getCSV(Arrays.asList("bar", "baz"));
 
     assertThat(response.status()).isEqualTo(200);
     assertThat(response.reason()).isEqualTo("OK");
@@ -348,6 +351,7 @@ public abstract class AbstractClientTest {
         .hasOneOfPath("/?foo=bar,baz", "/?foo=bar%2Cbaz");
   }
 
+  @SuppressWarnings("UnusedReturnValue")
   public interface TestInterface {
 
     @RequestLine("POST /?foo=bar&foo=baz&qux=")

--- a/core/src/test/java/feign/client/AbstractClientTest.java
+++ b/core/src/test/java/feign/client/AbstractClientTest.java
@@ -17,7 +17,6 @@ import static feign.Util.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.junit.Assert.assertEquals;
-
 import feign.Client;
 import feign.CollectionFormat;
 import feign.Feign.Builder;
@@ -72,7 +71,8 @@ public abstract class AbstractClientTest {
     assertEquals("foo", api.patch(""));
 
     MockWebServerAssertions.assertThat(server.takeRequest())
-        .hasHeaders(entry("Accept", "text/plain"), entry("Content-Length", "0"))
+        .hasHeaders(entry("Accept", Collections.singletonList("text/plain")),
+            entry("Content-Length", Collections.singletonList("0")))
         .hasNoHeaderNamed("Content-Type")
         .hasMethod("PATCH");
   }

--- a/core/src/test/java/feign/client/AbstractClientTest.java
+++ b/core/src/test/java/feign/client/AbstractClientTest.java
@@ -92,7 +92,7 @@ public abstract class AbstractClientTest {
         .containsEntry("Content-Length", Collections.singletonList("3"))
         .containsEntry("Foo", Collections.singletonList("Bar"));
     assertThat(response.body().asInputStream())
-        .hasContentEqualTo(new ByteArrayInputStream("foo".getBytes(UTF_8)));
+        .hasSameContentAs(new ByteArrayInputStream("foo".getBytes(UTF_8)));
 
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod()).isEqualToIgnoringCase("POST");
@@ -207,7 +207,7 @@ public abstract class AbstractClientTest {
     assertThat(response.reason()).isEqualTo("OK");
     assertThat(response.body().length()).isNull();
     assertThat(response.body().asInputStream())
-        .hasContentEqualTo(new ByteArrayInputStream("foo".getBytes(UTF_8)));
+        .hasSameContentAs(new ByteArrayInputStream("foo".getBytes(UTF_8)));
   }
 
   @Test

--- a/core/src/test/java/feign/codec/DefaultDecoderTest.java
+++ b/core/src/test/java/feign/codec/DefaultDecoderTest.java
@@ -16,6 +16,8 @@ package feign.codec;
 import static feign.Util.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+
+import feign.Request.HttpMethod;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.Collection;
@@ -75,7 +77,7 @@ public class DefaultDecoderTest {
         .status(200)
         .reason("OK")
         .headers(headers)
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .body(inputStream, content.length())
         .build();
   }
@@ -85,7 +87,7 @@ public class DefaultDecoderTest {
         .status(200)
         .reason("OK")
         .headers(Collections.<String, Collection<String>>emptyMap())
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .build();
   }
 }

--- a/core/src/test/java/feign/codec/DefaultDecoderTest.java
+++ b/core/src/test/java/feign/codec/DefaultDecoderTest.java
@@ -16,7 +16,6 @@ package feign.codec;
 import static feign.Util.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-
 import feign.Request.HttpMethod;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;

--- a/core/src/test/java/feign/codec/DefaultErrorDecoderTest.java
+++ b/core/src/test/java/feign/codec/DefaultErrorDecoderTest.java
@@ -13,30 +13,31 @@
  */
 package feign.codec;
 
-import feign.Request;
-import feign.Util;
-import java.util.Collections;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import feign.FeignException;
-import feign.Response;
 import static feign.Util.RETRY_AFTER;
 import static feign.Util.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import feign.FeignException;
+import feign.Request;
+import feign.Request.HttpMethod;
+import feign.Response;
+import feign.Util;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class DefaultErrorDecoderTest {
 
   @Rule
   public final ExpectedException thrown = ExpectedException.none();
 
-  ErrorDecoder errorDecoder = new ErrorDecoder.Default();
+  private ErrorDecoder errorDecoder = new ErrorDecoder.Default();
 
-  Map<String, Collection<String>> headers = new LinkedHashMap<String, Collection<String>>();
+  private Map<String, Collection<String>> headers = new LinkedHashMap<>();
 
   @Test
   public void throwsFeignException() throws Throwable {
@@ -46,7 +47,7 @@ public class DefaultErrorDecoderTest {
     Response response = Response.builder()
         .status(500)
         .reason("Internal server error")
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .headers(headers)
         .build();
 
@@ -58,7 +59,7 @@ public class DefaultErrorDecoderTest {
     Response response = Response.builder()
         .status(500)
         .reason("Internal server error")
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .headers(headers)
         .body("hello world", UTF_8)
         .build();
@@ -72,11 +73,11 @@ public class DefaultErrorDecoderTest {
   }
 
   @Test
-  public void testFeignExceptionIncludesStatus() throws Throwable {
+  public void testFeignExceptionIncludesStatus() {
     Response response = Response.builder()
         .status(400)
         .reason("Bad request")
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .headers(headers)
         .build();
 
@@ -91,11 +92,11 @@ public class DefaultErrorDecoderTest {
     thrown.expect(FeignException.class);
     thrown.expectMessage("status 503 reading Service#foo()");
 
-    headers.put(RETRY_AFTER, Arrays.asList("Sat, 1 Jan 2000 00:00:00 GMT"));
+    headers.put(RETRY_AFTER, Collections.singletonList("Sat, 1 Jan 2000 00:00:00 GMT"));
     Response response = Response.builder()
         .status(503)
         .reason("Service Unavailable")
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .headers(headers)
         .build();
 

--- a/core/src/test/java/feign/codec/DefaultErrorDecoderTest.java
+++ b/core/src/test/java/feign/codec/DefaultErrorDecoderTest.java
@@ -16,7 +16,6 @@ package feign.codec;
 import static feign.Util.RETRY_AFTER;
 import static feign.Util.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
-
 import feign.FeignException;
 import feign.Request;
 import feign.Request.HttpMethod;

--- a/core/src/test/java/feign/stream/StreamDecoderTest.java
+++ b/core/src/test/java/feign/stream/StreamDecoderTest.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.Feign;
 import feign.Request;
+import feign.Request.HttpMethod;
 import feign.RequestLine;
 import feign.Response;
 import feign.Util;
@@ -83,7 +84,7 @@ public class StreamDecoderTest {
         .status(200)
         .reason("OK")
         .headers(Collections.emptyMap())
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .body("", UTF_8)
         .build();
 

--- a/core/src/test/java/feign/template/QueryTemplateTest.java
+++ b/core/src/test/java/feign/template/QueryTemplateTest.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2012-2018 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.template;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import feign.CollectionFormat;
+import feign.Util;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Test;
+
+public class QueryTemplateTest {
+
+  @Test
+  public void templateToQueryString() {
+    QueryTemplate template =
+        QueryTemplate.create("name", Arrays.asList("Bob", "James", "Jason"), Util.UTF_8);
+    assertThat(template.toString()).isEqualToIgnoringCase("name=Bob&name=James&name=Jason");
+  }
+
+  @Test
+  public void expandSingleValue() {
+    QueryTemplate template =
+        QueryTemplate.create("name", Collections.singletonList("{value}"), Util.UTF_8);
+    String expanded = template.expand(Collections.singletonMap("value", "Magnum P.I."));
+    assertThat(expanded).isEqualToIgnoringCase("name=Magnum%20P.I.");
+  }
+
+  @Test
+  public void expandMultipleValues() {
+    QueryTemplate template =
+        QueryTemplate.create("name", Arrays.asList("Bob", "James", "Jason"), Util.UTF_8);
+    String expanded = template.expand(Collections.emptyMap());
+    assertThat(expanded).isEqualToIgnoringCase("name=Bob&name=James&name=Jason");
+  }
+
+  @Test
+  public void unresolvedQuery() {
+    QueryTemplate template =
+        QueryTemplate.create("name", Collections.singletonList("{value}"), Util.UTF_8);
+    String expanded = template.expand(Collections.emptyMap());
+    assertThat(expanded).isNullOrEmpty();
+  }
+
+  @Test
+  public void unresolvedMultiValueQueryTemplates() {
+    QueryTemplate template =
+        QueryTemplate.create("name", Arrays.asList("{bob}", "{james}", "{jason}"), Util.UTF_8);
+    String expanded = template.expand(Collections.emptyMap());
+    assertThat(expanded).isNullOrEmpty();
+  }
+
+  @Test
+  public void collectionFormat() {
+    QueryTemplate template =
+        QueryTemplate
+            .create("name", Arrays.asList("James", "Jason"), Util.UTF_8, CollectionFormat.CSV);
+    String expanded = template.expand(Collections.emptyMap());
+    assertThat(expanded).isEqualToIgnoringCase("name=James,Jason");
+  }
+
+}

--- a/core/src/test/java/feign/template/UriTemplateTest.java
+++ b/core/src/test/java/feign/template/UriTemplateTest.java
@@ -1,0 +1,277 @@
+/**
+ * Copyright 2012-2018 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.template;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import feign.Util;
+import java.net.URI;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class UriTemplateTest {
+
+  @Test
+  public void emptyRelativeTemplate() {
+    String template = "/";
+    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    assertThat(uriTemplate.expand(Collections.emptyMap())).isEqualToIgnoringCase("/");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void nullTemplate() {
+    UriTemplate.create(null, Util.UTF_8);
+  }
+
+  @Test
+  public void emptyTemplate() {
+    UriTemplate.create("", Util.UTF_8);
+  }
+
+  @Test
+  public void simpleTemplate() {
+    String template = "https://www.example.com/foo/{bar}";
+    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+
+    /* verify that the template has 1 variables names foo */
+    List<String> uriTemplateVariables = uriTemplate.getVariables();
+    assertThat(uriTemplateVariables).contains("bar").hasSize(1);
+
+    /* expand the template */
+    Map<String, Object> variables = new LinkedHashMap<>();
+    variables.put("bar", "bar");
+    String expandedTemplate = uriTemplate.expand(variables);
+    assertThat(expandedTemplate).isEqualToIgnoringCase("https://www.example.com/foo/bar");
+    assertThat(URI.create(expandedTemplate)).isNotNull();
+  }
+
+  @Test
+  public void simpleTemplateMultipleExpressions() {
+    String template = "https://www.example.com/{foo}/{bar}/details";
+    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+
+    /* verify that the template has 2 variables names foo and bar */
+    List<String> uriTemplateVariables = uriTemplate.getVariables();
+    assertThat(uriTemplateVariables).contains("foo", "bar").hasSize(2);
+
+    /* expand the template */
+    Map<String, Object> variables = new LinkedHashMap<>();
+    variables.put("foo", "first");
+    variables.put("bar", "second");
+    String expandedTemplate = uriTemplate.expand(variables);
+    assertThat(expandedTemplate)
+        .isEqualToIgnoringCase("https://www.example.com/first/second/details");
+    assertThat(URI.create(expandedTemplate)).isNotNull();
+  }
+
+  @Test
+  public void simpleTemplateMultipleSequentialExpressions() {
+    String template = "https://www.example.com/{foo}{bar}/{baz}/details";
+    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+
+    /* verify that the template has 2 variables names foo and bar */
+    List<String> uriTemplateVariables = uriTemplate.getVariables();
+    assertThat(uriTemplateVariables).contains("foo", "bar", "baz").hasSize(3);
+
+    /* expand the template */
+    Map<String, Object> variables = new LinkedHashMap<>();
+    variables.put("foo", "first");
+    variables.put("bar", "second");
+    variables.put("baz", "third");
+    String expandedTemplate = uriTemplate.expand(variables);
+    assertThat(expandedTemplate)
+        .isEqualToIgnoringCase("https://www.example.com/firstsecond/third/details");
+    assertThat(URI.create(expandedTemplate)).isNotNull();
+  }
+
+  @Test
+  public void simpleTemplateUnresolvedVariablesAreRemoved() {
+    String template = "https://www.example.com/{foo}?name={name}";
+    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    assertThat(uriTemplate.getVariables()).contains("foo", "name").hasSize(2);
+
+    Map<String, Object> variables = new LinkedHashMap<>();
+    variables.put("name", "Albert");
+    String expandedTemplate = uriTemplate.expand(variables);
+    assertThat(expandedTemplate).isEqualToIgnoringCase("https://www.example.com/?name=Albert");
+    assertThat(URI.create(expandedTemplate)).isNotNull();
+  }
+
+  @Test
+  public void missingVariablesOnPathAreRemoved() {
+    String template = "https://www.example.com/{foo}/items?name={name}";
+    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    assertThat(uriTemplate.getVariables()).contains("foo", "name").hasSize(2);
+
+    Map<String, Object> variables = new LinkedHashMap<>();
+    variables.put("name", "Albert");
+    String expandedTemplate = uriTemplate.expand(variables);
+    assertThat(expandedTemplate)
+        .isEqualToIgnoringCase("https://www.example.com//items?name=Albert");
+    assertThat(URI.create(expandedTemplate)).isNotNull();
+  }
+
+  @Test
+  public void simpleTemplateWithRegularExpressions() {
+    String template = "https://www.example.com/{foo:[0-9]{4}}/{bar}";
+    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    assertThat(uriTemplate.getVariables()).contains("foo", "bar").hasSize(2);
+
+    Map<String, Object> variables = new LinkedHashMap<>();
+    variables.put("foo", 1234);
+    variables.put("bar", "stuff");
+    String expandedTemplate = uriTemplate.expand(variables);
+    assertThat(expandedTemplate).isEqualToIgnoringCase("https://www.example.com/1234/stuff");
+    assertThat(URI.create(expandedTemplate)).isNotNull();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void simpleTemplateWithRegularExpressionsValidation() {
+    String template = "https://www.example.com/{foo:[0-9]{4}}/{bar}";
+    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    assertThat(uriTemplate.getVariables()).contains("foo", "bar").hasSize(2);
+
+    Map<String, Object> variables = new LinkedHashMap<>();
+    variables.put("foo", "abcd");
+    variables.put("bar", "stuff");
+
+    /* the foo variable must be a number and no more than four, this should fail */
+    uriTemplate.expand(variables);
+    fail("Should not be able to expand, pattern does not match");
+  }
+
+  @Test
+  public void nestedExpressionsAreLiterals() {
+    /* the template of {foo{bar}}, will be treated as literals as nested templates are ignored */
+    String template = "https://www.example.com/{foo{bar}}/{baz}";
+    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    assertThat(uriTemplate.getVariables()).contains("baz").hasSize(1);
+
+    Map<String, Object> variables = new LinkedHashMap<>();
+    variables.put("baz", "stuff");
+    String expandedTemplate = uriTemplate.expand(variables);
+    assertThat(expandedTemplate)
+        .isEqualToIgnoringCase("https://www.example.com/%7Bfoo%7Bbar%7D%7D/stuff");
+    assertThat(URI.create(expandedTemplate))
+        .isNotNull(); // this should fail, the result is not a valid uri
+  }
+
+  @Test
+  public void literalTemplate() {
+    String template = "https://www.example.com/do/stuff";
+    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    String expandedTemplate = uriTemplate.expand(Collections.emptyMap());
+    assertThat(expandedTemplate).isEqualToIgnoringCase(template);
+    assertThat(URI.create(expandedTemplate)).isNotNull();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void rejectEmptyExpressions() {
+    String template = "https://www.example.com/{}/things";
+    UriTemplate.create(template, Util.UTF_8);
+    fail("Should not accept empty expressions");
+  }
+
+  @Test
+  public void testToString() {
+    String template = "https://www.example.com/foo/{bar}/{baz:[0-9]}";
+    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    assertThat(uriTemplate.toString()).isEqualToIgnoringCase(template);
+  }
+
+  @Test
+  public void encodeVariables() {
+    String template = "https://www.example.com/{first}/{last}";
+    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    Map<String, Object> variables = new LinkedHashMap<>();
+    variables.put("first", "John Jacob");
+    variables.put("last", "Jingleheimer Schmidt");
+    String expandedTemplate = uriTemplate.expand(variables);
+    assertThat(expandedTemplate)
+        .isEqualToIgnoringCase("https://www.example.com/John%20Jacob/Jingleheimer%20Schmidt");
+  }
+
+  @Test
+  public void encodeLiterals() {
+    String template = "https://www.example.com/A Team";
+    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    String expandedTemplate = uriTemplate.expand(Collections.emptyMap());
+    assertThat(expandedTemplate)
+        .isEqualToIgnoringCase("https://www.example.com/A%20Team");
+  }
+
+  @Test
+  public void ensurePlusIsSupportedOnPath() {
+    String template = "https://www.example.com/sam+adams/beer/{type}";
+    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    String expanded = uriTemplate.expand(Collections.emptyMap());
+    assertThat(expanded).isEqualToIgnoringCase("https://www.example.com/sam+adams/beer/");
+  }
+
+  @Test
+  public void incompleteTemplateIsALiteral() {
+    String template = "https://www.example.com/testing/foo}}";
+    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    assertThat(uriTemplate.expand(Collections.emptyMap()))
+        .isEqualToIgnoringCase("https://www.example.com/testing/foo%7D%7D");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void substituteNullMap() {
+    UriTemplate.create("stuff", Util.UTF_8).expand(null);
+  }
+
+  @Test
+  public void skipAlreadyEncodedLiteral() {
+    String template = "https://www.example.com/A%20Team";
+    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    String expandedTemplate = uriTemplate.expand(Collections.emptyMap());
+    assertThat(expandedTemplate)
+        .isEqualToIgnoringCase("https://www.example.com/A%20Team");
+  }
+
+  @Test
+  public void skipAlreadyEncodedVariable() {
+    String template = "https://www.example.com/testing/{foo}";
+    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    String encodedVariable = UriUtils.encode("Johnny Appleseed", Util.UTF_8);
+    Map<String, Object> variables = new LinkedHashMap<>();
+    variables.put("foo", encodedVariable);
+    assertThat(uriTemplate.expand(variables))
+        .isEqualToIgnoringCase("https://www.example.com/testing/" + encodedVariable);
+  }
+
+  @Test
+  public void skipSlashes() {
+    String template = "https://www.example.com/{path}";
+    UriTemplate uriTemplate = UriTemplate.create(template, false, Util.UTF_8);
+    Map<String, Object> variables = new LinkedHashMap<>();
+    variables.put("path", "me/you/first");
+    String encoded = uriTemplate.expand(variables);
+    assertThat(encoded).isEqualToIgnoringCase("https://www.example.com/me/you/first");
+  }
+
+  @Test
+  public void encodeSlashes() {
+    String template = "https://www.example.com/{path}";
+    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    Map<String, Object> variables = new LinkedHashMap<>();
+    variables.put("path", "me/you/first");
+    String encoded = uriTemplate.expand(variables);
+    assertThat(encoded).isEqualToIgnoringCase("https://www.example.com/me%2Fyou%2Ffirst");
+  }
+}

--- a/core/src/test/java/feign/template/UriTemplateTest.java
+++ b/core/src/test/java/feign/template/UriTemplateTest.java
@@ -274,4 +274,12 @@ public class UriTemplateTest {
     String encoded = uriTemplate.expand(variables);
     assertThat(encoded).isEqualToIgnoringCase("https://www.example.com/me%2Fyou%2Ffirst");
   }
+
+  @Test
+  public void testLiteralTemplateWithQueryString() {
+    String template = "https://api.example.com?wsdl";
+    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    String expanded = uriTemplate.expand(Collections.emptyMap());
+    assertThat(expanded).isEqualToIgnoringCase("https://api.example.com?wsdl");
+  }
 }

--- a/core/src/test/java/feign/template/UriUtilsTest.java
+++ b/core/src/test/java/feign/template/UriUtilsTest.java
@@ -11,39 +11,26 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package feign.mock;
+package feign.template;
 
-import feign.Request;
-import feign.RequestTemplate;
-import feign.Target;
 
-public class MockTarget<E> implements Target<E> {
+import static org.assertj.core.api.Assertions.assertThat;
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
 
-  private final Class<E> type;
+public class UriUtilsTest {
 
-  public MockTarget(Class<E> type) {
-    this.type = type;
+  @Test
+  public void encodeSpaces() {
+    String value = "James Bond";
+    assertThat(UriUtils.encode(value, StandardCharsets.UTF_8))
+        .isEqualToIgnoringCase("James%20Bond");
   }
 
-  @Override
-  public Class<E> type() {
-    return type;
+  @Test
+  public void ensureReservedAreNotEncoded() {
+    String value = "This Is Great!()~'";
+    assertThat(UriUtils.encode(value, StandardCharsets.UTF_8))
+        .isEqualToIgnoringCase("This%20Is%20Great!()~'");
   }
-
-  @Override
-  public String name() {
-    return type.getSimpleName();
-  }
-
-  @Override
-  public String url() {
-    return "";
-  }
-
-  @Override
-  public Request apply(RequestTemplate input) {
-    input.target(url());
-    return input.request();
-  }
-
 }

--- a/example-github/pom.xml
+++ b/example-github/pom.xml
@@ -21,7 +21,7 @@
   <groupId>io.github.openfeign</groupId>
   <artifactId>feign-example-github</artifactId>
   <packaging>jar</packaging>
-  <version>9.0.0</version>
+  <version>10.0.0-SNAPSHOT</version>
   <name>GitHub Example</name>
 
   <dependencies>

--- a/example-github/src/main/java/feign/example/github/GitHubExample.java
+++ b/example-github/src/main/java/feign/example/github/GitHubExample.java
@@ -80,14 +80,14 @@ public class GitHubExample {
     GitHub github = GitHub.connect();
 
     System.out.println("Let's fetch and print a list of the contributors to this org.");
-    List<String> contributors = github.contributors("netflix");
+    List<String> contributors = github.contributors("openfeign");
     for (String contributor : contributors) {
       System.out.println(contributor);
     }
 
     System.out.println("Now, let's cause an error.");
     try {
-      github.contributors("netflix", "some-unknown-project");
+      github.contributors("openfeign", "some-unknown-project");
     } catch (GitHubClientError e) {
       System.out.println(e.getMessage());
     }

--- a/example-wikipedia/pom.xml
+++ b/example-wikipedia/pom.xml
@@ -21,7 +21,7 @@
   <groupId>io.github.openfeign</groupId>
   <artifactId>feign-example-wikipedia</artifactId>
   <packaging>jar</packaging>
-  <version>9.0.0</version>
+  <version>10.0.0-SNAPSHOT</version>
   <name>Wikipedia Example</name>
 
   <dependencies>
@@ -76,6 +76,14 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>6</source>
+          <target>6</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/gson/src/test/java/feign/gson/GsonCodecTest.java
+++ b/gson/src/test/java/feign/gson/GsonCodecTest.java
@@ -196,7 +196,8 @@ public class GsonCodecTest {
             .status(200)
             .reason("OK")
             .headers(Collections.emptyMap())
-            .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+            .request(
+                Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
             .body(zonesJson, UTF_8)
             .build();
     assertEquals(zones, decoder.decode(response, new TypeToken<List<Zone>>() {}.getType()));

--- a/gson/src/test/java/feign/gson/GsonCodecTest.java
+++ b/gson/src/test/java/feign/gson/GsonCodecTest.java
@@ -18,6 +18,7 @@ import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import feign.Request;
+import feign.Request.HttpMethod;
 import feign.Util;
 import org.junit.Test;
 import java.io.IOException;
@@ -38,8 +39,8 @@ import static org.junit.Assert.assertNull;
 public class GsonCodecTest {
 
   @Test
-  public void encodesMapObjectNumericalValuesAsInteger() throws Exception {
-    Map<String, Object> map = new LinkedHashMap<String, Object>();
+  public void encodesMapObjectNumericalValuesAsInteger() {
+    Map<String, Object> map = new LinkedHashMap<>();
     map.put("foo", 1);
 
     RequestTemplate template = new RequestTemplate();
@@ -53,14 +54,14 @@ public class GsonCodecTest {
 
   @Test
   public void decodesMapObjectNumericalValuesAsInteger() throws Exception {
-    Map<String, Object> map = new LinkedHashMap<String, Object>();
+    Map<String, Object> map = new LinkedHashMap<>();
     map.put("foo", 1);
 
     Response response = Response.builder()
         .status(200)
         .reason("OK")
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
-        .headers(Collections.<String, Collection<String>>emptyMap())
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.emptyMap())
         .body("{\"foo\": 1}", UTF_8)
         .build();
     assertEquals(
@@ -68,9 +69,9 @@ public class GsonCodecTest {
   }
 
   @Test
-  public void encodesFormParams() throws Exception {
+  public void encodesFormParams() {
 
-    Map<String, Object> form = new LinkedHashMap<String, Object>();
+    Map<String, Object> form = new LinkedHashMap<>();
     form.put("foo", 1);
     form.put("bar", Arrays.asList(2, 3));
 
@@ -117,8 +118,8 @@ public class GsonCodecTest {
     Response response = Response.builder()
         .status(200)
         .reason("OK")
-        .headers(Collections.<String, Collection<String>>emptyMap())
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.emptyMap())
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .body(zonesJson, UTF_8)
         .build();
     assertEquals(zones,
@@ -130,8 +131,8 @@ public class GsonCodecTest {
     Response response = Response.builder()
         .status(204)
         .reason("OK")
-        .headers(Collections.<String, Collection<String>>emptyMap())
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.emptyMap())
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .build();
     assertNull(new GsonDecoder().decode(response, String.class));
   }
@@ -141,8 +142,8 @@ public class GsonCodecTest {
     Response response = Response.builder()
         .status(204)
         .reason("OK")
-        .headers(Collections.<String, Collection<String>>emptyMap())
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.emptyMap())
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .body(new byte[0])
         .build();
     assertNull(new GsonDecoder().decode(response, String.class));
@@ -184,9 +185,9 @@ public class GsonCodecTest {
 
   @Test
   public void customDecoder() throws Exception {
-    GsonDecoder decoder = new GsonDecoder(Arrays.<TypeAdapter<?>>asList(upperZone));
+    GsonDecoder decoder = new GsonDecoder(Collections.singletonList(upperZone));
 
-    List<Zone> zones = new LinkedList<Zone>();
+    List<Zone> zones = new LinkedList<>();
     zones.add(new Zone("DENOMINATOR.IO."));
     zones.add(new Zone("DENOMINATOR.IO.", "ABCD"));
 
@@ -194,18 +195,18 @@ public class GsonCodecTest {
         Response.builder()
             .status(200)
             .reason("OK")
-            .headers(Collections.<String, Collection<String>>emptyMap())
-            .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
+            .headers(Collections.emptyMap())
+            .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
             .body(zonesJson, UTF_8)
             .build();
     assertEquals(zones, decoder.decode(response, new TypeToken<List<Zone>>() {}.getType()));
   }
 
   @Test
-  public void customEncoder() throws Exception {
-    GsonEncoder encoder = new GsonEncoder(Arrays.<TypeAdapter<?>>asList(upperZone));
+  public void customEncoder() {
+    GsonEncoder encoder = new GsonEncoder(Collections.singletonList(upperZone));
 
-    List<Zone> zones = new LinkedList<Zone>();
+    List<Zone> zones = new LinkedList<>();
     zones.add(new Zone("denominator.io."));
     zones.add(new Zone("denominator.io.", "abcd"));
 
@@ -230,8 +231,8 @@ public class GsonCodecTest {
     Response response = Response.builder()
         .status(404)
         .reason("NOT FOUND")
-        .headers(Collections.<String, Collection<String>>emptyMap())
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.emptyMap())
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .build();
     assertThat((byte[]) new GsonDecoder().decode(response, byte[].class)).isEmpty();
   }

--- a/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
+++ b/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
@@ -87,8 +87,8 @@ public final class ApacheHttpClient implements Client {
   }
 
   HttpUriRequest toHttpUriRequest(Request request, Request.Options options)
-      throws UnsupportedEncodingException, MalformedURLException, URISyntaxException {
-    RequestBuilder requestBuilder = RequestBuilder.create(request.method());
+      throws URISyntaxException {
+    RequestBuilder requestBuilder = RequestBuilder.create(request.httpMethod().name());
 
     // per request timeouts
     RequestConfig requestConfig =
@@ -196,7 +196,7 @@ public final class ApacheHttpClient implements Client {
         .build();
   }
 
-  Response.Body toFeignBody(HttpResponse httpResponse) throws IOException {
+  Response.Body toFeignBody(HttpResponse httpResponse) {
     final HttpEntity entity = httpResponse.getEntity();
     if (entity == null) {
       return null;

--- a/jackson-jaxb/src/test/java/feign/jackson/jaxb/JacksonJaxbCodecTest.java
+++ b/jackson-jaxb/src/test/java/feign/jackson/jaxb/JacksonJaxbCodecTest.java
@@ -13,19 +13,20 @@
  */
 package feign.jackson.jaxb;
 
+import static feign.Util.UTF_8;
+import static feign.assertj.FeignAssertions.assertThat;
+
 import feign.Request;
+import feign.Request.HttpMethod;
+import feign.RequestTemplate;
+import feign.Response;
 import feign.Util;
-import org.junit.Test;
-import java.util.Collection;
 import java.util.Collections;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
-import feign.RequestTemplate;
-import feign.Response;
-import static feign.Util.UTF_8;
-import static feign.assertj.FeignAssertions.assertThat;
+import org.junit.Test;
 
 public class JacksonJaxbCodecTest {
 
@@ -44,8 +45,8 @@ public class JacksonJaxbCodecTest {
     Response response = Response.builder()
         .status(200)
         .reason("OK")
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
-        .headers(Collections.<String, Collection<String>>emptyMap())
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.emptyMap())
         .body("{\"value\":\"Test\"}", UTF_8)
         .build();
     JacksonJaxbJsonDecoder decoder = new JacksonJaxbJsonDecoder();
@@ -54,14 +55,16 @@ public class JacksonJaxbCodecTest {
         .isEqualTo(new MockObject("Test"));
   }
 
-  /** Enabled via {@link feign.Feign.Builder#decode404()} */
+  /**
+   * Enabled via {@link feign.Feign.Builder#decode404()}
+   */
   @Test
   public void notFoundDecodesToEmpty() throws Exception {
     Response response = Response.builder()
         .status(404)
         .reason("NOT FOUND")
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
-        .headers(Collections.<String, Collection<String>>emptyMap())
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.emptyMap())
         .build();
     assertThat((byte[]) new JacksonJaxbJsonDecoder().decode(response, byte[].class)).isEmpty();
   }
@@ -73,7 +76,8 @@ public class JacksonJaxbCodecTest {
     @XmlElement
     private String value;
 
-    MockObject() {}
+    MockObject() {
+    }
 
     MockObject(String value) {
       this.value = value;

--- a/jackson-jaxb/src/test/java/feign/jackson/jaxb/JacksonJaxbCodecTest.java
+++ b/jackson-jaxb/src/test/java/feign/jackson/jaxb/JacksonJaxbCodecTest.java
@@ -15,7 +15,6 @@ package feign.jackson.jaxb;
 
 import static feign.Util.UTF_8;
 import static feign.assertj.FeignAssertions.assertThat;
-
 import feign.Request;
 import feign.Request.HttpMethod;
 import feign.RequestTemplate;
@@ -76,8 +75,7 @@ public class JacksonJaxbCodecTest {
     @XmlElement
     private String value;
 
-    MockObject() {
-    }
+    MockObject() {}
 
     MockObject(String value) {
       this.value = value;

--- a/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
+++ b/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import feign.Request;
+import feign.Request.HttpMethod;
 import feign.Util;
 import org.junit.Test;
 import java.io.Closeable;
@@ -59,7 +60,7 @@ public class JacksonCodecTest {
       + "]" + System.lineSeparator();
 
   @Test
-  public void encodesMapObjectNumericalValuesAsInteger() throws Exception {
+  public void encodesMapObjectNumericalValuesAsInteger() {
     Map<String, Object> map = new LinkedHashMap<String, Object>();
     map.put("foo", 1);
 
@@ -73,7 +74,7 @@ public class JacksonCodecTest {
   }
 
   @Test
-  public void encodesFormParams() throws Exception {
+  public void encodesFormParams() {
     Map<String, Object> form = new LinkedHashMap<String, Object>();
     form.put("foo", 1);
     form.put("bar", Arrays.asList(2, 3));
@@ -90,15 +91,15 @@ public class JacksonCodecTest {
 
   @Test
   public void decodes() throws Exception {
-    List<Zone> zones = new LinkedList<Zone>();
+    List<Zone> zones = new LinkedList<>();
     zones.add(new Zone("denominator.io."));
     zones.add(new Zone("denominator.io.", "ABCD"));
 
     Response response = Response.builder()
         .status(200)
         .reason("OK")
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
-        .headers(Collections.<String, Collection<String>>emptyMap())
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.emptyMap())
         .body(zonesJson, UTF_8)
         .build();
     assertEquals(zones,
@@ -110,8 +111,8 @@ public class JacksonCodecTest {
     Response response = Response.builder()
         .status(204)
         .reason("OK")
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
-        .headers(Collections.<String, Collection<String>>emptyMap())
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.emptyMap())
         .build();
     assertNull(new JacksonDecoder().decode(response, String.class));
   }
@@ -121,8 +122,8 @@ public class JacksonCodecTest {
     Response response = Response.builder()
         .status(204)
         .reason("OK")
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
-        .headers(Collections.<String, Collection<String>>emptyMap())
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.emptyMap())
         .body(new byte[0])
         .build();
     assertNull(new JacksonDecoder().decode(response, String.class));
@@ -131,7 +132,7 @@ public class JacksonCodecTest {
   @Test
   public void customDecoder() throws Exception {
     JacksonDecoder decoder = new JacksonDecoder(
-        Arrays.<Module>asList(
+        Arrays.asList(
             new SimpleModule().addDeserializer(Zone.class, new ZoneDeserializer())));
 
     List<Zone> zones = new LinkedList<Zone>();
@@ -141,17 +142,17 @@ public class JacksonCodecTest {
     Response response = Response.builder()
         .status(200)
         .reason("OK")
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
-        .headers(Collections.<String, Collection<String>>emptyMap())
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.emptyMap())
         .body(zonesJson, UTF_8)
         .build();
     assertEquals(zones, decoder.decode(response, new TypeReference<List<Zone>>() {}.getType()));
   }
 
   @Test
-  public void customEncoder() throws Exception {
+  public void customEncoder() {
     JacksonEncoder encoder = new JacksonEncoder(
-        Arrays.<Module>asList(new SimpleModule().addSerializer(Zone.class, new ZoneSerializer())));
+        Arrays.asList(new SimpleModule().addSerializer(Zone.class, new ZoneSerializer())));
 
     List<Zone> zones = new LinkedList<Zone>();
     zones.add(new Zone("denominator.io."));
@@ -178,8 +179,8 @@ public class JacksonCodecTest {
     Response response = Response.builder()
         .status(200)
         .reason("OK")
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
-        .headers(Collections.<String, Collection<String>>emptyMap())
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.emptyMap())
         .body(zonesJson, UTF_8)
         .build();
     Object decoded = JacksonIteratorDecoder.create().decode(response,
@@ -201,8 +202,8 @@ public class JacksonCodecTest {
     Response response = Response.builder()
         .status(204)
         .reason("OK")
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
-        .headers(Collections.<String, Collection<String>>emptyMap())
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.emptyMap())
         .build();
     assertNull(JacksonIteratorDecoder.create().decode(response, Iterator.class));
   }
@@ -212,8 +213,8 @@ public class JacksonCodecTest {
     Response response = Response.builder()
         .status(204)
         .reason("OK")
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
-        .headers(Collections.<String, Collection<String>>emptyMap())
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.emptyMap())
         .body(new byte[0])
         .build();
     assertNull(JacksonIteratorDecoder.create().decode(response, Iterator.class));
@@ -284,8 +285,8 @@ public class JacksonCodecTest {
     Response response = Response.builder()
         .status(404)
         .reason("NOT FOUND")
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
-        .headers(Collections.<String, Collection<String>>emptyMap())
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.emptyMap())
         .build();
     assertThat((byte[]) new JacksonDecoder().decode(response, byte[].class)).isEmpty();
   }
@@ -296,8 +297,8 @@ public class JacksonCodecTest {
     Response response = Response.builder()
         .status(404)
         .reason("NOT FOUND")
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
-        .headers(Collections.<String, Collection<String>>emptyMap())
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.emptyMap())
         .build();
     assertThat((byte[]) JacksonIteratorDecoder.create().decode(response, byte[].class)).isEmpty();
   }

--- a/jackson/src/test/java/feign/jackson/JacksonIteratorTest.java
+++ b/jackson/src/test/java/feign/jackson/JacksonIteratorTest.java
@@ -16,7 +16,6 @@ package feign.jackson;
 import static feign.Util.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.core.Is.isA;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.Request;
 import feign.Request.HttpMethod;

--- a/jackson/src/test/java/feign/jackson/JacksonIteratorTest.java
+++ b/jackson/src/test/java/feign/jackson/JacksonIteratorTest.java
@@ -13,25 +13,26 @@
  */
 package feign.jackson;
 
+import static feign.Util.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.core.Is.isA;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.Request;
+import feign.Request.HttpMethod;
 import feign.Response;
 import feign.Util;
 import feign.codec.DecodeException;
 import feign.jackson.JacksonIteratorDecoder.JacksonIterator;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-import static feign.Util.UTF_8;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.core.Is.isA;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class JacksonIteratorTest {
 
@@ -88,8 +89,8 @@ public class JacksonIteratorTest {
     Response response = Response.builder()
         .status(200)
         .reason("OK")
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
-        .headers(Collections.<String, Collection<String>>emptyMap())
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.emptyMap())
         .body(inputStream, jsonBytes.length)
         .build();
 
@@ -112,8 +113,8 @@ public class JacksonIteratorTest {
     Response response = Response.builder()
         .status(200)
         .reason("OK")
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
-        .headers(Collections.<String, Collection<String>>emptyMap())
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.emptyMap())
         .body(inputStream, jsonBytes.length)
         .build();
 
@@ -142,8 +143,8 @@ public class JacksonIteratorTest {
     Response response = Response.builder()
         .status(200)
         .reason("OK")
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
-        .headers(Collections.<String, Collection<String>>emptyMap())
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.emptyMap())
         .body(json, UTF_8)
         .build();
     return iterator(type, response);

--- a/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
+++ b/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
@@ -231,7 +231,7 @@ public class JAXBCodecTest {
     Response response = Response.builder()
         .status(200)
         .reason("OK")
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .headers(Collections.<String, Collection<String>>emptyMap())
         .body(template.body())
         .build();

--- a/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
+++ b/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
@@ -16,7 +16,6 @@ package feign.jaxb;
 import static feign.Util.UTF_8;
 import static feign.assertj.FeignAssertions.assertThat;
 import static org.junit.Assert.assertEquals;
-
 import feign.Request;
 import feign.Request.HttpMethod;
 import feign.RequestTemplate;

--- a/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
+++ b/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
@@ -13,11 +13,16 @@
  */
 package feign.jaxb;
 
+import static feign.Util.UTF_8;
+import static feign.assertj.FeignAssertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
 import feign.Request;
+import feign.Request.HttpMethod;
+import feign.RequestTemplate;
+import feign.Response;
 import feign.Util;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import feign.codec.Encoder;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.Collections;
@@ -26,12 +31,9 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
-import feign.RequestTemplate;
-import feign.Response;
-import feign.codec.Encoder;
-import static feign.Util.UTF_8;
-import static feign.assertj.FeignAssertions.assertThat;
-import static org.junit.Assert.assertEquals;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class JAXBCodecTest {
 
@@ -166,8 +168,8 @@ public class JAXBCodecTest {
     Response response = Response.builder()
         .status(200)
         .reason("OK")
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
-        .headers(Collections.<String, Collection<String>>emptyMap())
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.emptyMap())
         .body(mockXml, UTF_8)
         .build();
 
@@ -193,7 +195,7 @@ public class JAXBCodecTest {
     Response response = Response.builder()
         .status(200)
         .reason("OK")
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .headers(Collections.<String, Collection<String>>emptyMap())
         .body("<foo/>", UTF_8)
         .build();
@@ -239,13 +241,15 @@ public class JAXBCodecTest {
 
   }
 
-  /** Enabled via {@link feign.Feign.Builder#decode404()} */
+  /**
+   * Enabled via {@link feign.Feign.Builder#decode404()}
+   */
   @Test
   public void notFoundDecodesToEmpty() throws Exception {
     Response response = Response.builder()
         .status(404)
         .reason("NOT FOUND")
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .headers(Collections.<String, Collection<String>>emptyMap())
         .build();
     assertThat((byte[]) new JAXBDecoder(new JAXBContextFactory.Builder().build())

--- a/jaxb/src/test/java/feign/jaxb/examples/IAMExample.java
+++ b/jaxb/src/test/java/feign/jaxb/examples/IAMExample.java
@@ -66,7 +66,7 @@ public class IAMExample {
 
     @Override
     public Request apply(RequestTemplate in) {
-      in.insert(0, url());
+      in.target(url());
       return super.apply(in);
     }
   }

--- a/jaxrs/src/main/java/feign/jaxrs/JAXRSContract.java
+++ b/jaxrs/src/main/java/feign/jaxrs/JAXRSContract.java
@@ -15,6 +15,7 @@ package feign.jaxrs;
 
 import feign.Contract;
 import feign.MethodMetadata;
+import feign.Request;
 import javax.ws.rs.*;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -54,7 +55,7 @@ public class JAXRSContract extends Contract.BaseContract {
         // added
         pathValue = pathValue.substring(0, pathValue.length() - 1);
       }
-      data.template().insert(0, pathValue);
+      data.template().uri(pathValue);
     }
     Consumes consumes = clz.getAnnotation(Consumes.class);
     if (consumes != null) {
@@ -76,7 +77,7 @@ public class JAXRSContract extends Contract.BaseContract {
       checkState(data.template().method() == null,
           "Method %s contains multiple HTTP methods. Found: %s and %s", method.getName(),
           data.template().method(), http.value());
-      data.template().method(http.value());
+      data.template().method(Request.HttpMethod.valueOf(http.value()));
     } else if (annotationType == Path.class) {
       String pathValue = emptyToNull(Path.class.cast(methodAnnotation).value());
       if (pathValue == null) {
@@ -91,7 +92,7 @@ public class JAXRSContract extends Contract.BaseContract {
       // strip these out appropriately.
       methodAnnotationValue =
           methodAnnotationValue.replaceAll("\\{\\s*(.+?)\\s*(:.+?)?\\}", "\\{$1\\}");
-      data.template().append(methodAnnotationValue);
+      data.template().uri(methodAnnotationValue, true);
     } else if (annotationType == Produces.class) {
       handleProducesAnnotation(data, (Produces) methodAnnotation, "method " + method.getName());
     } else if (annotationType == Consumes.class) {

--- a/jaxrs/src/test/java/feign/jaxrs/JAXRSContractTest.java
+++ b/jaxrs/src/test/java/feign/jaxrs/JAXRSContractTest.java
@@ -14,6 +14,7 @@
 package feign.jaxrs;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -128,8 +129,8 @@ public class JAXRSContractTest {
 
     assertThat(md.template())
         .hasHeaders(
-            entry("Content-Type", asList("application/json")),
-            entry("Accept", asList("application/xml", "text/plain")));
+            entry("Content-Type", Collections.singletonList("application/json")),
+            entry("Accept", asList("application/xml", "text/html", "text/plain")));
   }
 
   @Test
@@ -164,8 +165,8 @@ public class JAXRSContractTest {
     MethodMetadata md = parseAndValidateMetadata(ProducesAndConsumes.class, "consumesMultiple");
 
     assertThat(md.template())
-        .hasHeaders(entry("Accept", asList("text/html")),
-            entry("Content-Type", asList("application/xml", "application/json")));
+        .hasHeaders(entry("Content-Type", asList("application/xml", "application/json")),
+            entry("Accept", Collections.singletonList("text/html")));
   }
 
   @Test

--- a/jaxrs/src/test/java/feign/jaxrs/JAXRSContractTest.java
+++ b/jaxrs/src/test/java/feign/jaxrs/JAXRSContractTest.java
@@ -77,7 +77,7 @@ public class JAXRSContractTest {
   public void customMethodWithoutPath() throws Exception {
     assertThat(parseAndValidateMetadata(CustomMethod.class, "patch").template())
         .hasMethod("PATCH")
-        .hasUrl("");
+        .hasUrl("/");
   }
 
   @Test
@@ -215,7 +215,7 @@ public class JAXRSContractTest {
   @Test
   public void emptyPathOnType() throws Exception {
     assertThat(parseAndValidateMetadata(EmptyPathOnType.class, "base").template())
-        .hasUrl("");
+        .hasUrl("/");
   }
 
   @Test

--- a/jaxrs/src/test/java/feign/jaxrs/JAXRSContractTest.java
+++ b/jaxrs/src/test/java/feign/jaxrs/JAXRSContractTest.java
@@ -13,6 +13,7 @@
  */
 package feign.jaxrs;
 
+import java.util.ArrayList;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -81,31 +82,31 @@ public class JAXRSContractTest {
   @Test
   public void queryParamsInPathExtract() throws Exception {
     assertThat(parseAndValidateMetadata(WithQueryParamsInPath.class, "none").template())
-        .hasUrl("/")
+        .hasPath("/")
         .hasQueries();
 
     assertThat(parseAndValidateMetadata(WithQueryParamsInPath.class, "one").template())
-        .hasUrl("/")
+        .hasPath("/")
         .hasQueries(
             entry("Action", asList("GetUser")));
 
     assertThat(parseAndValidateMetadata(WithQueryParamsInPath.class, "two").template())
-        .hasUrl("/")
+        .hasPath("/")
         .hasQueries(
             entry("Action", asList("GetUser")),
             entry("Version", asList("2010-05-08")));
 
     assertThat(parseAndValidateMetadata(WithQueryParamsInPath.class, "three").template())
-        .hasUrl("/")
+        .hasPath("/")
         .hasQueries(
             entry("Action", asList("GetUser")),
             entry("Version", asList("2010-05-08")),
             entry("limit", asList("1")));
 
     assertThat(parseAndValidateMetadata(WithQueryParamsInPath.class, "empty").template())
-        .hasUrl("/")
+        .hasPath("/")
         .hasQueries(
-            entry("flag", asList(new String[] {null})),
+            entry("flag", new ArrayList<>()),
             entry("Action", asList("GetUser")),
             entry("Version", asList("2010-05-08")));
   }
@@ -114,10 +115,11 @@ public class JAXRSContractTest {
   public void producesAddsAcceptHeader() throws Exception {
     MethodMetadata md = parseAndValidateMetadata(ProducesAndConsumes.class, "produces");
 
+    /* multiple @Produces annotations should be additive */
     assertThat(md.template())
         .hasHeaders(
             entry("Content-Type", asList("application/json")),
-            entry("Accept", asList("application/xml")));
+            entry("Accept", asList("application/xml", "text/html")));
   }
 
   @Test
@@ -150,9 +152,11 @@ public class JAXRSContractTest {
   public void consumesAddsContentTypeHeader() throws Exception {
     MethodMetadata md = parseAndValidateMetadata(ProducesAndConsumes.class, "consumes");
 
+    /* multiple @Consumes annotations are additive */
     assertThat(md.template())
-        .hasHeaders(entry("Accept", asList("text/html")),
-            entry("Content-Type", asList("application/xml")));
+        .hasHeaders(
+            entry("Content-Type", asList("application/xml", "application/json")),
+            entry("Accept", asList("text/html")));
   }
 
   @Test

--- a/jaxrs2/src/main/java/feign/jaxrs2/JAXRSClient.java
+++ b/jaxrs2/src/main/java/feign/jaxrs2/JAXRSClient.java
@@ -56,7 +56,7 @@ public class JAXRSClient implements Client {
         .target(request.url())
         .request()
         .headers(toMultivaluedMap(request.headers()))
-        .method(request.method(), createRequestEntity(request));
+        .method(request.httpMethod().name(), createRequestEntity(request));
 
     return feign.Response.builder()
         .request(request)
@@ -117,8 +117,8 @@ public class JAXRSClient implements Client {
   private MultivaluedMap<String, Object> toMultivaluedMap(Map<String, Collection<String>> headers) {
     final MultivaluedHashMap<String, Object> mvHeaders = new MultivaluedHashMap<>();
 
-    headers.entrySet().forEach(entry -> entry.getValue().stream()
-        .forEach(value -> mvHeaders.add(entry.getKey(), value)));
+    headers.forEach((key, value1) -> value1
+        .forEach(value -> mvHeaders.add(key, value)));
 
     return mvHeaders;
   }

--- a/jaxrs2/src/test/java/feign/jaxrs2/JAXRSClientTest.java
+++ b/jaxrs2/src/test/java/feign/jaxrs2/JAXRSClientTest.java
@@ -95,7 +95,7 @@ public class JAXRSClientTest extends AbstractClientTest {
 
     /* queries with no values are omitted from the uri. See RFC 6750 */
     MockWebServerAssertions.assertThat(server.takeRequest()).hasMethod("POST")
-        .hasPath("/?foo=bar&foo=baz")
+        .hasPath("/?foo=bar&foo=baz&qux")
         .hasBody("foo");
   }
 

--- a/jaxrs2/src/test/java/feign/jaxrs2/JAXRSClientTest.java
+++ b/jaxrs2/src/test/java/feign/jaxrs2/JAXRSClientTest.java
@@ -17,7 +17,6 @@ import static feign.Util.UTF_8;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-
 import feign.Feign;
 import feign.Feign.Builder;
 import feign.Headers;
@@ -28,6 +27,7 @@ import feign.assertj.MockWebServerAssertions;
 import feign.client.AbstractClientTest;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.Collections;
 import javax.ws.rs.ProcessingException;
 import okhttp3.mockwebserver.MockResponse;
 import org.assertj.core.data.MapEntry;
@@ -112,8 +112,8 @@ public class JAXRSClientTest extends AbstractClientTest {
 
     MockWebServerAssertions.assertThat(server.takeRequest())
         .hasHeaders(
-            MapEntry.entry("Accept", "text/plain"),
-            MapEntry.entry("Content-Type", "text/plain"))
+            MapEntry.entry("Accept", Collections.singletonList("text/plain")),
+            MapEntry.entry("Content-Type", Collections.singletonList("text/plain")))
         .hasMethod("GET");
   }
 

--- a/jaxrs2/src/test/java/feign/jaxrs2/JAXRSClientTest.java
+++ b/jaxrs2/src/test/java/feign/jaxrs2/JAXRSClientTest.java
@@ -91,7 +91,7 @@ public class JAXRSClientTest extends AbstractClientTest {
         .containsEntry("Content-Length", asList("3"))
         .containsEntry("Foo", asList("Bar"));
     assertThat(response.body().asInputStream())
-        .hasContentEqualTo(new ByteArrayInputStream("foo".getBytes(UTF_8)));
+        .hasSameContentAs(new ByteArrayInputStream("foo".getBytes(UTF_8)));
 
     /* queries with no values are omitted from the uri. See RFC 6750 */
     MockWebServerAssertions.assertThat(server.takeRequest()).hasMethod("POST")

--- a/jaxrs2/src/test/java/feign/jaxrs2/JAXRSClientTest.java
+++ b/jaxrs2/src/test/java/feign/jaxrs2/JAXRSClientTest.java
@@ -13,6 +13,12 @@
  */
 package feign.jaxrs2;
 
+import static feign.Util.UTF_8;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import feign.Feign;
 import feign.Feign.Builder;
 import feign.Headers;
 import feign.RequestLine;
@@ -20,20 +26,17 @@ import feign.Response;
 import feign.Util;
 import feign.assertj.MockWebServerAssertions;
 import feign.client.AbstractClientTest;
-import feign.jaxrs2.JAXRSClient;
-import feign.Feign;
-import okhttp3.mockwebserver.MockResponse;
-import org.junit.Test;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import javax.ws.rs.ProcessingException;
-import static feign.Util.UTF_8;
-import static java.util.Arrays.asList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
+import okhttp3.mockwebserver.MockResponse;
+import org.assertj.core.data.MapEntry;
 import org.junit.Assume;
+import org.junit.Test;
 
-/** Tests client-specific behavior, such as ensuring Content-Length is sent when specified. */
+/**
+ * Tests client-specific behavior, such as ensuring Content-Length is sent when specified.
+ */
 public class JAXRSClientTest extends AbstractClientTest {
 
   @Override
@@ -90,8 +93,9 @@ public class JAXRSClientTest extends AbstractClientTest {
     assertThat(response.body().asInputStream())
         .hasContentEqualTo(new ByteArrayInputStream("foo".getBytes(UTF_8)));
 
+    /* queries with no values are omitted from the uri. See RFC 6750 */
     MockWebServerAssertions.assertThat(server.takeRequest()).hasMethod("POST")
-        .hasPath("/?foo=bar&foo=baz&qux=")
+        .hasPath("/?foo=bar&foo=baz")
         .hasBody("foo");
   }
 
@@ -107,8 +111,9 @@ public class JAXRSClientTest extends AbstractClientTest {
     assertEquals("AAAAAAAA", Util.toString(response.body().asReader()));
 
     MockWebServerAssertions.assertThat(server.takeRequest())
-        .hasHeaders("Accept: text/plain", "Content-Type: text/plain") // Note: OkHttp adds content
-                                                                      // length.
+        .hasHeaders(
+            MapEntry.entry("Accept", "text/plain"),
+            MapEntry.entry("Content-Type", "text/plain"))
         .hasMethod("GET");
   }
 

--- a/mock/src/main/java/feign/mock/RequestKey.java
+++ b/mock/src/main/java/feign/mock/RequestKey.java
@@ -108,7 +108,7 @@ public class RequestKey {
   }
 
   private RequestKey(Request request) {
-    this.method = HttpMethod.valueOf(request.method());
+    this.method = HttpMethod.valueOf(request.httpMethod().name());
     this.url = buildUrl(request);
     this.headers = RequestHeaders.of(request.headers());
     this.charset = request.charset();

--- a/mock/src/test/java/feign/mock/RequestKeyTest.java
+++ b/mock/src/test/java/feign/mock/RequestKeyTest.java
@@ -57,7 +57,7 @@ public class RequestKeyTest {
   public void create() throws Exception {
     Map<String, Collection<String>> map = new HashMap<String, Collection<String>>();
     map.put("my-header", Arrays.asList("val"));
-    Request request = Request.create("GET", "a", map, "content".getBytes(StandardCharsets.UTF_8),
+    Request request = Request.create(Request.HttpMethod.GET, "a", map, "content".getBytes(StandardCharsets.UTF_8),
         StandardCharsets.UTF_16);
     requestKey = RequestKey.create(request);
 

--- a/mock/src/test/java/feign/mock/RequestKeyTest.java
+++ b/mock/src/test/java/feign/mock/RequestKeyTest.java
@@ -57,8 +57,9 @@ public class RequestKeyTest {
   public void create() throws Exception {
     Map<String, Collection<String>> map = new HashMap<String, Collection<String>>();
     map.put("my-header", Arrays.asList("val"));
-    Request request = Request.create(Request.HttpMethod.GET, "a", map, "content".getBytes(StandardCharsets.UTF_8),
-        StandardCharsets.UTF_16);
+    Request request =
+        Request.create(Request.HttpMethod.GET, "a", map, "content".getBytes(StandardCharsets.UTF_8),
+            StandardCharsets.UTF_16);
     requestKey = RequestKey.create(request);
 
     assertThat(requestKey.getMethod(), equalTo(HttpMethod.GET));

--- a/okhttp/src/main/java/feign/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/feign/okhttp/OkHttpClient.java
@@ -13,6 +13,7 @@
  */
 package feign.okhttp;
 
+import feign.Request.HttpMethod;
 import okhttp3.Headers;
 import okhttp3.MediaType;
 import okhttp3.Request;
@@ -32,7 +33,7 @@ import feign.Client;
  * This module directs Feign's http requests to
  * <a href="http://square.github.io/okhttp/">OkHttp</a>, which enables SPDY and better network
  * control. Ex.
- * 
+ *
  * <pre>
  * GitHub github = Feign.builder().client(new OkHttpClient()).target(GitHub.class,
  * "https://api.github.com");
@@ -76,7 +77,8 @@ public final class OkHttpClient implements Client {
     }
 
     byte[] inputBody = input.body();
-    boolean isMethodWithBody = "POST".equals(input.method()) || "PUT".equals(input.method());
+    boolean isMethodWithBody =
+        HttpMethod.POST == input.httpMethod() || HttpMethod.PUT == input.httpMethod();
     if (isMethodWithBody) {
       requestBuilder.removeHeader("Content-Type");
       if (inputBody == null) {
@@ -87,7 +89,7 @@ public final class OkHttpClient implements Client {
     }
 
     RequestBody body = inputBody != null ? RequestBody.create(mediaType, inputBody) : null;
-    requestBuilder.method(input.method(), body);
+    requestBuilder.method(input.httpMethod().name(), body);
     return requestBuilder.build();
   }
 

--- a/okhttp/src/test/java/feign/okhttp/OkHttpClientTest.java
+++ b/okhttp/src/test/java/feign/okhttp/OkHttpClientTest.java
@@ -22,6 +22,7 @@ import feign.Util;
 import feign.assertj.MockWebServerAssertions;
 import feign.client.AbstractClientTest;
 import feign.Feign;
+import java.util.Collections;
 import okhttp3.mockwebserver.MockResponse;
 import org.assertj.core.data.MapEntry;
 import org.junit.Test;
@@ -49,8 +50,8 @@ public class OkHttpClientTest extends AbstractClientTest {
 
     MockWebServerAssertions.assertThat(server.takeRequest())
         .hasHeaders(
-            MapEntry.entry("Accept", "text/plain"),
-            MapEntry.entry("Content-Type", "text/plain"))
+            MapEntry.entry("Accept", Collections.singletonList("text/plain")),
+            MapEntry.entry("Content-Type", Collections.singletonList("text/plain")))
         .hasMethod("GET");
   }
 

--- a/okhttp/src/test/java/feign/okhttp/OkHttpClientTest.java
+++ b/okhttp/src/test/java/feign/okhttp/OkHttpClientTest.java
@@ -23,6 +23,7 @@ import feign.assertj.MockWebServerAssertions;
 import feign.client.AbstractClientTest;
 import feign.Feign;
 import okhttp3.mockwebserver.MockResponse;
+import org.assertj.core.data.MapEntry;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
@@ -47,8 +48,9 @@ public class OkHttpClientTest extends AbstractClientTest {
     assertEquals("AAAAAAAA", Util.toString(response.body().asReader()));
 
     MockWebServerAssertions.assertThat(server.takeRequest())
-        .hasHeaders("Accept: text/plain", "Content-Type: text/plain") // Note: OkHttp adds content
-                                                                      // length.
+        .hasHeaders(
+            MapEntry.entry("Accept", "text/plain"),
+            MapEntry.entry("Content-Type", "text/plain"))
         .hasMethod("GET");
   }
 

--- a/ribbon/src/main/java/feign/ribbon/LBClient.java
+++ b/ribbon/src/main/java/feign/ribbon/LBClient.java
@@ -21,6 +21,7 @@ import com.netflix.client.RequestSpecificRetryHandler;
 import com.netflix.client.config.CommonClientConfigKey;
 import com.netflix.client.config.IClientConfig;
 import com.netflix.loadbalancer.ILoadBalancer;
+import feign.Request.HttpMethod;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
@@ -96,7 +97,7 @@ public final class LBClient extends
     if (clientConfig.get(CommonClientConfigKey.OkToRetryOnAllOperations, false)) {
       return new RequestSpecificRetryHandler(true, true, this.getRetryHandler(), requestConfig);
     }
-    if (!request.toRequest().method().equals("GET")) {
+    if (request.toRequest().httpMethod() != HttpMethod.GET) {
       return new RequestSpecificRetryHandler(true, false, this.getRetryHandler(), requestConfig);
     } else {
       return new RequestSpecificRetryHandler(true, true, this.getRetryHandler(), requestConfig);
@@ -121,8 +122,8 @@ public final class LBClient extends
       // create a new Map to avoid side effect, not to change the old headers
       Map<String, Collection<String>> headers = new LinkedHashMap<String, Collection<String>>();
       headers.putAll(request.headers());
-      headers.put(Util.CONTENT_LENGTH, Arrays.asList(String.valueOf(bodyLength)));
-      return Request.create(request.method(), getUri().toASCIIString(), headers, body,
+      headers.put(Util.CONTENT_LENGTH, Collections.singletonList(String.valueOf(bodyLength)));
+      return Request.create(request.httpMethod(), getUri().toASCIIString(), headers, body,
           request.charset());
     }
 

--- a/ribbon/src/main/java/feign/ribbon/LoadBalancingTarget.java
+++ b/ribbon/src/main/java/feign/ribbon/LoadBalancingTarget.java
@@ -106,7 +106,7 @@ public class LoadBalancingTarget<T> implements Target<T> {
   public Request apply(RequestTemplate input) {
     Server currentServer = lb.chooseServer(null);
     String url = format("%s://%s%s", scheme, currentServer.getHostPort(), path);
-    input.insert(0, url);
+    input.target(url);
     try {
       return input.request();
     } finally {

--- a/ribbon/src/test/java/feign/ribbon/LBClientTest.java
+++ b/ribbon/src/test/java/feign/ribbon/LBClientTest.java
@@ -13,6 +13,7 @@
  */
 package feign.ribbon;
 
+import feign.Request.HttpMethod;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
@@ -39,7 +40,7 @@ public class LBClientTest {
     // test for RibbonRequest.toRequest()
     // the url has a query whose value is an encoded json string
     String urlWithEncodedJson = "http://test.feign.com/p?q=%7b%22a%22%3a1%7d";
-    String method = "GET";
+    HttpMethod method = HttpMethod.GET;
     URI uri = new URI(urlWithEncodedJson);
     Map<String, Collection<String>> headers = new LinkedHashMap<String, Collection<String>>();
     // create a Request for recreating another Request by toRequest()

--- a/ribbon/src/test/java/feign/ribbon/RibbonClientTest.java
+++ b/ribbon/src/test/java/feign/ribbon/RibbonClientTest.java
@@ -203,7 +203,9 @@ public class RibbonClientTest {
   @Test
   public void urlEncodeQueryStringParameters() throws IOException, InterruptedException {
     String queryStringValue = "some string with space";
-    String expectedQueryStringValue = "some+string+with+space";
+
+    /* values must be pct encoded, see RFC 6750 */
+    String expectedQueryStringValue = "some%20string%20with%20space";
     String expectedRequestLine = String.format("GET /?a=%s HTTP/1.1", expectedQueryStringValue);
 
     server1.enqueue(new MockResponse().setBody("success!"));

--- a/sax/src/test/java/feign/sax/SAXDecoderTest.java
+++ b/sax/src/test/java/feign/sax/SAXDecoderTest.java
@@ -14,6 +14,7 @@
 package feign.sax;
 
 import feign.Request;
+import feign.Request.HttpMethod;
 import feign.Util;
 import org.junit.Rule;
 import org.junit.Test;
@@ -74,7 +75,7 @@ public class SAXDecoderTest {
     return Response.builder()
         .status(200)
         .reason("OK")
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .headers(Collections.<String, Collection<String>>emptyMap())
         .body(statusFailed, UTF_8)
         .build();
@@ -85,7 +86,7 @@ public class SAXDecoderTest {
     Response response = Response.builder()
         .status(204)
         .reason("OK")
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .headers(Collections.<String, Collection<String>>emptyMap())
         .build();
     assertNull(decoder.decode(response, String.class));
@@ -97,7 +98,7 @@ public class SAXDecoderTest {
     Response response = Response.builder()
         .status(404)
         .reason("NOT FOUND")
-        .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .headers(Collections.<String, Collection<String>>emptyMap())
         .build();
     assertThat((byte[]) decoder.decode(response, byte[].class)).isEmpty();

--- a/sax/src/test/java/feign/sax/examples/IAMExample.java
+++ b/sax/src/test/java/feign/sax/examples/IAMExample.java
@@ -59,7 +59,7 @@ public class IAMExample {
 
     @Override
     public Request apply(RequestTemplate in) {
-      in.insert(0, url());
+      in.target(url());
       return super.apply(in);
     }
   }

--- a/slf4j/src/test/java/feign/slf4j/Slf4jLoggerTest.java
+++ b/slf4j/src/test/java/feign/slf4j/Slf4jLoggerTest.java
@@ -13,6 +13,7 @@
  */
 package feign.slf4j;
 
+import feign.Request.HttpMethod;
 import feign.Util;
 import org.junit.Rule;
 import org.junit.Test;
@@ -29,12 +30,13 @@ public class Slf4jLoggerTest {
 
   private static final String CONFIG_KEY = "someMethod()";
   private static final Request REQUEST =
-      new RequestTemplate().method("GET").append("http://api.example.com").request();
+      new RequestTemplate().method(HttpMethod.GET).target("http://api.example.com")
+          .resolve(Collections.emptyMap()).request();
   private static final Response RESPONSE =
       Response.builder()
           .status(200)
           .reason("OK")
-          .request(Request.create("GET", "/api", Collections.emptyMap(), null, Util.UTF_8))
+          .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
           .headers(Collections.<String, Collection<String>>emptyMap())
           .body(new byte[0])
           .build();


### PR DESCRIPTION
Fixes #693, #675, #637, #607, #735, #503, #429 and I'm sure a few more

This change refactors `RequestTemplate` in an attempt to adhere to the [RFC-6570 - URI Template](https://tools.ietf.org/html/rfc6570) specification more closely.  The reason for this is to reduce the amount of inconsistency between `@Param`, `@QueryMap`, `@Header`, `@HeaderMap`, and `@Body` template expansion.

First, `RequestTemplate` now delegates uri, header, query, and body template parsing to `UriTemplate`, `HeaderTemplate`, `QueryTemplate`, and `BodyTemplate` respectively.  These components are all variations on a `Template`.  

Second, `RequestTemplate` _feigns_ immutable.  However, once a template is _resolved_, it should be considered effectively immutable.  Following is a breakdown of the breaking changes:

`UriTemplate` adheres to RFC 6570 explicitly and supports Level 1 (Simple String) variable expansion.  Unresolved variables are ignored and removed from the uri.  This includes query parameter pairs.  All
literal and expanded variables are pct-encoded according to the Charset provided in the `RequestTemplate`.

`HeaderTemplate` supports Level 1 (Simple String) variable expansion.  Unresolved variables are ignored.  Empty headers are removed.  No encoding is performed.

`QueryTemplate` is a subset of a `UriTemplate` and reacts in the same way.  Unresolved pairs are ignored and not present on the final template.  All literals and expanded variables are pct-encoded
according to the Charset provided.

`BodyTemplate` supports Level 1 (Simple String) variable expansion.  Unresolved variables produce empty strings.  Values are not encoded.

All remaining customizations, including custom encoders, collection format . expansion and charset encoding are still supported and made backward compatible.

Finally, a number of inconsistent methods on `RequestTemplate` have been deprecated for public use and all deprecated usage throughout the library has been replaced.