### PR TITLE
added a method to get a target name from RequestTemplate

### DIFF
--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -966,6 +966,15 @@ public final class RequestTemplate implements Serializable {
   public Target<?> feignTarget() {
     return feignTarget;
   }
+  
+  public String getTargetName() {
+
+    if (feignTarget != null) {
+      return this.feignTarget.name();
+    } else {
+      return null;
+    }
+  }
 
   /**
    * Factory for creating RequestTemplate.


### PR DESCRIPTION
Hello, I'm now in a huge MSA project and need a method like below.

In our MSA project, I need to specify the target instance of a microservice by using EurekaClient. To do it, I should figure out what the target microservice name is. This is the reason why I added a method returning target service name.

Thanks.