### PR TITLE
Ignore Travis when formatting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -537,6 +537,9 @@
         <configuration>
           <lineEnding>LF</lineEnding>
           <configFile>${main.basedir}/src/config/eclipse-java-style.xml</configFile>
+          <excludes>
+            <exclude>travis/**</exclude>
+          </excludes>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
Configured the code formatting plugin to ignore any files in the travis folder.  This was impacting certain builds after the signing keys are made available.