### PR TITLE
Refactored RequestTemplate Body Handling

### DIFF
--- a/core/src/main/java/feign/Feign.java
+++ b/core/src/main/java/feign/Feign.java
@@ -13,6 +13,7 @@
  */
 package feign;
 
+import feign.querymap.FieldQueryMapEncoder;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
@@ -103,7 +104,7 @@ public abstract class Feign {
     private Logger logger = new NoOpLogger();
     private Encoder encoder = new Encoder.Default();
     private Decoder decoder = new Decoder.Default();
-    private QueryMapEncoder queryMapEncoder = new QueryMapEncoder.Default();
+    private QueryMapEncoder queryMapEncoder = new FieldQueryMapEncoder();
     private ErrorDecoder errorDecoder = new ErrorDecoder.Default();
     private Options options = new Options();
     private InvocationHandlerFactory invocationHandlerFactory =

--- a/core/src/main/java/feign/template/BodyTemplate.java
+++ b/core/src/main/java/feign/template/BodyTemplate.java
@@ -31,15 +31,16 @@ public final class BodyTemplate extends Template {
    * @return a Body Template instance.
    */
   public static BodyTemplate create(String template) {
-    return new BodyTemplate(template, Util.UTF_8);
+    return new BodyTemplate(template);
   }
 
-  private BodyTemplate(String value, Charset charset) {
-    super(value, ExpansionOptions.ALLOW_UNRESOLVED, EncodingOptions.NOT_REQUIRED, false, charset);
+  private BodyTemplate(String value) {
+    super(value, ExpansionOptions.ALLOW_UNRESOLVED, EncodingOptions.NOT_REQUIRED, false,
+        Util.UTF_8);
   }
 
   @Override
   public String expand(Map<String, ?> variables) {
-    return UriUtils.decode(super.expand(variables), Util.UTF_8);
+    return UriUtils.decode(super.expand(variables), this.getCharset());
   }
 }

--- a/core/src/main/java/feign/template/HeaderTemplate.java
+++ b/core/src/main/java/feign/template/HeaderTemplate.java
@@ -34,6 +34,7 @@ public final class HeaderTemplate extends Template {
   private String name;
 
   public static HeaderTemplate create(String name, Iterable<String> values) {
+
     if (name == null || name.isEmpty()) {
       throw new IllegalArgumentException("name is required.");
     }
@@ -55,7 +56,7 @@ public final class HeaderTemplate extends Template {
         template.append(", ");
       }
     }
-    return new HeaderTemplate(template.toString(), name, values, Util.UTF_8);
+    return new HeaderTemplate(template.toString(), name, values);
   }
 
   /**
@@ -78,8 +79,8 @@ public final class HeaderTemplate extends Template {
    *
    * @param template to parse.
    */
-  private HeaderTemplate(String template, String name, Iterable<String> values, Charset charset) {
-    super(template, ExpansionOptions.REQUIRED, EncodingOptions.NOT_REQUIRED, false, charset);
+  private HeaderTemplate(String template, String name, Iterable<String> values) {
+    super(template, ExpansionOptions.REQUIRED, EncodingOptions.NOT_REQUIRED, false, Util.UTF_8);
     this.values = StreamSupport.stream(values.spliterator(), false)
         .filter(Util::isNotBlank)
         .collect(Collectors.toSet());

--- a/core/src/main/java/feign/template/QueryTemplate.java
+++ b/core/src/main/java/feign/template/QueryTemplate.java
@@ -15,7 +15,6 @@ package feign.template;
 
 import feign.CollectionFormat;
 import feign.Util;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -41,11 +40,10 @@ public final class QueryTemplate extends Template {
    *
    * @param name of the query parameter.
    * @param values in the template.
-   * @param charset for the template.
    * @return a QueryTemplate.
    */
-  public static QueryTemplate create(String name, Iterable<String> values, Charset charset) {
-    return create(name, values, charset, CollectionFormat.EXPLODED);
+  public static QueryTemplate create(String name, Iterable<String> values) {
+    return create(name, values, CollectionFormat.EXPLODED);
   }
 
   /**
@@ -53,13 +51,11 @@ public final class QueryTemplate extends Template {
    *
    * @param name of the query parameter.
    * @param values in the template.
-   * @param charset for the template.
    * @param collectionFormat to use.
    * @return a QueryTemplate
    */
   public static QueryTemplate create(String name,
                                      Iterable<String> values,
-                                     Charset charset,
                                      CollectionFormat collectionFormat) {
     if (name == null || name.isEmpty()) {
       throw new IllegalArgumentException("name is required.");
@@ -83,7 +79,7 @@ public final class QueryTemplate extends Template {
       }
     }
 
-    return new QueryTemplate(template.toString(), name, remaining, charset, collectionFormat);
+    return new QueryTemplate(template.toString(), name, remaining, collectionFormat);
   }
 
   /**
@@ -100,7 +96,7 @@ public final class QueryTemplate extends Template {
     queryValues.addAll(StreamSupport.stream(values.spliterator(), false)
         .filter(Util::isNotBlank)
         .collect(Collectors.toList()));
-    return create(queryTemplate.getName(), queryValues, queryTemplate.getCharset(),
+    return create(queryTemplate.getName(), queryValues,
         collectionFormat);
   }
 
@@ -116,11 +112,10 @@ public final class QueryTemplate extends Template {
       String template,
       String name,
       Iterable<String> values,
-      Charset charset,
       CollectionFormat collectionFormat) {
-    super(template, ExpansionOptions.REQUIRED, EncodingOptions.REQUIRED, true, charset);
+    super(template, ExpansionOptions.REQUIRED, EncodingOptions.REQUIRED, true, Util.UTF_8);
     this.name = new Template(name, ExpansionOptions.ALLOW_UNRESOLVED, EncodingOptions.REQUIRED,
-        false, charset);
+        false, Util.UTF_8);
     this.collectionFormat = collectionFormat;
     this.values = StreamSupport.stream(values.spliterator(), false)
         .filter(Util::isNotBlank)

--- a/core/src/main/java/feign/template/UriTemplate.java
+++ b/core/src/main/java/feign/template/UriTemplate.java
@@ -13,6 +13,7 @@
  */
 package feign.template;
 
+import feign.Util;
 import java.nio.charset.Charset;
 
 /**
@@ -31,11 +32,10 @@ public class UriTemplate extends Template {
    * Create a Uri Template.
    *
    * @param template representing the uri.
-   * @param charset for encoding.
    * @return a new Uri Template instance.
    */
-  public static UriTemplate create(String template, Charset charset) {
-    return new UriTemplate(template, true, charset);
+  public static UriTemplate create(String template) {
+    return new UriTemplate(template, true);
   }
 
   /**
@@ -43,11 +43,10 @@ public class UriTemplate extends Template {
    *
    * @param template representing the uri
    * @param encodeSlash flag if slash characters should be encoded.
-   * @param charset for the template.
    * @return a new Uri Template instance.
    */
-  public static UriTemplate create(String template, boolean encodeSlash, Charset charset) {
-    return new UriTemplate(template, encodeSlash, charset);
+  public static UriTemplate create(String template, boolean encodeSlash) {
+    return new UriTemplate(template, encodeSlash);
   }
 
   /**
@@ -58,8 +57,7 @@ public class UriTemplate extends Template {
    * @return a new UriTemplate with the fragment appended.
    */
   public static UriTemplate append(UriTemplate uriTemplate, String fragment) {
-    return new UriTemplate(uriTemplate.toString() + fragment, uriTemplate.encodeSlash(),
-        uriTemplate.getCharset());
+    return new UriTemplate(uriTemplate.toString() + fragment, uriTemplate.encodeSlash());
   }
 
   /**
@@ -67,9 +65,8 @@ public class UriTemplate extends Template {
    *
    * @param template for the uri.
    * @param encodeSlash flag for encoding slash characters.
-   * @param charset to use when encoding.
    */
-  private UriTemplate(String template, boolean encodeSlash, Charset charset) {
-    super(template, ExpansionOptions.REQUIRED, EncodingOptions.REQUIRED, encodeSlash, charset);
+  private UriTemplate(String template, boolean encodeSlash) {
+    super(template, ExpansionOptions.REQUIRED, EncodingOptions.REQUIRED, encodeSlash, Util.UTF_8);
   }
 }

--- a/core/src/test/java/feign/DefaultContractTest.java
+++ b/core/src/test/java/feign/DefaultContractTest.java
@@ -149,7 +149,7 @@ public class DefaultContractTest {
         .hasHeaders(
             entry("Content-Type", asList("application/xml")),
             entry("Content-Length",
-                asList(String.valueOf(md.template().requestBody().asBytes().length))));
+                asList(String.valueOf(md.template().body().length))));
   }
 
   @Test
@@ -160,7 +160,7 @@ public class DefaultContractTest {
         .hasHeaders(
             entry("Content-Type", asList("application/xml")),
             entry("Content-Length",
-                asList(String.valueOf(md.template().requestBody().asBytes().length))));
+                asList(String.valueOf(md.template().body().length))));
   }
 
   @Test
@@ -171,7 +171,7 @@ public class DefaultContractTest {
         .hasHeaders(
             entry("Content-Type", asList("application/xml")),
             entry("Content-Length",
-                asList(String.valueOf(md.template().requestBody().asBytes().length))));
+                asList(String.valueOf(md.template().body().length))));
   }
 
   @Test

--- a/core/src/test/java/feign/DefaultQueryMapEncoderTest.java
+++ b/core/src/test/java/feign/DefaultQueryMapEncoderTest.java
@@ -13,6 +13,7 @@
  */
 package feign;
 
+import feign.querymap.FieldQueryMapEncoder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -26,7 +27,7 @@ public class DefaultQueryMapEncoderTest {
   @Rule
   public final ExpectedException thrown = ExpectedException.none();
 
-  private final QueryMapEncoder encoder = new QueryMapEncoder.Default();
+  private final QueryMapEncoder encoder = new FieldQueryMapEncoder();
 
   @Test
   public void testEncodesObject_visibleFields() {

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -94,18 +94,6 @@ public class RequestTemplateTest {
   }
 
   @Test
-  public void resolveTemplateWithBinaryBody() {
-    RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)
-        .uri("{zoneId}")
-        .body(new byte[] {7, 3, -3, -7}, null);
-
-    template = template.resolve(mapOf("zoneId", "/hostedzone/Z1PA6795UKMFR9"));
-
-    assertThat(template)
-        .hasUrl("/hostedzone/Z1PA6795UKMFR9");
-  }
-
-  @Test
   public void canInsertAbsoluteHref() {
     RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)
         .uri("/hostedzone/Z1PA6795UKMFR9");
@@ -419,5 +407,15 @@ public class RequestTemplateTest {
     assertThat(template.headers().keySet()).containsExactly("key1");
 
     template.headers().put("key2", Collections.singletonList("other value"));
+  }
+
+  @Test
+  public void resolveTemplateWithBinaryBody() {
+    RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)
+        .uri("{zoneId}")
+        .body(new byte[] {7, 3, -3, -7}, null);
+    template = template.resolve(mapOf("zoneId", "/hostedzone/Z1PA6795UKMFR9"));
+    assertThat(template)
+        .hasUrl("/hostedzone/Z1PA6795UKMFR9");
   }
 }

--- a/core/src/test/java/feign/template/QueryTemplateTest.java
+++ b/core/src/test/java/feign/template/QueryTemplateTest.java
@@ -26,14 +26,14 @@ public class QueryTemplateTest {
   @Test
   public void templateToQueryString() {
     QueryTemplate template =
-        QueryTemplate.create("name", Arrays.asList("Bob", "James", "Jason"), Util.UTF_8);
+        QueryTemplate.create("name", Arrays.asList("Bob", "James", "Jason"));
     assertThat(template.toString()).isEqualToIgnoringCase("name=Bob&name=James&name=Jason");
   }
 
   @Test
   public void expandSingleValue() {
     QueryTemplate template =
-        QueryTemplate.create("name", Collections.singletonList("{value}"), Util.UTF_8);
+        QueryTemplate.create("name", Collections.singletonList("{value}"));
     String expanded = template.expand(Collections.singletonMap("value", "Magnum P.I."));
     assertThat(expanded).isEqualToIgnoringCase("name=Magnum%20P.I.");
   }
@@ -41,7 +41,7 @@ public class QueryTemplateTest {
   @Test
   public void expandMultipleValues() {
     QueryTemplate template =
-        QueryTemplate.create("name", Arrays.asList("Bob", "James", "Jason"), Util.UTF_8);
+        QueryTemplate.create("name", Arrays.asList("Bob", "James", "Jason"));
     String expanded = template.expand(Collections.emptyMap());
     assertThat(expanded).isEqualToIgnoringCase("name=Bob&name=James&name=Jason");
   }
@@ -49,7 +49,7 @@ public class QueryTemplateTest {
   @Test
   public void unresolvedQuery() {
     QueryTemplate template =
-        QueryTemplate.create("name", Collections.singletonList("{value}"), Util.UTF_8);
+        QueryTemplate.create("name", Collections.singletonList("{value}"));
     String expanded = template.expand(Collections.emptyMap());
     assertThat(expanded).isNullOrEmpty();
   }
@@ -57,7 +57,7 @@ public class QueryTemplateTest {
   @Test
   public void unresolvedMultiValueQueryTemplates() {
     QueryTemplate template =
-        QueryTemplate.create("name", Arrays.asList("{bob}", "{james}", "{jason}"), Util.UTF_8);
+        QueryTemplate.create("name", Arrays.asList("{bob}", "{james}", "{jason}"));
     String expanded = template.expand(Collections.emptyMap());
     assertThat(expanded).isNullOrEmpty();
   }
@@ -66,7 +66,7 @@ public class QueryTemplateTest {
   public void collectionFormat() {
     QueryTemplate template =
         QueryTemplate
-            .create("name", Arrays.asList("James", "Jason"), Util.UTF_8, CollectionFormat.CSV);
+            .create("name", Arrays.asList("James", "Jason"), CollectionFormat.CSV);
     String expanded = template.expand(Collections.emptyMap());
     assertThat(expanded).isEqualToIgnoringCase("name=James,Jason");
   }
@@ -74,7 +74,7 @@ public class QueryTemplateTest {
   @Test
   public void expandName() {
     QueryTemplate template =
-        QueryTemplate.create("{name}", Arrays.asList("James", "Jason"), Util.UTF_8);
+        QueryTemplate.create("{name}", Arrays.asList("James", "Jason"));
     String expanded = template.expand(Collections.singletonMap("name", "firsts"));
     assertThat(expanded).isEqualToIgnoringCase("firsts=James&firsts=Jason");
   }
@@ -82,7 +82,7 @@ public class QueryTemplateTest {
   @Test
   public void expandPureParameter() {
     QueryTemplate template =
-        QueryTemplate.create("{name}", Collections.emptyList(), Util.UTF_8);
+        QueryTemplate.create("{name}", Collections.emptyList());
     String expanded = template.expand(Collections.singletonMap("name", "firsts"));
     assertThat(expanded).isEqualToIgnoringCase("firsts");
   }
@@ -90,7 +90,7 @@ public class QueryTemplateTest {
   @Test
   public void expandPureParameterWithSlash() {
     QueryTemplate template =
-        QueryTemplate.create("/path/{name}", Collections.emptyList(), Util.UTF_8);
+        QueryTemplate.create("/path/{name}", Collections.emptyList());
     String expanded = template.expand(Collections.singletonMap("name", "firsts"));
     assertThat(expanded).isEqualToIgnoringCase("/path/firsts");
   }
@@ -98,7 +98,7 @@ public class QueryTemplateTest {
   @Test
   public void expandNameUnresolved() {
     QueryTemplate template =
-        QueryTemplate.create("{parameter}", Arrays.asList("James", "Jason"), Util.UTF_8);
+        QueryTemplate.create("{parameter}", Arrays.asList("James", "Jason"));
     String expanded = template.expand(Collections.singletonMap("name", "firsts"));
     assertThat(expanded).isEqualToIgnoringCase("%7Bparameter%7D=James&%7Bparameter%7D=Jason");
   }

--- a/core/src/test/java/feign/template/UriTemplateTest.java
+++ b/core/src/test/java/feign/template/UriTemplateTest.java
@@ -28,24 +28,24 @@ public class UriTemplateTest {
   @Test
   public void emptyRelativeTemplate() {
     String template = "/";
-    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    UriTemplate uriTemplate = UriTemplate.create(template);
     assertThat(uriTemplate.expand(Collections.emptyMap())).isEqualToIgnoringCase("/");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void nullTemplate() {
-    UriTemplate.create(null, Util.UTF_8);
+    UriTemplate.create(null);
   }
 
   @Test
   public void emptyTemplate() {
-    UriTemplate.create("", Util.UTF_8);
+    UriTemplate.create("");
   }
 
   @Test
   public void simpleTemplate() {
     String template = "https://www.example.com/foo/{bar}";
-    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    UriTemplate uriTemplate = UriTemplate.create(template);
 
     /* verify that the template has 1 variables names foo */
     List<String> uriTemplateVariables = uriTemplate.getVariables();
@@ -62,7 +62,7 @@ public class UriTemplateTest {
   @Test
   public void simpleTemplateMultipleExpressions() {
     String template = "https://www.example.com/{foo}/{bar}/details";
-    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    UriTemplate uriTemplate = UriTemplate.create(template);
 
     /* verify that the template has 2 variables names foo and bar */
     List<String> uriTemplateVariables = uriTemplate.getVariables();
@@ -81,7 +81,7 @@ public class UriTemplateTest {
   @Test
   public void simpleTemplateMultipleSequentialExpressions() {
     String template = "https://www.example.com/{foo}{bar}/{baz}/details";
-    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    UriTemplate uriTemplate = UriTemplate.create(template);
 
     /* verify that the template has 2 variables names foo and bar */
     List<String> uriTemplateVariables = uriTemplate.getVariables();
@@ -101,7 +101,7 @@ public class UriTemplateTest {
   @Test
   public void simpleTemplateUnresolvedVariablesAreRemoved() {
     String template = "https://www.example.com/{foo}?name={name}";
-    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    UriTemplate uriTemplate = UriTemplate.create(template);
     assertThat(uriTemplate.getVariables()).contains("foo", "name").hasSize(2);
 
     Map<String, Object> variables = new LinkedHashMap<>();
@@ -114,7 +114,7 @@ public class UriTemplateTest {
   @Test
   public void missingVariablesOnPathAreRemoved() {
     String template = "https://www.example.com/{foo}/items?name={name}";
-    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    UriTemplate uriTemplate = UriTemplate.create(template);
     assertThat(uriTemplate.getVariables()).contains("foo", "name").hasSize(2);
 
     Map<String, Object> variables = new LinkedHashMap<>();
@@ -128,7 +128,7 @@ public class UriTemplateTest {
   @Test
   public void simpleTemplateWithRegularExpressions() {
     String template = "https://www.example.com/{foo:[0-9]{4}}/{bar}";
-    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    UriTemplate uriTemplate = UriTemplate.create(template);
     assertThat(uriTemplate.getVariables()).contains("foo", "bar").hasSize(2);
 
     Map<String, Object> variables = new LinkedHashMap<>();
@@ -142,7 +142,7 @@ public class UriTemplateTest {
   @Test(expected = IllegalArgumentException.class)
   public void simpleTemplateWithRegularExpressionsValidation() {
     String template = "https://www.example.com/{foo:[0-9]{4}}/{bar}";
-    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    UriTemplate uriTemplate = UriTemplate.create(template);
     assertThat(uriTemplate.getVariables()).contains("foo", "bar").hasSize(2);
 
     Map<String, Object> variables = new LinkedHashMap<>();
@@ -158,7 +158,7 @@ public class UriTemplateTest {
   public void nestedExpressionsAreLiterals() {
     /* the template of {foo{bar}}, will be treated as literals as nested templates are ignored */
     String template = "https://www.example.com/{foo{bar}}/{baz}";
-    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    UriTemplate uriTemplate = UriTemplate.create(template);
     assertThat(uriTemplate.getVariables()).contains("baz").hasSize(1);
 
     Map<String, Object> variables = new LinkedHashMap<>();
@@ -173,7 +173,7 @@ public class UriTemplateTest {
   @Test
   public void literalTemplate() {
     String template = "https://www.example.com/do/stuff";
-    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    UriTemplate uriTemplate = UriTemplate.create(template);
     String expandedTemplate = uriTemplate.expand(Collections.emptyMap());
     assertThat(expandedTemplate).isEqualToIgnoringCase(template);
     assertThat(URI.create(expandedTemplate)).isNotNull();
@@ -182,21 +182,21 @@ public class UriTemplateTest {
   @Test(expected = IllegalArgumentException.class)
   public void rejectEmptyExpressions() {
     String template = "https://www.example.com/{}/things";
-    UriTemplate.create(template, Util.UTF_8);
+    UriTemplate.create(template);
     fail("Should not accept empty expressions");
   }
 
   @Test
   public void testToString() {
     String template = "https://www.example.com/foo/{bar}/{baz:[0-9]}";
-    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    UriTemplate uriTemplate = UriTemplate.create(template);
     assertThat(uriTemplate.toString()).isEqualToIgnoringCase(template);
   }
 
   @Test
   public void encodeVariables() {
     String template = "https://www.example.com/{first}/{last}";
-    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    UriTemplate uriTemplate = UriTemplate.create(template);
     Map<String, Object> variables = new LinkedHashMap<>();
     variables.put("first", "John Jacob");
     variables.put("last", "Jingleheimer Schmidt");
@@ -208,7 +208,7 @@ public class UriTemplateTest {
   @Test
   public void encodeLiterals() {
     String template = "https://www.example.com/A Team";
-    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    UriTemplate uriTemplate = UriTemplate.create(template);
     String expandedTemplate = uriTemplate.expand(Collections.emptyMap());
     assertThat(expandedTemplate)
         .isEqualToIgnoringCase("https://www.example.com/A%20Team");
@@ -217,7 +217,7 @@ public class UriTemplateTest {
   @Test
   public void ensurePlusIsSupportedOnPath() {
     String template = "https://www.example.com/sam+adams/beer/{type}";
-    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    UriTemplate uriTemplate = UriTemplate.create(template);
     String expanded = uriTemplate.expand(Collections.emptyMap());
     assertThat(expanded).isEqualToIgnoringCase("https://www.example.com/sam+adams/beer/");
   }
@@ -225,20 +225,20 @@ public class UriTemplateTest {
   @Test
   public void incompleteTemplateIsALiteral() {
     String template = "https://www.example.com/testing/foo}}";
-    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    UriTemplate uriTemplate = UriTemplate.create(template);
     assertThat(uriTemplate.expand(Collections.emptyMap()))
         .isEqualToIgnoringCase("https://www.example.com/testing/foo%7D%7D");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void substituteNullMap() {
-    UriTemplate.create("stuff", Util.UTF_8).expand(null);
+    UriTemplate.create("stuff").expand(null);
   }
 
   @Test
   public void skipAlreadyEncodedLiteral() {
     String template = "https://www.example.com/A%20Team";
-    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    UriTemplate uriTemplate = UriTemplate.create(template);
     String expandedTemplate = uriTemplate.expand(Collections.emptyMap());
     assertThat(expandedTemplate)
         .isEqualToIgnoringCase("https://www.example.com/A%20Team");
@@ -247,8 +247,8 @@ public class UriTemplateTest {
   @Test
   public void skipAlreadyEncodedVariable() {
     String template = "https://www.example.com/testing/{foo}";
-    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
-    String encodedVariable = UriUtils.encode("Johnny Appleseed", Util.UTF_8);
+    UriTemplate uriTemplate = UriTemplate.create(template);
+    String encodedVariable = UriUtils.encode("Johnny Appleseed");
     Map<String, Object> variables = new LinkedHashMap<>();
     variables.put("foo", encodedVariable);
     assertThat(uriTemplate.expand(variables))
@@ -258,7 +258,7 @@ public class UriTemplateTest {
   @Test
   public void skipSlashes() {
     String template = "https://www.example.com/{path}";
-    UriTemplate uriTemplate = UriTemplate.create(template, false, Util.UTF_8);
+    UriTemplate uriTemplate = UriTemplate.create(template, false);
     Map<String, Object> variables = new LinkedHashMap<>();
     variables.put("path", "me/you/first");
     String encoded = uriTemplate.expand(variables);
@@ -268,7 +268,7 @@ public class UriTemplateTest {
   @Test
   public void encodeSlashes() {
     String template = "https://www.example.com/{path}";
-    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    UriTemplate uriTemplate = UriTemplate.create(template);
     Map<String, Object> variables = new LinkedHashMap<>();
     variables.put("path", "me/you/first");
     String encoded = uriTemplate.expand(variables);
@@ -278,7 +278,7 @@ public class UriTemplateTest {
   @Test
   public void testLiteralTemplateWithQueryString() {
     String template = "https://api.example.com?wsdl";
-    UriTemplate uriTemplate = UriTemplate.create(template, Util.UTF_8);
+    UriTemplate uriTemplate = UriTemplate.create(template);
     String expanded = uriTemplate.expand(Collections.emptyMap());
     assertThat(expanded).isEqualToIgnoringCase("https://api.example.com?wsdl");
   }

--- a/jaxb/src/test/java/feign/jaxb/examples/AWSSignatureVersion4.java
+++ b/jaxb/src/test/java/feign/jaxb/examples/AWSSignatureVersion4.java
@@ -75,7 +75,9 @@ public class AWSSignatureVersion4 {
     canonicalRequest.append("host").append('\n');
 
     // HexEncode(Hash(Payload))
-    String bodyText = input.requestBody().asString();
+    String bodyText =
+        input.charset() != null && input.body() != null ? new String(input.body(), input.charset())
+            : null;
     if (bodyText != null) {
       canonicalRequest.append(hex(sha256(bodyText)));
     } else {

--- a/mock/src/main/java/feign/mock/MockClient.java
+++ b/mock/src/main/java/feign/mock/MockClient.java
@@ -83,7 +83,7 @@ public class MockClient implements Client {
 
     RequestResponse expectedRequestResponse = responseIterator.next();
     if (!expectedRequestResponse.requestKey.equalsExtended(requestKey)) {
-      throw new VerificationAssertionError("Expected: \n%s,\nbut was: \n%s",
+      throw new VerificationAssertionError("Expected %s, but was %s",
           expectedRequestResponse.requestKey,
           requestKey);
     }

--- a/mock/src/test/java/feign/mock/MockClientSequentialTest.java
+++ b/mock/src/test/java/feign/mock/MockClientSequentialTest.java
@@ -167,7 +167,7 @@ public class MockClientSequentialTest {
       githubSequential.contributors("7 7", "netflix", "feign");
       fail();
     } catch (VerificationAssertionError e) {
-      assertThat(e.getMessage(), startsWith("Expected: \nRequest ["));
+      assertThat(e.getMessage(), startsWith("Expected Request ["));
     }
   }
 

--- a/ribbon/src/main/java/feign/ribbon/LBClient.java
+++ b/ribbon/src/main/java/feign/ribbon/LBClient.java
@@ -118,7 +118,7 @@ public final class LBClient extends
     Request toRequest() {
       // add header "Content-Length" according to the request body
       final byte[] body = request.body();
-      final int bodyLength = body != null ? body.length : 0;
+      final int bodyLength = request.contentLength();
       // create a new Map to avoid side effect, not to change the old headers
       Map<String, Collection<String>> headers = new LinkedHashMap<String, Collection<String>>();
       headers.putAll(request.headers());

--- a/ribbon/src/test/java/feign/ribbon/LBClientTest.java
+++ b/ribbon/src/test/java/feign/ribbon/LBClientTest.java
@@ -54,8 +54,8 @@ public class LBClientTest {
     // test that requestOrigin and requestRecreate are same except the header 'Content-Length'
     // ps, requestOrigin and requestRecreate won't be null
     assertThat(requestOrigin.toString())
-        .contains(String.format("%s %s HTTP/1.1\n", method, urlWithEncodedJson));
-    assertThat(requestRecreate.toString())
-        .contains(String.format("%s %s HTTP/1.1\nContent-Length: 0\n", method, urlWithEncodedJson));
+        .isEqualTo(String.format("%s %s HTTP/1.1\n", method, urlWithEncodedJson));
+    assertThat(requestRecreate.toString()).isEqualTo(
+        String.format("%s %s HTTP/1.1\nContent-Length: 0\n", method, urlWithEncodedJson));
   }
 }

--- a/sax/src/test/java/feign/sax/examples/AWSSignatureVersion4.java
+++ b/sax/src/test/java/feign/sax/examples/AWSSignatureVersion4.java
@@ -75,7 +75,9 @@ public class AWSSignatureVersion4 {
     canonicalRequest.append("host").append('\n');
 
     // HexEncode(Hash(Payload))
-    String bodyText = input.requestBody().asString();
+    String bodyText =
+        input.charset() != null && input.body() != null ? new String(input.body(), input.charset())
+            : null;
     if (bodyText != null) {
       canonicalRequest.append(hex(sha256(bodyText)));
     } else {


### PR DESCRIPTION
Fixes #857

Changes introduced in #821 deprecated a number of methods on `RequestTemplate`
whose usage throughout the rest of the library was quite prevalent.
While attempting to refactor that usage, a number of additional issues
related to #821 came to light.  The most important one is that the charset
at the `RequestTemplate` level applied only to the resulting `Request` and
did not need to be applied to the `Template` based classes.

It was this mistake, propagating the `RequestTemplate#charset` to the
`Template` objects, was the root cause of the NPE addressed in #821.

This change reverts #821 in favor of a simpler approach that addresses
the original issue and maintains the `Request.Body` abstraction, while
removing the `@deprecation` notices.

Revert "NPE when resolving a template with binary body (#821)"
This reverts commit 4da6d5cad674e4eeae5b56035ac1f94992499449.