### PR TITLE
Removed Duplicate Expansion

### DIFF
--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -167,7 +167,7 @@ public final class RequestTemplate implements Serializable {
         QueryTemplate queryTemplate = queryTemplates.next();
         String queryExpanded = queryTemplate.expand(variables);
         if (Util.isNotBlank(queryExpanded)) {
-          query.append(queryTemplate.expand(variables));
+          query.append(queryExpanded);
           if (queryTemplates.hasNext()) {
             query.append("&");
           }


### PR DESCRIPTION
Fixes #904

Query Template expanded twice.  This is unnecessary and would have
caused a performance issue at scale.