### PR TITLE
The @Headers does not work

### DIFF
--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -333,11 +333,11 @@ public interface Contract {
           new LinkedHashMap<String, Collection<String>>(input.length);
       for (String header : input) {
         int colon = header.indexOf(':');
-        String name = header.substring(0, colon);
+        String name = header.substring(0, colon).trim();
         if (!result.containsKey(name)) {
           result.put(name, new ArrayList<String>(1));
         }
-        result.get(name).add(header.substring(colon + 2));
+        result.get(name).add(header.substring(colon + 1).trim());
       }
       return result;
     }

--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -333,7 +333,7 @@ public interface Contract {
           new LinkedHashMap<String, Collection<String>>(input.length);
       for (String header : input) {
         int colon = header.indexOf(':');
-        String name = header.substring(0, colon).trim();
+        String name = header.substring(0, colon);
         if (!result.containsKey(name)) {
           result.put(name, new ArrayList<String>(1));
         }

--- a/core/src/test/java/feign/DefaultContractTest.java
+++ b/core/src/test/java/feign/DefaultContractTest.java
@@ -158,6 +158,16 @@ public class DefaultContractTest {
             entry("Content-Type", asList("application/xml")),
             entry("Content-Length", asList(String.valueOf(md.template().body().length))));
   }
+  
+  @Test
+  public void headersContainsWhitespaces() throws Exception {
+    MethodMetadata md = parseAndValidateMetadata(HeadersContainsWhitespaces.class, "post");
+
+    assertThat(md.template())
+        .hasHeaders(
+            entry("Content-Type", asList("application/xml")),
+            entry("Content-Length", asList(String.valueOf(md.template().body().length))));
+  }
 
   @Test
   public void withPathAndURIParam() throws Exception {
@@ -445,6 +455,14 @@ public class DefaultContractTest {
     Response post();
   }
 
+  @Headers("Content-Type:    application/xml   ")
+  interface HeadersContainsWhitespaces {
+
+    @RequestLine("POST /")
+    @Body("<v01:getAccountsListOfUser/>")
+    Response post();
+  }
+  
   interface WithURIParam {
 
     @RequestLine("GET /{1}/{2}")


### PR DESCRIPTION
The @Headers does not work when it has blank space around ":".
I'd expect to be able to do something like the following
`@RequestLine("POST /xml")`
`@Headers("Content-Type : text/xml")`
` String sentXml(String x);`
Unfortunately this doesn't seem to work because it has a blank space before ":".  The service receive a HTTP request that contains headers "Content-Type: application/x-www-form-urlencoded" because the HttpURLConnection cannot  recognize “Content-Type ”.

> if (!method.equals("PUT") && (poster != null || streaming())) {
                requests.setIfNotSet ("Content-type",
                        "application/x-www-form-urlencoded");
            }

It does not friendly to developer. 
