### PR TITLE
Fixes NullPointerException when accessing a FeignException's content

### DIFF
--- a/core/src/main/java/feign/FeignException.java
+++ b/core/src/main/java/feign/FeignException.java
@@ -60,7 +60,7 @@ public class FeignException extends RuntimeException {
     if (content != null) {
       return new String(content, UTF_8);
     } else {
-      return null;
+      return "";
     }
   }
 

--- a/core/src/main/java/feign/FeignException.java
+++ b/core/src/main/java/feign/FeignException.java
@@ -57,7 +57,11 @@ public class FeignException extends RuntimeException {
   }
 
   public String contentUTF8() {
-    return new String(content, UTF_8);
+    if (content != null) {
+      return new String(content, UTF_8);
+    } else {
+      return null;
+    }
   }
 
   static FeignException errorReading(Request request, Response response, IOException cause) {

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -541,7 +541,7 @@ public class FeignTest {
     } catch (FeignException e) {
       assertThat(e.getMessage())
           .isEqualTo("timeout reading POST http://localhost:" + server.getPort() + "/");
-      assertThat(e.contentUTF8()).isEqualTo(null);
+      assertThat(e.contentUTF8()).isEqualTo("");
     }
   }
 


### PR DESCRIPTION
If the content of a FeignException is null, `contentUTF8()` now returns `null` rather than throwing a NullPointerException. `null` is chosen to allow possible future releases to return an empty optional rather than a blank String. Fixes #912