### PR TITLE
GH-801: Adding support for JDK Proxy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -495,8 +495,11 @@
             <exclude>**/.idea/**</exclude>
             <exclude>**/target/**</exclude>
             <exclude>LICENSE</exclude>
+            <exclude>NOTICE</exclude>
+            <exclude>OSSMETADATA</exclude>
             <exclude>**/*.md</exclude>
             <exclude>bnd.bnd</exclude>
+            <exclude>travis/**</exclude>
             <exclude>src/test/resources/**</exclude>
             <exclude>src/main/resources/**</exclude>
           </excludes>


### PR DESCRIPTION
Fixes #801

Adding a `Proxied` client implementation that extends the `Default`
client allowing for a JDK Proxy, along with explict credential support.