### PR TITLE
This pr resolves QueryMap inheritance issue #927

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -33,6 +33,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.9</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.jvnet</groupId>
       <artifactId>animal-sniffer-annotation</artifactId>
       <optional>true</optional>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -33,12 +33,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.9</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.jvnet</groupId>
       <artifactId>animal-sniffer-annotation</artifactId>
       <optional>true</optional>

--- a/core/src/main/java/feign/querymap/FieldQueryMapEncoder.java
+++ b/core/src/main/java/feign/querymap/FieldQueryMapEncoder.java
@@ -16,7 +16,6 @@ package feign.querymap;
 import feign.QueryMapEncoder;
 import feign.codec.EncodeException;
 import org.apache.commons.lang3.reflect.FieldUtils;
-
 import java.lang.reflect.Field;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -70,7 +69,7 @@ public class FieldQueryMapEncoder implements QueryMapEncoder {
 
     private static ObjectParamMetadata parseObjectType(Class<?> type) {
       return new ObjectParamMetadata(
-              FieldUtils.getAllFieldsList(type).stream()
+          FieldUtils.getAllFieldsList(type).stream()
               .filter(field -> !field.isSynthetic())
               .peek(field -> field.setAccessible(true))
               .collect(Collectors.toList()));

--- a/core/src/main/java/feign/querymap/FieldQueryMapEncoder.java
+++ b/core/src/main/java/feign/querymap/FieldQueryMapEncoder.java
@@ -15,7 +15,6 @@ package feign.querymap;
 
 import feign.QueryMapEncoder;
 import feign.codec.EncodeException;
-import org.apache.commons.lang3.reflect.FieldUtils;
 import java.lang.reflect.Field;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -68,11 +67,17 @@ public class FieldQueryMapEncoder implements QueryMapEncoder {
     }
 
     private static ObjectParamMetadata parseObjectType(Class<?> type) {
-      return new ObjectParamMetadata(
-          FieldUtils.getAllFieldsList(type).stream()
-              .filter(field -> !field.isSynthetic())
-              .peek(field -> field.setAccessible(true))
-              .collect(Collectors.toList()));
+      List<Field> allFields = new ArrayList();
+
+      for (Class currentClass = type; currentClass != null; currentClass =
+          currentClass.getSuperclass()) {
+        Collections.addAll(allFields, currentClass.getDeclaredFields());
+      }
+
+      return new ObjectParamMetadata(allFields.stream()
+          .filter(field -> !field.isSynthetic())
+          .peek(field -> field.setAccessible(true))
+          .collect(Collectors.toList()));
     }
   }
 }

--- a/core/src/main/java/feign/querymap/FieldQueryMapEncoder.java
+++ b/core/src/main/java/feign/querymap/FieldQueryMapEncoder.java
@@ -15,6 +15,8 @@ package feign.querymap;
 
 import feign.QueryMapEncoder;
 import feign.codec.EncodeException;
+import org.apache.commons.lang3.reflect.FieldUtils;
+
 import java.lang.reflect.Field;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -68,7 +70,7 @@ public class FieldQueryMapEncoder implements QueryMapEncoder {
 
     private static ObjectParamMetadata parseObjectType(Class<?> type) {
       return new ObjectParamMetadata(
-          Arrays.stream(type.getDeclaredFields())
+              FieldUtils.getAllFieldsList(type).stream()
               .filter(field -> !field.isSynthetic())
               .peek(field -> field.setAccessible(true))
               .collect(Collectors.toList()));

--- a/core/src/test/java/feign/ChildPojo.java
+++ b/core/src/test/java/feign/ChildPojo.java
@@ -14,34 +14,35 @@
 package feign;
 
 class ParentPojo {
-    public String parentPublicProperty;
-    protected String parentProtectedProperty;
+  public String parentPublicProperty;
+  protected String parentProtectedProperty;
 
-    public String getParentPublicProperty() {
-        return parentPublicProperty;
-    }
+  public String getParentPublicProperty() {
+    return parentPublicProperty;
+  }
 
-    public void setParentPublicProperty(String parentPublicProperty) {
-        this.parentPublicProperty = parentPublicProperty;
-    }
+  public void setParentPublicProperty(String parentPublicProperty) {
+    this.parentPublicProperty = parentPublicProperty;
+  }
 
-    public String getParentProtectedProperty() {
-        return parentProtectedProperty;
-    }
+  public String getParentProtectedProperty() {
+    return parentProtectedProperty;
+  }
 
-    public void setParentProtectedProperty(String parentProtectedProperty) {
-        this.parentProtectedProperty = parentProtectedProperty;
-    }
+  public void setParentProtectedProperty(String parentProtectedProperty) {
+    this.parentProtectedProperty = parentProtectedProperty;
+  }
 }
 
+
 public class ChildPojo extends ParentPojo {
-    private String childPrivateProperty;
+  private String childPrivateProperty;
 
-    public String getChildPrivateProperty() {
-        return childPrivateProperty;
-    }
+  public String getChildPrivateProperty() {
+    return childPrivateProperty;
+  }
 
-    public void setChildPrivateProperty(String childPrivateProperty) {
-        this.childPrivateProperty = childPrivateProperty;
-    }
+  public void setChildPrivateProperty(String childPrivateProperty) {
+    this.childPrivateProperty = childPrivateProperty;
+  }
 }

--- a/core/src/test/java/feign/ChildPojo.java
+++ b/core/src/test/java/feign/ChildPojo.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2012-2019 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign;
+
+class ParentPojo {
+    public String parentPublicProperty;
+    protected String parentProtectedProperty;
+
+    public String getParentPublicProperty() {
+        return parentPublicProperty;
+    }
+
+    public void setParentPublicProperty(String parentPublicProperty) {
+        this.parentPublicProperty = parentPublicProperty;
+    }
+
+    public String getParentProtectedProperty() {
+        return parentProtectedProperty;
+    }
+
+    public void setParentProtectedProperty(String parentProtectedProperty) {
+        this.parentProtectedProperty = parentProtectedProperty;
+    }
+}
+
+public class ChildPojo extends ParentPojo {
+    private String childPrivateProperty;
+
+    public String getChildPrivateProperty() {
+        return childPrivateProperty;
+    }
+
+    public void setChildPrivateProperty(String childPrivateProperty) {
+        this.childPrivateProperty = childPrivateProperty;
+    }
+}

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -866,10 +866,10 @@ public class FeignTest {
     server.enqueue(new MockResponse());
     api.queryMapPropertyInheritence(childPojo);
     assertThat(server.takeRequest())
-            .hasQueryParams(
-                    "parentPublicProperty=third",
-                    "parentProtectedProperty=second",
-                    "childPrivateProperty=first");
+        .hasQueryParams(
+            "parentPublicProperty=third",
+            "parentProtectedProperty=second",
+            "childPrivateProperty=first");
   }
 
   @Test


### PR DESCRIPTION
Add logic for finding fields which comes via inheritance on `FieldQueryMapEncoder#ObjectParamMetadata.parseObjectType()` method.  This provides appending parent object's fields as query parameter.

Fixes [#927]