### PR TITLE
Avoided url appending with slash when matrix parameter exists

### DIFF
--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -406,7 +406,7 @@ public final class RequestTemplate implements Serializable {
     if (uri == null) {
       uri = "/";
     } else if ((!uri.isEmpty() && !uri.startsWith("/") && !uri.startsWith("{")
-        && !uri.startsWith("?"))) {
+        && !uri.startsWith("?") && !uri.startsWith(";"))) {
       /* if the start of the url is a literal, it must begin with a slash. */
       uri = "/" + uri;
     }

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -469,4 +469,13 @@ public class RequestTemplateTest {
 
     assertThat(template.url()).isEqualTo("https://example.com/path?key1=value1#fragment");
   }
+
+  @Test
+  public void slashShouldNotBeAppendedForMatrixParams(){
+    RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)
+            .uri("/path;key1=value1;key2=value2",true);
+
+    assertThat(template.url()).isEqualTo("/path;key1=value1;key2=value2");
+
+  }
 }


### PR DESCRIPTION
Fixed an issue of passing matrix parameter using RequestTemplate

More details at  https://github.com/OpenFeign/feign/issues/998