### PR TITLE
404 + Optional = empty()

### DIFF
--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -22,6 +22,7 @@ import feign.Request.Options;
 import feign.codec.DecodeException;
 import feign.codec.Decoder;
 import feign.codec.ErrorDecoder;
+import feign.optionals.OptionalDecoder;
 import static feign.ExceptionPropagationPolicy.UNWRAP;
 import static feign.FeignException.errorExecuting;
 import static feign.FeignException.errorReading;
@@ -148,6 +149,10 @@ final class SynchronousMethodHandler implements MethodHandler {
           shouldClose = closeAfterDecode;
           return result;
         }
+      } else if (response.status() == 404 && OptionalDecoder.isOptional(metadata.returnType())) {
+        Object result = decode(response);
+        shouldClose = closeAfterDecode;
+        return result;
       } else if (decode404 && response.status() == 404 && void.class != metadata.returnType()) {
         Object result = decode(response);
         shouldClose = closeAfterDecode;

--- a/core/src/main/java/feign/optionals/OptionalDecoder.java
+++ b/core/src/main/java/feign/optionals/OptionalDecoder.java
@@ -42,7 +42,7 @@ public final class OptionalDecoder implements Decoder {
     return Optional.ofNullable(delegate.decode(response, enclosedType));
   }
 
-  static boolean isOptional(Type type) {
+  public static boolean isOptional(Type type) {
     if (!(type instanceof ParameterizedType)) {
       return false;
     }


### PR DESCRIPTION
In HTTP language missing resource is explained by 404. In Java, the same is Optional.empty(). Feign should by default map 404 to empty

Currently, the mapping can be forced by property `decode404=true`. It means that `Optional` without `decode404=true` is useless - `Optional.empty` in never returned, because Feign transforms 404 into `FeignException`.

But applying `decoder404=true` has bad impact. Let's see:

There are two methods:

```
Optional<User> findByLogin(String login);
User findById(Long id);
```

When user is searched by login, it is normal business case that user is not found - for example, wrong login is typed. In such case I expect endpoint should return 404 - in HTTP language user not found.
Because method returns Optional<User>, it means 'empty' is normal case. Optional forces developer to handle that case. I expect 404 will be translated into Optional.empty

But when user is searched by id, it means user was already found - maybe in previous action. Missing user is not normal case. I expect that endpoint should return 404, but Feign should throw FeignException. That is because method returns User, and null in not acceptable - if acceptable, Optional<User> will be applied. Contrary to previous case, I want force developer to NOT handle the case. The case - no user for given id - is runtime error which should be handled like any other runtime error - by general handler.

Conclusion:
If method returns Optional, 404 should be mapped to Optional.empty.
If method returns concrete class, 404 should trigger FeignException.
"decode404=true" force developer to null check every time and is not a solution.
Solution is this commit