### PR TITLE
Add support for SOAP Envelope declarations to be inherited

### DIFF
--- a/soap/src/main/java/feign/soap/SOAPDecoder.java
+++ b/soap/src/main/java/feign/soap/SOAPDecoder.java
@@ -17,7 +17,9 @@ import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
 import javax.xml.soap.MessageFactory;
+import javax.xml.soap.SOAPBody;
 import javax.xml.soap.SOAPConstants;
 import javax.xml.soap.SOAPException;
 import javax.xml.soap.SOAPMessage;
@@ -84,15 +86,18 @@ public class SOAPDecoder implements Decoder {
 
   private final JAXBContextFactory jaxbContextFactory;
   private final String soapProtocol;
+  private final boolean useFirstChild;
 
   public SOAPDecoder(JAXBContextFactory jaxbContextFactory) {
     this.jaxbContextFactory = jaxbContextFactory;
     this.soapProtocol = SOAPConstants.DEFAULT_SOAP_PROTOCOL;
+    this.useFirstChild = false;
   }
 
   private SOAPDecoder(Builder builder) {
     this.soapProtocol = builder.soapProtocol;
     this.jaxbContextFactory = builder.jaxbContextFactory;
+    this.useFirstChild = builder.useFirstChild;
   }
 
   @Override
@@ -119,8 +124,13 @@ public class SOAPDecoder implements Decoder {
           throw new SOAPFaultException(message.getSOAPBody().getFault());
         }
 
-        return jaxbContextFactory.createUnmarshaller((Class<?>) type)
-            .unmarshal(message.getSOAPBody().extractContentAsDocument());
+        Unmarshaller unmarshaller = jaxbContextFactory.createUnmarshaller((Class<?>) type);
+
+        if (this.useFirstChild) {
+          return unmarshaller.unmarshal(message.getSOAPBody().getFirstChild());
+        } else {
+          return unmarshaller.unmarshal(message.getSOAPBody().extractContentAsDocument());
+        }
       }
     } catch (SOAPException | JAXBException e) {
       throw new DecodeException(response.status(), e.toString(), response.request(), e);
@@ -137,6 +147,7 @@ public class SOAPDecoder implements Decoder {
   public static class Builder {
     String soapProtocol = SOAPConstants.DEFAULT_SOAP_PROTOCOL;
     JAXBContextFactory jaxbContextFactory;
+    boolean useFirstChild = false;
 
     public Builder withJAXBContextFactory(JAXBContextFactory jaxbContextFactory) {
       this.jaxbContextFactory = jaxbContextFactory;
@@ -154,6 +165,17 @@ public class SOAPDecoder implements Decoder {
      */
     public Builder withSOAPProtocol(String soapProtocol) {
       this.soapProtocol = soapProtocol;
+      return this;
+    }
+
+    /**
+     * Alters the behavior of the code to use the {@link SOAPBody#getFirstChild()} in place of
+     * {@link SOAPBody#extractContentAsDocument()}.
+     *
+     * @return the builder instance.
+     */
+    public Builder useFirstChild() {
+      this.useFirstChild = true;
       return this;
     }
 

--- a/soap/src/test/java/feign/soap/SOAPCodecTest.java
+++ b/soap/src/test/java/feign/soap/SOAPCodecTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import java.lang.reflect.Type;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -45,7 +46,7 @@ public class SOAPCodecTest {
   public final ExpectedException thrown = ExpectedException.none();
 
   @Test
-  public void encodesSoap() throws Exception {
+  public void encodesSoap() {
     Encoder encoder = new SOAPEncoder.Builder()
         .withJAXBContextFactory(new JAXBContextFactory.Builder().build())
         .build();
@@ -89,14 +90,14 @@ public class SOAPCodecTest {
 
 
   @Test
-  public void encodesSoapWithCustomJAXBMarshallerEncoding() throws Exception {
+  public void encodesSoapWithCustomJAXBMarshallerEncoding() {
     JAXBContextFactory jaxbContextFactory =
         new JAXBContextFactory.Builder().withMarshallerJAXBEncoding("UTF-16").build();
 
     Encoder encoder = new SOAPEncoder.Builder()
         // .withWriteXmlDeclaration(true)
         .withJAXBContextFactory(jaxbContextFactory)
-        .withCharsetEncoding(Charset.forName("UTF-16"))
+        .withCharsetEncoding(StandardCharsets.UTF_16)
         .build();
 
     GetPrice mock = new GetPrice();
@@ -115,13 +116,13 @@ public class SOAPCodecTest {
         "</GetPrice>" +
         "</SOAP-ENV:Body>" +
         "</SOAP-ENV:Envelope>";
-    byte[] utf16Bytes = soapEnvelop.getBytes("UTF-16LE");
+    byte[] utf16Bytes = soapEnvelop.getBytes(StandardCharsets.UTF_16LE);
     assertThat(template).hasBody(utf16Bytes);
   }
 
 
   @Test
-  public void encodesSoapWithCustomJAXBSchemaLocation() throws Exception {
+  public void encodesSoapWithCustomJAXBSchemaLocation() {
     JAXBContextFactory jaxbContextFactory =
         new JAXBContextFactory.Builder()
             .withMarshallerSchemaLocation("http://apihost http://apihost/schema.xsd")
@@ -149,7 +150,7 @@ public class SOAPCodecTest {
 
 
   @Test
-  public void encodesSoapWithCustomJAXBNoSchemaLocation() throws Exception {
+  public void encodesSoapWithCustomJAXBNoSchemaLocation() {
     JAXBContextFactory jaxbContextFactory =
         new JAXBContextFactory.Builder()
             .withMarshallerNoNamespaceSchemaLocation("http://apihost/schema.xsd")
@@ -176,7 +177,7 @@ public class SOAPCodecTest {
   }
 
   @Test
-  public void encodesSoapWithCustomJAXBFormattedOuput() throws Exception {
+  public void encodesSoapWithCustomJAXBFormattedOuput() {
     Encoder encoder = new SOAPEncoder.Builder().withFormattedOutput(true)
         .withJAXBContextFactory(new JAXBContextFactory.Builder()
             .build())
@@ -233,6 +234,40 @@ public class SOAPCodecTest {
   }
 
   @Test
+  public void decodesSoapWithSchemaOnEnvelope() throws Exception {
+    GetPrice mock = new GetPrice();
+    mock.item = new Item();
+    mock.item.value = "Apples";
+
+    String mockSoapEnvelop = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>"
+        + "<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" "
+        + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"http://apihost/schema.xsd\" "
+        + "xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">"
+        + "<SOAP-ENV:Header/>"
+        + "<SOAP-ENV:Body>"
+        + "<GetPrice>"
+        + "<Item xsi:type=\"xsd:string\">Apples</Item>"
+        + "</GetPrice>"
+        + "</SOAP-ENV:Body>"
+        + "</SOAP-ENV:Envelope>";
+
+    Response response = Response.builder()
+        .status(200)
+        .reason("OK")
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.emptyMap())
+        .body(mockSoapEnvelop, UTF_8)
+        .build();
+
+    SOAPDecoder decoder = new SOAPDecoder.Builder()
+        .withJAXBContextFactory(new JAXBContextFactory.Builder().build())
+        .useFirstChild()
+        .build();
+
+    assertEquals(mock, decoder.decode(response, GetPrice.class));
+  }
+
+  @Test
   public void decodesSoap1_2Protocol() throws Exception {
     GetPrice mock = new GetPrice();
     mock.item = new Item();
@@ -281,7 +316,7 @@ public class SOAPCodecTest {
         .status(200)
         .reason("OK")
         .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
-        .headers(Collections.<String, Collection<String>>emptyMap())
+        .headers(Collections.emptyMap())
         .body("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>"
             + "<Envelope xmlns=\"http://schemas.xmlsoap.org/soap/envelope/\">"
             + "<Header/>"
@@ -326,7 +361,7 @@ public class SOAPCodecTest {
         .status(200)
         .reason("OK")
         .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
-        .headers(Collections.<String, Collection<String>>emptyMap())
+        .headers(Collections.emptyMap())
         .body(template.body())
         .build();
 
@@ -343,7 +378,7 @@ public class SOAPCodecTest {
         .status(404)
         .reason("NOT FOUND")
         .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
-        .headers(Collections.<String, Collection<String>>emptyMap())
+        .headers(Collections.emptyMap())
         .build();
     assertThat((byte[]) new JAXBDecoder(new JAXBContextFactory.Builder().build())
         .decode(response, byte[].class)).isNull();

--- a/soap/src/test/java/feign/soap/package-info.java
+++ b/soap/src/test/java/feign/soap/package-info.java
@@ -14,5 +14,6 @@
 @XmlSchema(
     elementFormDefault = XmlNsForm.UNQUALIFIED)
 package feign.soap;
+
 import javax.xml.bind.annotation.XmlNsForm;
 import javax.xml.bind.annotation.XmlSchema;

--- a/soap/src/test/java/feign/soap/package-info.java
+++ b/soap/src/test/java/feign/soap/package-info.java
@@ -1,0 +1,5 @@
+@XmlSchema(
+    elementFormDefault = XmlNsForm.UNQUALIFIED)
+package feign.soap;
+import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;

--- a/soap/src/test/java/feign/soap/package-info.java
+++ b/soap/src/test/java/feign/soap/package-info.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2012-2019 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 @XmlSchema(
     elementFormDefault = XmlNsForm.UNQUALIFIED)
 package feign.soap;


### PR DESCRIPTION
Fixes #1127

In certain situations the declarations on the SOAP envelope are not
inherited by JAXB when reading the documents.  This is particularly
troublesome when it is not possible to correct the XML at the source.

To support this a new `useFirstChild` option has been added to the
`SOAPDecoder` builder that will use `SOAPBody#getFirstChild()`
instead of `SOAPBody#extractContentAsDocument()`.  This will allow
users to supply a `package-info.java` to manage the element namespaces
explictly and define what should occur if the namespace declarations
are missing.