### PR TITLE
Add test scope to java-hamcrest dependency

### DIFF
--- a/jaxrs2/pom.xml
+++ b/jaxrs2/pom.xml
@@ -101,6 +101,7 @@
       <groupId>org.hamcrest</groupId>
       <artifactId>java-hamcrest</artifactId>
       <version>2.0.0.0</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
`feign-jaxrs2` brings in `java-hamcrest` as a compile dependency, when it is only needed in tests.