### PR TITLE
Fixes 1003: Do not wrap exceptions in RuntimeException

### DIFF
--- a/reactive/pom.xml
+++ b/reactive/pom.xml
@@ -72,6 +72,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>io.projectreactor</groupId>
+      <artifactId>reactor-test</artifactId>
+      <version>${reactor.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.github.openfeign</groupId>
       <artifactId>feign-okhttp</artifactId>
       <version>${project.version}</version>

--- a/reactive/src/main/java/feign/reactive/ReactiveInvocationHandler.java
+++ b/reactive/src/main/java/feign/reactive/ReactiveInvocationHandler.java
@@ -13,16 +13,16 @@
  */
 package feign.reactive;
 
-import feign.FeignException;
 import feign.InvocationHandlerFactory.MethodHandler;
 import feign.Target;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
-import java.lang.reflect.Type;
 import java.util.Map;
-import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscription;
 
 public abstract class ReactiveInvocationHandler implements InvocationHandler {
 
@@ -90,22 +90,50 @@ public abstract class ReactiveInvocationHandler implements InvocationHandler {
                                       Object[] arguments);
 
   /**
-   * Invoke the Method Handler as a Callable.
+   * Invoke the Method Handler as a Publisher.
    *
    * @param methodHandler to invoke
    * @param arguments for the method
-   * @return a Callable wrapper for the invocation.
+   * @return a Publisher wrapper for the invocation.
    */
-  Callable<?> invokeMethod(MethodHandler methodHandler, Object[] arguments) {
-    return () -> {
-      try {
-        return methodHandler.invoke(arguments);
-      } catch (Throwable th) {
-        if (th instanceof FeignException) {
-          throw (FeignException) th;
+  Publisher<?> invokeMethod(MethodHandler methodHandler, Object[] arguments) {
+    return subscriber -> subscriber.onSubscribe(new Subscription() {
+      private final AtomicBoolean isTerminated = new AtomicBoolean(false);
+
+      @Override
+      public void request(long n) {
+        if (n <= 0 && !terminated()) {
+          subscriber.onError(new IllegalArgumentException("negative subscription request"));
         }
-        throw new RuntimeException(th);
+        if (!isTerminated()) {
+          try {
+            Object result = methodHandler.invoke(arguments);
+            if (null != result) {
+              subscriber.onNext(result);
+            }
+          } catch (Throwable th) {
+            if (!terminated()) {
+              subscriber.onError(th);
+            }
+          }
+        }
+        if (!terminated()) {
+          subscriber.onComplete();
+        }
       }
-    };
+
+      @Override
+      public void cancel() {
+        isTerminated.set(true);
+      }
+
+      private boolean isTerminated() {
+        return isTerminated.get();
+      }
+
+      private boolean terminated() {
+        return isTerminated.getAndSet(true);
+      }
+    });
   }
 }

--- a/reactive/src/main/java/feign/reactive/ReactorInvocationHandler.java
+++ b/reactive/src/main/java/feign/reactive/ReactorInvocationHandler.java
@@ -17,7 +17,6 @@ import feign.InvocationHandlerFactory.MethodHandler;
 import feign.Target;
 import java.lang.reflect.Method;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -32,11 +31,11 @@ public class ReactorInvocationHandler extends ReactiveInvocationHandler {
 
   @Override
   protected Publisher invoke(Method method, MethodHandler methodHandler, Object[] arguments) {
-    Callable<?> invocation = this.invokeMethod(methodHandler, arguments);
+    Publisher<?> invocation = this.invokeMethod(methodHandler, arguments);
     if (Flux.class.isAssignableFrom(method.getReturnType())) {
-      return Flux.from(Mono.fromCallable(invocation)).subscribeOn(Schedulers.elastic());
+      return Flux.from(invocation).subscribeOn(Schedulers.elastic());
     } else if (Mono.class.isAssignableFrom(method.getReturnType())) {
-      return Mono.fromCallable(invocation).subscribeOn(Schedulers.elastic());
+      return Mono.from(invocation).subscribeOn(Schedulers.elastic());
     }
     throw new IllegalArgumentException(
         "Return type " + method.getReturnType().getName() + " is not supported");

--- a/reactive/src/main/java/feign/reactive/RxJavaInvocationHandler.java
+++ b/reactive/src/main/java/feign/reactive/RxJavaInvocationHandler.java
@@ -30,7 +30,7 @@ public class RxJavaInvocationHandler extends ReactiveInvocationHandler {
 
   @Override
   protected Publisher invoke(Method method, MethodHandler methodHandler, Object[] arguments) {
-    return Flowable.fromCallable(this.invokeMethod(methodHandler, arguments))
+    return Flowable.fromPublisher(this.invokeMethod(methodHandler, arguments))
         .observeOn(Schedulers.trampoline());
   }
 }

--- a/reactive/src/test/java/feign/reactive/ReactiveFeignIntegrationTest.java
+++ b/reactive/src/test/java/feign/reactive/ReactiveFeignIntegrationTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import feign.Client;
-import feign.InvocationHandlerFactory;
 import feign.Logger;
 import feign.Logger.Level;
 import feign.Param;
@@ -38,20 +37,16 @@ import feign.Response;
 import feign.ResponseMapper;
 import feign.RetryableException;
 import feign.Retryer;
-import feign.Target;
 import feign.codec.Decoder;
 import feign.codec.ErrorDecoder;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
 import feign.jaxrs.JAXRSContract;
 import io.reactivex.Flowable;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Map;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import okhttp3.mockwebserver.MockResponse;
@@ -63,6 +58,7 @@ import org.mockito.AdditionalAnswers;
 import org.mockito.stubbing.Answer;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 public class ReactiveFeignIntegrationTest {
 
@@ -100,16 +96,18 @@ public class ReactiveFeignIntegrationTest {
         .target(TestReactorService.class, this.getServerUrl());
     assertThat(service).isNotNull();
 
-    String version = service.version()
-        .block();
-    assertThat(version).isNotNull();
+    StepVerifier.create(service.version())
+            .expectNext("1.0")
+            .expectComplete()
+            .verify();
     assertThat(webServer.takeRequest().getPath()).isEqualToIgnoringCase("/version");
 
 
     /* test encoding and decoding */
-    User user = service.user("test")
-        .blockFirst();
-    assertThat(user).isNotNull().hasFieldOrPropertyWithValue("username", "test");
+    StepVerifier.create(service.user("test"))
+            .assertNext(user -> assertThat(user).hasFieldOrPropertyWithValue("username", "test"))
+            .expectComplete()
+            .verify();
     assertThat(webServer.takeRequest().getPath()).isEqualToIgnoringCase("/users/test");
 
   }
@@ -127,15 +125,17 @@ public class ReactiveFeignIntegrationTest {
         .target(TestReactiveXService.class, this.getServerUrl());
     assertThat(service).isNotNull();
 
-    String version = service.version()
-        .firstElement().blockingGet();
-    assertThat(version).isNotNull();
+    StepVerifier.create(service.version())
+            .expectNext("1.0")
+            .expectComplete()
+            .verify();
     assertThat(webServer.takeRequest().getPath()).isEqualToIgnoringCase("/version");
 
     /* test encoding and decoding */
-    User user = service.user("test")
-        .firstElement().blockingGet();
-    assertThat(user).isNotNull().hasFieldOrPropertyWithValue("username", "test");
+    StepVerifier.create(service.user("test"))
+            .assertNext(user -> assertThat(user).hasFieldOrPropertyWithValue("username", "test"))
+            .expectComplete()
+            .verify();
     assertThat(webServer.takeRequest().getPath()).isEqualToIgnoringCase("/users/test");
   }
 
@@ -164,7 +164,10 @@ public class ReactiveFeignIntegrationTest {
     TestReactorService service = ReactorFeign.builder()
         .requestInterceptor(mockInterceptor)
         .target(TestReactorService.class, this.getServerUrl());
-    service.version().block();
+    StepVerifier.create(service.version())
+            .expectNext("1.0")
+            .expectComplete()
+            .verify();
     verify(mockInterceptor, times(1)).apply(any(RequestTemplate.class));
   }
 
@@ -176,7 +179,10 @@ public class ReactiveFeignIntegrationTest {
     TestReactorService service = ReactorFeign.builder()
         .requestInterceptors(Arrays.asList(mockInterceptor, mockInterceptor))
         .target(TestReactorService.class, this.getServerUrl());
-    service.version().block();
+    StepVerifier.create(service.version())
+            .expectNext("1.0")
+            .expectComplete()
+            .verify();
     verify(mockInterceptor, times(2)).apply(any(RequestTemplate.class));
   }
 
@@ -193,7 +199,10 @@ public class ReactiveFeignIntegrationTest {
     TestReactorService service = ReactorFeign.builder()
         .mapAndDecode(responseMapper, decoder)
         .target(TestReactorService.class, this.getServerUrl());
-    service.version().block();
+    StepVerifier.create(service.version())
+            .expectNext("1.0")
+            .expectComplete()
+            .verify();
     verify(responseMapper, times(1))
         .map(any(Response.class), any(Type.class));
     verify(decoder, times(1)).decode(any(Response.class), any(Type.class));
@@ -208,16 +217,16 @@ public class ReactiveFeignIntegrationTest {
     TestReactiveXService service = RxJavaFeign.builder()
         .queryMapEncoder(encoder)
         .target(TestReactiveXService.class, this.getServerUrl());
-    String results = service.search(new SearchQuery())
-        .blockingSingle();
-    assertThat(results).isNotEmpty();
+    StepVerifier.create(service.search(new SearchQuery()))
+            .expectNext("No Results Found")
+            .expectComplete()
+            .verify();
     verify(encoder, times(1)).encode(any(Object.class));
   }
 
-  @SuppressWarnings({"ResultOfMethodCallIgnored", "ThrowableNotThrown"})
+  @SuppressWarnings({"ThrowableNotThrown"})
   @Test
   public void testErrorDecoder() {
-    this.thrown.expect(RuntimeException.class);
     this.webServer.enqueue(new MockResponse().setBody("Bad Request").setResponseCode(400));
 
     ErrorDecoder errorDecoder = mock(ErrorDecoder.class);
@@ -227,8 +236,11 @@ public class ReactiveFeignIntegrationTest {
     TestReactiveXService service = RxJavaFeign.builder()
         .errorDecoder(errorDecoder)
         .target(TestReactiveXService.class, this.getServerUrl());
-    service.search(new SearchQuery())
-        .blockingSingle();
+    StepVerifier.create(service.search(new SearchQuery()))
+            .expectErrorSatisfies(ex -> assertThat(ex)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("bad request"))
+            .verify();
     verify(errorDecoder, times(1)).decode(anyString(), any(Response.class));
   }
 
@@ -243,7 +255,10 @@ public class ReactiveFeignIntegrationTest {
     TestReactorService service = ReactorFeign.builder()
         .retryer(spy)
         .target(TestReactorService.class, this.getServerUrl());
-    service.version().log().block();
+    StepVerifier.create(service.version())
+            .expectNext("1.0")
+            .expectComplete()
+            .verify();
     verify(spy, times(1)).continueOrPropagate(any(RetryableException.class));
   }
 
@@ -261,7 +276,10 @@ public class ReactiveFeignIntegrationTest {
     TestReactorService service = ReactorFeign.builder()
         .client(client)
         .target(TestReactorService.class, this.getServerUrl());
-    service.version().block();
+    StepVerifier.create(service.version())
+            .expectNext("1.0")
+            .expectComplete()
+            .verify();
     verify(client, times(1)).execute(any(Request.class), any(Options.class));
   }
 
@@ -272,8 +290,10 @@ public class ReactiveFeignIntegrationTest {
     TestJaxRSReactorService service = ReactorFeign.builder()
         .contract(new JAXRSContract())
         .target(TestJaxRSReactorService.class, this.getServerUrl());
-    String version = service.version().block();
-    assertThat(version).isNotNull();
+    StepVerifier.create(service.version())
+            .expectNext("1.0")
+            .expectComplete()
+            .verify();
     assertThat(webServer.takeRequest().getPath()).isEqualToIgnoringCase("/version");
   }
 

--- a/reactive/src/test/java/feign/reactive/ReactiveInvocationHandlerTest.java
+++ b/reactive/src/test/java/feign/reactive/ReactiveInvocationHandlerTest.java
@@ -19,28 +19,25 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
-import feign.FeignException;
 import feign.InvocationHandlerFactory.MethodHandler;
 import feign.RequestLine;
 import feign.Target;
-import feign.reactive.ReactorInvocationHandler;
-import feign.reactive.RxJavaInvocationHandler;
 import io.reactivex.Flowable;
+
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Collections;
-import org.junit.Rule;
+
+import org.junit.Before;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ReactiveInvocationHandlerTest {
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   @Mock
   private Target target;
@@ -50,10 +47,15 @@ public class ReactiveInvocationHandlerTest {
 
   private Method method;
 
+  @Before
+  public void setUp() throws NoSuchMethodException {
+    method = TestReactorService.class.getMethod("version");
+  }
+
   @SuppressWarnings("unchecked")
   @Test
   public void invokeOnSubscribeReactor() throws Throwable {
-    Method method = TestReactorService.class.getMethod("version");
+    given(this.methodHandler.invoke(any())).willReturn("Result");
     ReactorInvocationHandler handler = new ReactorInvocationHandler(this.target,
         Collections.singletonMap(method, this.methodHandler));
 
@@ -62,17 +64,33 @@ public class ReactiveInvocationHandlerTest {
     verifyZeroInteractions(this.methodHandler);
 
     /* subscribe and execute the method */
-    Mono mono = (Mono) result;
-    mono.log().block();
+    StepVerifier.create((Mono) result)
+            .expectNext("Result")
+            .expectComplete()
+            .verify();
     verify(this.methodHandler, times(1)).invoke(any());
   }
 
-  @SuppressWarnings("unchecked")
+  @Test
+  public void invokeOnSubscribeEmptyReactor() throws Throwable {
+    given(this.methodHandler.invoke(any())).willReturn(null);
+    ReactorInvocationHandler handler = new ReactorInvocationHandler(this.target,
+            Collections.singletonMap(method, this.methodHandler));
+
+    Object result = handler.invoke(method, this.methodHandler, new Object[] {});
+    assertThat(result).isInstanceOf(Mono.class);
+    verifyZeroInteractions(this.methodHandler);
+
+    /* subscribe and execute the method */
+    StepVerifier.create((Mono) result)
+            .expectComplete()
+            .verify();
+    verify(this.methodHandler, times(1)).invoke(any());
+  }
+
   @Test
   public void invokeFailureReactor() throws Throwable {
-    this.thrown.expect(RuntimeException.class);
-    given(this.methodHandler.invoke(any())).willThrow(new RuntimeException("Could Not Decode"));
-    given(this.method.getReturnType()).willReturn((Class) Class.forName(Mono.class.getName()));
+    given(this.methodHandler.invoke(any())).willThrow(new IOException("Could Not Decode"));
     ReactorInvocationHandler handler = new ReactorInvocationHandler(this.target,
         Collections.singletonMap(this.method, this.methodHandler));
 
@@ -81,12 +99,13 @@ public class ReactiveInvocationHandlerTest {
     verifyZeroInteractions(this.methodHandler);
 
     /* subscribe and execute the method, should result in an error */
-    Mono mono = (Mono) result;
-    mono.log().block();
+    StepVerifier.create((Mono) result)
+            .expectError(IOException.class)
+            .verify();
     verify(this.methodHandler, times(1)).invoke(any());
   }
 
-  @SuppressWarnings("ResultOfMethodCallIgnored")
+  @SuppressWarnings("unchecked")
   @Test
   public void invokeOnSubscribeRxJava() throws Throwable {
     given(this.methodHandler.invoke(any())).willReturn("Result");
@@ -99,16 +118,34 @@ public class ReactiveInvocationHandlerTest {
     verifyZeroInteractions(this.methodHandler);
 
     /* subscribe and execute the method */
-    Flowable flow = (Flowable) result;
-    flow.firstElement().blockingGet();
+    StepVerifier.create((Flowable) result)
+            .expectNext("Result")
+            .expectComplete()
+            .verify();
     verify(this.methodHandler, times(1)).invoke(any());
   }
 
-  @SuppressWarnings("ResultOfMethodCallIgnored")
+  @Test
+  public void invokeOnSubscribeEmptyRxJava() throws Throwable {
+    given(this.methodHandler.invoke(any())).willReturn(null);
+    RxJavaInvocationHandler handler =
+            new RxJavaInvocationHandler(this.target,
+                    Collections.singletonMap(this.method, this.methodHandler));
+
+    Object result = handler.invoke(this.method, this.methodHandler, new Object[] {});
+    assertThat(result).isInstanceOf(Flowable.class);
+    verifyZeroInteractions(this.methodHandler);
+
+    /* subscribe and execute the method */
+    StepVerifier.create((Flowable) result)
+            .expectComplete()
+            .verify();
+    verify(this.methodHandler, times(1)).invoke(any());
+  }
+
   @Test
   public void invokeFailureRxJava() throws Throwable {
-    this.thrown.expect(RuntimeException.class);
-    given(this.methodHandler.invoke(any())).willThrow(new RuntimeException("Could Not Decode"));
+    given(this.methodHandler.invoke(any())).willThrow(new IOException("Could Not Decode"));
     RxJavaInvocationHandler handler =
         new RxJavaInvocationHandler(this.target,
             Collections.singletonMap(this.method, this.methodHandler));
@@ -118,8 +155,9 @@ public class ReactiveInvocationHandlerTest {
     verifyZeroInteractions(this.methodHandler);
 
     /* subscribe and execute the method */
-    Flowable flow = (Flowable) result;
-    flow.firstElement().blockingGet();
+    StepVerifier.create((Flowable) result)
+            .expectError(IOException.class)
+            .verify();
     verify(this.methodHandler, times(1)).invoke(any());
   }
 


### PR DESCRIPTION
Fixes #1003

Initially, the ReactiveInvocationHandler.java was wrapping method invocation in a Callable. That has a few drawbacks, one of which is the fact that we cannot propagate Throwable property and we need to wrap it in some new Exception class.
This PR wraps methodInvocation in a generic Publisher instead. Publisher allows us to signal Throwables back as an error signal and without additional wrapping. 