### PR TITLE
Fixed JAXRS contract trying to modify an unmodified list

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ See [Headers](#headers) for examples.
 > ```java
 > public interface ContentService {
 >   @RequestLine("GET /api/documents/{contentType}")
->   @Headers("Accept {contentType}")
+>   @Headers("Accept: {contentType}")
 >   String getDocumentByType(@Param("contentType") String type);
 > }
 >```


### PR DESCRIPTION
This merge request create a new ArrayList when trying to add new element into the template's queries and headers when dealing with the parameters in API. This bug is reported in #891 .

Beside this, it also overwrite the class and method level annotations to generate Accept and Content-Type named header with parameter with the same name, which I mentioned in #890.