### PR TITLE
Fixes NPE when a Response does not provide headers

### DIFF
--- a/core/src/main/java/feign/Response.java
+++ b/core/src/main/java/feign/Response.java
@@ -22,6 +22,7 @@ import java.io.Reader;
 import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Locale;
 import java.util.Map;
@@ -49,7 +50,9 @@ public final class Response implements Closeable {
     this.status = builder.status;
     this.request = builder.request;
     this.reason = builder.reason; // nullable
-    this.headers = Collections.unmodifiableMap(caseInsensitiveCopyOf(builder.headers));
+    this.headers = (builder.headers != null)
+        ? Collections.unmodifiableMap(caseInsensitiveCopyOf(builder.headers))
+        : new LinkedHashMap<>();
     this.body = builder.body; // nullable
   }
 

--- a/core/src/test/java/feign/ResponseTest.java
+++ b/core/src/test/java/feign/ResponseTest.java
@@ -71,4 +71,14 @@ public class ResponseTest {
         Arrays.asList("Cookie-A=Value", "Cookie-B=Value", "Cookie-C=Value");
     assertThat(response.headers()).containsOnly(entry(("set-cookie"), expectedHeaderValue));
   }
+
+  @Test
+  public void headersAreOptional() {
+    Response response = Response.builder()
+        .status(200)
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .body(new byte[0])
+        .build();
+    assertThat(response.headers()).isNotNull().isEmpty();
+  }
 }


### PR DESCRIPTION
Fixes #853

There are some scenarios reported where a server does
not provide headers with the response.  While this is
not typically expected, it's simple enough for Feign to
be resilient to it.  This change checks the headers provided
in the builder and if none are provided, an empty map is
used in it's place.