### PR TITLE
Return null (empty target object) if status code is 204

### DIFF
--- a/jaxb/src/main/java/feign/jaxb/JAXBDecoder.java
+++ b/jaxb/src/main/java/feign/jaxb/JAXBDecoder.java
@@ -66,7 +66,7 @@ public class JAXBDecoder implements Decoder {
 
   @Override
   public Object decode(Response response, Type type) throws IOException {
-    if (response.status() == 404)
+    if (response.status() == 404 || response.status() == 204)
       return Util.emptyValueOf(type);
     if (response.body() == null)
       return null;


### PR DESCRIPTION
As mention in #791 JAXBDecoder should check also for status code 204 before trying to decode response body.