### PR TITLE
Remove query template empty argument filtering 

### DIFF
--- a/core/src/main/java/feign/template/QueryTemplate.java
+++ b/core/src/main/java/feign/template/QueryTemplate.java
@@ -72,7 +72,6 @@ public final class QueryTemplate extends Template {
 
     /* remove all empty values from the array */
     Collection<String> remaining = StreamSupport.stream(values.spliterator(), false)
-        .filter(Util::isNotBlank)
         .collect(Collectors.toList());
 
     StringBuilder template = new StringBuilder();

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -54,6 +54,18 @@ public class FeignTest {
   public final MockWebServer server = new MockWebServer();
 
   @Test
+  public void emptyQueryArrayParameter() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
+
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+
+    api.emptyArrayElement(Arrays.asList("first", "", "third"));
+
+    assertThat(server.takeRequest())
+            .hasPath("/test?people=first&people=&people=third");
+  }
+
+  @Test
   public void iterableQueryParams() throws Exception {
     server.enqueue(new MockResponse().setBody("foo"));
 
@@ -937,6 +949,9 @@ public class FeignTest {
               @Param("customer_name") String customer,
               @Param("user_name") String user,
               @Param("password") String password);
+
+    @RequestLine("GET /test?people={people}")
+    Response emptyArrayElement(@Param(value = "people", encoded = true) Collection<String> people);
 
     @RequestLine("GET /{1}/{2}")
     Response uriParam(@Param("1") String one, URI endpoint, @Param("2") String two);


### PR DESCRIPTION
To allow empty values appear in request.
I've found only one way to change it. I don't like that both query string and arguments parsed via one class. Also removed code was added to create filter I have removed. It's strange. But test works fine after removing filter.