### PR TITLE
Managing Jackson a the parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,25 @@
         <artifactId>mockwebserver</artifactId>
         <version>${okhttp3.version}</version>
       </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
To address a number of vulnerabilities Synk identified, this change
forces the default Jackson Version to 2.9.8