### PR TITLE
Remove Template Expression naming restrictions

### DIFF
--- a/core/src/main/java/feign/template/Expressions.java
+++ b/core/src/main/java/feign/template/Expressions.java
@@ -38,7 +38,8 @@ public final class Expressions {
      *
      * see https://tools.ietf.org/html/rfc6570#section-2.3 for more information.
      */
-    expressions.put(Pattern.compile("(\\w[-\\w.\\[\\]]*[ ]*)(:(.+))?"),
+
+    expressions.put(Pattern.compile("^([+#./;?&]?)(.*)$"),
         SimpleExpression.class);
   }
 
@@ -70,10 +71,18 @@ public final class Expressions {
     Matcher matcher = expressionPattern.matcher(expression);
     if (matcher.matches()) {
       /* we have a valid variable expression, extract the name from the first group */
-      variableName = matcher.group(1).trim();
-      if (matcher.group(2) != null && matcher.group(3) != null) {
-        /* this variable contains an optional pattern */
-        variablePattern = matcher.group(3);
+      variableName = matcher.group(2).trim();
+      if (variableName.contains(":")) {
+        /* split on the colon */
+        String[] parts = variableName.split(":");
+        variableName = parts[0];
+        variablePattern = parts[1];
+      }
+
+      /* look for nested expressions */
+      if (variableName.contains("{")) {
+        /* nested, literal */
+        return null;
       }
     }
 

--- a/core/src/test/java/feign/template/QueryTemplateTest.java
+++ b/core/src/test/java/feign/template/QueryTemplateTest.java
@@ -176,4 +176,15 @@ public class QueryTemplateTest {
     /* brackets will be pct-encoded */
     assertThat(expanded).isEqualToIgnoringCase("collection%5B%5D=1,2");
   }
+
+  @Test
+  public void expandCollectionValueWithDollar() {
+    QueryTemplate template =
+        QueryTemplate.create("$collection", Collections.singletonList("{$collection}"),
+            Util.UTF_8, CollectionFormat.CSV);
+    String expanded = template.expand(Collections.singletonMap("$collection",
+        Arrays.asList("1", "2")));
+    /* brackets will be pct-encoded */
+    assertThat(expanded).isEqualToIgnoringCase("$collection=1,2");
+  }
 }


### PR DESCRIPTION
Fixes #1036

Relaxed the regular expression used to determine if an expression
is valid to support additional expression variable names.  We will
no longer restrict what an expression name can be.