### PR TITLE
Ensure all brackets are decoded in JSON based Body Templates

### DIFF
--- a/core/src/main/java/feign/template/BodyTemplate.java
+++ b/core/src/main/java/feign/template/BodyTemplate.java
@@ -50,14 +50,9 @@ public final class BodyTemplate extends Template {
   public String expand(Map<String, ?> variables) {
     String expanded = super.expand(variables);
     if (this.json) {
-      /* decode only the first and last character */
-      StringBuilder sb = new StringBuilder();
-      sb.append(JSON_TOKEN_START);
-      sb.append(expanded,
-          expanded.indexOf(JSON_TOKEN_START_ENCODED) + JSON_TOKEN_START_ENCODED.length(),
-          expanded.lastIndexOf(JSON_TOKEN_END_ENCODED));
-      sb.append(JSON_TOKEN_END);
-      return sb.toString();
+      /* restore all start and end tokens */
+      expanded = expanded.replaceAll(JSON_TOKEN_START_ENCODED, JSON_TOKEN_START);
+      expanded = expanded.replaceAll(JSON_TOKEN_END_ENCODED, JSON_TOKEN_END);
     }
     return expanded;
   }

--- a/core/src/test/java/feign/template/BodyTemplateTest.java
+++ b/core/src/test/java/feign/template/BodyTemplateTest.java
@@ -14,7 +14,6 @@
 package feign.template;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Collections;
 import org.junit.Test;
 
@@ -22,7 +21,8 @@ public class BodyTemplateTest {
 
   @Test
   public void bodyTemplatesSupportJsonOnlyWhenEncoded() {
-    String bodyTemplate = "%7B\"resize\": %7B\"method\": \"fit\",\"width\": {size},\"height\": {size}%7D%7D";
+    String bodyTemplate =
+        "%7B\"resize\": %7B\"method\": \"fit\",\"width\": {size},\"height\": {size}%7D%7D";
     BodyTemplate template = BodyTemplate.create(bodyTemplate);
     String expanded = template.expand(Collections.singletonMap("size", "100"));
     assertThat(expanded)

--- a/core/src/test/java/feign/template/BodyTemplateTest.java
+++ b/core/src/test/java/feign/template/BodyTemplateTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2012-2019 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package feign.template;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/core/src/test/java/feign/template/BodyTemplateTest.java
+++ b/core/src/test/java/feign/template/BodyTemplateTest.java
@@ -1,0 +1,19 @@
+package feign.template;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import org.junit.Test;
+
+public class BodyTemplateTest {
+
+  @Test
+  public void bodyTemplatesSupportJsonOnlyWhenEncoded() {
+    String bodyTemplate = "%7B\"resize\": %7B\"method\": \"fit\",\"width\": {size},\"height\": {size}%7D%7D";
+    BodyTemplate template = BodyTemplate.create(bodyTemplate);
+    String expanded = template.expand(Collections.singletonMap("size", "100"));
+    assertThat(expanded)
+        .isEqualToIgnoringCase(
+            "{\"resize\": {\"method\": \"fit\",\"width\": 100,\"height\": 100}}");
+  }
+}


### PR DESCRIPTION
Fixes #1129

When JSON is detected in a Body Template, all start and end tokens
that may have been pct-encoded are decoded, ensuring that the
expanded result is valid JSON.