### PR TITLE
JacksonEncoder avoids intermediate String request body

### DIFF
--- a/jackson/src/main/java/feign/jackson/JacksonEncoder.java
+++ b/jackson/src/main/java/feign/jackson/JacksonEncoder.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import feign.RequestTemplate;
 import feign.codec.EncodeException;
@@ -48,7 +49,7 @@ public class JacksonEncoder implements Encoder {
   public void encode(Object object, Type bodyType, RequestTemplate template) {
     try {
       JavaType javaType = mapper.getTypeFactory().constructType(bodyType);
-      template.body(mapper.writerFor(javaType).writeValueAsString(object));
+      template.body(mapper.writerFor(javaType).writeValueAsBytes(object), StandardCharsets.UTF_8);
     } catch (JsonProcessingException e) {
       throw new EncodeException(e.getMessage(), e);
     }

--- a/jackson/src/main/java/feign/jackson/JacksonEncoder.java
+++ b/jackson/src/main/java/feign/jackson/JacksonEncoder.java
@@ -20,11 +20,11 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import java.lang.reflect.Type;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import feign.RequestTemplate;
 import feign.codec.EncodeException;
 import feign.codec.Encoder;
+import feign.Util;
 
 public class JacksonEncoder implements Encoder {
 
@@ -49,7 +49,7 @@ public class JacksonEncoder implements Encoder {
   public void encode(Object object, Type bodyType, RequestTemplate template) {
     try {
       JavaType javaType = mapper.getTypeFactory().constructType(bodyType);
-      template.body(mapper.writerFor(javaType).writeValueAsBytes(object), StandardCharsets.UTF_8);
+      template.body(mapper.writerFor(javaType).writeValueAsBytes(object), Util.UTF_8);
     } catch (JsonProcessingException e) {
       throw new EncodeException(e.getMessage(), e);
     }


### PR DESCRIPTION
Serialize Jackson request object directly to UTF-8 byte array without intermediate String representation.

See https://github.com/FasterXML/jackson-docs/wiki/Presentation:-Jackson-Performance#basics-things-you-should-do-anyway