### PR TITLE
fix inconsistent bug

### DIFF
--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -117,13 +117,17 @@ public interface Contract {
 
         if (parameterTypes[i] == URI.class) {
           data.urlIndex(i);
-        } else if (!isHttpAnnotation && parameterTypes[i] != Request.Options.class
-            && !data.isAlreadyProcessed(i)) {
-          checkState(data.formParams().isEmpty(),
-              "Body parameters cannot be used with form parameters.");
-          checkState(data.bodyIndex() == null, "Method has too many Body parameters: %s", method);
-          data.bodyIndex(i);
-          data.bodyType(Types.resolve(targetType, targetType, genericParameterTypes[i]));
+        } else if (!isHttpAnnotation && parameterTypes[i] != Request.Options.class) {
+          if (data.isAlreadyProcessed(i)) {
+            checkState(data.formParams().isEmpty() || data.bodyIndex() == null,
+                "Body parameters cannot be used with form parameters.");
+          } else {
+            checkState(data.formParams().isEmpty(),
+                "Body parameters cannot be used with form parameters.");
+            checkState(data.bodyIndex() == null, "Method has too many Body parameters: %s", method);
+            data.bodyIndex(i);
+            data.bodyType(Types.resolve(targetType, targetType, genericParameterTypes[i]));
+          }
         }
       }
 

--- a/core/src/test/java/feign/DefaultContractTest.java
+++ b/core/src/test/java/feign/DefaultContractTest.java
@@ -227,6 +227,42 @@ public class DefaultContractTest {
         entry(2, asList("password")));
   }
 
+  @Test
+  public void formParamAndBodyParams() throws Exception {
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("Body parameters cannot be used with form parameters.");
+
+    parseAndValidateMetadata(FormParams.class,
+        "formParamAndBodyParams", String.class, String.class);
+    Fail.failBecauseExceptionWasNotThrown(IllegalStateException.class);
+  }
+
+  @Test
+  public void bodyParamsAndformParam() throws Exception {
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("Body parameters cannot be used with form parameters.");
+
+    parseAndValidateMetadata(FormParams.class,
+        "bodyParamsAndformParam", String.class, String.class);
+    Fail.failBecauseExceptionWasNotThrown(IllegalStateException.class);
+  }
+
+  @Test
+  public void formParamParseIntoFormParams() throws Exception {
+
+    MethodMetadata md = parseAndValidateMetadata(FormParams.class,
+        "loginNoBodyTemplate", String.class, String.class, String.class);
+
+    assertThat(md.formParams())
+        .containsExactly("customer_name", "user_name", "password");
+
+    assertThat(md.indexToName()).containsExactly(
+        entry(0, asList("customer_name")),
+        entry(1, asList("user_name")),
+        entry(2, asList("password")));
+  }
+
+
   /**
    * Body type is only for the body param.
    */
@@ -490,6 +526,22 @@ public class DefaultContractTest {
                @Param("customer_name") String customer,
                @Param("user_name") String user,
                @Param("password") String password);
+
+    @RequestLine("POST /")
+    void loginNoBodyTemplate(
+                             @Param("customer_name") String customer,
+                             @Param("user_name") String user,
+                             @Param("password") String password);
+
+    @RequestLine("POST /")
+    void formParamAndBodyParams(
+                                @Param("customer_name") String customer,
+                                String body);
+
+    @RequestLine("POST /")
+    void bodyParamsAndformParam(
+                                String body,
+                                @Param("customer_name") String customer);
   }
 
   interface HeaderMapInterface {


### PR DESCRIPTION
According to test case，if we use Fegin like:

```java

@RequestLine("POST /")
void formParamAndBodyParams(
        @Param("customer_name") String customer,
        String body);

```

Fegin will throw exception message `Body parameters cannot be used with form parameters.`.

But we reverse params like:

```java

@RequestLine("POST /")
void bodyParamsAndformParam(
        String body,
        @Param("customer_name") String customer);

```

Fegin not throw exception , only ignore `formParams`, so it is inconsistent.

This PR fix this inconsistent , always check `Body parameters` and `form parameters`.
