### PR TITLE
Fix Response.InputStreamBody missing toString implementation

### DIFF
--- a/core/src/main/java/feign/Response.java
+++ b/core/src/main/java/feign/Response.java
@@ -32,6 +32,7 @@ import static feign.Util.checkNotNull;
 import static feign.Util.checkState;
 import static feign.Util.decodeOrDefault;
 import static feign.Util.valuesOrEmpty;
+import static feign.Util.toByteArray;
 
 /**
  * An immutable response to an http invocation which only returns string content.
@@ -276,6 +277,15 @@ public final class Response implements Closeable {
     @Override
     public void close() throws IOException {
       inputStream.close();
+    }
+
+    @Override
+    public String toString() {
+        try {
+            return new String(toByteArray(inputStream), UTF_8);
+        } catch (Exception e) {
+            return super.toString();
+        }
     }
   }
 


### PR DESCRIPTION
Fixes #981

Issue stated that an incorrect value was printed for the `Response` class when different log levels (DEBUG, INFO) where used - the problem was not due to log level, only that when `Response.toString()` is called it calls the `toString()` function of it's member variable `body`, and the body can be either `InputStreamBody` or `ByteArrayBody`. 

`ByteArrayBody`'s overloaded `toString()` function already exists and uses functions from the `Util` class, and this commit follows by using more functions of the `Util` class to implement a proper `toString()` implementation.