### PR TITLE
Make jaxb modules build on java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,16 +24,16 @@ cache:
   directories:
   - $HOME/.m2
 
-#matrix:
-#  include:
-#    - os: linux
-#      jdk: oraclejdk8
-#      addons:
-#        apt:
-#          packages:
-#            - oracle-java8-installer
-#     - os: linux
-#      jdk: openjdk11
+matrix:
+ include:
+   - os: linux
+     jdk: oraclejdk8
+     addons:
+       apt:
+         packages:
+           - oracle-java8-installer
+    - os: linux
+     jdk: openjdk11
 
 # Don't build release tags. This avoids publish conflicts because the version commit exists both on master and the release tag.
 # See https://github.com/travis-ci/travis-ci/issues/1532

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,9 @@ matrix:
        apt:
          packages:
            - oracle-java8-installer
-    - os: linux
+   - os: linux
+     jdk: openjdk8
+   - os: linux
      jdk: openjdk11
 
 # Don't build release tags. This avoids publish conflicts because the version commit exists both on master and the release tag.

--- a/jackson-jaxb/pom.xml
+++ b/jackson-jaxb/pom.xml
@@ -70,4 +70,30 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <activation>
+        <jdk>11</jdk>
+      </activation>
+
+      <!--
+        JAXB was removed from java SDK on JEP 320
+        http://openjdk.java.net/jeps/320
+       -->
+      <dependencies>
+        <dependency>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+          <version>2.3.1</version>
+        </dependency>
+        <dependency>
+          <groupId>org.glassfish.jaxb</groupId>
+          <artifactId>jaxb-runtime</artifactId>
+          <version>2.4.0-b180830.0438</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
 </project>

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -50,17 +50,23 @@
         <jdk>11</jdk>
       </activation>
 
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <argLine>--add-modules java.xml.bind</argLine>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
+      <!--
+        JAXB was removed from java SDK on JEP 320
+        http://openjdk.java.net/jeps/320
+       -->
+      <dependencies>
+        <dependency>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+          <version>2.3.1</version>
+        </dependency>
+        <dependency>
+          <groupId>org.glassfish.jaxb</groupId>
+          <artifactId>jaxb-runtime</artifactId>
+          <version>2.4.0-b180830.0438</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
     </profile>
   </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <jackson.version>2.9.6</jackson.version>
     <assertj.version>3.10.0</assertj.version>
 
-    <animal-sniffer-maven-plugin.version>1.15</animal-sniffer-maven-plugin.version>
+    <animal-sniffer-maven-plugin.version>1.17</animal-sniffer-maven-plugin.version>
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
     <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
     <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
@@ -358,6 +358,13 @@
             </goals>
           </execution>
         </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>7.0-beta</version>
+          </dependency>
+        </dependencies>
       </plugin>
 
       <!-- Ensures checksums are added to published jars -->

--- a/pom.xml
+++ b/pom.xml
@@ -315,6 +315,7 @@
           <version>${maven-surefire-plugin.version}</version>
           <configuration>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
+            <trimStackTrace>false</trimStackTrace>
           </configuration>
         </plugin>
       </plugins>
@@ -474,14 +475,27 @@
 
   <profiles>
     <profile>
+      <id>java11</id>
       <activation>
-        <jdk>1.8</jdk>
+        <jdk>11</jdk>
       </activation>
 
       <modules>
-        <module>jackson-jaxb</module>
-        <module>jaxb</module>
+        <module>java11</module>
       </modules>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-release-plugin</artifactId>
+            <configuration>
+              <!-- so far we don't have a way to release using java 11 -->
+              <dryRun>true</dryRun>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -474,29 +474,6 @@
   </build>
 
   <profiles>
-    <profile>
-      <id>java11</id>
-      <activation>
-        <jdk>11</jdk>
-      </activation>
-
-      <modules>
-        <module>java11</module>
-      </modules>
-
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-release-plugin</artifactId>
-            <configuration>
-              <!-- so far we don't have a way to release using java 11 -->
-              <dryRun>true</dryRun>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
 
     <profile>
       <id>validateCodeFormat</id>


### PR DESCRIPTION
This was one of the last steps missing to get a functional java 11 build.

JAXB is now gone from java as part of JEP 320 http://openjdk.java.net/jeps/320

Added a dependency for java 11 builds