### PR TITLE
Ignore GPG Keys in Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ atlassian-ide-plugin.xml
 
 # NetBeans specific files/directories
 .nbattrs
+
+# encrypted values
+*.asc


### PR DESCRIPTION
Travis needs a local copy of the gpg key to install the library
in Maven Central.  This change ignores that local file because
our formatting checks consider this file "changed" creating
false-negative build results.