### PR TITLE
Allow 1xx status codes

### DIFF
--- a/core/src/main/java/feign/Response.java
+++ b/core/src/main/java/feign/Response.java
@@ -45,7 +45,7 @@ public final class Response implements Closeable {
   private final Request request;
 
   private Response(Builder builder) {
-    checkState(builder.status >= 100, "Invalid status code: %s", builder.status);
+    checkState(builder.status >= 100 && builder.status < 600, "Invalid status code: %s", builder.status);
     checkState(builder.request != null, "original request is required");
     this.status = builder.status;
     this.request = builder.request;

--- a/core/src/main/java/feign/Response.java
+++ b/core/src/main/java/feign/Response.java
@@ -45,7 +45,8 @@ public final class Response implements Closeable {
   private final Request request;
 
   private Response(Builder builder) {
-    checkState(builder.status >= 100 && builder.status < 600, "Invalid status code: %s", builder.status);
+    checkState(builder.status >= 100 && builder.status < 600, "Invalid status code: %s",
+        builder.status);
     checkState(builder.request != null, "original request is required");
     this.status = builder.status;
     this.request = builder.request;

--- a/core/src/main/java/feign/Response.java
+++ b/core/src/main/java/feign/Response.java
@@ -45,7 +45,7 @@ public final class Response implements Closeable {
   private final Request request;
 
   private Response(Builder builder) {
-    checkState(builder.status >= 200, "Invalid status code: %s", builder.status);
+    checkState(builder.status >= 100, "Invalid status code: %s", builder.status);
     checkState(builder.request != null, "original request is required");
     this.status = builder.status;
     this.request = builder.request;

--- a/core/src/main/java/feign/Response.java
+++ b/core/src/main/java/feign/Response.java
@@ -45,8 +45,6 @@ public final class Response implements Closeable {
   private final Request request;
 
   private Response(Builder builder) {
-    checkState(builder.status >= 100 && builder.status < 600, "Invalid status code: %s",
-        builder.status);
     checkState(builder.request != null, "original request is required");
     this.status = builder.status;
     this.request = builder.request;

--- a/core/src/test/java/feign/ResponseTest.java
+++ b/core/src/test/java/feign/ResponseTest.java
@@ -100,8 +100,7 @@ public class ResponseTest {
         .status(600)
         .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .body((Response.Body) null)
-        .build()
-    );
+        .build());
 
     assertThat(thrown).isInstanceOf(IllegalStateException.class);
     assertThat(thrown).hasMessage("Invalid status code: 600");

--- a/core/src/test/java/feign/ResponseTest.java
+++ b/core/src/test/java/feign/ResponseTest.java
@@ -22,6 +22,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import static feign.assertj.FeignAssertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.entry;
 
 public class ResponseTest {
@@ -91,5 +92,17 @@ public class ResponseTest {
             .build();
 
     assertThat(response.status()).isEqualTo(103);
+  }
+
+  @Test
+  public void statusCodesBeyond5xxAreNotSupported() {
+    Throwable thrown = catchThrowable( () -> Response.builder()
+            .status(600)
+            .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+            .body((Response.Body) null)
+            .build());
+
+    assertThat(thrown).isInstanceOf(IllegalStateException.class);
+    assertThat(thrown).hasMessage("Invalid status code: 600");
   }
 }

--- a/core/src/test/java/feign/ResponseTest.java
+++ b/core/src/test/java/feign/ResponseTest.java
@@ -86,21 +86,22 @@ public class ResponseTest {
   @Test
   public void support1xxStatusCodes() {
     Response response = Response.builder()
-            .status(103)
-            .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
-            .body((Response.Body) null)
-            .build();
+        .status(103)
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .body((Response.Body) null)
+        .build();
 
     assertThat(response.status()).isEqualTo(103);
   }
 
   @Test
   public void statusCodesBeyond5xxAreNotSupported() {
-    Throwable thrown = catchThrowable( () -> Response.builder()
-            .status(600)
-            .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
-            .body((Response.Body) null)
-            .build());
+    Throwable thrown = catchThrowable(() -> Response.builder()
+        .status(600)
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .body((Response.Body) null)
+        .build()
+    );
 
     assertThat(thrown).isInstanceOf(IllegalStateException.class);
     assertThat(thrown).hasMessage("Invalid status code: 600");

--- a/core/src/test/java/feign/ResponseTest.java
+++ b/core/src/test/java/feign/ResponseTest.java
@@ -14,6 +14,7 @@
 package feign;
 
 import feign.Request.HttpMethod;
+import org.assertj.core.util.Lists;
 import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collection;
@@ -22,7 +23,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import static feign.assertj.FeignAssertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.entry;
 
 public class ResponseTest {
@@ -95,14 +95,15 @@ public class ResponseTest {
   }
 
   @Test
-  public void statusCodesBeyond5xxAreNotSupported() {
-    Throwable thrown = catchThrowable(() -> Response.builder()
-        .status(600)
-        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
-        .body((Response.Body) null)
-        .build());
+  public void statusCodesOfAnyValueAreAllowed() {
+    Lists.list(600, 50, 35600).forEach(statusCode -> {
+      Response response = Response.builder()
+          .status(statusCode)
+          .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+          .body((Response.Body) null)
+          .build();
 
-    assertThat(thrown).isInstanceOf(IllegalStateException.class);
-    assertThat(thrown).hasMessage("Invalid status code: 600");
+      assertThat(response.status()).isEqualTo(statusCode);
+    });
   }
 }

--- a/core/src/test/java/feign/ResponseTest.java
+++ b/core/src/test/java/feign/ResponseTest.java
@@ -81,4 +81,15 @@ public class ResponseTest {
         .build();
     assertThat(response.headers()).isNotNull().isEmpty();
   }
+
+  @Test
+  public void support1xxStatusCodes() {
+    Response response = Response.builder()
+            .status(103)
+            .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+            .body((Response.Body) null)
+            .build();
+
+    assertThat(response.status()).isEqualTo(103);
+  }
 }


### PR DESCRIPTION
Previously [Response](https://github.com/OpenFeign/feign/blob/master/core/src/main/java/feign/Response.java#L47) didn't allow status codes in the 1xx series, only 200 and beyond were allowed. This fixes that by allowing status codes in the range from 100 <= status < 600.

Fixes #836