### PR TITLE
Adds support for per request timeout options. Fixes #562

### DIFF
--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -13,9 +13,6 @@
  */
 package feign;
 
-import static feign.Util.checkState;
-import static feign.Util.emptyToNull;
-import feign.Request.HttpMethod;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -29,6 +26,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import feign.Request.HttpMethod;
+import static feign.Util.checkState;
+import static feign.Util.emptyToNull;
 
 /**
  * Defines what annotations and values are valid on interfaces.
@@ -111,7 +111,7 @@ public interface Contract {
         }
         if (parameterTypes[i] == URI.class) {
           data.urlIndex(i);
-        } else if (!isHttpAnnotation) {
+        } else if (!isHttpAnnotation && parameterTypes[i] != Request.Options.class) {
           checkState(data.formParams().isEmpty(),
               "Body parameters cannot be used with form parameters.");
           checkState(data.bodyIndex() == null, "Method has too many Body parameters: %s", method);

--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -187,8 +187,10 @@ final class SynchronousMethodHandler implements MethodHandler {
     if (argv == null || argv.length == 0) {
       return this.options;
     }
-    return Stream.of(argv).filter(o -> o instanceof Options).findAny().map(o -> (Options) o)
-                 .orElse(this.options);
+    return (Options) Stream.of(argv)
+        .filter(o -> o instanceof Options)
+        .findFirst()
+        .orElse(this.options);
   }
 
   static class Factory {

--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -16,6 +16,7 @@ package feign;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import feign.InvocationHandlerFactory.MethodHandler;
 import feign.Request.Options;
 import feign.codec.DecodeException;
@@ -72,10 +73,11 @@ final class SynchronousMethodHandler implements MethodHandler {
   @Override
   public Object invoke(Object[] argv) throws Throwable {
     RequestTemplate template = buildTemplateFromArgs.create(argv);
+    Options options = findOptions(argv);
     Retryer retryer = this.retryer.clone();
     while (true) {
       try {
-        return executeAndDecode(template);
+        return executeAndDecode(template, options);
       } catch (RetryableException e) {
         try {
           retryer.continueOrPropagate(e);
@@ -95,7 +97,7 @@ final class SynchronousMethodHandler implements MethodHandler {
     }
   }
 
-  Object executeAndDecode(RequestTemplate template) throws Throwable {
+  Object executeAndDecode(RequestTemplate template, Options options) throws Throwable {
     Request request = targetRequest(template);
 
     if (logLevel != Logger.Level.NONE) {
@@ -179,6 +181,14 @@ final class SynchronousMethodHandler implements MethodHandler {
     } catch (RuntimeException e) {
       throw new DecodeException(response.status(), e.getMessage(), e);
     }
+  }
+
+  Options findOptions(Object[] argv) {
+    if (argv == null || argv.length == 0) {
+      return this.options;
+    }
+    return Stream.of(argv).filter(o -> o instanceof Options).findAny().map(o -> (Options) o)
+                 .orElse(this.options);
   }
 
   static class Factory {

--- a/core/src/test/java/feign/OptionsTest.java
+++ b/core/src/test/java/feign/OptionsTest.java
@@ -1,0 +1,56 @@
+package feign;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.TimeUnit;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author pengfei.zhao
+ */
+public class OptionsTest {
+
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void socketTimeoutTest() {
+    final MockWebServer server = new MockWebServer();
+    server.enqueue(new MockResponse().setBody("foo").setBodyDelay(3, TimeUnit.SECONDS));
+
+    final OptionsInterface api = Feign.builder()
+        .options(new Request.Options(1000, 1000))
+        .target(OptionsInterface.class, server.url("/").toString());
+
+    thrown.expect(FeignException.class);
+    thrown.expectCause(CoreMatchers.isA(SocketTimeoutException.class));
+
+    api.get();
+  }
+
+  @Test
+  public void normalResponseTest() {
+    final MockWebServer server = new MockWebServer();
+    server.enqueue(new MockResponse().setBody("foo").setBodyDelay(3, TimeUnit.SECONDS));
+
+    final OptionsInterface api = Feign.builder()
+        .options(new Request.Options(1000, 1000))
+        .target(OptionsInterface.class, server.url("/").toString());
+
+    assertThat(api.get(new Request.Options(1000, 4 * 1000))).isEqualTo("foo");
+  }
+
+
+  interface OptionsInterface {
+    @RequestLine("GET /")
+    String get(Request.Options options);
+
+    @RequestLine("GET /")
+    String get();
+  }
+}


### PR DESCRIPTION
Adds support for per request timeout options
Fixes [#562](https://github.com/OpenFeign/feign/issues/562)

As @kdavisk6 said

```
interface MyClient {
   @RequestLine("GET /data")
   public MyResponse getMyData(Request.Options options);
}
```
In Spring Cloud 
```
interface MyClient {
   @RequestMapping(path = "/data")
   public MyResponse getMyData(Request.Options options);
}
```