### PR TITLE
Exposes Charset on Request.Body for inspection

### DIFF
--- a/core/src/main/java/feign/Request.java
+++ b/core/src/main/java/feign/Request.java
@@ -82,6 +82,10 @@ public final class Request {
       return new Request.Body(null, null, null);
     }
 
+    public Charset charset() {
+      return this.encoding;
+    }
+
   }
 
   public enum HttpMethod {
@@ -187,7 +191,7 @@ public final class Request {
    * @deprecated use {@link #requestBody()} instead
    */
   public Charset charset() {
-    return body.encoding;
+    return body.charset();
   }
 
   /**


### PR DESCRIPTION
Fixes #847

When `Request.Body` was introduced, `Request.charset()` was deprecated
in favor of `Request.Body`, but `Request.Body` did not expose the
`Charset` publically.  This change adds a new `charset()` function to
`Request.Body` correcting this oversight.