### PR TITLE
Adding Support for Query Parameter Name Expansion

### DIFF
--- a/core/src/main/java/feign/template/BodyTemplate.java
+++ b/core/src/main/java/feign/template/BodyTemplate.java
@@ -35,7 +35,7 @@ public final class BodyTemplate extends Template {
   }
 
   private BodyTemplate(String value, Charset charset) {
-    super(value, ExpansionOptions.REQUIRED, EncodingOptions.NOT_REQUIRED, false, charset);
+    super(value, ExpansionOptions.ALLOW_UNRESOLVED, EncodingOptions.NOT_REQUIRED, false, charset);
   }
 
   @Override

--- a/core/src/main/java/feign/template/BodyTemplate.java
+++ b/core/src/main/java/feign/template/BodyTemplate.java
@@ -35,7 +35,7 @@ public final class BodyTemplate extends Template {
   }
 
   private BodyTemplate(String value, Charset charset) {
-    super(value, false, false, false, charset);
+    super(value, ExpansionOptions.REQUIRED, EncodingOptions.NOT_REQUIRED, false, charset);
   }
 
   @Override

--- a/core/src/main/java/feign/template/Expression.java
+++ b/core/src/main/java/feign/template/Expression.java
@@ -68,4 +68,9 @@ abstract class Expression implements TemplateChunk {
     }
     return "{" + this.name + "}";
   }
+
+  @Override
+  public String toString() {
+    return this.getValue();
+  }
 }

--- a/core/src/main/java/feign/template/HeaderTemplate.java
+++ b/core/src/main/java/feign/template/HeaderTemplate.java
@@ -79,7 +79,7 @@ public final class HeaderTemplate extends Template {
    * @param template to parse.
    */
   private HeaderTemplate(String template, String name, Iterable<String> values, Charset charset) {
-    super(template, false, false, false, charset);
+    super(template, ExpansionOptions.REQUIRED, EncodingOptions.NOT_REQUIRED, false, charset);
     this.values = StreamSupport.stream(values.spliterator(), false)
         .filter(Util::isNotBlank)
         .collect(Collectors.toSet());

--- a/core/src/main/java/feign/template/QueryTemplate.java
+++ b/core/src/main/java/feign/template/QueryTemplate.java
@@ -19,7 +19,6 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -119,8 +118,8 @@ public final class QueryTemplate extends Template {
       Iterable<String> values,
       Charset charset,
       CollectionFormat collectionFormat) {
-    super(template, false, true, true, charset);
-    this.name = new Template(name, false, true, false, charset);
+    super(template, ExpansionOptions.REQUIRED, EncodingOptions.REQUIRED, true, charset);
+    this.name = new Template(name, ExpansionOptions.REQUIRED, EncodingOptions.REQUIRED, false, charset);
     this.collectionFormat = collectionFormat;
     this.values = StreamSupport.stream(values.spliterator(), false)
         .filter(Util::isNotBlank)

--- a/core/src/main/java/feign/template/QueryTemplate.java
+++ b/core/src/main/java/feign/template/QueryTemplate.java
@@ -119,7 +119,8 @@ public final class QueryTemplate extends Template {
       Charset charset,
       CollectionFormat collectionFormat) {
     super(template, ExpansionOptions.REQUIRED, EncodingOptions.REQUIRED, true, charset);
-    this.name = new Template(name, ExpansionOptions.REQUIRED, EncodingOptions.REQUIRED, false, charset);
+    this.name = new Template(name, ExpansionOptions.ALLOW_UNRESOLVED, EncodingOptions.REQUIRED,
+        false, charset);
     this.collectionFormat = collectionFormat;
     this.values = StreamSupport.stream(values.spliterator(), false)
         .filter(Util::isNotBlank)

--- a/core/src/main/java/feign/template/Template.java
+++ b/core/src/main/java/feign/template/Template.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
  * <a href="https://tools.ietf.org/html/rfc6570">RFC 6570</a>, with some relaxed rules, allowing the
  * concept to be used in areas outside of the uri.
  */
-public abstract class Template {
+public class Template {
 
   private static final Logger logger = Logger.getLogger(Template.class.getName());
   private static final Pattern QUERY_STRING_PATTERN = Pattern.compile("(?<!\\{)(\\?)");

--- a/core/src/main/java/feign/template/Template.java
+++ b/core/src/main/java/feign/template/Template.java
@@ -34,7 +34,7 @@ public class Template {
   private static final Pattern QUERY_STRING_PATTERN = Pattern.compile("(?<!\\{)(\\?)");
   private final String template;
   private final boolean allowUnresolved;
-  private final boolean encode;
+  private final EncodingOptions encode;
   private final boolean encodeSlash;
   private final Charset charset;
   private final List<TemplateChunk> templateChunks = new ArrayList<>();
@@ -48,12 +48,13 @@ public class Template {
    * @param encodeSlash if slash characters should be encoded.
    */
   Template(
-      String value, boolean allowUnresolved, boolean encode, boolean encodeSlash, Charset charset) {
+      String value, ExpansionOptions allowUnresolved, EncodingOptions encode, boolean encodeSlash,
+      Charset charset) {
     if (value == null) {
       throw new IllegalArgumentException("template is required.");
     }
     this.template = value;
-    this.allowUnresolved = allowUnresolved;
+    this.allowUnresolved = ExpansionOptions.ALLOW_UNRESOLVED == allowUnresolved;
     this.encode = encode;
     this.encodeSlash = encodeSlash;
     this.charset = charset;
@@ -78,7 +79,7 @@ public class Template {
         Expression expression = (Expression) chunk;
         Object value = variables.get(expression.getName());
         if (value != null) {
-          String expanded = expression.expand(value, this.encode);
+          String expanded = expression.expand(value, this.encode.isEncodingRequired());
           if (!this.encodeSlash) {
             logger.fine("Explicit slash decoding specified, decoding all slashes in uri");
             expanded = expanded.replaceAll("\\%2F", "/");
@@ -105,7 +106,7 @@ public class Template {
    * @return the encoded value.
    */
   private String encode(String value) {
-    return this.encode ? UriUtils.encode(value, this.charset) : value;
+    return this.encode.isEncodingRequired() ? UriUtils.encode(value, this.charset) : value;
   }
 
   /**
@@ -116,7 +117,7 @@ public class Template {
    * @return the encoded value
    */
   private String encode(String value, boolean query) {
-    if (this.encode) {
+    if (this.encode.isEncodingRequired()) {
       return query ? UriUtils.queryEncode(value, this.charset)
           : UriUtils.pathEncode(value, this.charset);
     } else {
@@ -218,15 +219,11 @@ public class Template {
         .map(TemplateChunk::getValue).collect(Collectors.joining());
   }
 
-  public boolean allowUnresolved() {
-    return allowUnresolved;
-  }
-
   public boolean encode() {
-    return encode;
+    return encode.isEncodingRequired();
   }
 
-  public boolean encodeSlash() {
+  boolean encodeSlash() {
     return encodeSlash;
   }
 
@@ -313,6 +310,24 @@ public class Template {
       }
       throw new IllegalStateException("No More Elements");
     }
+  }
+
+  public enum EncodingOptions {
+    REQUIRED(true), NOT_REQUIRED(false);
+
+    private boolean shouldEncode;
+
+    EncodingOptions(boolean shouldEncode) {
+      this.shouldEncode = shouldEncode;
+    }
+
+    public boolean isEncodingRequired() {
+      return this.shouldEncode;
+    }
+  }
+
+  public enum ExpansionOptions {
+    ALLOW_UNRESOLVED, REQUIRED
   }
 
 }

--- a/core/src/main/java/feign/template/UriTemplate.java
+++ b/core/src/main/java/feign/template/UriTemplate.java
@@ -70,6 +70,6 @@ public class UriTemplate extends Template {
    * @param charset to use when encoding.
    */
   private UriTemplate(String template, boolean encodeSlash, Charset charset) {
-    super(template, false, true, encodeSlash, charset);
+    super(template, ExpansionOptions.REQUIRED, EncodingOptions.REQUIRED, encodeSlash, charset);
   }
 }

--- a/core/src/test/java/feign/DefaultContractTest.java
+++ b/core/src/test/java/feign/DefaultContractTest.java
@@ -148,7 +148,8 @@ public class DefaultContractTest {
     assertThat(md.template())
         .hasHeaders(
             entry("Content-Type", asList("application/xml")),
-            entry("Content-Length", asList(String.valueOf(md.template().body().length))));
+            entry("Content-Length",
+                asList(String.valueOf(md.template().requestBody().asBytes().length))));
   }
 
   @Test
@@ -158,7 +159,8 @@ public class DefaultContractTest {
     assertThat(md.template())
         .hasHeaders(
             entry("Content-Type", asList("application/xml")),
-            entry("Content-Length", asList(String.valueOf(md.template().body().length))));
+            entry("Content-Length",
+                asList(String.valueOf(md.template().requestBody().asBytes().length))));
   }
 
   @Test
@@ -168,7 +170,8 @@ public class DefaultContractTest {
     assertThat(md.template())
         .hasHeaders(
             entry("Content-Type", asList("application/xml")),
-            entry("Content-Length", asList(String.valueOf(md.template().body().length))));
+            entry("Content-Length",
+                asList(String.valueOf(md.template().requestBody().asBytes().length))));
   }
 
   @Test

--- a/core/src/test/java/feign/DefaultContractTest.java
+++ b/core/src/test/java/feign/DefaultContractTest.java
@@ -15,6 +15,7 @@ package feign;
 
 import com.google.gson.reflect.TypeToken;
 import java.util.ArrayList;
+import java.util.Collections;
 import org.assertj.core.api.Fail;
 import org.junit.Rule;
 import org.junit.Test;

--- a/core/src/test/java/feign/template/QueryTemplateTest.java
+++ b/core/src/test/java/feign/template/QueryTemplateTest.java
@@ -94,4 +94,12 @@ public class QueryTemplateTest {
     String expanded = template.expand(Collections.singletonMap("name", "firsts"));
     assertThat(expanded).isEqualToIgnoringCase("/path/firsts");
   }
+
+  @Test
+  public void expandNameUnresolved() {
+    QueryTemplate template =
+        QueryTemplate.create("{parameter}", Arrays.asList("James", "Jason"), Util.UTF_8);
+    String expanded = template.expand(Collections.singletonMap("name", "firsts"));
+    assertThat(expanded).isEqualToIgnoringCase("%7Bparameter%7D=James&%7Bparameter%7D=Jason");
+  }
 }

--- a/core/src/test/java/feign/template/QueryTemplateTest.java
+++ b/core/src/test/java/feign/template/QueryTemplateTest.java
@@ -71,4 +71,27 @@ public class QueryTemplateTest {
     assertThat(expanded).isEqualToIgnoringCase("name=James,Jason");
   }
 
+  @Test
+  public void expandName() {
+    QueryTemplate template =
+        QueryTemplate.create("{name}", Arrays.asList("James", "Jason"), Util.UTF_8);
+    String expanded = template.expand(Collections.singletonMap("name", "firsts"));
+    assertThat(expanded).isEqualToIgnoringCase("firsts=James&firsts=Jason");
+  }
+
+  @Test
+  public void expandPureParameter() {
+    QueryTemplate template =
+        QueryTemplate.create("{name}", Collections.emptyList(), Util.UTF_8);
+    String expanded = template.expand(Collections.singletonMap("name", "firsts"));
+    assertThat(expanded).isEqualToIgnoringCase("firsts");
+  }
+
+  @Test
+  public void expandPureParameterWithSlash() {
+    QueryTemplate template =
+        QueryTemplate.create("/path/{name}", Collections.emptyList(), Util.UTF_8);
+    String expanded = template.expand(Collections.singletonMap("name", "firsts"));
+    assertThat(expanded).isEqualToIgnoringCase("/path/firsts");
+  }
 }


### PR DESCRIPTION
Fixes #838

`QueryTemplate` assumed that all query names were literals.  This change
adds support for Expressions in Query Parameter names, providing better
adherence to RFC 6570.

RequestLines such as `@RequestLine("GET /uri?{parameter}={value}")` are
now fully expanded whereas before, only `{value}` would be.