### PR TITLE
Added configuration for reactive scheduler

### DIFF
--- a/reactive/src/main/java/feign/reactive/ReactorFeign.java
+++ b/reactive/src/main/java/feign/reactive/ReactorFeign.java
@@ -51,7 +51,7 @@ public class ReactorFeign extends ReactiveFeign {
   }
 
   private static class ReactorInvocationHandlerFactory implements InvocationHandlerFactory {
-    private Scheduler scheduler;
+    private final Scheduler scheduler;
 
     private ReactorInvocationHandlerFactory(Scheduler scheduler) {
       this.scheduler = scheduler;

--- a/reactive/src/main/java/feign/reactive/ReactorFeign.java
+++ b/reactive/src/main/java/feign/reactive/ReactorFeign.java
@@ -14,7 +14,8 @@
 package feign.reactive;
 
 import feign.Feign;
-import feign.reactive.ReactiveFeign.Builder;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.util.Map;
@@ -29,24 +30,36 @@ public class ReactorFeign extends ReactiveFeign {
 
   public static class Builder extends ReactiveFeign.Builder {
 
+    private Scheduler scheduler = Schedulers.elastic();
+
     @Override
     public Feign build() {
-      super.invocationHandlerFactory(new ReactorInvocationHandlerFactory());
+      super.invocationHandlerFactory(new ReactorInvocationHandlerFactory(scheduler));
       return super.build();
     }
 
     @Override
-    public Feign.Builder invocationHandlerFactory(
-                                                  InvocationHandlerFactory invocationHandlerFactory) {
+    public Builder invocationHandlerFactory(InvocationHandlerFactory invocationHandlerFactory) {
       throw new UnsupportedOperationException(
           "Invocation Handler Factory overrides are not supported.");
+    }
+
+    public Builder scheduleOn(Scheduler scheduler) {
+      this.scheduler = scheduler;
+      return this;
     }
   }
 
   private static class ReactorInvocationHandlerFactory implements InvocationHandlerFactory {
+    private Scheduler scheduler;
+
+    private ReactorInvocationHandlerFactory(Scheduler scheduler) {
+      this.scheduler = scheduler;
+    }
+
     @Override
     public InvocationHandler create(Target target, Map<Method, MethodHandler> dispatch) {
-      return new ReactorInvocationHandler(target, dispatch);
+      return new ReactorInvocationHandler(target, dispatch, scheduler);
     }
   }
 }

--- a/reactive/src/main/java/feign/reactive/ReactorInvocationHandler.java
+++ b/reactive/src/main/java/feign/reactive/ReactorInvocationHandler.java
@@ -23,7 +23,7 @@ import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 
 public class ReactorInvocationHandler extends ReactiveInvocationHandler {
-  private Scheduler scheduler;
+  private final Scheduler scheduler;
 
   ReactorInvocationHandler(Target<?> target,
       Map<Method, MethodHandler> dispatch,

--- a/reactive/src/main/java/feign/reactive/ReactorInvocationHandler.java
+++ b/reactive/src/main/java/feign/reactive/ReactorInvocationHandler.java
@@ -20,22 +20,25 @@ import java.util.Map;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
+import reactor.core.scheduler.Scheduler;
 
 public class ReactorInvocationHandler extends ReactiveInvocationHandler {
+  private Scheduler scheduler;
 
   ReactorInvocationHandler(Target<?> target,
-      Map<Method, MethodHandler> dispatch) {
+      Map<Method, MethodHandler> dispatch,
+      Scheduler scheduler) {
     super(target, dispatch);
+    this.scheduler = scheduler;
   }
 
   @Override
   protected Publisher invoke(Method method, MethodHandler methodHandler, Object[] arguments) {
     Publisher<?> invocation = this.invokeMethod(methodHandler, arguments);
     if (Flux.class.isAssignableFrom(method.getReturnType())) {
-      return Flux.from(invocation).subscribeOn(Schedulers.elastic());
+      return Flux.from(invocation).subscribeOn(scheduler);
     } else if (Mono.class.isAssignableFrom(method.getReturnType())) {
-      return Mono.from(invocation).subscribeOn(Schedulers.elastic());
+      return Mono.from(invocation).subscribeOn(scheduler);
     }
     throw new IllegalArgumentException(
         "Return type " + method.getReturnType().getName() + " is not supported");

--- a/reactive/src/main/java/feign/reactive/RxJavaFeign.java
+++ b/reactive/src/main/java/feign/reactive/RxJavaFeign.java
@@ -19,6 +19,8 @@ import java.util.Map;
 import feign.Feign;
 import feign.InvocationHandlerFactory;
 import feign.Target;
+import io.reactivex.Scheduler;
+import io.reactivex.schedulers.Schedulers;
 
 public class RxJavaFeign extends ReactiveFeign {
 
@@ -28,25 +30,36 @@ public class RxJavaFeign extends ReactiveFeign {
 
   public static class Builder extends ReactiveFeign.Builder {
 
+    private Scheduler scheduler = Schedulers.trampoline();
+
     @Override
     public Feign build() {
-      super.invocationHandlerFactory(new RxJavaInvocationHandlerFactory());
+      super.invocationHandlerFactory(new RxJavaInvocationHandlerFactory(scheduler));
       return super.build();
     }
 
     @Override
-    public Feign.Builder invocationHandlerFactory(
-                                                  InvocationHandlerFactory invocationHandlerFactory) {
+    public Builder invocationHandlerFactory(InvocationHandlerFactory invocationHandlerFactory) {
       throw new UnsupportedOperationException(
           "Invocation Handler Factory overrides are not supported.");
     }
 
+    public Builder scheduleOn(Scheduler scheduler) {
+      this.scheduler = scheduler;
+      return this;
+    }
   }
 
   private static class RxJavaInvocationHandlerFactory implements InvocationHandlerFactory {
+    private Scheduler scheduler;
+
+    private RxJavaInvocationHandlerFactory(Scheduler scheduler) {
+      this.scheduler = scheduler;
+    }
+
     @Override
     public InvocationHandler create(Target target, Map<Method, MethodHandler> dispatch) {
-      return new RxJavaInvocationHandler(target, dispatch);
+      return new RxJavaInvocationHandler(target, dispatch, scheduler);
     }
   }
 

--- a/reactive/src/main/java/feign/reactive/RxJavaFeign.java
+++ b/reactive/src/main/java/feign/reactive/RxJavaFeign.java
@@ -51,7 +51,7 @@ public class RxJavaFeign extends ReactiveFeign {
   }
 
   private static class RxJavaInvocationHandlerFactory implements InvocationHandlerFactory {
-    private Scheduler scheduler;
+    private final Scheduler scheduler;
 
     private RxJavaInvocationHandlerFactory(Scheduler scheduler) {
       this.scheduler = scheduler;

--- a/reactive/src/main/java/feign/reactive/RxJavaInvocationHandler.java
+++ b/reactive/src/main/java/feign/reactive/RxJavaInvocationHandler.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import org.reactivestreams.Publisher;
 
 public class RxJavaInvocationHandler extends ReactiveInvocationHandler {
-  private Scheduler scheduler;
+  private final Scheduler scheduler;
 
   RxJavaInvocationHandler(Target<?> target,
       Map<Method, MethodHandler> dispatch,

--- a/reactive/src/main/java/feign/reactive/RxJavaInvocationHandler.java
+++ b/reactive/src/main/java/feign/reactive/RxJavaInvocationHandler.java
@@ -16,21 +16,24 @@ package feign.reactive;
 import feign.InvocationHandlerFactory.MethodHandler;
 import feign.Target;
 import io.reactivex.Flowable;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.Scheduler;
 import java.lang.reflect.Method;
 import java.util.Map;
 import org.reactivestreams.Publisher;
 
 public class RxJavaInvocationHandler extends ReactiveInvocationHandler {
+  private Scheduler scheduler;
 
   RxJavaInvocationHandler(Target<?> target,
-      Map<Method, MethodHandler> dispatch) {
+      Map<Method, MethodHandler> dispatch,
+      Scheduler scheduler) {
     super(target, dispatch);
+    this.scheduler = scheduler;
   }
 
   @Override
   protected Publisher invoke(Method method, MethodHandler methodHandler, Object[] arguments) {
     return Flowable.fromPublisher(this.invokeMethod(methodHandler, arguments))
-        .observeOn(Schedulers.trampoline());
+        .observeOn(scheduler);
   }
 }

--- a/reactive/src/test/java/feign/reactive/ReactiveInvocationHandlerTest.java
+++ b/reactive/src/test/java/feign/reactive/ReactiveInvocationHandlerTest.java
@@ -23,17 +23,16 @@ import feign.InvocationHandlerFactory.MethodHandler;
 import feign.RequestLine;
 import feign.Target;
 import io.reactivex.Flowable;
-
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Collections;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -57,7 +56,7 @@ public class ReactiveInvocationHandlerTest {
   public void invokeOnSubscribeReactor() throws Throwable {
     given(this.methodHandler.invoke(any())).willReturn("Result");
     ReactorInvocationHandler handler = new ReactorInvocationHandler(this.target,
-        Collections.singletonMap(method, this.methodHandler));
+        Collections.singletonMap(method, this.methodHandler), Schedulers.elastic());
 
     Object result = handler.invoke(method, this.methodHandler, new Object[] {});
     assertThat(result).isInstanceOf(Mono.class);
@@ -75,7 +74,7 @@ public class ReactiveInvocationHandlerTest {
   public void invokeOnSubscribeEmptyReactor() throws Throwable {
     given(this.methodHandler.invoke(any())).willReturn(null);
     ReactorInvocationHandler handler = new ReactorInvocationHandler(this.target,
-            Collections.singletonMap(method, this.methodHandler));
+        Collections.singletonMap(method, this.methodHandler), Schedulers.elastic());
 
     Object result = handler.invoke(method, this.methodHandler, new Object[] {});
     assertThat(result).isInstanceOf(Mono.class);
@@ -92,7 +91,7 @@ public class ReactiveInvocationHandlerTest {
   public void invokeFailureReactor() throws Throwable {
     given(this.methodHandler.invoke(any())).willThrow(new IOException("Could Not Decode"));
     ReactorInvocationHandler handler = new ReactorInvocationHandler(this.target,
-        Collections.singletonMap(this.method, this.methodHandler));
+        Collections.singletonMap(this.method, this.methodHandler), Schedulers.elastic());
 
     Object result = handler.invoke(this.method, this.methodHandler, new Object[] {});
     assertThat(result).isInstanceOf(Mono.class);
@@ -111,7 +110,8 @@ public class ReactiveInvocationHandlerTest {
     given(this.methodHandler.invoke(any())).willReturn("Result");
     RxJavaInvocationHandler handler =
         new RxJavaInvocationHandler(this.target,
-            Collections.singletonMap(this.method, this.methodHandler));
+            Collections.singletonMap(this.method, this.methodHandler),
+            io.reactivex.schedulers.Schedulers.trampoline());
 
     Object result = handler.invoke(this.method, this.methodHandler, new Object[] {});
     assertThat(result).isInstanceOf(Flowable.class);
@@ -129,8 +129,9 @@ public class ReactiveInvocationHandlerTest {
   public void invokeOnSubscribeEmptyRxJava() throws Throwable {
     given(this.methodHandler.invoke(any())).willReturn(null);
     RxJavaInvocationHandler handler =
-            new RxJavaInvocationHandler(this.target,
-                    Collections.singletonMap(this.method, this.methodHandler));
+        new RxJavaInvocationHandler(this.target,
+            Collections.singletonMap(this.method, this.methodHandler),
+            io.reactivex.schedulers.Schedulers.trampoline());
 
     Object result = handler.invoke(this.method, this.methodHandler, new Object[] {});
     assertThat(result).isInstanceOf(Flowable.class);
@@ -148,7 +149,8 @@ public class ReactiveInvocationHandlerTest {
     given(this.methodHandler.invoke(any())).willThrow(new IOException("Could Not Decode"));
     RxJavaInvocationHandler handler =
         new RxJavaInvocationHandler(this.target,
-            Collections.singletonMap(this.method, this.methodHandler));
+            Collections.singletonMap(this.method, this.methodHandler),
+            io.reactivex.schedulers.Schedulers.trampoline());
 
     Object result = handler.invoke(this.method, this.methodHandler, new Object[] {});
     assertThat(result).isInstanceOf(Flowable.class);


### PR DESCRIPTION
Added configuration for reactive schedulers.

Sometimes it's quite an extreme measure to schedule execution on an unbound thread pool. This PR mitigates that by adding control which scheduler to use for request execution.