### PR TITLE
No Longer prepend uri with slash if it is a query string

### DIFF
--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -464,7 +464,7 @@ public final class RequestTemplate implements Serializable {
       this.target = targetUri.getScheme() + "://" + targetUri.getAuthority() + targetUri.getPath();
     } catch (IllegalArgumentException iae) {
       /* the uri provided is not a valid one, we can't continue */
-      throw new FeignException("Target is not a valid URI.", iae);
+      throw new IllegalArgumentException("Target is not a valid URI.", iae);
     }
     return this;
   }

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -540,7 +540,8 @@ public class FeignTest {
         .errorDecoder(new ErrorDecoder() {
           @Override
           public Exception decode(String methodKey, Response response) {
-            return new RetryableException(response.status(), "play it again sam!", HttpMethod.POST, null);
+            return new RetryableException(response.status(), "play it again sam!", HttpMethod.POST,
+                null);
           }
         }).target(TestInterface.class, "http://localhost:" + server.getPort());
 

--- a/core/src/test/java/feign/LoggerTest.java
+++ b/core/src/test/java/feign/LoggerTest.java
@@ -318,7 +318,7 @@ public class LoggerTest {
               return this;
             }
           })
-          .target(SendsStuff.class, "http://sna%fu.abc");
+          .target(SendsStuff.class, "http://sna%25fu.abc");
 
       thrown.expect(FeignException.class);
 

--- a/core/src/test/java/feign/TargetTest.java
+++ b/core/src/test/java/feign/TargetTest.java
@@ -13,14 +13,13 @@
  */
 package feign;
 
+import static feign.assertj.MockWebServerAssertions.assertThat;
+import feign.Target.HardCodedTarget;
 import java.net.URI;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.Rule;
 import org.junit.Test;
-import feign.Target.HardCodedTarget;
-import org.springframework.stereotype.Repository;
-import static feign.assertj.MockWebServerAssertions.assertThat;
 
 public class TargetTest {
 

--- a/core/src/test/java/feign/TargetTest.java
+++ b/core/src/test/java/feign/TargetTest.java
@@ -13,11 +13,13 @@
  */
 package feign;
 
+import java.net.URI;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.Rule;
 import org.junit.Test;
 import feign.Target.HardCodedTarget;
+import org.springframework.stereotype.Repository;
 import static feign.assertj.MockWebServerAssertions.assertThat;
 
 public class TargetTest {
@@ -67,5 +69,42 @@ public class TargetTest {
     Feign.builder().target(custom).get("slash/foo", "slash/bar");
 
     assertThat(server.takeRequest()).hasPath("/default/slash/foo?query=slash/bar");
+  }
+
+  interface UriTarget {
+
+    @RequestLine("GET")
+    Response get(URI uri);
+  }
+
+  @Test
+  public void emptyTarget() throws InterruptedException {
+    server.enqueue(new MockResponse());
+
+    UriTarget uriTarget = Feign.builder()
+        .target(Target.EmptyTarget.create(UriTarget.class));
+
+    String host = server.getHostName();
+    int port = server.getPort();
+
+    uriTarget.get(URI.create("http://" + host + ":" + port + "/path?query=param"));
+
+    assertThat(server.takeRequest()).hasPath("/path?query=param").hasQueryParams("query=param");
+  }
+
+  @Test
+  public void hardCodedTargetWithURI() throws InterruptedException {
+    server.enqueue(new MockResponse());
+
+    String host = server.getHostName();
+    int port = server.getPort();
+    String base = "http://" + host + ":" + port;
+
+    UriTarget uriTarget = Feign.builder()
+        .target(UriTarget.class, base);
+
+    uriTarget.get(URI.create("http://" + host + ":" + port + "/path?query=param"));
+
+    assertThat(server.takeRequest()).hasPath("/path?query=param").hasQueryParams("query=param");
   }
 }


### PR DESCRIPTION
Fixes #887

Changes to target and uri parsing did not take into account
Empty Targets or URI provided methods.  In these scenarios,
the target contains the entire path and the uri will be the
query string only.  This change takes that into account and
no longer prepends a slash in these cases.