### PR TITLE
Refactored Header and Query parameter JAXRS Contract Parsing

### DIFF
--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -540,7 +540,8 @@ public class FeignTest {
         .errorDecoder(new ErrorDecoder() {
           @Override
           public Exception decode(String methodKey, Response response) {
-            return new RetryableException(response.status(), "play it again sam!", HttpMethod.POST, null);
+            return new RetryableException(response.status(), "play it again sam!", HttpMethod.POST,
+                null);
           }
         }).target(TestInterface.class, "http://localhost:" + server.getPort());
 

--- a/jaxrs/src/main/java/feign/jaxrs/JAXRSContract.java
+++ b/jaxrs/src/main/java/feign/jaxrs/JAXRSContract.java
@@ -154,7 +154,7 @@ public class JAXRSContract extends Contract.BaseContract {
         String name = QueryParam.class.cast(parameterAnnotation).value();
         checkState(emptyToNull(name) != null, "QueryParam.value() was empty on parameter %s",
             paramIndex);
-        Collection<String> query = addTemplatedParam(data.template().queries().get(name), name);
+        String query = addTemplatedParam(name);
         data.template().query(name, query);
         nameParam(data, name, paramIndex);
         isHttpParam = true;
@@ -162,7 +162,7 @@ public class JAXRSContract extends Contract.BaseContract {
         String name = HeaderParam.class.cast(parameterAnnotation).value();
         checkState(emptyToNull(name) != null, "HeaderParam.value() was empty on parameter %s",
             paramIndex);
-        Collection<String> header = addTemplatedParam(data.template().headers().get(name), name);
+        String header = addTemplatedParam(name);
         data.template().header(name, header);
         nameParam(data, name, paramIndex);
         isHttpParam = true;
@@ -179,11 +179,7 @@ public class JAXRSContract extends Contract.BaseContract {
   }
 
   // Not using override as the super-type's method is deprecated and will be removed.
-  protected Collection<String> addTemplatedParam(Collection<String> possiblyNull, String name) {
-    if (possiblyNull == null) {
-      possiblyNull = new ArrayList<String>();
-    }
-    possiblyNull.add(String.format("{%s}", name));
-    return possiblyNull;
+  private String addTemplatedParam(String name) {
+    return String.format("{%s}", name);
   }
 }

--- a/jaxrs/src/test/java/feign/jaxrs/JAXRSContractTest.java
+++ b/jaxrs/src/test/java/feign/jaxrs/JAXRSContractTest.java
@@ -14,6 +14,7 @@
 package feign.jaxrs;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import org.junit.Rule;
 import org.junit.Test;
@@ -394,6 +395,18 @@ public class JAXRSContractTest {
             .hasUrl("/base/specific");
   }
 
+
+  @Test
+  public void producesWithHeaderParamContainAllHeaders() throws Exception {
+    assertThat(parseAndValidateMetadata(MixedAnnotations.class, "getWithHeaders",
+        String.class, String.class, String.class)
+            .template())
+                .hasHeaders(entry("Accept", Arrays.asList("{Accept}", "application/json")))
+                .hasQueries(
+                    entry("multiple", Arrays.asList("stuff", "{multiple}")),
+                    entry("another", Collections.singletonList("{another}")));
+  }
+
   interface Methods {
 
     @POST
@@ -637,5 +650,15 @@ public class JAXRSContractTest {
       throws NoSuchMethodException {
     return contract.parseAndValidateMetadata(targetType,
         targetType.getMethod(method, parameterTypes));
+  }
+
+  interface MixedAnnotations {
+
+    @GET
+    @Path("/api/stuff?multiple=stuff")
+    @Produces("application/json")
+    Response getWithHeaders(@HeaderParam("Accept") String accept,
+                            @QueryParam("multiple") String multiple,
+                            @QueryParam("another") String another);
   }
 }


### PR DESCRIPTION
Fixes #890 

As part of 10.x, the `headers()` and `queries()` collections on the
`RequestTemplate` were made read only.  The `JAXRSContract` was still
attempting to manipulate those directly.  This was missed due to a
use case not accounted for in the tests.  I've added the appropriate
use case and corrected the usage of the template.