### PR TITLE
Unexpected JavaLogger behavior fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,7 +690,7 @@ public class Example {
   public static void main(String[] args) {
     GitHub github = Feign.builder()
                      .decoder(new GsonDecoder())
-                     .logger(new Logger.JavaLogger(GitHub.class.getName()).appendToFile("logs/http.log"))
+                     .logger(new Logger.JavaLogger("GitHub.Logger").appendToFile("logs/http.log"))
                      .logLevel(Logger.Level.FULL)
                      .target(GitHub.class, "https://api.github.com");
   }

--- a/README.md
+++ b/README.md
@@ -697,11 +697,8 @@ public class Example {
 }
 ```
 
----
-**NOTE**
-
-Avoid using of default ```JavaLogger()``` constructor - it was marked as deprecated and will be removed soon.
----
+> **A Note on JavaLogger**: 
+> Avoid using of default ```JavaLogger()``` constructor - it was marked as deprecated and will be removed soon.
 
 The SLF4JLogger (see above) may also be of interest.
 

--- a/README.md
+++ b/README.md
@@ -690,12 +690,18 @@ public class Example {
   public static void main(String[] args) {
     GitHub github = Feign.builder()
                      .decoder(new GsonDecoder())
-                     .logger(new Logger.JavaLogger().appendToFile("logs/http.log"))
+                     .logger(new Logger.JavaLogger(GitHub.class.getName()).appendToFile("logs/http.log"))
                      .logLevel(Logger.Level.FULL)
                      .target(GitHub.class, "https://api.github.com");
   }
 }
 ```
+
+---
+**NOTE**
+
+Avoid using of default ```JavaLogger()``` constructor - it was marked as deprecated and will be removed soon.
+---
 
 The SLF4JLogger (see above) may also be of interest.
 

--- a/core/src/main/java/feign/Logger.java
+++ b/core/src/main/java/feign/Logger.java
@@ -167,40 +167,30 @@ public abstract class Logger {
 
     final java.util.logging.Logger logger;
 
-    private final static AtomicInteger loggerCounter = new AtomicInteger();
-
     /**
-     * Deprecated - use {@link #JavaLogger(String)} instead.
-     * Deprecation reason - unexpected inner behavior when multiple JavaLogger appended to their log files
+     * @deprecated Use {@link #JavaLogger(String)} instead.
      *
-     * This constructor can be used to create just one logger. In this way nothing will change.
-     * Example = Logger.JavaLogger().appendToFile("logs/first.log")
+     *             This constructor can be used to create just one logger. Example =
+     *             {@code Logger.JavaLogger().appendToFile("logs/first.log")}
      *
-     * But if this constructor is used several times in different places with different files we will have bad situation
-     * We call constructor and that means for client that we created new instance, that will write logs to given file
-     * But in fact we created only wrapper. Our worker class java.util.logging.Logger instance will be same for all
-     * JavaLoggers because or getLogger() method logic. And each time we create and apply file to logger -
-     * we apply file handler to same logger.
+     *             If you create multiple loggers for multiple clients and provide different files
+     *             to write log - you'll have unexpected behavior - all clients will write same log
+     *             to each file.
      *
-     * Correct way to change this - is to ask client for unique logger name to give loggerManager change to differ files
-     * But some users already using this method for single call without any class name. So, I decided to make workaround
-     *
-     * I'll create logger with Logger.class name for first instance.
-     * But each other calls of constructor will check if someone already created first logger. If so - I'll create
-     * logger with name Logger.class[1-..]. We will have Logger, Logger1, Logger2, etc. This looks not very good, but
-     * provides backward compatibility. But I mark this constructor as Deprecated and recommend other constructor with
-     * the name to provide inner logger for.
+     *             That's why this constructor will be removed in future.
      */
     @Deprecated
     public JavaLogger() {
-      int thisLoggerId = loggerCounter.getAndIncrement();
-      if (thisLoggerId == 0 ) {
-        logger = java.util.logging.Logger.getLogger(Logger.class.getName());
-      } else {
-        logger = java.util.logging.Logger.getLogger(Logger.class.getName() + thisLoggerId);
-      }
+      logger = java.util.logging.Logger.getLogger(Logger.class.getName());
     }
 
+    /**
+     * Constructor for JavaLogger class
+     * 
+     * @param loggerName - A name for the logger. This should be a dot-separated name and should
+     *        normally be based on the package name or class name of the subsystem, such as java.net
+     *        or javax.swing
+     */
     public JavaLogger(String loggerName) {
       logger = java.util.logging.Logger.getLogger(loggerName);
     }

--- a/core/src/main/java/feign/Logger.java
+++ b/core/src/main/java/feign/Logger.java
@@ -168,7 +168,7 @@ public abstract class Logger {
     final java.util.logging.Logger logger;
 
     /**
-     * @deprecated Use {@link #JavaLogger(String)} instead.
+     * @deprecated Use {@link #JavaLogger(String)} or {@link #JavaLogger(Class)} instead.
      *
      *             This constructor can be used to create just one logger. Example =
      *             {@code Logger.JavaLogger().appendToFile("logs/first.log")}
@@ -187,12 +187,21 @@ public abstract class Logger {
     /**
      * Constructor for JavaLogger class
      * 
-     * @param loggerName - A name for the logger. This should be a dot-separated name and should
+     * @param loggerName a name for the logger. This should be a dot-separated name and should
      *        normally be based on the package name or class name of the subsystem, such as java.net
      *        or javax.swing
      */
     public JavaLogger(String loggerName) {
       logger = java.util.logging.Logger.getLogger(loggerName);
+    }
+
+    /**
+     * Constructor for JavaLogger class
+     *
+     * @param clazz the returned logger will be named after clazz
+     */
+    public JavaLogger(Class<?> clazz) {
+      logger = java.util.logging.Logger.getLogger(clazz.getName());
     }
 
     @Override

--- a/core/src/test/java/feign/MultipleLoggerTest.java
+++ b/core/src/test/java/feign/MultipleLoggerTest.java
@@ -42,4 +42,14 @@ public class MultipleLoggerTest {
     assert (logger2.getHandlers().length == 1);
   }
 
+  @Test
+  public void testJavaLoggerInstantationWithClazz() throws Exception {
+    Logger.JavaLogger l1 = new Logger.JavaLogger(String.class).appendToFile("1.log");
+    Logger.JavaLogger l2 = new Logger.JavaLogger(Integer.class).appendToFile("2.log");
+    java.util.logging.Logger logger1 = getInnerLogger(l1);
+    assert (logger1.getHandlers().length == 1);
+    java.util.logging.Logger logger2 = getInnerLogger(l2);
+    assert (logger2.getHandlers().length == 1);
+  }
+
 }

--- a/core/src/test/java/feign/MultipleLoggerTest.java
+++ b/core/src/test/java/feign/MultipleLoggerTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2012-2019 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign;
+
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+
+public class MultipleLoggerTest {
+
+    private static java.util.logging.Logger getInnerLogger(Logger.JavaLogger logger) throws Exception {
+        Field inner = logger.getClass().getDeclaredField("logger");
+        inner.setAccessible(true);
+        return (java.util.logging.Logger) inner.get(logger);
+    }
+
+    @Test
+    public void testMultipleJavaLoggersHaveOneLoggerPerInstance() throws Exception {
+        Logger.JavaLogger l1 = new Logger.JavaLogger().appendToFile("1.log");
+        Logger.JavaLogger l2 = new Logger.JavaLogger().appendToFile("2.log");
+        java.util.logging.Logger logger1 = getInnerLogger(l1);
+        assert (logger1.getHandlers().length == 1);
+        java.util.logging.Logger logger2 = getInnerLogger(l2);
+        assert (logger2.getHandlers().length == 1);
+    }
+
+    @Test
+    public void testAppendSeveralFilesToOneJavaLogger() throws Exception {
+        Logger.JavaLogger logger = new Logger.JavaLogger().appendToFile("1.log").appendToFile("2.log");
+        java.util.logging.Logger inner = getInnerLogger(logger);
+        assert (inner.getHandlers().length == 2);
+    }
+
+    @Test
+    public void testJavaLoggerInstantationWithLoggerName() throws Exception {
+        Logger.JavaLogger l1 = new Logger.JavaLogger("First client").appendToFile("1.log");
+        Logger.JavaLogger l2 = new Logger.JavaLogger("Second client").appendToFile("2.log");
+        java.util.logging.Logger logger1 = getInnerLogger(l1);
+        assert (logger1.getHandlers().length == 1);
+        java.util.logging.Logger logger2 = getInnerLogger(l2);
+        assert (logger2.getHandlers().length == 1);
+    }
+
+}

--- a/core/src/test/java/feign/MultipleLoggerTest.java
+++ b/core/src/test/java/feign/MultipleLoggerTest.java
@@ -14,42 +14,32 @@
 package feign;
 
 import org.junit.Test;
-
 import java.lang.reflect.Field;
 
 public class MultipleLoggerTest {
 
-    private static java.util.logging.Logger getInnerLogger(Logger.JavaLogger logger) throws Exception {
-        Field inner = logger.getClass().getDeclaredField("logger");
-        inner.setAccessible(true);
-        return (java.util.logging.Logger) inner.get(logger);
-    }
+  private static java.util.logging.Logger getInnerLogger(Logger.JavaLogger logger)
+      throws Exception {
+    Field inner = logger.getClass().getDeclaredField("logger");
+    inner.setAccessible(true);
+    return (java.util.logging.Logger) inner.get(logger);
+  }
 
-    @Test
-    public void testMultipleJavaLoggersHaveOneLoggerPerInstance() throws Exception {
-        Logger.JavaLogger l1 = new Logger.JavaLogger().appendToFile("1.log");
-        Logger.JavaLogger l2 = new Logger.JavaLogger().appendToFile("2.log");
-        java.util.logging.Logger logger1 = getInnerLogger(l1);
-        assert (logger1.getHandlers().length == 1);
-        java.util.logging.Logger logger2 = getInnerLogger(l2);
-        assert (logger2.getHandlers().length == 1);
-    }
+  @Test
+  public void testAppendSeveralFilesToOneJavaLogger() throws Exception {
+    Logger.JavaLogger logger = new Logger.JavaLogger().appendToFile("1.log").appendToFile("2.log");
+    java.util.logging.Logger inner = getInnerLogger(logger);
+    assert (inner.getHandlers().length == 2);
+  }
 
-    @Test
-    public void testAppendSeveralFilesToOneJavaLogger() throws Exception {
-        Logger.JavaLogger logger = new Logger.JavaLogger().appendToFile("1.log").appendToFile("2.log");
-        java.util.logging.Logger inner = getInnerLogger(logger);
-        assert (inner.getHandlers().length == 2);
-    }
-
-    @Test
-    public void testJavaLoggerInstantationWithLoggerName() throws Exception {
-        Logger.JavaLogger l1 = new Logger.JavaLogger("First client").appendToFile("1.log");
-        Logger.JavaLogger l2 = new Logger.JavaLogger("Second client").appendToFile("2.log");
-        java.util.logging.Logger logger1 = getInnerLogger(l1);
-        assert (logger1.getHandlers().length == 1);
-        java.util.logging.Logger logger2 = getInnerLogger(l2);
-        assert (logger2.getHandlers().length == 1);
-    }
+  @Test
+  public void testJavaLoggerInstantationWithLoggerName() throws Exception {
+    Logger.JavaLogger l1 = new Logger.JavaLogger("First client").appendToFile("1.log");
+    Logger.JavaLogger l2 = new Logger.JavaLogger("Second client").appendToFile("2.log");
+    java.util.logging.Logger logger1 = getInnerLogger(l1);
+    assert (logger1.getHandlers().length == 1);
+    java.util.logging.Logger logger2 = getInnerLogger(l2);
+    assert (logger2.getHandlers().length == 1);
+  }
 
 }


### PR DESCRIPTION
Investigating #985 task I've created solution. I'm not sure this solution is good, but I tried to explain my thoughts and solution inside code. Also, I copy explanation here.
Also I'm not sure it's a good idea to create log files during test run. But I don't really know how to remove them after tests...

> This constructor can be used to create just one logger. In this way nothing will change.
> Example = Logger.JavaLogger().appendToFile("logs/first.log")
> 
> But if this constructor is used several times in different places with different files we will have bad situation
> We call constructor and that means for client that we created new instance, that will write logs to given file
> But in fact we created only wrapper. Our worker class java.util.logging.Logger instance will be same for all
> JavaLoggers because or getLogger() method logic. And each time we create and apply file to logger -
> we apply file handler to same logger.
> 
> Correct way to change this - is to ask client for unique logger name to give loggerManager change to differ files
> But some users already using this method for single call without any class name. So, I decided to make workaround
> 
> I'll create logger with Logger.class name for first instance.
> But each other calls of constructor will check if someone already created first logger. If so - I'll create
> logger with name Logger.class[1-..]. We will have Logger, Logger1, Logger2, etc. This looks not very good, but
> provides backward compatibility. But I mark this constructor as Deprecated and recommend other constructor with
> the name to provide inner logger for.