### PR TITLE
GH-1023: Correct Reactive Examples

### DIFF
--- a/reactive/README.md
+++ b/reactive/README.md
@@ -31,7 +31,6 @@ public class ExampleReactor {
       .target(GitHubReactor.class, "https://api.github.com");
     
     List<Contributor> contributors = gitHub.contributors("OpenFeign", "feign")
-      .map(Contributor::new)
       .collect(Collectors.toList())
       .block();
   }
@@ -57,7 +56,6 @@ public class ExampleRxJava2 {
       .target(GitHub.class, "https://api.github.com");
     
     List<Contributor> contributors = gitHub.contributors("OpenFeign", "feign")
-      .map(Contributor::new)
       .collect(Collectors.toList())
       .block();
   }


### PR DESCRIPTION
Fixes #1023

Removed unnecessary `map` statement in the examples.