### PR TITLE
Include variables Query Parameter Names when listing template parameters

### DIFF
--- a/core/src/main/java/feign/template/QueryTemplate.java
+++ b/core/src/main/java/feign/template/QueryTemplate.java
@@ -146,7 +146,7 @@ public final class QueryTemplate {
   }
 
   public List<String> getVariables() {
-    List<String> variables = new ArrayList<>();
+    List<String> variables = new ArrayList<>(this.name.getVariables());
     for (Template template : this.values) {
       variables.addAll(template.getVariables());
     }


### PR DESCRIPTION
Fixes #1089

Query Template names, which also happen to be templates, were not being
considered when listing out all of the variable names in a Query Template.