### PR TITLE
Fixes RecordedRequestAssert.hasNoHeaderNamed 

### DIFF
--- a/core/src/test/java/feign/assertj/RecordedRequestAssert.java
+++ b/core/src/test/java/feign/assertj/RecordedRequestAssert.java
@@ -159,7 +159,7 @@ public final class RecordedRequestAssert
     Set<String> found = new LinkedHashSet<String>();
     for (String header : actual.getHeaders().names()) {
       for (String name : names) {
-        if (header.toLowerCase().startsWith(name.toLowerCase() + ":")) {
+        if (header.equalsIgnoreCase(name)) {
           found.add(header);
         }
       }

--- a/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
+++ b/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
@@ -153,7 +153,7 @@ public final class ApacheHttpClient implements Client {
   }
 
   private ContentType getContentType(Request request) {
-    ContentType contentType = ContentType.DEFAULT_TEXT;
+    ContentType contentType = null;
     for (Map.Entry<String, Collection<String>> entry : request.headers().entrySet())
       if (entry.getKey().equalsIgnoreCase("Content-Type")) {
         Collection<String> values = entry.getValue();


### PR DESCRIPTION
Now it returns 'false' in corresponding cases.

Fixes #679