### PR TITLE
#932 To support application/www-form-urlencoded working with ApacheHt…

### DIFF
--- a/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
+++ b/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
@@ -145,8 +145,6 @@ public final class ApacheHttpClient implements Client {
       }
 
       requestBuilder.setEntity(entity);
-    } else {
-      requestBuilder.setEntity(new ByteArrayEntity(new byte[0]));
     }
 
     return requestBuilder.build();

--- a/httpclient/src/test/java/feign/httpclient/ApacheHttpClientTest.java
+++ b/httpclient/src/test/java/feign/httpclient/ApacheHttpClientTest.java
@@ -68,7 +68,7 @@ public class ApacheHttpClientTest extends AbstractClientTest {
     @Path("/withBody")
     public String withBody(@QueryParam("foo") String foo, String bar);
 
-    @PUT
+    @GET
     @Path("/withoutBody")
     public String withoutBody(@QueryParam("foo") String foo);
   }


### PR DESCRIPTION
…tpClient and RequestBuilder.

Only when entity is null, then RequestBuilder creates UrlFormEncodedEntity.

Ref. RequestBuilder.build()
```java
...
        HttpEntity entityCopy = this.entity;
        if (this.parameters != null && !this.parameters.isEmpty()) {
            if (entityCopy != null || !"POST".equalsIgnoreCase(this.method) && !"PUT".equalsIgnoreCase(this.method)) {
                try {
                    uriNotNull = (new URIBuilder(uriNotNull)).setCharset(this.charset).addParameters(this.parameters).build();
                } catch (URISyntaxException var5) {
                }
            } else {
                entityCopy = new UrlEncodedFormEntity(this.parameters, this.charset != null ? this.charset : HTTP.DEF_CONTENT_CHARSET);
            }
        }
...
```