### PR TITLE
Fixes a typo in Contract.java method

### DIFF
--- a/benchmark/src/main/java/feign/benchmark/WhatShouldWeCacheBenchmarks.java
+++ b/benchmark/src/main/java/feign/benchmark/WhatShouldWeCacheBenchmarks.java
@@ -56,9 +56,9 @@ public class WhatShouldWeCacheBenchmarks {
     feignContract = new Contract.Default();
     cachedContact = new Contract() {
       private final List<MethodMetadata> cached =
-          new Default().parseAndValidatateMetadata(FeignTestInterface.class);
+          new Default().parseAndValidateMetadata(FeignTestInterface.class);
 
-      public List<MethodMetadata> parseAndValidatateMetadata(Class<?> declaring) {
+      public List<MethodMetadata> parseAndValidateMetadata(Class<?> declaring) {
         return cached;
       }
     };
@@ -84,7 +84,7 @@ public class WhatShouldWeCacheBenchmarks {
    */
   @Benchmark
   public List<MethodMetadata> parseFeignContract() {
-    return feignContract.parseAndValidatateMetadata(FeignTestInterface.class);
+    return feignContract.parseAndValidateMetadata(FeignTestInterface.class);
   }
 
   /**

--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -33,13 +33,16 @@ public interface Contract {
    *
    * @param targetType {@link feign.Target#type() type} of the Feign interface.
    */
-  // TODO: break this and correct spelling at some point
-  List<MethodMetadata> parseAndValidatateMetadata(Class<?> targetType);
+  List<MethodMetadata> parseAndValidateMetadata(Class<?> targetType);
 
   abstract class BaseContract implements Contract {
 
+    /**
+     * @param targetType {@link feign.Target#type() type} of the Feign interface.
+     * @see #parseAndValidateMetadata(Class)
+     */
     @Override
-    public List<MethodMetadata> parseAndValidatateMetadata(Class<?> targetType) {
+    public List<MethodMetadata> parseAndValidateMetadata(Class<?> targetType) {
       checkState(targetType.getTypeParameters().length == 0, "Parameterized types unsupported: %s",
           targetType.getSimpleName());
       checkState(targetType.getInterfaces().length <= 1, "Only single inheritance supported: %s",
@@ -68,12 +71,12 @@ public interface Contract {
      * @deprecated use {@link #parseAndValidateMetadata(Class, Method)} instead.
      */
     @Deprecated
-    public MethodMetadata parseAndValidatateMetadata(Method method) {
+    public MethodMetadata parseAndValidateMetadata(Method method) {
       return parseAndValidateMetadata(method.getDeclaringClass(), method);
     }
 
     /**
-     * Called indirectly by {@link #parseAndValidatateMetadata(Class)}.
+     * Called indirectly by {@link #parseAndValidateMetadata(Class)}.
      */
     protected MethodMetadata parseAndValidateMetadata(Class<?> targetType, Method method) {
       MethodMetadata data = new MethodMetadata();

--- a/core/src/main/java/feign/DeclarativeContract.java
+++ b/core/src/main/java/feign/DeclarativeContract.java
@@ -31,9 +31,9 @@ public abstract class DeclarativeContract extends BaseContract {
       new HashMap<>();
 
   @Override
-  public final List<MethodMetadata> parseAndValidatateMetadata(Class<?> targetType) {
+  public final List<MethodMetadata> parseAndValidateMetadata(Class<?> targetType) {
     // any implementations must register processors
-    return super.parseAndValidatateMetadata(targetType);
+    return super.parseAndValidateMetadata(targetType);
   }
 
   /**

--- a/core/src/main/java/feign/ReflectiveFeign.java
+++ b/core/src/main/java/feign/ReflectiveFeign.java
@@ -151,7 +151,7 @@ public class ReflectiveFeign extends Feign {
     }
 
     public Map<String, MethodHandler> apply(Target key) {
-      List<MethodMetadata> metadata = contract.parseAndValidatateMetadata(key.type());
+      List<MethodMetadata> metadata = contract.parseAndValidateMetadata(key.type());
       Map<String, MethodHandler> result = new LinkedHashMap<String, MethodHandler>();
       for (MethodMetadata md : metadata) {
         BuildTemplateByResolvingArgs buildTemplate;

--- a/core/src/test/java/feign/ContractWithRuntimeInjectionTest.java
+++ b/core/src/test/java/feign/ContractWithRuntimeInjectionTest.java
@@ -93,8 +93,8 @@ public class ContractWithRuntimeInjectionTest {
      * Injects {@link MethodMetadata#indexToExpander(Map)} via {@link BeanFactory#getBean(Class)}.
      */
     @Override
-    public List<MethodMetadata> parseAndValidatateMetadata(Class<?> targetType) {
-      List<MethodMetadata> result = new Contract.Default().parseAndValidatateMetadata(targetType);
+    public List<MethodMetadata> parseAndValidateMetadata(Class<?> targetType) {
+      List<MethodMetadata> result = new Contract.Default().parseAndValidateMetadata(targetType);
       for (MethodMetadata md : result) {
         Map<Integer, Param.Expander> indexToExpander = new LinkedHashMap<Integer, Param.Expander>();
         for (Map.Entry<Integer, Class<? extends Param.Expander>> entry : md.indexToExpanderClass()

--- a/core/src/test/java/feign/DefaultContractTest.java
+++ b/core/src/test/java/feign/DefaultContractTest.java
@@ -584,7 +584,7 @@ public class DefaultContractTest {
 
   @Test
   public void simpleParameterizedBaseApi() throws Exception {
-    List<MethodMetadata> md = contract.parseAndValidatateMetadata(SimpleParameterizedApi.class);
+    List<MethodMetadata> md = contract.parseAndValidateMetadata(SimpleParameterizedApi.class);
 
     assertThat(md).hasSize(1);
 
@@ -600,7 +600,7 @@ public class DefaultContractTest {
   public void parameterizedApiUnsupported() throws Exception {
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("Parameterized types unsupported: SimpleParameterizedBaseApi");
-    contract.parseAndValidatateMetadata(SimpleParameterizedBaseApi.class);
+    contract.parseAndValidateMetadata(SimpleParameterizedBaseApi.class);
   }
 
   interface OverrideParameterizedApi extends SimpleParameterizedBaseApi<String> {
@@ -614,7 +614,7 @@ public class DefaultContractTest {
   public void overrideBaseApiUnsupported() throws Exception {
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("Overrides unsupported: OverrideParameterizedApi#get(String)");
-    contract.parseAndValidatateMetadata(OverrideParameterizedApi.class);
+    contract.parseAndValidateMetadata(OverrideParameterizedApi.class);
   }
 
   interface Child<T> extends SimpleParameterizedBaseApi<List<T>> {
@@ -629,7 +629,7 @@ public class DefaultContractTest {
   public void onlySingleLevelInheritanceSupported() throws Exception {
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("Only single-level inheritance supported: GrandChild");
-    contract.parseAndValidatateMetadata(GrandChild.class);
+    contract.parseAndValidateMetadata(GrandChild.class);
   }
 
   @Headers("Foo: Bar")
@@ -671,7 +671,7 @@ public class DefaultContractTest {
 
   @Test
   public void parameterizedBaseApi() throws Exception {
-    List<MethodMetadata> md = contract.parseAndValidatateMetadata(ParameterizedApi.class);
+    List<MethodMetadata> md = contract.parseAndValidateMetadata(ParameterizedApi.class);
 
     Map<String, MethodMetadata> byConfigKey = new LinkedHashMap<String, MethodMetadata>();
     for (MethodMetadata m : md) {
@@ -706,7 +706,7 @@ public class DefaultContractTest {
   @Test
   public void parameterizedHeaderExpandApi() throws Exception {
     List<MethodMetadata> md =
-        contract.parseAndValidatateMetadata(ParameterizedHeaderExpandApi.class);
+        contract.parseAndValidateMetadata(ParameterizedHeaderExpandApi.class);
 
     assertThat(md).hasSize(1);
 
@@ -725,7 +725,7 @@ public class DefaultContractTest {
   @Test
   public void parameterizedHeaderNotStartingWithCurlyBraceExpandApi() throws Exception {
     List<MethodMetadata> md =
-        contract.parseAndValidatateMetadata(
+        contract.parseAndValidateMetadata(
             ParameterizedHeaderNotStartingWithCurlyBraceExpandApi.class);
 
     assertThat(md).hasSize(1);
@@ -765,7 +765,7 @@ public class DefaultContractTest {
   @Test
   public void parameterizedHeaderExpandApiBaseClass() throws Exception {
     List<MethodMetadata> mds =
-        contract.parseAndValidatateMetadata(ParameterizedHeaderExpandInheritedApi.class);
+        contract.parseAndValidateMetadata(ParameterizedHeaderExpandInheritedApi.class);
 
     Map<String, MethodMetadata> byConfigKey = new LinkedHashMap<String, MethodMetadata>();
     for (MethodMetadata m : mds) {
@@ -816,7 +816,7 @@ public class DefaultContractTest {
     thrown.expectMessage(
         "RequestLine annotation didn't start with an HTTP verb on method MissingMethod#updateSharing");
 
-    contract.parseAndValidatateMetadata(MissingMethod.class);
+    contract.parseAndValidateMetadata(MissingMethod.class);
   }
 
   interface StaticMethodOnInterface {
@@ -830,7 +830,7 @@ public class DefaultContractTest {
 
   @Test
   public void staticMethodsOnInterfaceIgnored() throws Exception {
-    List<MethodMetadata> mds = contract.parseAndValidatateMetadata(StaticMethodOnInterface.class);
+    List<MethodMetadata> mds = contract.parseAndValidateMetadata(StaticMethodOnInterface.class);
     assertThat(mds).hasSize(1);
     MethodMetadata md = mds.get(0);
     assertThat(md.configKey()).isEqualTo("StaticMethodOnInterface#get(String)");
@@ -847,7 +847,7 @@ public class DefaultContractTest {
 
   @Test
   public void defaultMethodsOnInterfaceIgnored() throws Exception {
-    List<MethodMetadata> mds = contract.parseAndValidatateMetadata(DefaultMethodOnInterface.class);
+    List<MethodMetadata> mds = contract.parseAndValidateMetadata(DefaultMethodOnInterface.class);
     assertThat(mds).hasSize(1);
     MethodMetadata md = mds.get(0);
     assertThat(md.configKey()).isEqualTo("DefaultMethodOnInterface#get(String)");
@@ -860,7 +860,7 @@ public class DefaultContractTest {
 
   @Test
   public void paramIsASubstringOfAQuery() throws Exception {
-    List<MethodMetadata> mds = contract.parseAndValidatateMetadata(SubstringQuery.class);
+    List<MethodMetadata> mds = contract.parseAndValidateMetadata(SubstringQuery.class);
 
     assertThat(mds.get(0).template().queries()).containsExactly(
         entry("q", asList("body:{body}")));

--- a/hystrix/src/main/java/feign/hystrix/HystrixDelegatingContract.java
+++ b/hystrix/src/main/java/feign/hystrix/HystrixDelegatingContract.java
@@ -43,8 +43,8 @@ public final class HystrixDelegatingContract implements Contract {
   }
 
   @Override
-  public List<MethodMetadata> parseAndValidatateMetadata(Class<?> targetType) {
-    List<MethodMetadata> metadatas = this.delegate.parseAndValidatateMetadata(targetType);
+  public List<MethodMetadata> parseAndValidateMetadata(Class<?> targetType) {
+    List<MethodMetadata> metadatas = this.delegate.parseAndValidateMetadata(targetType);
 
     for (MethodMetadata metadata : metadatas) {
       Type type = metadata.returnType();

--- a/reactive/src/main/java/feign/reactive/ReactiveDelegatingContract.java
+++ b/reactive/src/main/java/feign/reactive/ReactiveDelegatingContract.java
@@ -32,8 +32,8 @@ public class ReactiveDelegatingContract implements Contract {
   }
 
   @Override
-  public List<MethodMetadata> parseAndValidatateMetadata(Class<?> targetType) {
-    List<MethodMetadata> methodsMetadata = this.delegate.parseAndValidatateMetadata(targetType);
+  public List<MethodMetadata> parseAndValidateMetadata(Class<?> targetType) {
+    List<MethodMetadata> methodsMetadata = this.delegate.parseAndValidateMetadata(targetType);
 
     for (final MethodMetadata metadata : methodsMetadata) {
       final Type type = metadata.returnType();

--- a/reactive/src/test/java/feign/reactive/ReactiveDelegatingContractTest.java
+++ b/reactive/src/test/java/feign/reactive/ReactiveDelegatingContractTest.java
@@ -34,26 +34,26 @@ public class ReactiveDelegatingContractTest {
   public void onlyReactiveReturnTypesSupported() {
     this.thrown.expect(IllegalArgumentException.class);
     Contract contract = new ReactiveDelegatingContract(new Contract.Default());
-    contract.parseAndValidatateMetadata(TestSynchronousService.class);
+    contract.parseAndValidateMetadata(TestSynchronousService.class);
   }
 
   @Test
   public void reactorTypes() {
     Contract contract = new ReactiveDelegatingContract(new Contract.Default());
-    contract.parseAndValidatateMetadata(TestReactorService.class);
+    contract.parseAndValidateMetadata(TestReactorService.class);
   }
 
   @Test
   public void reactivexTypes() {
     Contract contract = new ReactiveDelegatingContract(new Contract.Default());
-    contract.parseAndValidatateMetadata(TestReactiveXService.class);
+    contract.parseAndValidateMetadata(TestReactiveXService.class);
   }
 
   @Test
   public void streamsAreNotSupported() {
     this.thrown.expect(IllegalArgumentException.class);
     Contract contract = new ReactiveDelegatingContract(new Contract.Default());
-    contract.parseAndValidatateMetadata(StreamsService.class);
+    contract.parseAndValidateMetadata(StreamsService.class);
   }
 
   public interface TestSynchronousService {


### PR DESCRIPTION
* The method parseAndValidatateMetadata has been renamed to parseAndValidateMetadata and has been deprecated;
* Replaced all usages along the project;
* Documented which method to use instead of the deprecated one.

Signed-off-by: Cézar Augusto <cezaraugustome@gmail.com>