### PR TITLE
Updated Expression Patterns to allow brackets

### DIFF
--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -543,6 +543,7 @@ public final class RequestTemplate implements Serializable {
     return query(name, Arrays.asList(values));
   }
 
+
   /**
    * Specify a Query String parameter, with the specified values. Values can be literals or template
    * expressions.
@@ -552,7 +553,21 @@ public final class RequestTemplate implements Serializable {
    * @return a RequestTemplate for chaining.
    */
   public RequestTemplate query(String name, Iterable<String> values) {
-    return appendQuery(name, values);
+    return appendQuery(name, values, this.collectionFormat);
+  }
+
+  /**
+   * Specify a Query String parameter, with the specified values.  Values can be literals or
+   * template expressions.
+   *
+   * @param name of the parameter.
+   * @param values for this parameter.
+   * @param collectionFormat to use when resolving collection based expressions.
+   * @return a Request Template for chaining.
+   */
+  public RequestTemplate query(String name, Iterable<String> values,
+      CollectionFormat collectionFormat) {
+    return appendQuery(name, values, collectionFormat);
   }
 
   /**
@@ -560,9 +575,11 @@ public final class RequestTemplate implements Serializable {
    *
    * @param name of the parameter.
    * @param values for the parameter, may be expressions.
+   * @param collectionFormat to use when resolving collection based query variables.
    * @return a RequestTemplate for chaining.
    */
-  private RequestTemplate appendQuery(String name, Iterable<String> values) {
+  private RequestTemplate appendQuery(String name, Iterable<String> values,
+      CollectionFormat collectionFormat) {
     if (!values.iterator().hasNext()) {
       /* empty value, clear the existing values */
       this.queries.remove(name);
@@ -572,12 +589,11 @@ public final class RequestTemplate implements Serializable {
     /* create a new query template out of the information here */
     this.queries.compute(name, (key, queryTemplate) -> {
       if (queryTemplate == null) {
-        return QueryTemplate.create(name, values, this.charset, this.collectionFormat);
+        return QueryTemplate.create(name, values, this.charset, collectionFormat);
       } else {
-        return QueryTemplate.append(queryTemplate, values, this.collectionFormat);
+        return QueryTemplate.append(queryTemplate, values, collectionFormat);
       }
     });
-    // this.queries.put(name, QueryTemplate.create(name, values));
     return this;
   }
 

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -557,16 +557,17 @@ public final class RequestTemplate implements Serializable {
   }
 
   /**
-   * Specify a Query String parameter, with the specified values.  Values can be literals or
-   * template expressions.
+   * Specify a Query String parameter, with the specified values. Values can be literals or template
+   * expressions.
    *
    * @param name of the parameter.
    * @param values for this parameter.
    * @param collectionFormat to use when resolving collection based expressions.
    * @return a Request Template for chaining.
    */
-  public RequestTemplate query(String name, Iterable<String> values,
-      CollectionFormat collectionFormat) {
+  public RequestTemplate query(String name,
+                               Iterable<String> values,
+                               CollectionFormat collectionFormat) {
     return appendQuery(name, values, collectionFormat);
   }
 
@@ -578,8 +579,9 @@ public final class RequestTemplate implements Serializable {
    * @param collectionFormat to use when resolving collection based query variables.
    * @return a RequestTemplate for chaining.
    */
-  private RequestTemplate appendQuery(String name, Iterable<String> values,
-      CollectionFormat collectionFormat) {
+  private RequestTemplate appendQuery(String name,
+                                      Iterable<String> values,
+                                      CollectionFormat collectionFormat) {
     if (!values.iterator().hasNext()) {
       /* empty value, clear the existing values */
       this.queries.remove(name);

--- a/core/src/main/java/feign/template/Expressions.java
+++ b/core/src/main/java/feign/template/Expressions.java
@@ -29,7 +29,17 @@ public final class Expressions {
 
   static {
     expressions = new LinkedHashMap<>();
-    expressions.put(Pattern.compile("(\\w[-\\w.]*[ ]*)(:(.+))?"), SimpleExpression.class);
+
+    /*
+     * basic pattern for variable names. this is compliant with RFC 6570 Simple Expressions ONLY
+     * with the following additional values allowed without required pct-encoding:
+     *
+     * - brackets - dashes
+     *
+     * see https://tools.ietf.org/html/rfc6570#section-2.3 for more information.
+     */
+    expressions.put(Pattern.compile("(\\w[-\\w.\\[\\]]*[ ]*)(:(.+))?"),
+        SimpleExpression.class);
   }
 
   public static Expression create(final String value, final FragmentType type) {

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -158,6 +158,22 @@ public class RequestTemplateTest {
   }
 
   @Test
+  public void resolveTemplateWithMixedCollectionFormatsByQuery() {
+    RequestTemplate template = new RequestTemplate()
+        .method(HttpMethod.GET)
+        .collectionFormat(CollectionFormat.EXPLODED)
+        .uri("/api/collections")
+        .query("keys", "{keys}") // default collection format
+        .query("values[]", Collections.singletonList("{values[]}"), CollectionFormat.CSV);
+
+    template = template.resolve(mapOf("keys", Arrays.asList("one", "two"),
+        "values[]", Arrays.asList("1", "2")));
+
+    assertThat(template.url())
+        .isEqualToIgnoringCase("/api/collections?keys=one&keys=two&values%5B%5D=1,2");
+  }
+
+  @Test
   public void resolveTemplateWithHeaderSubstitutions() {
     RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)
         .header("Auth-Token", "{authToken}");

--- a/core/src/test/java/feign/template/QueryTemplateTest.java
+++ b/core/src/test/java/feign/template/QueryTemplateTest.java
@@ -164,4 +164,16 @@ public class QueryTemplateTest {
     assertThat(expanded).isEqualToIgnoringCase(
         "json=%7B%22name%22:%22feign%22,%22version%22:%20%2210%22%7D");
   }
+
+
+  @Test
+  public void expandCollectionValueWithBrackets() {
+    QueryTemplate template =
+        QueryTemplate.create("collection[]", Collections.singletonList("{collection[]}"),
+            Util.UTF_8, CollectionFormat.CSV);
+    String expanded = template.expand(Collections.singletonMap("collection[]",
+        Arrays.asList("1", "2")));
+    /* brackets will be pct-encoded */
+    assertThat(expanded).isEqualToIgnoringCase("collection%5B%5D=1,2");
+  }
 }


### PR DESCRIPTION
Fixes #928

Relaxed the regular expression that is used to determine if a given
value is an Expression per the URI Template Spec RFC 6570.  We already
deviated by allowing dashes to exist without pct-encoding, this change
adds braces `[]` to this list.

Also included is the ability to set Collection Format per Query, overriding
the Template default.  This allows for mixed Collection formats in the
same template and provides a way for Contract extensions to determine
which expansion type they want when parsing a contract.