### PR TITLE
Declarative contracts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,8 @@ jobs:
       install: true
       script:
         - ./mvnw -B -nsu -s ./travis/settings.xml -P release -pl -:feign-benchmark -DskipTests=true deploy
+
+env:
+  global:
+    # Ex. travis encrypt GITHUB_TOKEN=token_for_tests
+    - secure: "H4PuppuPE3lkvVQ1osulhgWeZmpIkDKj/z74lx4MUeDPNtcuqpwmTVWtL5Zyjf8CxlALX2djx4RIBshaQAu4GtKarPLONinNLZ/TCtoK8dF08/ESxLEiLQzwGkS+geWoEFiZncB5Px2T7ZbUfVFO3crVY9CLn35znR8k1uidocL0JlyVPGwCwuBxFmDhs3BZh3JvbwSikAVRvlCRU6BbREFQbSK1EamuUju/rlo+dx7W5tiiuEJJ50c8vpgatTFyy821YP82fMRrhuBDpS4/rsL9DmLhQTEbCjZW+22DhEFPRlo0XIfidC7APybXnu3oO+jFuGaFKiQdy7sjB03g/Bz5H7jAIAkbl8UpbjN+IoeUU/OgMuBYf5wJjPDYUEdI3CXqywPn0xYZwVsOcSg+UkQGYdW9ux/U+nKsYLXLWWhst2QMFzbmO94KCrpgCW4mshr/5WP4XU6cEJwDsKMAUPWuOk0KMMjIufSgvPvteWZwT9akZwzEMuGaUQ5kLr1X6xTPv1cKXTreitaoOLQs28kmPVfTwVEdareaSVXcRqeflJJBSXkAgBqGhV5CAEUaUgt9/QD0Jj5RGyRPllFcydXVLTPeg62X/L5COswlvJhPkvfNnkbMpDQZYojKKPmAf+UqZJmVYPpOoNEXygldueKeunWkna/wYkMj0YnOkM8="

--- a/core/src/main/java/feign/MethodMetadata.java
+++ b/core/src/main/java/feign/MethodMetadata.java
@@ -15,11 +15,7 @@ package feign;
 
 import java.io.Serializable;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import feign.Param.Expander;
 
 public final class MethodMetadata implements Serializable {
@@ -41,6 +37,7 @@ public final class MethodMetadata implements Serializable {
       new LinkedHashMap<Integer, Class<? extends Expander>>();
   private Map<Integer, Boolean> indexToEncoded = new LinkedHashMap<Integer, Boolean>();
   private transient Map<Integer, Expander> indexToExpander;
+  private BitSet parameterToIgnore = new BitSet();
 
   MethodMetadata() {}
 
@@ -163,4 +160,50 @@ public final class MethodMetadata implements Serializable {
   public Map<Integer, Expander> indexToExpander() {
     return indexToExpander;
   }
+
+  /**
+   * @param i individual parameter that should be ignored
+   * @return this instance
+   */
+  public MethodMetadata ignoreParamater(int i) {
+    this.parameterToIgnore.set(i);
+    return this;
+  }
+
+  public BitSet parameterToIgnore() {
+    return parameterToIgnore;
+  }
+
+  public MethodMetadata parameterToIgnore(BitSet parameterToIgnore) {
+    this.parameterToIgnore = parameterToIgnore;
+    return this;
+  }
+
+  /**
+   * @param i individual parameter to check if should be ignored
+   * @return true when field should not be processed by feign
+   */
+  public boolean shouldIgnoreParamater(int i) {
+    return parameterToIgnore.get(i);
+  }
+
+  /**
+   * @param index
+   * @return true if the parameter {@code index} was already consumed by a any
+   *         {@link MethodMetadata} holder
+   */
+  public boolean isAlreadyProcessed(Integer index) {
+    return index.equals(urlIndex)
+        || index.equals(bodyIndex)
+        || index.equals(headerMapIndex)
+        || index.equals(queryMapIndex)
+        || indexToName.containsKey(index)
+        || indexToExpanderClass.containsKey(index)
+        || indexToEncoded.containsKey(index)
+        || (indexToExpander != null && indexToExpander.containsKey(index))
+        || parameterToIgnore.get(index);
+  }
+
+
+
 }

--- a/core/src/main/java/feign/Request.java
+++ b/core/src/main/java/feign/Request.java
@@ -230,6 +230,12 @@ public final class Request {
     private final int readTimeoutMillis;
     private final boolean followRedirects;
 
+    @Override
+    public String toString() {
+      return "Options [connectTimeoutMillis=" + connectTimeoutMillis + ", readTimeoutMillis="
+          + readTimeoutMillis + ", followRedirects=" + followRedirects + "]";
+    }
+
     public Options(int connectTimeoutMillis, int readTimeoutMillis, boolean followRedirects) {
       this.connectTimeoutMillis = connectTimeoutMillis;
       this.readTimeoutMillis = readTimeoutMillis;

--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -187,8 +187,9 @@ final class SynchronousMethodHandler implements MethodHandler {
     if (argv == null || argv.length == 0) {
       return this.options;
     }
-    return (Options) Stream.of(argv)
-        .filter(o -> o instanceof Options)
+    return Stream.of(argv)
+        .filter(Options.class::isInstance)
+        .map(Options.class::cast)
         .findFirst()
         .orElse(this.options);
   }

--- a/core/src/test/java/feign/ContractWithRuntimeInjectionTest.java
+++ b/core/src/test/java/feign/ContractWithRuntimeInjectionTest.java
@@ -82,7 +82,7 @@ public class ContractWithRuntimeInjectionTest {
     }
   }
 
-  static class ContractWithRuntimeInjection extends Contract.Default {
+  static class ContractWithRuntimeInjection implements Contract {
     final BeanFactory beanFactory;
 
     ContractWithRuntimeInjection(BeanFactory beanFactory) {
@@ -94,7 +94,7 @@ public class ContractWithRuntimeInjectionTest {
      */
     @Override
     public List<MethodMetadata> parseAndValidatateMetadata(Class<?> targetType) {
-      List<MethodMetadata> result = super.parseAndValidatateMetadata(targetType);
+      List<MethodMetadata> result = new Contract.Default().parseAndValidatateMetadata(targetType);
       for (MethodMetadata md : result) {
         Map<Integer, Param.Expander> indexToExpander = new LinkedHashMap<Integer, Param.Expander>();
         for (Map.Entry<Integer, Class<? extends Param.Expander>> entry : md.indexToExpanderClass()

--- a/core/src/test/java/feign/DefaultContractTest.java
+++ b/core/src/test/java/feign/DefaultContractTest.java
@@ -814,7 +814,7 @@ public class DefaultContractTest {
   public void missingMethod() throws Exception {
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage(
-        "RequestLine annotation didn't start with an HTTP verb on method updateSharing");
+        "RequestLine annotation didn't start with an HTTP verb on method MissingMethod#updateSharing");
 
     contract.parseAndValidatateMetadata(MissingMethod.class);
   }

--- a/core/src/test/java/feign/assertj/RequestTemplateAssert.java
+++ b/core/src/test/java/feign/assertj/RequestTemplateAssert.java
@@ -93,4 +93,19 @@ public final class RequestTemplateAssert
     objects.assertNull(info, actual.headers().get(encoded));
     return this;
   }
+
+  public RequestTemplateAssert noRequestBody() {
+    isNotNull();
+    if (actual.requestBody() != null) {
+      if (actual.requestBody().bodyTemplate() != null) {
+        failWithMessage("\nExpecting requestBody.bodyTemplate to be null, but was:<%s>",
+            actual.requestBody().bodyTemplate());
+      }
+      if (actual.requestBody().asBytes() != null) {
+        failWithMessage("\nExpecting requestBody.data to be null, but was:<%s>",
+            actual.requestBody().asString());
+      }
+    }
+    return this;
+  }
 }

--- a/jaxrs/src/main/java/feign/jaxrs/JAXRSContract.java
+++ b/jaxrs/src/main/java/feign/jaxrs/JAXRSContract.java
@@ -138,7 +138,6 @@ public class JAXRSContract extends DeclarativeContract {
         checkState(emptyToNull(name) != null, "PathParam.value() was empty on parameter %s",
             paramIndex);
         nameParam(data, name, paramIndex);
-        return true;
       });
       registerParameterAnnotation(QueryParam.class, (param, data, paramIndex) -> {
         final String name = param.value();
@@ -147,7 +146,6 @@ public class JAXRSContract extends DeclarativeContract {
         final String query = addTemplatedParam(name);
         data.template().query(name, query);
         nameParam(data, name, paramIndex);
-        return true;
       });
       registerParameterAnnotation(HeaderParam.class, (param, data, paramIndex) -> {
         final String name = param.value();
@@ -156,7 +154,6 @@ public class JAXRSContract extends DeclarativeContract {
         final String header = addTemplatedParam(name);
         data.template().header(name, header);
         nameParam(data, name, paramIndex);
-        return true;
       });
       registerParameterAnnotation(FormParam.class, (param, data, paramIndex) -> {
         final String name = param.value();
@@ -164,7 +161,6 @@ public class JAXRSContract extends DeclarativeContract {
             paramIndex);
         data.formParams().add(name);
         nameParam(data, name, paramIndex);
-        return true;
       });
     }
   }

--- a/jaxrs/src/main/java/feign/jaxrs/JAXRSContract.java
+++ b/jaxrs/src/main/java/feign/jaxrs/JAXRSContract.java
@@ -13,25 +13,22 @@
  */
 package feign.jaxrs;
 
-import feign.Contract;
-import feign.MethodMetadata;
-import feign.Request;
-import javax.ws.rs.*;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
 import static feign.Util.checkState;
 import static feign.Util.emptyToNull;
 import static feign.Util.removeValues;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import javax.ws.rs.*;
+import feign.Contract.DeclarativeContract;
+import feign.MethodMetadata;
+import feign.Request;
 
 /**
  * Please refer to the <a href="https://github.com/Netflix/feign/tree/master/feign-jaxrs">Feign
  * JAX-RS README</a>.
  */
-public class JAXRSContract extends Contract.BaseContract {
+public class JAXRSContract extends DeclarativeContract {
 
   static final String ACCEPT = "Accept";
   static final String CONTENT_TYPE = "Content-Type";
@@ -44,10 +41,12 @@ public class JAXRSContract extends Contract.BaseContract {
     return super.parseAndValidateMetadata(targetType, method);
   }
 
-  @Override
-  protected void processAnnotationOnClass(MethodMetadata data, Class<?> clz) {
-    Path path = clz.getAnnotation(Path.class);
-    if (path != null && !path.value().isEmpty()) {
+  public JAXRSContract() {
+    super.registerClassAnnotation(Path.class, (path, data) -> {
+      if (path.value().isEmpty()) {
+        return;
+      }
+
       String pathValue = path.value();
       if (!pathValue.startsWith("/")) {
         pathValue = "/" + pathValue;
@@ -62,34 +61,46 @@ public class JAXRSContract extends Contract.BaseContract {
       // strip these out appropriately.
       pathValue = pathValue.replaceAll("\\{\\s*(.+?)\\s*(:.+?)?\\}", "\\{$1\\}");
       data.template().uri(pathValue);
-    }
-    Consumes consumes = clz.getAnnotation(Consumes.class);
-    if (consumes != null) {
-      handleConsumesAnnotation(data, consumes, clz.getName());
-    }
-    Produces produces = clz.getAnnotation(Produces.class);
-    if (produces != null) {
-      handleProducesAnnotation(data, produces, clz.getName());
-    }
+    });
+    super.registerClassAnnotation(Consumes.class, this::handleConsumesAnnotation);
+    super.registerClassAnnotation(Produces.class, this::handleProducesAnnotation);
+
+    // trying to minimize the diff
+    registerMethodsAnnotations();
+    registerParamAnnotations();
   }
 
+
+  /**
+   * Overwriting
+   * {@link DeclarativeContract#processAnnotationOnMethod(MethodMetadata, Annotation, Method)}
+   * breaks the idea behind it of declaring annotations and how they should be processed.
+   *
+   * Will eventually need to find a different way of reading an annotation annotation.
+   */
   @Override
   protected void processAnnotationOnMethod(MethodMetadata data,
                                            Annotation methodAnnotation,
                                            Method method) {
-    Class<? extends Annotation> annotationType = methodAnnotation.annotationType();
-    HttpMethod http = annotationType.getAnnotation(HttpMethod.class);
+    final Class<? extends Annotation> annotationType = methodAnnotation.annotationType();
+    final HttpMethod http = annotationType.getAnnotation(HttpMethod.class);
     if (http != null) {
       checkState(data.template().method() == null,
           "Method %s contains multiple HTTP methods. Found: %s and %s", method.getName(),
           data.template().method(), http.value());
       data.template().method(Request.HttpMethod.valueOf(http.value()));
-    } else if (annotationType == Path.class) {
-      String pathValue = emptyToNull(Path.class.cast(methodAnnotation).value());
+    } else {
+      super.processAnnotationOnMethod(data, methodAnnotation, method);
+    }
+  }
+
+  protected void registerMethodsAnnotations() {
+    super.registerMethodAnnotation(Path.class, (path, data) -> {
+      final String pathValue = emptyToNull(path.value());
       if (pathValue == null) {
         return;
       }
-      String methodAnnotationValue = Path.class.cast(methodAnnotation).value();
+      String methodAnnotationValue = path.value();
       if (!methodAnnotationValue.startsWith("/") && !data.template().url().endsWith("/")) {
         methodAnnotationValue = "/" + methodAnnotationValue;
       }
@@ -99,83 +110,63 @@ public class JAXRSContract extends Contract.BaseContract {
       methodAnnotationValue =
           methodAnnotationValue.replaceAll("\\{\\s*(.+?)\\s*(:.+?)?\\}", "\\{$1\\}");
       data.template().uri(methodAnnotationValue, true);
-    } else if (annotationType == Produces.class) {
-      handleProducesAnnotation(data, (Produces) methodAnnotation, "method " + method.getName());
-    } else if (annotationType == Consumes.class) {
-      handleConsumesAnnotation(data, (Consumes) methodAnnotation, "method " + method.getName());
-    }
+    });
+    super.registerMethodAnnotation(Consumes.class, this::handleConsumesAnnotation);
+    super.registerMethodAnnotation(Produces.class, this::handleProducesAnnotation);
   }
 
-  private void handleProducesAnnotation(MethodMetadata data, Produces produces, String name) {
-    String[] serverProduces =
+  private void handleProducesAnnotation(Produces produces, MethodMetadata data) {
+    final String[] serverProduces =
         removeValues(produces.value(), (mediaType) -> emptyToNull(mediaType) == null, String.class);
-    checkState(serverProduces.length > 0, "Produces.value() was empty on %s", name);
+    checkState(serverProduces.length > 0, "Produces.value() was empty on %s", data.configKey());
     data.template().header(ACCEPT, Collections.emptyList()); // remove any previous produces
     data.template().header(ACCEPT, serverProduces);
   }
 
-  private void handleConsumesAnnotation(MethodMetadata data, Consumes consumes, String name) {
-    String[] serverConsumes =
+  private void handleConsumesAnnotation(Consumes consumes, MethodMetadata data) {
+    final String[] serverConsumes =
         removeValues(consumes.value(), (mediaType) -> emptyToNull(mediaType) == null, String.class);
-    checkState(serverConsumes.length > 0, "Consumes.value() was empty on %s", name);
+    checkState(serverConsumes.length > 0, "Consumes.value() was empty on %s", data.configKey());
     data.template().header(CONTENT_TYPE, Collections.emptyList()); // remove any previous consumes
     data.template().header(CONTENT_TYPE, serverConsumes[0]);
   }
 
-  /**
-   * Allows derived contracts to specify unsupported jax-rs parameter annotations which should be
-   * ignored. Required for JAX-RS 2 compatibility.
-   */
-  protected boolean isUnsupportedHttpParameterAnnotation(Annotation parameterAnnotation) {
-    return false;
-  }
-
-  @Override
-  protected boolean processAnnotationsOnParameter(MethodMetadata data,
-                                                  Annotation[] annotations,
-                                                  int paramIndex) {
-    boolean isHttpParam = false;
-    for (Annotation parameterAnnotation : annotations) {
-      Class<? extends Annotation> annotationType = parameterAnnotation.annotationType();
-      // masc20180327. parameter with unsupported jax-rs annotations should not be passed as body
-      // params.
-      // this will prevent interfaces from becoming unusable entirely due to single (unsupported)
-      // endpoints.
-      // https://github.com/OpenFeign/feign/issues/669
-      if (this.isUnsupportedHttpParameterAnnotation(parameterAnnotation)) {
-        isHttpParam = true;
-      } else if (annotationType == PathParam.class) {
-        String name = PathParam.class.cast(parameterAnnotation).value();
+  protected void registerParamAnnotations() {
+    {
+      registerParameterAnnotation(PathParam.class, (param, data, paramIndex) -> {
+        final String name = param.value();
         checkState(emptyToNull(name) != null, "PathParam.value() was empty on parameter %s",
             paramIndex);
         nameParam(data, name, paramIndex);
-        isHttpParam = true;
-      } else if (annotationType == QueryParam.class) {
-        String name = QueryParam.class.cast(parameterAnnotation).value();
+        return true;
+      });
+      registerParameterAnnotation(QueryParam.class, (param, data, paramIndex) -> {
+        final String name = param.value();
         checkState(emptyToNull(name) != null, "QueryParam.value() was empty on parameter %s",
             paramIndex);
-        String query = addTemplatedParam(name);
+        final String query = addTemplatedParam(name);
         data.template().query(name, query);
         nameParam(data, name, paramIndex);
-        isHttpParam = true;
-      } else if (annotationType == HeaderParam.class) {
-        String name = HeaderParam.class.cast(parameterAnnotation).value();
+        return true;
+      });
+      registerParameterAnnotation(HeaderParam.class, (param, data, paramIndex) -> {
+        final String name = param.value();
         checkState(emptyToNull(name) != null, "HeaderParam.value() was empty on parameter %s",
             paramIndex);
-        String header = addTemplatedParam(name);
+        final String header = addTemplatedParam(name);
         data.template().header(name, header);
         nameParam(data, name, paramIndex);
-        isHttpParam = true;
-      } else if (annotationType == FormParam.class) {
-        String name = FormParam.class.cast(parameterAnnotation).value();
+        return true;
+      });
+      registerParameterAnnotation(FormParam.class, (param, data, paramIndex) -> {
+        final String name = param.value();
         checkState(emptyToNull(name) != null, "FormParam.value() was empty on parameter %s",
             paramIndex);
         data.formParams().add(name);
         nameParam(data, name, paramIndex);
-        isHttpParam = true;
-      }
+        return true;
+      });
     }
-    return isHttpParam;
   }
 
   // Not using override as the super-type's method is deprecated and will be removed.

--- a/jaxrs/src/test/java/feign/jaxrs/JAXRSContractTest.java
+++ b/jaxrs/src/test/java/feign/jaxrs/JAXRSContractTest.java
@@ -13,36 +13,20 @@
  */
 package feign.jaxrs;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
+import static feign.assertj.FeignAssertions.assertThat;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 import java.net.URI;
-import java.util.List;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.GET;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.HttpMethod;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
+import java.util.*;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import feign.MethodMetadata;
 import feign.Response;
-import static feign.assertj.FeignAssertions.assertThat;
-import static java.util.Arrays.asList;
-import static org.assertj.core.data.MapEntry.entry;
 
 /**
  * Tests interfaces defined per {@link JAXRSContract} are interpreted into expected
@@ -115,7 +99,7 @@ public class JAXRSContractTest {
 
   @Test
   public void producesAddsAcceptHeader() throws Exception {
-    MethodMetadata md = parseAndValidateMetadata(ProducesAndConsumes.class, "produces");
+    final MethodMetadata md = parseAndValidateMetadata(ProducesAndConsumes.class, "produces");
 
     /* multiple @Produces annotations should be additive */
     assertThat(md.template())
@@ -126,7 +110,8 @@ public class JAXRSContractTest {
 
   @Test
   public void producesMultipleAddsAcceptHeader() throws Exception {
-    MethodMetadata md = parseAndValidateMetadata(ProducesAndConsumes.class, "producesMultiple");
+    final MethodMetadata md =
+        parseAndValidateMetadata(ProducesAndConsumes.class, "producesMultiple");
 
     assertThat(md.template())
         .hasHeaders(
@@ -137,7 +122,7 @@ public class JAXRSContractTest {
   @Test
   public void producesNada() throws Exception {
     thrown.expect(IllegalStateException.class);
-    thrown.expectMessage("Produces.value() was empty on method producesNada");
+    thrown.expectMessage("Produces.value() was empty on ProducesAndConsumes#producesNada");
 
     parseAndValidateMetadata(ProducesAndConsumes.class, "producesNada");
   }
@@ -145,14 +130,14 @@ public class JAXRSContractTest {
   @Test
   public void producesEmpty() throws Exception {
     thrown.expect(IllegalStateException.class);
-    thrown.expectMessage("Produces.value() was empty on method producesEmpty");
+    thrown.expectMessage("Produces.value() was empty on ProducesAndConsumes#producesEmpty");
 
     parseAndValidateMetadata(ProducesAndConsumes.class, "producesEmpty");
   }
 
   @Test
   public void consumesAddsContentTypeHeader() throws Exception {
-    MethodMetadata md = parseAndValidateMetadata(ProducesAndConsumes.class, "consumes");
+    final MethodMetadata md = parseAndValidateMetadata(ProducesAndConsumes.class, "consumes");
 
     /* multiple @Consumes annotations are additive */
     assertThat(md.template())
@@ -163,7 +148,8 @@ public class JAXRSContractTest {
 
   @Test
   public void consumesMultipleAddsContentTypeHeader() throws Exception {
-    MethodMetadata md = parseAndValidateMetadata(ProducesAndConsumes.class, "consumesMultiple");
+    final MethodMetadata md =
+        parseAndValidateMetadata(ProducesAndConsumes.class, "consumesMultiple");
 
     assertThat(md.template())
         .hasHeaders(entry("Content-Type", asList("application/xml")),
@@ -173,7 +159,7 @@ public class JAXRSContractTest {
   @Test
   public void consumesNada() throws Exception {
     thrown.expect(IllegalStateException.class);
-    thrown.expectMessage("Consumes.value() was empty on method consumesNada");
+    thrown.expectMessage("Consumes.value() was empty on ProducesAndConsumes#consumesNada");
 
     parseAndValidateMetadata(ProducesAndConsumes.class, "consumesNada");
   }
@@ -181,14 +167,15 @@ public class JAXRSContractTest {
   @Test
   public void consumesEmpty() throws Exception {
     thrown.expect(IllegalStateException.class);
-    thrown.expectMessage("Consumes.value() was empty on method consumesEmpty");
+    thrown.expectMessage("Consumes.value() was empty on ProducesAndConsumes#consumesEmpty");
 
     parseAndValidateMetadata(ProducesAndConsumes.class, "consumesEmpty");
   }
 
   @Test
   public void producesAndConsumesOnClassAddsHeader() throws Exception {
-    MethodMetadata md = parseAndValidateMetadata(ProducesAndConsumes.class, "producesAndConsumes");
+    final MethodMetadata md =
+        parseAndValidateMetadata(ProducesAndConsumes.class, "producesAndConsumes");
 
     assertThat(md.template())
         .hasHeaders(entry("Content-Type", asList("application/json")),
@@ -197,7 +184,7 @@ public class JAXRSContractTest {
 
   @Test
   public void bodyParamIsGeneric() throws Exception {
-    MethodMetadata md = parseAndValidateMetadata(BodyParams.class, "post", List.class);
+    final MethodMetadata md = parseAndValidateMetadata(BodyParams.class, "post", List.class);
 
     assertThat(md.bodyIndex())
         .isEqualTo(0);
@@ -273,7 +260,7 @@ public class JAXRSContractTest {
 
   @Test
   public void withPathAndURIParams() throws Exception {
-    MethodMetadata md = parseAndValidateMetadata(WithURIParam.class,
+    final MethodMetadata md = parseAndValidateMetadata(WithURIParam.class,
         "uriParam", String.class, URI.class, String.class);
 
     assertThat(md.indexToName()).containsExactly(
@@ -286,7 +273,7 @@ public class JAXRSContractTest {
 
   @Test
   public void pathAndQueryParams() throws Exception {
-    MethodMetadata md =
+    final MethodMetadata md =
         parseAndValidateMetadata(WithPathAndQueryParams.class,
             "recordsByNameAndType", int.class, String.class, String.class);
 
@@ -308,7 +295,7 @@ public class JAXRSContractTest {
 
   @Test
   public void formParamsParseIntoIndexToName() throws Exception {
-    MethodMetadata md = parseAndValidateMetadata(FormParams.class,
+    final MethodMetadata md = parseAndValidateMetadata(FormParams.class,
         "login", String.class, String.class, String.class);
 
     assertThat(md.formParams())
@@ -325,7 +312,7 @@ public class JAXRSContractTest {
    */
   @Test
   public void formParamsDoesNotSetBodyType() throws Exception {
-    MethodMetadata md = parseAndValidateMetadata(FormParams.class,
+    final MethodMetadata md = parseAndValidateMetadata(FormParams.class,
         "login", String.class, String.class, String.class);
 
     assertThat(md.bodyType()).isNull();
@@ -341,7 +328,7 @@ public class JAXRSContractTest {
 
   @Test
   public void headerParamsParseIntoIndexToName() throws Exception {
-    MethodMetadata md = parseAndValidateMetadata(HeaderParams.class, "logout", String.class);
+    final MethodMetadata md = parseAndValidateMetadata(HeaderParams.class, "logout", String.class);
 
     assertThat(md.template())
         .hasHeaders(entry("Auth-Token", asList("{Auth-Token}")));
@@ -644,9 +631,9 @@ public class JAXRSContractTest {
     Response get();
   }
 
-  private MethodMetadata parseAndValidateMetadata(Class<?> targetType,
-                                                  String method,
-                                                  Class<?>... parameterTypes)
+  protected MethodMetadata parseAndValidateMetadata(Class<?> targetType,
+                                                    String method,
+                                                    Class<?>... parameterTypes)
       throws NoSuchMethodException {
     return contract.parseAndValidateMetadata(targetType,
         targetType.getMethod(method, parameterTypes));

--- a/jaxrs2/src/main/java/feign/jaxrs2/JAXRS2Contract.java
+++ b/jaxrs2/src/main/java/feign/jaxrs2/JAXRS2Contract.java
@@ -28,8 +28,8 @@ public final class JAXRS2Contract extends JAXRSContract {
     // this will prevent interfaces from becoming unusable entirely due to single (unsupported)
     // endpoints.
     // https://github.com/OpenFeign/feign/issues/669
-    super.registerParameterAnnotation(Suspended.class, (ann, data, i) -> true);
-    super.registerParameterAnnotation(Context.class, (ann, data, i) -> true);
+    super.registerParameterAnnotation(Suspended.class, (ann, data, i) -> data.ignoreParamater(i));
+    super.registerParameterAnnotation(Context.class, (ann, data, i) -> data.ignoreParamater(i));
   }
 
 }

--- a/jaxrs2/src/main/java/feign/jaxrs2/JAXRS2Contract.java
+++ b/jaxrs2/src/main/java/feign/jaxrs2/JAXRS2Contract.java
@@ -16,23 +16,20 @@ package feign.jaxrs2;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Context;
 import feign.jaxrs.JAXRSContract;
-import java.lang.annotation.Annotation;
 
 /**
  * Please refer to the <a href="https://github.com/Netflix/feign/tree/master/feign-jaxrs2">Feign
  * JAX-RS 2 README</a>.
  */
 public final class JAXRS2Contract extends JAXRSContract {
-  @Override
-  protected boolean isUnsupportedHttpParameterAnnotation(Annotation parameterAnnotation) {
-    Class<? extends Annotation> annotationType = parameterAnnotation.annotationType();
 
-    // masc20180327. parameter with unsupported jax-rs annotations should not be passed as body
-    // params.
+  public JAXRS2Contract() {
+    // parameter with unsupported jax-rs annotations should not be passed as body params.
     // this will prevent interfaces from becoming unusable entirely due to single (unsupported)
     // endpoints.
     // https://github.com/OpenFeign/feign/issues/669
-    return (annotationType == Suspended.class ||
-        annotationType == Context.class);
+    super.registerParameterAnnotation(Suspended.class, (ann, data, i) -> true);
+    super.registerParameterAnnotation(Context.class, (ann, data, i) -> true);
   }
+
 }

--- a/jaxrs2/src/test/java/feign/jaxrs2/JAXRS2ContractTest.java
+++ b/jaxrs2/src/test/java/feign/jaxrs2/JAXRS2ContractTest.java
@@ -13,6 +13,15 @@
  */
 package feign.jaxrs2;
 
+import static feign.assertj.FeignAssertions.assertThat;
+import org.junit.Test;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
+import feign.MethodMetadata;
 import feign.jaxrs.JAXRSContract;
 import feign.jaxrs.JAXRSContractTest;
 
@@ -25,6 +34,22 @@ public class JAXRS2ContractTest extends JAXRSContractTest {
   @Override
   protected JAXRSContract createContract() {
     return new JAXRS2Contract();
+  }
+
+  @Test
+  public void injectJaxrsInternals() throws Exception {
+    final MethodMetadata methodMetadata =
+        parseAndValidateMetadata(JaxrsInternals.class, "inject", AsyncResponse.class,
+            UriInfo.class);
+    assertThat(methodMetadata.template())
+        .noRequestBody();
+  }
+
+
+  @Path("/")
+  public interface JaxrsInternals {
+    @GET
+    void inject(@Suspended AsyncResponse ar, @Context UriInfo info);
   }
 
 }


### PR DESCRIPTION
This is a preparation work for feign code generation that I'm working on this branch:
https://github.com/velo/feign/tree/apt-generator

With generated client, we will be able to generate clients that will work with graalVM and also don't have java 11 reflective warning. Fixing both:
https://github.com/OpenFeign/feign/issues/935
https://github.com/OpenFeign/feign/issues/944

The key work for the code generation is the new `DeclarativeContract`. Which would allow to reuse the annotation logic when generating client. So, same contract code used by feign reflectively would be used on APT code generation.

The idea of this PR is to review the design of this new `DeclarativeContract`