### PR TITLE
Updated README with JDK compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Feign uses tools like Jersey and CXF to write java clients for ReST or SOAP serv
 
 Feign works by processing annotations into a templatized request. Arguments are applied to these templates in a straightforward fashion before output.  Although Feign is limited to supporting text-based APIs, it dramatically simplifies system aspects such as replaying requests. Furthermore, Feign makes it easy to unit test your conversions knowing this.
 
+### Java Version Compatibility
+
+Feign 10.x and above are built on Java 8 and should work on Java 9, 10, and 11.  For those that need JDK 6 compatibility, please use the most Feign 9.x
+
 ### Basics
 
 Usage typically looks like this, an adaptation of the [canonical Retrofit sample](https://github.com/square/retrofit/blob/master/samples/src/main/java/com/example/retrofit/SimpleService.java).


### PR DESCRIPTION
Closes #777 

Specifies with JDK versions Feign is built on and which ones the community has stated work.