### PR TITLE
Feature/replace deprecated body

### DIFF
--- a/core/src/main/java/feign/Client.java
+++ b/core/src/main/java/feign/Client.java
@@ -114,7 +114,7 @@ public interface Client {
         connection.addRequestProperty("Accept", "*/*");
       }
 
-      if (request.body() != null) {
+      if (request.requestBody().asBytes() != null) {
         if (contentLength != null) {
           connection.setFixedLengthStreamingMode(contentLength);
         } else {
@@ -128,7 +128,7 @@ public interface Client {
           out = new DeflaterOutputStream(out);
         }
         try {
-          out.write(request.body());
+          out.write(request.requestBody().asBytes());
         } finally {
           try {
             out.close();

--- a/core/src/main/java/feign/FeignException.java
+++ b/core/src/main/java/feign/FeignException.java
@@ -69,7 +69,7 @@ public class FeignException extends RuntimeException {
         response.status(),
         format("%s reading %s %s", cause.getMessage(), request.httpMethod(), request.url()),
         cause,
-        request.body());
+        request.requestBody().asBytes());
   }
 
   public static FeignException errorStatus(String methodKey, Response response) {

--- a/core/src/main/java/feign/Logger.java
+++ b/core/src/main/java/feign/Logger.java
@@ -54,11 +54,11 @@ public abstract class Logger {
       }
 
       int bodyLength = 0;
-      if (request.body() != null) {
-        bodyLength = request.body().length;
+      if (request.requestBody().asBytes() != null) {
+        bodyLength = request.requestBody().asBytes().length;
         if (logLevel.ordinal() >= Level.FULL.ordinal()) {
           String bodyText =
-              request.charset() != null ? new String(request.body(), request.charset()) : null;
+              request.charset() != null ? new String(request.requestBody().asBytes(), request.charset()) : null;
           log(configKey, ""); // CRLF
           log(configKey, "%s", bodyText != null ? bodyText : "Binary data");
         }

--- a/core/src/main/java/feign/Logger.java
+++ b/core/src/main/java/feign/Logger.java
@@ -58,7 +58,9 @@ public abstract class Logger {
         bodyLength = request.requestBody().asBytes().length;
         if (logLevel.ordinal() >= Level.FULL.ordinal()) {
           String bodyText =
-              request.charset() != null ? new String(request.requestBody().asBytes(), request.charset()) : null;
+              request.charset() != null
+                  ? new String(request.requestBody().asBytes(), request.charset())
+                  : null;
           log(configKey, ""); // CRLF
           log(configKey, "%s", bodyText != null ? bodyText : "Binary data");
         }

--- a/core/src/main/java/feign/Request.java
+++ b/core/src/main/java/feign/Request.java
@@ -190,6 +190,17 @@ public final class Request {
     return body.encoding;
   }
 
+  /**
+   * If present, this is the replayable body to send to the server. In some cases, this may be
+   * interpretable as text.
+   *
+   * @see #charset()
+   * @deprecated use {@link #requestBody()} instead
+   */
+  public byte[] body() {
+    return body.data;
+  }
+
   public Body requestBody() {
     return body;
   }

--- a/core/src/main/java/feign/Request.java
+++ b/core/src/main/java/feign/Request.java
@@ -190,17 +190,6 @@ public final class Request {
     return body.encoding;
   }
 
-  /**
-   * If present, this is the replayable body to send to the server. In some cases, this may be
-   * interpretable as text.
-   *
-   * @see #charset()
-   * @deprecated use {@link #requestBody()} instead
-   */
-  public byte[] body() {
-    return body.data;
-  }
-
   public Body requestBody() {
     return body;
   }

--- a/core/src/test/java/feign/TargetTest.java
+++ b/core/src/test/java/feign/TargetTest.java
@@ -61,7 +61,7 @@ public class TargetTest {
             urlEncoded.httpMethod(),
             urlEncoded.url().replace("%2F", "/"),
             urlEncoded.headers(),
-            urlEncoded.body(), urlEncoded.charset());
+            urlEncoded.requestBody().asBytes(), urlEncoded.charset());
       }
     };
 

--- a/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
+++ b/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
@@ -134,14 +134,14 @@ public final class ApacheHttpClient implements Client {
     }
 
     // request body
-    if (request.body() != null) {
+    if (request.requestBody().asBytes() != null) {
       HttpEntity entity = null;
       if (request.charset() != null) {
         ContentType contentType = getContentType(request);
-        String content = new String(request.body(), request.charset());
+        String content = new String(request.requestBody().asBytes(), request.charset());
         entity = new StringEntity(content, contentType);
       } else {
-        entity = new ByteArrayEntity(request.body());
+        entity = new ByteArrayEntity(request.requestBody().asBytes());
       }
 
       requestBuilder.setEntity(entity);

--- a/java11/src/main/java/feign/http2client/Http2Client.java
+++ b/java11/src/main/java/feign/http2client/Http2Client.java
@@ -80,10 +80,10 @@ public class Http2Client implements Client {
     }
 
     final BodyPublisher body;
-    if (request.body() == null) {
+    if (request.requestBody().asBytes() == null) {
       body = BodyPublishers.noBody();
     } else {
-      body = BodyPublishers.ofByteArray(request.body());
+      body = BodyPublishers.ofByteArray(request.requestBody().asBytes());
     }
 
     final Builder requestBuilder = HttpRequest.newBuilder()

--- a/jaxrs2/src/main/java/feign/jaxrs2/JAXRSClient.java
+++ b/jaxrs2/src/main/java/feign/jaxrs2/JAXRSClient.java
@@ -69,12 +69,12 @@ public class JAXRSClient implements Client {
   }
 
   private Entity<byte[]> createRequestEntity(feign.Request request) {
-    if (request.body() == null) {
+    if (request.requestBody().asBytes() == null) {
       return null;
     }
 
     return Entity.entity(
-        request.body(),
+        request.requestBody().asBytes(),
         new Variant(mediaType(request.headers()), locale(request.headers()),
             encoding(request.charset())));
   }

--- a/mock/src/main/java/feign/mock/RequestKey.java
+++ b/mock/src/main/java/feign/mock/RequestKey.java
@@ -112,7 +112,7 @@ public class RequestKey {
     this.url = buildUrl(request);
     this.headers = RequestHeaders.of(request.headers());
     this.charset = request.charset();
-    this.body = request.body();
+    this.body = request.requestBody().asBytes();
   }
 
   public HttpMethod getMethod() {

--- a/mock/src/test/java/feign/mock/MockClientTest.java
+++ b/mock/src/test/java/feign/mock/MockClientTest.java
@@ -165,7 +165,7 @@ public class MockClientTest {
         mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 1);
     assertThat(results, hasSize(1));
 
-    byte[] body = mockClient.verifyOne(HttpMethod.POST, "/repos/netflix/feign/contributors").body();
+    byte[] body = mockClient.verifyOne(HttpMethod.POST, "/repos/netflix/feign/contributors").requestBody().asBytes();
     assertThat(body, notNullValue());
 
     String message = new String(body);

--- a/mock/src/test/java/feign/mock/MockClientTest.java
+++ b/mock/src/test/java/feign/mock/MockClientTest.java
@@ -165,7 +165,8 @@ public class MockClientTest {
         mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 1);
     assertThat(results, hasSize(1));
 
-    byte[] body = mockClient.verifyOne(HttpMethod.POST, "/repos/netflix/feign/contributors").requestBody().asBytes();
+    byte[] body = mockClient.verifyOne(HttpMethod.POST, "/repos/netflix/feign/contributors")
+        .requestBody().asBytes();
     assertThat(body, notNullValue());
 
     String message = new String(body);

--- a/okhttp/src/main/java/feign/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/feign/okhttp/OkHttpClient.java
@@ -71,7 +71,7 @@ public final class OkHttpClient implements Client {
       requestBuilder.addHeader("Accept", "*/*");
     }
 
-    byte[] inputBody = input.body();
+    byte[] inputBody = input.requestBody().asBytes();
     boolean isMethodWithBody =
         HttpMethod.POST == input.httpMethod() || HttpMethod.PUT == input.httpMethod()
             || HttpMethod.PATCH == input.httpMethod();

--- a/ribbon/src/main/java/feign/ribbon/LBClient.java
+++ b/ribbon/src/main/java/feign/ribbon/LBClient.java
@@ -117,7 +117,7 @@ public final class LBClient extends
 
     Request toRequest() {
       // add header "Content-Length" according to the request body
-      final byte[] body = request.body();
+      final byte[] body = request.requestBody().asBytes();
       final int bodyLength = body != null ? body.length : 0;
       // create a new Map to avoid side effect, not to change the old headers
       Map<String, Collection<String>> headers = new LinkedHashMap<String, Collection<String>>();


### PR DESCRIPTION
In this pr the old `body()` method calls replaced with `requestBody().asBytes()` method which both exists in `Request` class. The intention is to remove deprecated code and keep source code clean.
