### PR TITLE
Adds support for per request timeout options. Fixes #562

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Unwrap RetryableException and throw cause (#737)
 * Supports PATCH without a body paramter (#824)
 * Feign-Ribbon integration now depends on Ribbon 2.3.0, updated from Ribbon 2.1.1 (#826)
+* Add support for per request timeout options with @ApiTimeout (#562)
 
 ### Version 10.0
 * Feign baseline is now JDK 8

--- a/core/src/main/java/feign/ApiTimeout.java
+++ b/core/src/main/java/feign/ApiTimeout.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2012-2019 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation to define custom request timeouts for single feign method or for all methods in feign
+ * class
+ */
+@Retention(RUNTIME)
+@Target({METHOD, TYPE})
+public @interface ApiTimeout {
+
+  int connectTimeoutMillis() default 10 * 1000;
+
+  int readTimeoutMillis() default 60 * 1000;
+}

--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2018 The Feign Authors
+ * Copyright 2012-2019 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -226,6 +226,15 @@ public interface Contract {
         data.template().headers(null); // to clear
         data.template().headers(headers);
       }
+      if (targetType.isAnnotationPresent(ApiTimeout.class)) {
+        ApiTimeout apiAnnotation = targetType.getAnnotation(ApiTimeout.class);
+        int connectTimeoutMillis = apiAnnotation.connectTimeoutMillis();
+        int readTimeoutMillis = apiAnnotation.readTimeoutMillis();
+        checkState(connectTimeoutMillis > 0 && readTimeoutMillis > 0,
+            "Api timeout annotation contains negative params on type %s.",
+            targetType.getName());
+        data.options(new RequestOptions(connectTimeoutMillis, readTimeoutMillis));
+      }
     }
 
     @Override
@@ -265,6 +274,14 @@ public interface Contract {
         checkState(headersOnMethod.length > 0, "Headers annotation was empty on method %s.",
             method.getName());
         data.template().headers(toMap(headersOnMethod));
+      } else if (annotationType == ApiTimeout.class) {
+        ApiTimeout apiAnnotation = ApiTimeout.class.cast(methodAnnotation);
+        int connectTimeoutMillis = apiAnnotation.connectTimeoutMillis();
+        int readTimeoutMillis = apiAnnotation.readTimeoutMillis();
+        checkState(connectTimeoutMillis > 0 && readTimeoutMillis > 0,
+            "Api timeout annotation contains negative params on method %s.",
+            method.getName());
+        data.options(new RequestOptions(connectTimeoutMillis, readTimeoutMillis));
       }
     }
 

--- a/core/src/main/java/feign/MethodMetadata.java
+++ b/core/src/main/java/feign/MethodMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2018 The Feign Authors
+ * Copyright 2012-2019 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,11 +15,7 @@ package feign;
 
 import java.io.Serializable;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import feign.Param.Expander;
 
 public final class MethodMetadata implements Serializable {
@@ -41,6 +37,7 @@ public final class MethodMetadata implements Serializable {
       new LinkedHashMap<Integer, Class<? extends Expander>>();
   private Map<Integer, Boolean> indexToEncoded = new LinkedHashMap<Integer, Boolean>();
   private transient Map<Integer, Expander> indexToExpander;
+  private Optional<RequestOptions> options = Optional.empty();
 
   MethodMetadata() {}
 
@@ -162,5 +159,17 @@ public final class MethodMetadata implements Serializable {
    */
   public Map<Integer, Expander> indexToExpander() {
     return indexToExpander;
+  }
+
+  /**
+   * When exists, this settings will be used to construct custom {@link Request.Options} for method
+   */
+  public Optional<RequestOptions> options() {
+    return options;
+  }
+
+  public MethodMetadata options(RequestOptions options) {
+    this.options = Optional.ofNullable(options);
+    return this;
   }
 }

--- a/core/src/main/java/feign/ReflectiveFeign.java
+++ b/core/src/main/java/feign/ReflectiveFeign.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2018 The Feign Authors
+ * Copyright 2012-2019 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -162,8 +162,11 @@ public class ReflectiveFeign extends Feign {
         } else {
           buildTemplate = new BuildTemplateByResolvingArgs(md, queryMapEncoder);
         }
+        Options requestOptions = md.options()
+            .map(o -> new Options(o.getConnectTimeoutMillis(), o.getReadTimeoutMillis()))
+            .orElse(options);
         result.put(md.configKey(),
-            factory.create(key, md, buildTemplate, options, decoder, errorDecoder));
+            factory.create(key, md, buildTemplate, requestOptions, decoder, errorDecoder));
       }
       return result;
     }

--- a/core/src/main/java/feign/RequestOptions.java
+++ b/core/src/main/java/feign/RequestOptions.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2012-2019 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign;
+
+public final class RequestOptions {
+
+  private final int connectTimeoutMillis;
+  private final int readTimeoutMillis;
+
+  RequestOptions(int connectTimeoutMillis, int readTimeoutMillis) {
+    this.connectTimeoutMillis = connectTimeoutMillis;
+    this.readTimeoutMillis = readTimeoutMillis;
+  }
+
+  public int getConnectTimeoutMillis() {
+    return connectTimeoutMillis;
+  }
+
+  public int getReadTimeoutMillis() {
+    return readTimeoutMillis;
+  }
+}

--- a/core/src/test/java/feign/RequestOptionsTest.java
+++ b/core/src/test/java/feign/RequestOptionsTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2012-2019 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import java.util.concurrent.TimeUnit;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RequestOptionsTest {
+
+  private static final int DEFAULT_READ_TIMEOUT = 7 * 1000;
+  private static final int CUSTOM_READ_TIMEOUT = 3 * 1000;
+
+  @Rule
+  public final MockWebServer server = new MockWebServer();
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  private HasReadTimeoutApiMethod api;
+
+  @Before
+  public void instantiateApi() {
+    api = Feign.builder()
+        .options(new Request.Options(15 * 1000, DEFAULT_READ_TIMEOUT))
+        .target(HasReadTimeoutApiMethod.class, "http://localhost:" + server.getPort());
+    server.enqueue(new MockResponse().setBody("5").setBodyDelay(DEFAULT_READ_TIMEOUT - 1 * 1000,
+        TimeUnit.MILLISECONDS));
+  }
+
+  @Test
+  public void testCustomReadTimeOutApplied() {
+    thrown.expect(FeignException.class);
+    thrown.expectMessage("Read timed out");
+
+    api.withApiTimeout();
+  }
+
+  @Test
+  public void testDefaultReadTimeOutApplied() {
+    String result = api.withoutApiTimeout();
+    assertThat(result).isEqualTo("5");
+  }
+
+
+  interface HasReadTimeoutApiMethod {
+    @ApiTimeout(readTimeoutMillis = CUSTOM_READ_TIMEOUT)
+    @RequestLine("GET /api/withApiTimeout")
+    String withApiTimeout();
+
+    @RequestLine("GET /api/withoutApiTimeout")
+    String withoutApiTimeout();
+  }
+}


### PR DESCRIPTION
Annotation @ApiTimeout is added. And now it is possible to set per request timeout options.

Fixes #562

Unfortunately, I did not find a way to test connectTimeoutMillisis applied correctly. That's why I added a test only for readTimeoutMillis.