### PR TITLE
Makes iterator compatible with Java iterator expected behavior

### DIFF
--- a/jackson/src/main/java/feign/jackson/JacksonIteratorDecoder.java
+++ b/jackson/src/main/java/feign/jackson/JacksonIteratorDecoder.java
@@ -15,15 +15,12 @@ package feign.jackson;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
+import com.fasterxml.jackson.databind.*;
 import feign.Response;
-import feign.Util;
 import feign.codec.DecodeException;
 import feign.codec.Decoder;
+
 import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.IOException;
@@ -32,6 +29,8 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
+
 import static feign.Util.ensureClosed;
 
 /**
@@ -131,10 +130,17 @@ public final class JacksonIteratorDecoder implements Decoder {
 
     @Override
     public boolean hasNext() {
+      if (current == null) {
+        current = readNext();
+      }
+      return current != null;
+    }
+
+    private T readNext() {
       try {
         JsonToken jsonToken = parser.nextToken();
         if (jsonToken == null) {
-          return false;
+          return null;
         }
 
         if (jsonToken == JsonToken.START_ARRAY) {
@@ -142,22 +148,29 @@ public final class JacksonIteratorDecoder implements Decoder {
         }
 
         if (jsonToken == JsonToken.END_ARRAY) {
-          current = null;
           ensureClosed(this);
-          return false;
+          return null;
         }
 
-        current = objectReader.readValue(parser);
+        return objectReader.readValue(parser);
       } catch (IOException e) {
         // Input Stream closed automatically by parser
         throw new DecodeException(response.status(), e.getMessage(), response.request(), e);
       }
-      return current != null;
     }
 
     @Override
     public T next() {
-      return current;
+      if (current != null) {
+        T tmp = current;
+        current = null;
+        return tmp;
+      }
+      T next = readNext();
+      if (next == null) {
+        throw new NoSuchElementException();
+      }
+      return next;
     }
 
     @Override

--- a/jackson/src/main/java/feign/jackson/JacksonIteratorDecoder.java
+++ b/jackson/src/main/java/feign/jackson/JacksonIteratorDecoder.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.*;
 import feign.Response;
 import feign.codec.DecodeException;
 import feign.codec.Decoder;
-
 import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.IOException;
@@ -30,7 +29,6 @@ import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-
 import static feign.Util.ensureClosed;
 
 /**

--- a/jackson/src/test/java/feign/jackson/JacksonIteratorTest.java
+++ b/jackson/src/test/java/feign/jackson/JacksonIteratorTest.java
@@ -13,9 +13,6 @@
  */
 package feign.jackson;
 
-import static feign.Util.UTF_8;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.core.Is.isA;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.Request;
 import feign.Request.HttpMethod;
@@ -23,15 +20,22 @@ import feign.Response;
 import feign.Util;
 import feign.codec.DecodeException;
 import feign.jackson.JacksonIteratorDecoder.JacksonIterator;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+
+import static feign.Util.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.core.Is.isA;
 
 public class JacksonIteratorTest {
 
@@ -41,6 +45,31 @@ public class JacksonIteratorTest {
   @Test
   public void shouldDecodePrimitiveArrays() throws IOException {
     assertThat(iterator(Integer.class, "[0,1,2,3]")).containsExactly(0, 1, 2, 3);
+  }
+
+  @Test
+  public void shouldNotSkipElementsOnHasNext() throws IOException {
+    JacksonIterator<Integer> iterator = iterator(Integer.class, "[0]");
+    assertThat(iterator.hasNext()).isTrue();
+    assertThat(iterator.hasNext()).isTrue();
+    assertThat(iterator.next()).isEqualTo(0);
+    assertThat(iterator.hasNext()).isFalse();
+  }
+
+  @Test
+  public void hasNextIsNotMandatory() throws IOException {
+    JacksonIterator<Integer> iterator = iterator(Integer.class, "[0]");
+    assertThat(iterator.next()).isEqualTo(0);
+    assertThat(iterator.hasNext()).isFalse();
+  }
+
+  @Test
+  public void expectExceptionOnNoElements() throws IOException {
+    JacksonIterator<Integer> iterator = iterator(Integer.class, "[0]");
+    assertThat(iterator.next()).isEqualTo(0);
+    assertThatThrownBy(() -> iterator.next())
+            .hasMessage(null)
+            .isInstanceOf(NoSuchElementException.class);
   }
 
   @Test

--- a/jackson/src/test/java/feign/jackson/JacksonIteratorTest.java
+++ b/jackson/src/test/java/feign/jackson/JacksonIteratorTest.java
@@ -23,7 +23,6 @@ import feign.jackson.JacksonIteratorDecoder.JacksonIterator;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,7 +30,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import static feign.Util.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -68,8 +66,8 @@ public class JacksonIteratorTest {
     JacksonIterator<Integer> iterator = iterator(Integer.class, "[0]");
     assertThat(iterator.next()).isEqualTo(0);
     assertThatThrownBy(() -> iterator.next())
-            .hasMessage(null)
-            .isInstanceOf(NoSuchElementException.class);
+        .hasMessage(null)
+        .isInstanceOf(NoSuchElementException.class);
   }
 
   @Test


### PR DESCRIPTION
both next() and hasNext() should read from stream if needed. both also inspect 'current' member, next() resets it after consuming. exception is thrown when no more elements are available to return.