### PR TITLE
Fix ContentService example

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ See [Headers](#headers) for examples.
 > ```java
 > public interface ContentService {
 >   @RequestLine("GET /api/documents/{contentType}")
->   @Headers("Accept {contentType}")
+>   @Headers("Accept: {contentType}")
 >   String getDocumentByType(@Param("contentType") String type);
 > }
 >```


### PR DESCRIPTION
Currently ContentService example will trigger index out of bounds exception in feign.Contract.Default#toMap due to missing colon separator.