### PR TITLE
Unexpected JavaLogger behavior fixed

### DIFF
--- a/core/src/main/java/feign/FeignException.java
+++ b/core/src/main/java/feign/FeignException.java
@@ -25,27 +25,33 @@ public class FeignException extends RuntimeException {
   private static final long serialVersionUID = 0;
   private int status;
   private byte[] content;
+  private Request request;
 
-  protected FeignException(int status, String message, Throwable cause) {
+  protected FeignException(int status, String message, Request request, Throwable cause) {
     super(message, cause);
     this.status = status;
+    this.request = request;
   }
 
-  protected FeignException(int status, String message, Throwable cause, byte[] content) {
+  protected FeignException(int status, String message, Request request, Throwable cause,
+      byte[] content) {
     super(message, cause);
     this.status = status;
     this.content = content;
+    this.request = request;
   }
 
-  protected FeignException(int status, String message) {
+  protected FeignException(int status, String message, Request request) {
     super(message);
     this.status = status;
+    this.request = request;
   }
 
-  protected FeignException(int status, String message, byte[] content) {
+  protected FeignException(int status, String message, Request request, byte[] content) {
     super(message);
     this.status = status;
     this.content = content;
+    this.request = request;
   }
 
   public int status() {
@@ -54,6 +60,10 @@ public class FeignException extends RuntimeException {
 
   public byte[] content() {
     return this.content;
+  }
+
+  public Request request() {
+    return this.request;
   }
 
   public String contentUTF8() {
@@ -68,6 +78,7 @@ public class FeignException extends RuntimeException {
     return new FeignException(
         response.status(),
         format("%s reading %s %s", cause.getMessage(), request.httpMethod(), request.url()),
+        request,
         cause,
         request.requestBody().asBytes());
   }
@@ -83,49 +94,55 @@ public class FeignException extends RuntimeException {
     } catch (IOException ignored) { // NOPMD
     }
 
-    return errorStatus(response.status(), message, body);
+    return errorStatus(response.status(), message, response.request(), body);
   }
 
-  private static FeignException errorStatus(int status, String message, byte[] body) {
+  private static FeignException errorStatus(int status,
+                                            String message,
+                                            Request request,
+                                            byte[] body) {
     if (isClientError(status)) {
-      return clientErrorStatus(status, message, body);
+      return clientErrorStatus(status, message, request, body);
     }
     if (isServerError(status)) {
-      return serverErrorStatus(status, message, body);
+      return serverErrorStatus(status, message, request, body);
     }
-    return new FeignException(status, message, body);
+    return new FeignException(status, message, request, body);
   }
 
   private static boolean isClientError(int status) {
     return status >= 400 && status < 500;
   }
 
-  private static FeignClientException clientErrorStatus(int status, String message, byte[] body) {
+  private static FeignClientException clientErrorStatus(int status,
+                                                        String message,
+                                                        Request request,
+                                                        byte[] body) {
     switch (status) {
       case 400:
-        return new BadRequest(message, body);
+        return new BadRequest(message, request, body);
       case 401:
-        return new Unauthorized(message, body);
+        return new Unauthorized(message, request, body);
       case 403:
-        return new Forbidden(message, body);
+        return new Forbidden(message, request, body);
       case 404:
-        return new NotFound(message, body);
+        return new NotFound(message, request, body);
       case 405:
-        return new MethodNotAllowed(message, body);
+        return new MethodNotAllowed(message, request, body);
       case 406:
-        return new NotAcceptable(message, body);
+        return new NotAcceptable(message, request, body);
       case 409:
-        return new Conflict(message, body);
+        return new Conflict(message, request, body);
       case 410:
-        return new Gone(message, body);
+        return new Gone(message, request, body);
       case 415:
-        return new UnsupportedMediaType(message, body);
+        return new UnsupportedMediaType(message, request, body);
       case 429:
-        return new TooManyRequests(message, body);
+        return new TooManyRequests(message, request, body);
       case 422:
-        return new UnprocessableEntity(message, body);
+        return new UnprocessableEntity(message, request, body);
       default:
-        return new FeignClientException(status, message, body);
+        return new FeignClientException(status, message, request, body);
     }
   }
 
@@ -133,20 +150,23 @@ public class FeignException extends RuntimeException {
     return status >= 500 && status <= 599;
   }
 
-  private static FeignServerException serverErrorStatus(int status, String message, byte[] body) {
+  private static FeignServerException serverErrorStatus(int status,
+                                                        String message,
+                                                        Request request,
+                                                        byte[] body) {
     switch (status) {
       case 500:
-        return new InternalServerError(message, body);
+        return new InternalServerError(message, request, body);
       case 501:
-        return new NotImplemented(message, body);
+        return new NotImplemented(message, request, body);
       case 502:
-        return new BadGateway(message, body);
+        return new BadGateway(message, request, body);
       case 503:
-        return new ServiceUnavailable(message, body);
+        return new ServiceUnavailable(message, request, body);
       case 504:
-        return new GatewayTimeout(message, body);
+        return new GatewayTimeout(message, request, body);
       default:
-        return new FeignServerException(status, message, body);
+        return new FeignServerException(status, message, request, body);
     }
   }
 
@@ -156,114 +176,114 @@ public class FeignException extends RuntimeException {
         format("%s executing %s %s", cause.getMessage(), request.httpMethod(), request.url()),
         request.httpMethod(),
         cause,
-        null);
+        null, request);
   }
 
   public static class FeignClientException extends FeignException {
-    public FeignClientException(int status, String message, byte[] body) {
-      super(status, message, body);
+    public FeignClientException(int status, String message, Request request, byte[] body) {
+      super(status, message, request, body);
     }
   }
 
   public static class BadRequest extends FeignClientException {
-    public BadRequest(String message, byte[] body) {
-      super(400, message, body);
+    public BadRequest(String message, Request request, byte[] body) {
+      super(400, message, request, body);
     }
   }
 
   public static class Unauthorized extends FeignClientException {
-    public Unauthorized(String message, byte[] body) {
-      super(401, message, body);
+    public Unauthorized(String message, Request request, byte[] body) {
+      super(401, message, request, body);
     }
   }
 
   public static class Forbidden extends FeignClientException {
-    public Forbidden(String message, byte[] body) {
-      super(403, message, body);
+    public Forbidden(String message, Request request, byte[] body) {
+      super(403, message, request, body);
     }
   }
 
   public static class NotFound extends FeignClientException {
-    public NotFound(String message, byte[] body) {
-      super(404, message, body);
+    public NotFound(String message, Request request, byte[] body) {
+      super(404, message, request, body);
     }
   }
 
   public static class MethodNotAllowed extends FeignClientException {
-    public MethodNotAllowed(String message, byte[] body) {
-      super(405, message, body);
+    public MethodNotAllowed(String message, Request request, byte[] body) {
+      super(405, message, request, body);
     }
   }
 
   public static class NotAcceptable extends FeignClientException {
-    public NotAcceptable(String message, byte[] body) {
-      super(406, message, body);
+    public NotAcceptable(String message, Request request, byte[] body) {
+      super(406, message, request, body);
     }
   }
 
   public static class Conflict extends FeignClientException {
-    public Conflict(String message, byte[] body) {
-      super(409, message, body);
+    public Conflict(String message, Request request, byte[] body) {
+      super(409, message, request, body);
     }
   }
 
   public static class Gone extends FeignClientException {
-    public Gone(String message, byte[] body) {
-      super(410, message, body);
+    public Gone(String message, Request request, byte[] body) {
+      super(410, message, request, body);
     }
   }
 
   public static class UnsupportedMediaType extends FeignClientException {
-    public UnsupportedMediaType(String message, byte[] body) {
-      super(415, message, body);
+    public UnsupportedMediaType(String message, Request request, byte[] body) {
+      super(415, message, request, body);
     }
   }
 
   public static class TooManyRequests extends FeignClientException {
-    public TooManyRequests(String message, byte[] body) {
-      super(429, message, body);
+    public TooManyRequests(String message, Request request, byte[] body) {
+      super(429, message, request, body);
     }
   }
 
   public static class UnprocessableEntity extends FeignClientException {
-    public UnprocessableEntity(String message, byte[] body) {
-      super(422, message, body);
+    public UnprocessableEntity(String message, Request request, byte[] body) {
+      super(422, message, request, body);
     }
   }
 
   public static class FeignServerException extends FeignException {
-    public FeignServerException(int status, String message, byte[] body) {
-      super(status, message, body);
+    public FeignServerException(int status, String message, Request request, byte[] body) {
+      super(status, message, request, body);
     }
   }
 
   public static class InternalServerError extends FeignServerException {
-    public InternalServerError(String message, byte[] body) {
-      super(500, message, body);
+    public InternalServerError(String message, Request request, byte[] body) {
+      super(500, message, request, body);
     }
   }
 
   public static class NotImplemented extends FeignServerException {
-    public NotImplemented(String message, byte[] body) {
-      super(501, message, body);
+    public NotImplemented(String message, Request request, byte[] body) {
+      super(501, message, request, body);
     }
   }
 
   public static class BadGateway extends FeignServerException {
-    public BadGateway(String message, byte[] body) {
-      super(502, message, body);
+    public BadGateway(String message, Request request, byte[] body) {
+      super(502, message, request, body);
     }
   }
 
   public static class ServiceUnavailable extends FeignServerException {
-    public ServiceUnavailable(String message, byte[] body) {
-      super(503, message, body);
+    public ServiceUnavailable(String message, Request request, byte[] body) {
+      super(503, message, request, body);
     }
   }
 
   public static class GatewayTimeout extends FeignServerException {
-    public GatewayTimeout(String message, byte[] body) {
-      super(504, message, body);
+    public GatewayTimeout(String message, Request request, byte[] body) {
+      super(504, message, request, body);
     }
   }
 }

--- a/core/src/main/java/feign/FeignException.java
+++ b/core/src/main/java/feign/FeignException.java
@@ -23,6 +23,7 @@ import java.io.IOException;
  */
 public class FeignException extends RuntimeException {
 
+  private static final String EXCEPTION_MESSAGE_TEMPLATE_NULL_REQUEST = "request should not be null";
   private static final long serialVersionUID = 0;
   private int status;
   private byte[] content;
@@ -57,7 +58,7 @@ public class FeignException extends RuntimeException {
   protected FeignException(int status, String message, Request request, Throwable cause) {
     super(message, cause);
     this.status = status;
-    this.request = checkNotNull(request, "request");
+    this.request = checkRequestNotNull(request);
   }
 
   protected FeignException(int status, String message, Request request, Throwable cause,
@@ -65,20 +66,24 @@ public class FeignException extends RuntimeException {
     super(message, cause);
     this.status = status;
     this.content = content;
-    this.request = checkNotNull(request, "request");
+    this.request = checkRequestNotNull(request);
   }
 
   protected FeignException(int status, String message, Request request) {
     super(message);
     this.status = status;
-    this.request = checkNotNull(request, "request");
+    this.request = checkRequestNotNull(request);
   }
 
   protected FeignException(int status, String message, Request request, byte[] content) {
     super(message);
     this.status = status;
     this.content = content;
-    this.request = checkNotNull(request, "request");
+    this.request = checkRequestNotNull(request);
+  }
+
+  private Request checkRequestNotNull(Request request) {
+    return checkNotNull(request, EXCEPTION_MESSAGE_TEMPLATE_NULL_REQUEST);
   }
 
   public int status() {

--- a/core/src/main/java/feign/FeignException.java
+++ b/core/src/main/java/feign/FeignException.java
@@ -14,6 +14,7 @@
 package feign;
 
 import static feign.Util.UTF_8;
+import static feign.Util.checkNotNull;
 import static java.lang.String.format;
 import java.io.IOException;
 
@@ -27,10 +28,36 @@ public class FeignException extends RuntimeException {
   private byte[] content;
   private Request request;
 
+  protected FeignException(int status, String message, Throwable cause) {
+    super(message, cause);
+    this.status = status;
+    this.request = null;
+  }
+
+  protected FeignException(int status, String message, Throwable cause, byte[] content) {
+    super(message, cause);
+    this.status = status;
+    this.content = content;
+    this.request = null;
+  }
+
+  protected FeignException(int status, String message) {
+    super(message);
+    this.status = status;
+    this.request = null;
+  }
+
+  protected FeignException(int status, String message, byte[] content) {
+    super(message);
+    this.status = status;
+    this.content = content;
+    this.request = null;
+  }
+
   protected FeignException(int status, String message, Request request, Throwable cause) {
     super(message, cause);
     this.status = status;
-    this.request = request;
+    this.request = checkNotNull(request, "request");
   }
 
   protected FeignException(int status, String message, Request request, Throwable cause,
@@ -38,20 +65,20 @@ public class FeignException extends RuntimeException {
     super(message, cause);
     this.status = status;
     this.content = content;
-    this.request = request;
+    this.request = checkNotNull(request, "request");
   }
 
   protected FeignException(int status, String message, Request request) {
     super(message);
     this.status = status;
-    this.request = request;
+    this.request = checkNotNull(request, "request");
   }
 
   protected FeignException(int status, String message, Request request, byte[] content) {
     super(message);
     this.status = status;
     this.content = content;
-    this.request = request;
+    this.request = checkNotNull(request, "request");
   }
 
   public int status() {
@@ -64,6 +91,10 @@ public class FeignException extends RuntimeException {
 
   public Request request() {
     return this.request;
+  }
+
+  public boolean hasRequest() {
+    return (this.request != null);
   }
 
   public String contentUTF8() {

--- a/core/src/main/java/feign/Response.java
+++ b/core/src/main/java/feign/Response.java
@@ -281,11 +281,11 @@ public final class Response implements Closeable {
 
     @Override
     public String toString() {
-        try {
-            return new String(toByteArray(inputStream), UTF_8);
-        } catch (Exception e) {
-            return super.toString();
-        }
+      try {
+        return new String(toByteArray(inputStream), UTF_8);
+      } catch (Exception e) {
+        return super.toString();
+      }
     }
   }
 

--- a/core/src/main/java/feign/RetryableException.java
+++ b/core/src/main/java/feign/RetryableException.java
@@ -31,8 +31,8 @@ public class RetryableException extends FeignException {
    * @param retryAfter usually corresponds to the {@link feign.Util#RETRY_AFTER} header.
    */
   public RetryableException(int status, String message, HttpMethod httpMethod, Throwable cause,
-      Date retryAfter) {
-    super(status, message, cause);
+      Date retryAfter, Request request) {
+    super(status, message, request, cause);
     this.httpMethod = httpMethod;
     this.retryAfter = retryAfter != null ? retryAfter.getTime() : null;
   }
@@ -40,8 +40,9 @@ public class RetryableException extends FeignException {
   /**
    * @param retryAfter usually corresponds to the {@link feign.Util#RETRY_AFTER} header.
    */
-  public RetryableException(int status, String message, HttpMethod httpMethod, Date retryAfter) {
-    super(status, message);
+  public RetryableException(int status, String message, HttpMethod httpMethod, Date retryAfter,
+      Request request) {
+    super(status, message, request);
     this.httpMethod = httpMethod;
     this.retryAfter = retryAfter != null ? retryAfter.getTime() : null;
   }

--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -179,7 +179,7 @@ final class SynchronousMethodHandler implements MethodHandler {
     } catch (FeignException e) {
       throw e;
     } catch (RuntimeException e) {
-      throw new DecodeException(response.status(), e.getMessage(), e);
+      throw new DecodeException(response.status(), e.getMessage(), response.request(), e);
     }
   }
 

--- a/core/src/main/java/feign/codec/DecodeException.java
+++ b/core/src/main/java/feign/codec/DecodeException.java
@@ -14,6 +14,7 @@
 package feign.codec;
 
 import feign.FeignException;
+import feign.Request;
 import static feign.Util.checkNotNull;
 
 /**
@@ -28,15 +29,15 @@ public class DecodeException extends FeignException {
   /**
    * @param message the reason for the failure.
    */
-  public DecodeException(int status, String message) {
-    super(status, checkNotNull(message, "message"));
+  public DecodeException(int status, String message, Request request) {
+    super(status, checkNotNull(message, "message"), request);
   }
 
   /**
    * @param message possibly null reason for the failure.
    * @param cause the cause of the error.
    */
-  public DecodeException(int status, String message, Throwable cause) {
-    super(status, message, checkNotNull(cause, "cause"));
+  public DecodeException(int status, String message, Request request, Throwable cause) {
+    super(status, message, request, checkNotNull(cause, "cause"));
   }
 }

--- a/core/src/main/java/feign/codec/EncodeException.java
+++ b/core/src/main/java/feign/codec/EncodeException.java
@@ -29,7 +29,7 @@ public class EncodeException extends FeignException {
    * @param message the reason for the failure.
    */
   public EncodeException(String message) {
-    super(-1, checkNotNull(message, "message"));
+    super(-1, checkNotNull(message, "message"), null);
   }
 
   /**
@@ -37,6 +37,6 @@ public class EncodeException extends FeignException {
    * @param cause the cause of the error.
    */
   public EncodeException(String message, Throwable cause) {
-    super(-1, message, checkNotNull(cause, "cause"));
+    super(-1, message, null, checkNotNull(cause, "cause"));
   }
 }

--- a/core/src/main/java/feign/codec/EncodeException.java
+++ b/core/src/main/java/feign/codec/EncodeException.java
@@ -29,7 +29,7 @@ public class EncodeException extends FeignException {
    * @param message the reason for the failure.
    */
   public EncodeException(String message) {
-    super(-1, checkNotNull(message, "message"), null);
+    super(-1, checkNotNull(message, "message"));
   }
 
   /**
@@ -37,6 +37,6 @@ public class EncodeException extends FeignException {
    * @param cause the cause of the error.
    */
   public EncodeException(String message, Throwable cause) {
-    super(-1, message, null, checkNotNull(cause, "cause"));
+    super(-1, message, checkNotNull(cause, "cause"));
   }
 }

--- a/core/src/main/java/feign/codec/ErrorDecoder.java
+++ b/core/src/main/java/feign/codec/ErrorDecoder.java
@@ -18,11 +18,9 @@ import static feign.Util.RETRY_AFTER;
 import static feign.Util.checkNotNull;
 import static java.util.Locale.US;
 import static java.util.concurrent.TimeUnit.SECONDS;
-
 import feign.FeignException;
 import feign.Response;
 import feign.RetryableException;
-
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -99,7 +97,8 @@ public interface ErrorDecoder {
             exception.getMessage(),
             response.request().httpMethod(),
             exception,
-            retryAfter);
+            retryAfter,
+            response.request());
       }
       return exception;
     }

--- a/core/src/main/java/feign/codec/StringDecoder.java
+++ b/core/src/main/java/feign/codec/StringDecoder.java
@@ -31,6 +31,6 @@ public class StringDecoder implements Decoder {
       return Util.toString(body.asReader());
     }
     throw new DecodeException(response.status(),
-        format("%s is not a type supported by this decoder.", type));
+        format("%s is not a type supported by this decoder.", type), response.request());
   }
 }

--- a/core/src/test/java/feign/FeignExceptionTest.java
+++ b/core/src/test/java/feign/FeignExceptionTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2012-2019 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign;
+
+import org.junit.Test;
+
+public class FeignExceptionTest {
+
+    @Test(expected = NullPointerException.class)
+    public void nullRequestShouldThrowNPEwThrowable() {
+        new Derived(404, "message", null, new Throwable());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void nullRequestShouldThrowNPEwThrowableAndBytes() {
+        new Derived(404, "message", null, new Throwable(), new byte[1]);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void nullRequestShouldThrowNPE() {
+        new Derived(404, "message", null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void nullRequestShouldThrowNPEwBytes() {
+        new Derived(404, "message", null, new byte[1]);
+    }
+
+    static class Derived extends FeignException {
+
+        public Derived(int status, String message, Request request, Throwable cause) {
+            super(status, message, request, cause);
+        }
+
+        public Derived(int status, String message, Request request, Throwable cause, byte[] content) {
+            super(status, message, request, cause, content);
+        }
+
+        public Derived(int status, String message, Request request) {
+            super(status, message, request);
+        }
+
+        public Derived(int status, String message, Request request, byte[] content) {
+            super(status, message, request, content);
+        }
+    }
+
+}

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -481,7 +481,8 @@ public class FeignTest {
           public Object decode(Response response, Type type) throws IOException {
             String string = super.decode(response, type).toString();
             if ("retry!".equals(string)) {
-              throw new RetryableException(response.status(), string, HttpMethod.POST, null);
+              throw new RetryableException(response.status(), string, HttpMethod.POST, null,
+                  response.request());
             }
             return string;
           }
@@ -561,7 +562,7 @@ public class FeignTest {
           @Override
           public Exception decode(String methodKey, Response response) {
             return new RetryableException(response.status(), "play it again sam!", HttpMethod.POST,
-                null);
+                null, response.request());
           }
         }).target(TestInterface.class, "http://localhost:" + server.getPort());
 
@@ -586,7 +587,7 @@ public class FeignTest {
           @Override
           public Exception decode(String methodKey, Response response) {
             return new RetryableException(response.status(), "play it again sam!", HttpMethod.POST,
-                new TestInterfaceException(message), null);
+                new TestInterfaceException(message), null, response.request());
           }
         }).target(TestInterface.class, "http://localhost:" + server.getPort());
 
@@ -608,7 +609,8 @@ public class FeignTest {
         .errorDecoder(new ErrorDecoder() {
           @Override
           public Exception decode(String methodKey, Response response) {
-            return new RetryableException(response.status(), message, HttpMethod.POST, null);
+            return new RetryableException(response.status(), message, HttpMethod.POST, null,
+                response.request());
           }
         }).target(TestInterface.class, "http://localhost:" + server.getPort());
 

--- a/core/src/test/java/feign/MultipleLoggerTest.java
+++ b/core/src/test/java/feign/MultipleLoggerTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2012-2019 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign;
+
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+
+public class MultipleLoggerTest {
+
+    private static java.util.logging.Logger getInnerLogger(Logger.JavaLogger logger) throws Exception {
+        Field inner = logger.getClass().getDeclaredField("logger");
+        inner.setAccessible(true);
+        return (java.util.logging.Logger) inner.get(logger);
+    }
+
+    @Test
+    public void testMultipleJavaLoggersHaveOneLoggerPerInstance() throws Exception {
+        Logger.JavaLogger l1 = new Logger.JavaLogger().appendToFile("1.log");
+        Logger.JavaLogger l2 = new Logger.JavaLogger().appendToFile("2.log");
+        java.util.logging.Logger logger1 = getInnerLogger(l1);
+        assert (logger1.getHandlers().length == 1);
+        java.util.logging.Logger logger2 = getInnerLogger(l2);
+        assert (logger2.getHandlers().length == 1);
+    }
+
+    @Test
+    public void testAppendSeveralFilesToOneJavaLogger() throws Exception {
+        Logger.JavaLogger logger = new Logger.JavaLogger().appendToFile("1.log").appendToFile("2.log");
+        java.util.logging.Logger inner = getInnerLogger(logger);
+        assert (inner.getHandlers().length == 2);
+    }
+
+    @Test
+    public void testJavaLoggerInstantationWithLoggerName() throws Exception {
+        Logger.JavaLogger l1 = new Logger.JavaLogger("First client").appendToFile("1.log");
+        Logger.JavaLogger l2 = new Logger.JavaLogger("Second client").appendToFile("2.log");
+        java.util.logging.Logger logger1 = getInnerLogger(l1);
+        assert (logger1.getHandlers().length == 1);
+        java.util.logging.Logger logger2 = getInnerLogger(l2);
+        assert (logger2.getHandlers().length == 1);
+    }
+
+}

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -471,9 +471,9 @@ public class RequestTemplateTest {
   }
 
   @Test
-  public void slashShouldNotBeAppendedForMatrixParams(){
+  public void slashShouldNotBeAppendedForMatrixParams() {
     RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)
-            .uri("/path;key1=value1;key2=value2",true);
+        .uri("/path;key1=value1;key2=value2", true);
 
     assertThat(template.url()).isEqualTo("/path;key1=value1;key2=value2");
 

--- a/core/src/test/java/feign/RetryerTest.java
+++ b/core/src/test/java/feign/RetryerTest.java
@@ -28,7 +28,7 @@ public class RetryerTest {
 
   @Test
   public void only5TriesAllowedAndExponentialBackoff() throws Exception {
-    RetryableException e = new RetryableException(-1, null, null, null);
+    RetryableException e = new RetryableException(-1, null, null, null, null);
     Default retryer = new Retryer.Default();
     assertEquals(1, retryer.attempt);
     assertEquals(0, retryer.sleptForMillis);
@@ -61,14 +61,15 @@ public class RetryerTest {
       }
     };
 
-    retryer.continueOrPropagate(new RetryableException(-1, null, null, new Date(5000)));
+    retryer.continueOrPropagate(new RetryableException(-1, null, null, new Date(5000), null));
     assertEquals(2, retryer.attempt);
     assertEquals(1000, retryer.sleptForMillis);
   }
 
   @Test(expected = RetryableException.class)
   public void neverRetryAlwaysPropagates() {
-    Retryer.NEVER_RETRY.continueOrPropagate(new RetryableException(-1, null, null, new Date(5000)));
+    Retryer.NEVER_RETRY
+        .continueOrPropagate(new RetryableException(-1, null, null, new Date(5000), null));
   }
 
   @Test
@@ -77,7 +78,7 @@ public class RetryerTest {
 
     Thread.currentThread().interrupt();
     RetryableException expected =
-        new RetryableException(-1, null, null, new Date(System.currentTimeMillis() + 5000));
+        new RetryableException(-1, null, null, new Date(System.currentTimeMillis() + 5000), null);
     try {
       retryer.continueOrPropagate(expected);
       Thread.interrupted(); // reset interrupted flag in case it wasn't

--- a/core/src/test/java/feign/RetryerTest.java
+++ b/core/src/test/java/feign/RetryerTest.java
@@ -17,6 +17,8 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import java.util.Collections;
 import java.util.Date;
 import feign.Retryer.Default;
 import static org.junit.Assert.assertEquals;
@@ -26,9 +28,12 @@ public class RetryerTest {
   @Rule
   public final ExpectedException thrown = ExpectedException.none();
 
+  private final static Request REQUEST = Request
+          .create(Request.HttpMethod.GET, "/", Collections.emptyMap(), null, Util.UTF_8);
+
   @Test
   public void only5TriesAllowedAndExponentialBackoff() throws Exception {
-    RetryableException e = new RetryableException(-1, null, null, null, null);
+    RetryableException e = new RetryableException(-1, null, null, null, REQUEST);
     Default retryer = new Retryer.Default();
     assertEquals(1, retryer.attempt);
     assertEquals(0, retryer.sleptForMillis);
@@ -61,7 +66,7 @@ public class RetryerTest {
       }
     };
 
-    retryer.continueOrPropagate(new RetryableException(-1, null, null, new Date(5000), null));
+    retryer.continueOrPropagate(new RetryableException(-1, null, null, new Date(5000), REQUEST));
     assertEquals(2, retryer.attempt);
     assertEquals(1000, retryer.sleptForMillis);
   }
@@ -69,7 +74,7 @@ public class RetryerTest {
   @Test(expected = RetryableException.class)
   public void neverRetryAlwaysPropagates() {
     Retryer.NEVER_RETRY
-        .continueOrPropagate(new RetryableException(-1, null, null, new Date(5000), null));
+        .continueOrPropagate(new RetryableException(-1, null, null, new Date(5000), REQUEST));
   }
 
   @Test
@@ -78,7 +83,7 @@ public class RetryerTest {
 
     Thread.currentThread().interrupt();
     RetryableException expected =
-        new RetryableException(-1, null, null, new Date(System.currentTimeMillis() + 5000), null);
+        new RetryableException(-1, null, null, new Date(System.currentTimeMillis() + 5000), REQUEST);
     try {
       retryer.continueOrPropagate(expected);
       Thread.interrupted(); // reset interrupted flag in case it wasn't

--- a/core/src/test/java/feign/codec/RetryAfterDecoderTest.java
+++ b/core/src/test/java/feign/codec/RetryAfterDecoderTest.java
@@ -16,11 +16,8 @@ package feign.codec;
 import static feign.codec.ErrorDecoder.RetryAfterDecoder.RFC822_FORMAT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-
 import feign.codec.ErrorDecoder.RetryAfterDecoder;
-
 import java.text.ParseException;
-
 import org.junit.Test;
 
 public class RetryAfterDecoderTest {

--- a/core/src/test/java/feign/template/HeaderTemplateTest.java
+++ b/core/src/test/java/feign/template/HeaderTemplateTest.java
@@ -16,11 +16,9 @@ package feign.template;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;

--- a/jackson/src/main/java/feign/jackson/JacksonIteratorDecoder.java
+++ b/jackson/src/main/java/feign/jackson/JacksonIteratorDecoder.java
@@ -150,7 +150,7 @@ public final class JacksonIteratorDecoder implements Decoder {
         current = objectReader.readValue(parser);
       } catch (IOException e) {
         // Input Stream closed automatically by parser
-        throw new DecodeException(response.status(), e.getMessage(), e);
+        throw new DecodeException(response.status(), e.getMessage(), response.request(), e);
       }
       return current != null;
     }

--- a/jaxb/src/main/java/feign/jaxb/JAXBDecoder.java
+++ b/jaxb/src/main/java/feign/jaxb/JAXBDecoder.java
@@ -92,7 +92,7 @@ public class JAXBDecoder implements Decoder {
           saxParserFactory.newSAXParser().getXMLReader(),
           new InputSource(response.body().asInputStream())));
     } catch (JAXBException | ParserConfigurationException | SAXException e) {
-      throw new DecodeException(response.status(), e.toString(), e);
+      throw new DecodeException(response.status(), e.toString(), response.request(), e);
     } finally {
       if (response.body() != null) {
         response.body().close();

--- a/reactive/src/main/java/feign/reactive/ReactiveInvocationHandler.java
+++ b/reactive/src/main/java/feign/reactive/ReactiveInvocationHandler.java
@@ -20,7 +20,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
 

--- a/reactive/src/test/java/feign/reactive/ReactiveFeignIntegrationTest.java
+++ b/reactive/src/test/java/feign/reactive/ReactiveFeignIntegrationTest.java
@@ -97,17 +97,17 @@ public class ReactiveFeignIntegrationTest {
     assertThat(service).isNotNull();
 
     StepVerifier.create(service.version())
-            .expectNext("1.0")
-            .expectComplete()
-            .verify();
+        .expectNext("1.0")
+        .expectComplete()
+        .verify();
     assertThat(webServer.takeRequest().getPath()).isEqualToIgnoringCase("/version");
 
 
     /* test encoding and decoding */
     StepVerifier.create(service.user("test"))
-            .assertNext(user -> assertThat(user).hasFieldOrPropertyWithValue("username", "test"))
-            .expectComplete()
-            .verify();
+        .assertNext(user -> assertThat(user).hasFieldOrPropertyWithValue("username", "test"))
+        .expectComplete()
+        .verify();
     assertThat(webServer.takeRequest().getPath()).isEqualToIgnoringCase("/users/test");
 
   }
@@ -126,16 +126,16 @@ public class ReactiveFeignIntegrationTest {
     assertThat(service).isNotNull();
 
     StepVerifier.create(service.version())
-            .expectNext("1.0")
-            .expectComplete()
-            .verify();
+        .expectNext("1.0")
+        .expectComplete()
+        .verify();
     assertThat(webServer.takeRequest().getPath()).isEqualToIgnoringCase("/version");
 
     /* test encoding and decoding */
     StepVerifier.create(service.user("test"))
-            .assertNext(user -> assertThat(user).hasFieldOrPropertyWithValue("username", "test"))
-            .expectComplete()
-            .verify();
+        .assertNext(user -> assertThat(user).hasFieldOrPropertyWithValue("username", "test"))
+        .expectComplete()
+        .verify();
     assertThat(webServer.takeRequest().getPath()).isEqualToIgnoringCase("/users/test");
   }
 
@@ -165,9 +165,9 @@ public class ReactiveFeignIntegrationTest {
         .requestInterceptor(mockInterceptor)
         .target(TestReactorService.class, this.getServerUrl());
     StepVerifier.create(service.version())
-            .expectNext("1.0")
-            .expectComplete()
-            .verify();
+        .expectNext("1.0")
+        .expectComplete()
+        .verify();
     verify(mockInterceptor, times(1)).apply(any(RequestTemplate.class));
   }
 
@@ -180,9 +180,9 @@ public class ReactiveFeignIntegrationTest {
         .requestInterceptors(Arrays.asList(mockInterceptor, mockInterceptor))
         .target(TestReactorService.class, this.getServerUrl());
     StepVerifier.create(service.version())
-            .expectNext("1.0")
-            .expectComplete()
-            .verify();
+        .expectNext("1.0")
+        .expectComplete()
+        .verify();
     verify(mockInterceptor, times(2)).apply(any(RequestTemplate.class));
   }
 
@@ -200,9 +200,9 @@ public class ReactiveFeignIntegrationTest {
         .mapAndDecode(responseMapper, decoder)
         .target(TestReactorService.class, this.getServerUrl());
     StepVerifier.create(service.version())
-            .expectNext("1.0")
-            .expectComplete()
-            .verify();
+        .expectNext("1.0")
+        .expectComplete()
+        .verify();
     verify(responseMapper, times(1))
         .map(any(Response.class), any(Type.class));
     verify(decoder, times(1)).decode(any(Response.class), any(Type.class));
@@ -218,9 +218,9 @@ public class ReactiveFeignIntegrationTest {
         .queryMapEncoder(encoder)
         .target(TestReactiveXService.class, this.getServerUrl());
     StepVerifier.create(service.search(new SearchQuery()))
-            .expectNext("No Results Found")
-            .expectComplete()
-            .verify();
+        .expectNext("No Results Found")
+        .expectComplete()
+        .verify();
     verify(encoder, times(1)).encode(any(Object.class));
   }
 
@@ -237,10 +237,10 @@ public class ReactiveFeignIntegrationTest {
         .errorDecoder(errorDecoder)
         .target(TestReactiveXService.class, this.getServerUrl());
     StepVerifier.create(service.search(new SearchQuery()))
-            .expectErrorSatisfies(ex -> assertThat(ex)
-                    .isInstanceOf(IllegalStateException.class)
-                    .hasMessage("bad request"))
-            .verify();
+        .expectErrorSatisfies(ex -> assertThat(ex)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("bad request"))
+        .verify();
     verify(errorDecoder, times(1)).decode(anyString(), any(Response.class));
   }
 
@@ -256,9 +256,9 @@ public class ReactiveFeignIntegrationTest {
         .retryer(spy)
         .target(TestReactorService.class, this.getServerUrl());
     StepVerifier.create(service.version())
-            .expectNext("1.0")
-            .expectComplete()
-            .verify();
+        .expectNext("1.0")
+        .expectComplete()
+        .verify();
     verify(spy, times(1)).continueOrPropagate(any(RetryableException.class));
   }
 
@@ -277,9 +277,9 @@ public class ReactiveFeignIntegrationTest {
         .client(client)
         .target(TestReactorService.class, this.getServerUrl());
     StepVerifier.create(service.version())
-            .expectNext("1.0")
-            .expectComplete()
-            .verify();
+        .expectNext("1.0")
+        .expectComplete()
+        .verify();
     verify(client, times(1)).execute(any(Request.class), any(Options.class));
   }
 
@@ -291,9 +291,9 @@ public class ReactiveFeignIntegrationTest {
         .contract(new JAXRSContract())
         .target(TestJaxRSReactorService.class, this.getServerUrl());
     StepVerifier.create(service.version())
-            .expectNext("1.0")
-            .expectComplete()
-            .verify();
+        .expectNext("1.0")
+        .expectComplete()
+        .verify();
     assertThat(webServer.takeRequest().getPath()).isEqualToIgnoringCase("/version");
   }
 

--- a/reactive/src/test/java/feign/reactive/ReactiveInvocationHandlerTest.java
+++ b/reactive/src/test/java/feign/reactive/ReactiveInvocationHandlerTest.java
@@ -64,9 +64,9 @@ public class ReactiveInvocationHandlerTest {
 
     /* subscribe and execute the method */
     StepVerifier.create((Mono) result)
-            .expectNext("Result")
-            .expectComplete()
-            .verify();
+        .expectNext("Result")
+        .expectComplete()
+        .verify();
     verify(this.methodHandler, times(1)).invoke(any());
   }
 
@@ -82,8 +82,8 @@ public class ReactiveInvocationHandlerTest {
 
     /* subscribe and execute the method */
     StepVerifier.create((Mono) result)
-            .expectComplete()
-            .verify();
+        .expectComplete()
+        .verify();
     verify(this.methodHandler, times(1)).invoke(any());
   }
 
@@ -99,8 +99,8 @@ public class ReactiveInvocationHandlerTest {
 
     /* subscribe and execute the method, should result in an error */
     StepVerifier.create((Mono) result)
-            .expectError(IOException.class)
-            .verify();
+        .expectError(IOException.class)
+        .verify();
     verify(this.methodHandler, times(1)).invoke(any());
   }
 
@@ -119,9 +119,9 @@ public class ReactiveInvocationHandlerTest {
 
     /* subscribe and execute the method */
     StepVerifier.create((Flowable) result)
-            .expectNext("Result")
-            .expectComplete()
-            .verify();
+        .expectNext("Result")
+        .expectComplete()
+        .verify();
     verify(this.methodHandler, times(1)).invoke(any());
   }
 
@@ -139,8 +139,8 @@ public class ReactiveInvocationHandlerTest {
 
     /* subscribe and execute the method */
     StepVerifier.create((Flowable) result)
-            .expectComplete()
-            .verify();
+        .expectComplete()
+        .verify();
     verify(this.methodHandler, times(1)).invoke(any());
   }
 
@@ -158,8 +158,8 @@ public class ReactiveInvocationHandlerTest {
 
     /* subscribe and execute the method */
     StepVerifier.create((Flowable) result)
-            .expectError(IOException.class)
-            .verify();
+        .expectError(IOException.class)
+        .verify();
     verify(this.methodHandler, times(1)).invoke(any());
   }
 

--- a/sax/src/main/java/feign/sax/SAXDecoder.java
+++ b/sax/src/main/java/feign/sax/SAXDecoder.java
@@ -85,7 +85,7 @@ public class SAXDecoder implements Decoder {
       }
       return handler.result();
     } catch (SAXException e) {
-      throw new DecodeException(response.status(), e.getMessage(), e);
+      throw new DecodeException(response.status(), e.getMessage(), response.request(), e);
     }
   }
 

--- a/soap/src/main/java/feign/soap/SOAPDecoder.java
+++ b/soap/src/main/java/feign/soap/SOAPDecoder.java
@@ -123,7 +123,7 @@ public class SOAPDecoder implements Decoder {
             .unmarshal(message.getSOAPBody().extractContentAsDocument());
       }
     } catch (SOAPException | JAXBException e) {
-      throw new DecodeException(response.status(), e.toString(), e);
+      throw new DecodeException(response.status(), e.toString(), response.request(), e);
     } finally {
       if (response.body() != null) {
         response.body().close();


### PR DESCRIPTION
Investigating #985 task I've created solution. I'm not sure this solution is good, but I tried to explain my thoughts and solution inside code. Also, I copy explanation here. 
Also I'm not sure it's a good idea to create log files during test run. But I don't really know how to remove them after tests...

> This constructor can be used to create just one logger. In this way nothing will change.
> Example = Logger.JavaLogger().appendToFile("logs/first.log")
> 
> But if this constructor is used several times in different places with different files we will have bad situation
> We call constructor and that means for client that we created new instance, that will write logs to given file
> But in fact we created only wrapper. Our worker class java.util.logging.Logger instance will be same for all
> JavaLoggers because or getLogger() method logic. And each time we create and apply file to logger -
> we apply file handler to same logger.
> 
> Correct way to change this - is to ask client for unique logger name to give loggerManager change to differ files
> But some users already using this method for single call without any class name. So, I decided to make workaround
> 
> I'll create logger with Logger.class name for first instance.
> But each other calls of constructor will check if someone already created first logger. If so - I'll create
> logger with name Logger.class[1-..]. We will have Logger, Logger1, Logger2, etc. This looks not very good, but
> provides backward compatibility. But I mark this constructor as Deprecated and recommend other constructor with
> the name to provide inner logger for.
