### PR TITLE
Add composed Spring annotations support

### DIFF
--- a/spring4/README.md
+++ b/spring4/README.md
@@ -18,6 +18,21 @@ The ```consume``` adds the first value as the `Content-Type` header.
 #### `@RequestMapping`
 Appends the value to `Target.url()`.  Can have tokens corresponding to `@PathVariable` annotations.
 The method sets the request method.
+#### `@GetMapping`
+Appends the value to `Target.url()`.  Can have tokens corresponding to `@PathVariable` annotations. 
+Sets the `GET` request method. 
+#### `@PostMapping`
+Appends the value to `Target.url()`.  Can have tokens corresponding to `@PathVariable` annotations.
+Sets the `POST` request method. 
+#### `@PutMapping`
+Appends the value to `Target.url()`.  Can have tokens corresponding to `@PathVariable` annotations.
+Sets the `PUT` request method. 
+#### `@DeleteMapping`
+Appends the value to `Target.url()`.  Can have tokens corresponding to `@PathVariable` annotations.
+Sets the `DELETE` request method. 
+#### `@PatchMapping`
+Appends the value to `Target.url()`.  Can have tokens corresponding to `@PathVariable` annotations.
+Sets the `PATCH` request method. 
 ### Parameter Annotations
 #### `@PathVariable`
 Links the value of the corresponding parameter to a template variable declared in the path.

--- a/spring4/src/main/java/feign/spring/SpringContract.java
+++ b/spring4/src/main/java/feign/spring/SpringContract.java
@@ -45,39 +45,39 @@ public class SpringContract extends DeclarativeContract {
     });
 
 
-    registerMethodAnnotation(GetMapping.class, (postMapping, data) -> {
-      appendMappings(data, postMapping.value());
+    registerMethodAnnotation(GetMapping.class, (mapping, data) -> {
+      appendMappings(data, mapping.value());
       data.template().method(Request.HttpMethod.GET);
-      handleProducesAnnotation(data, postMapping.produces());
-      handleConsumesAnnotation(data, postMapping.consumes());
+      handleProducesAnnotation(data, mapping.produces());
+      handleConsumesAnnotation(data, mapping.consumes());
     });
 
-    registerMethodAnnotation(PostMapping.class, (postMapping, data) -> {
-      appendMappings(data, postMapping.value());
+    registerMethodAnnotation(PostMapping.class, (mapping, data) -> {
+      appendMappings(data, mapping.value());
       data.template().method(Request.HttpMethod.POST);
-      handleProducesAnnotation(data, postMapping.produces());
-      handleConsumesAnnotation(data, postMapping.consumes());
+      handleProducesAnnotation(data, mapping.produces());
+      handleConsumesAnnotation(data, mapping.consumes());
     });
 
-    registerMethodAnnotation(PutMapping.class, (postMapping, data) -> {
-      appendMappings(data, postMapping.value());
+    registerMethodAnnotation(PutMapping.class, (mapping, data) -> {
+      appendMappings(data, mapping.value());
       data.template().method(Request.HttpMethod.PUT);
-      handleProducesAnnotation(data, postMapping.produces());
-      handleConsumesAnnotation(data, postMapping.consumes());
+      handleProducesAnnotation(data, mapping.produces());
+      handleConsumesAnnotation(data, mapping.consumes());
     });
 
-    registerMethodAnnotation(DeleteMapping.class, (postMapping, data) -> {
-      appendMappings(data, postMapping.value());
+    registerMethodAnnotation(DeleteMapping.class, (mapping, data) -> {
+      appendMappings(data, mapping.value());
       data.template().method(Request.HttpMethod.DELETE);
-      handleProducesAnnotation(data, postMapping.produces());
-      handleConsumesAnnotation(data, postMapping.consumes());
+      handleProducesAnnotation(data, mapping.produces());
+      handleConsumesAnnotation(data, mapping.consumes());
     });
 
-    registerMethodAnnotation(PatchMapping.class, (postMapping, data) -> {
-      appendMappings(data, postMapping.value());
+    registerMethodAnnotation(PatchMapping.class, (mapping, data) -> {
+      appendMappings(data, mapping.value());
       data.template().method(Request.HttpMethod.PATCH);
-      handleProducesAnnotation(data, postMapping.produces());
-      handleConsumesAnnotation(data, postMapping.consumes());
+      handleProducesAnnotation(data, mapping.produces());
+      handleConsumesAnnotation(data, mapping.consumes());
     });
 
     registerMethodAnnotation(ResponseBody.class, (body, data) -> {

--- a/spring4/src/main/java/feign/spring/SpringContract.java
+++ b/spring4/src/main/java/feign/spring/SpringContract.java
@@ -13,19 +13,12 @@
  */
 package feign.spring;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
-import feign.Contract.BaseContract;
+import org.springframework.web.bind.annotation.*;
 import feign.DeclarativeContract;
 import feign.MethodMetadata;
+import feign.Request;
 
 public class SpringContract extends DeclarativeContract {
 
@@ -49,6 +42,42 @@ public class SpringContract extends DeclarativeContract {
 
       if (requestMapping.method().length == 1)
         data.template().method(requestMapping.method()[0].name());
+    });
+
+
+    registerMethodAnnotation(GetMapping.class, (postMapping, data) -> {
+      appendMappings(data, postMapping.value());
+      data.template().method(Request.HttpMethod.GET);
+      handleProducesAnnotation(data, postMapping.produces());
+      handleConsumesAnnotation(data, postMapping.consumes());
+    });
+
+    registerMethodAnnotation(PostMapping.class, (postMapping, data) -> {
+      appendMappings(data, postMapping.value());
+      data.template().method(Request.HttpMethod.POST);
+      handleProducesAnnotation(data, postMapping.produces());
+      handleConsumesAnnotation(data, postMapping.consumes());
+    });
+
+    registerMethodAnnotation(PutMapping.class, (postMapping, data) -> {
+      appendMappings(data, postMapping.value());
+      data.template().method(Request.HttpMethod.PUT);
+      handleProducesAnnotation(data, postMapping.produces());
+      handleConsumesAnnotation(data, postMapping.consumes());
+    });
+
+    registerMethodAnnotation(DeleteMapping.class, (postMapping, data) -> {
+      appendMappings(data, postMapping.value());
+      data.template().method(Request.HttpMethod.DELETE);
+      handleProducesAnnotation(data, postMapping.produces());
+      handleConsumesAnnotation(data, postMapping.consumes());
+    });
+
+    registerMethodAnnotation(PatchMapping.class, (postMapping, data) -> {
+      appendMappings(data, postMapping.value());
+      data.template().method(Request.HttpMethod.PATCH);
+      handleProducesAnnotation(data, postMapping.produces());
+      handleConsumesAnnotation(data, postMapping.consumes());
     });
 
     registerMethodAnnotation(ResponseBody.class, (body, data) -> {

--- a/spring4/src/test/java/feign/spring/SpringContractTest.java
+++ b/spring4/src/test/java/feign/spring/SpringContractTest.java
@@ -47,6 +47,7 @@ public class SpringContractTest {
   public void setup() throws IOException {
     mockClient = new MockClient()
         .noContent(HttpMethod.GET, "/health")
+        .noContent(HttpMethod.GET, "/health/1")
         .noContent(HttpMethod.GET, "/health/1?deep=true")
         .noContent(HttpMethod.GET, "/health/1?deep=true&dryRun=true")
         .ok(HttpMethod.GET, "/health/generic", "{}");
@@ -84,6 +85,13 @@ public class SpringContractTest {
   }
 
   @Test
+  public void composedAnnotation() {
+    resource.check("1");
+
+    mockClient.verifyOne(HttpMethod.GET, "/health/1");
+  }
+
+  @Test
   public void notAHttpMethod() {
     thrown.expectMessage("is not a method handled by feign");
 
@@ -114,6 +122,9 @@ public class SpringContractTest {
                       @PathVariable("id") String campaignId,
                       @RequestParam(value = "deep", defaultValue = "false") boolean deepCheck,
                       @RequestParam(value = "dryRun", defaultValue = "false") boolean dryRun);
+
+    @GetMapping(value = "/{id}")
+    public void check(@PathVariable("id") String campaignId);
 
     @ResponseStatus(value = HttpStatus.NOT_FOUND,
         reason = "This customer is not found in the system")


### PR DESCRIPTION
Add Spring's composed annotations support (like `@GetMapping`). These are convenience methods that are quite frequently used.

Changeset might look a bit repetitive, however, to process annotations differently it would require bigger refactoring which is not intended by this minor auxiliary PR. As was mentioned in #1069, worse case this entire spring4 support can be deleted later.