### PR TITLE
Remove deprecated code usage from core module

### DIFF
--- a/benchmark/src/main/java/feign/benchmark/DecoderIteratorsBenchmark.java
+++ b/benchmark/src/main/java/feign/benchmark/DecoderIteratorsBenchmark.java
@@ -75,6 +75,7 @@ public class DecoderIteratorsBenchmark {
     }
   }
 
+  @SuppressWarnings("deprecation")
   @Setup(Level.Invocation)
   public void buildResponse() {
     response = Response.builder()
@@ -82,7 +83,7 @@ public class DecoderIteratorsBenchmark {
         .reason("OK")
         .request(Request.create(HttpMethod.GET, "/", Collections.emptyMap(), null, Util.UTF_8))
         .headers(Collections.emptyMap())
-        .body(carsJson(Integer.valueOf(size)), Util.UTF_8)
+        .body(carsJson(Integer.parseInt(size)), Util.UTF_8)
         .build();
   }
 

--- a/core/src/main/java/feign/Client.java
+++ b/core/src/main/java/feign/Client.java
@@ -161,7 +161,7 @@ public interface Client {
         connection.addRequestProperty("Accept", "*/*");
       }
 
-      if (request.requestBody().asBytes() != null) {
+      if (request.body() != null) {
         if (contentLength != null) {
           connection.setFixedLengthStreamingMode(contentLength);
         } else {
@@ -175,7 +175,7 @@ public interface Client {
           out = new DeflaterOutputStream(out);
         }
         try {
-          out.write(request.requestBody().asBytes());
+          out.write(request.body());
         } finally {
           try {
             out.close();

--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2019 The Feign Authors
+ * Copyright 2012-2020 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -274,7 +274,6 @@ public interface Contract {
         if (expander != Param.ToStringExpander.class) {
           data.indexToExpanderClass().put(paramIndex, expander);
         }
-        data.indexToEncoded().put(paramIndex, paramAnnotation.encoded());
         if (!data.template().hasRequestVariable(name)) {
           data.formParams().add(name);
         }

--- a/core/src/main/java/feign/Feign.java
+++ b/core/src/main/java/feign/Feign.java
@@ -25,6 +25,7 @@ import feign.Target.HardCodedTarget;
 import feign.codec.Decoder;
 import feign.codec.Encoder;
 import feign.codec.ErrorDecoder;
+import feign.querymap.FieldQueryMapEncoder;
 import static feign.ExceptionPropagationPolicy.NONE;
 
 /**
@@ -103,7 +104,7 @@ public abstract class Feign {
     private Logger logger = new NoOpLogger();
     private Encoder encoder = new Encoder.Default();
     private Decoder decoder = new Decoder.Default();
-    private QueryMapEncoder queryMapEncoder = new QueryMapEncoder.Default();
+    private QueryMapEncoder queryMapEncoder = new FieldQueryMapEncoder();
     private ErrorDecoder errorDecoder = new ErrorDecoder.Default();
     private Options options = new Options();
     private InvocationHandlerFactory invocationHandlerFactory =

--- a/core/src/main/java/feign/FeignException.java
+++ b/core/src/main/java/feign/FeignException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2019 The Feign Authors
+ * Copyright 2012-2020 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/FeignException.java
+++ b/core/src/main/java/feign/FeignException.java
@@ -127,7 +127,7 @@ public class FeignException extends RuntimeException {
         format("%s reading %s %s", cause.getMessage(), request.httpMethod(), request.url()),
         request,
         cause,
-        request.requestBody().asBytes());
+        request.body());
   }
 
   public static FeignException errorStatus(String methodKey, Response response) {

--- a/core/src/main/java/feign/Logger.java
+++ b/core/src/main/java/feign/Logger.java
@@ -16,13 +16,10 @@ package feign;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.FileHandler;
 import java.util.logging.LogRecord;
 import java.util.logging.SimpleFormatter;
-import static feign.Util.UTF_8;
-import static feign.Util.decodeOrDefault;
-import static feign.Util.valuesOrEmpty;
+import static feign.Util.*;
 
 /**
  * Simple logging abstraction for debug messages. Adapted from {@code retrofit.RestAdapter.Log}.
@@ -55,12 +52,12 @@ public abstract class Logger {
       }
 
       int bodyLength = 0;
-      if (request.requestBody().asBytes() != null) {
-        bodyLength = request.requestBody().asBytes().length;
+      if (request.body() != null) {
+        bodyLength = request.length();
         if (logLevel.ordinal() >= Level.FULL.ordinal()) {
           String bodyText =
               request.charset() != null
-                  ? new String(request.requestBody().asBytes(), request.charset())
+                  ? new String(request.body(), request.charset())
                   : null;
           log(configKey, ""); // CRLF
           log(configKey, "%s", bodyText != null ? bodyText : "Binary data");

--- a/core/src/main/java/feign/QueryMap.java
+++ b/core/src/main/java/feign/QueryMap.java
@@ -53,9 +53,11 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * Once this conversion is applied, the query keys and resulting String values follow the same
  * contract as if they were set using {@link RequestTemplate#query(String, String...)}.
  */
+@SuppressWarnings("deprecation")
 @Retention(RUNTIME)
 @java.lang.annotation.Target(PARAMETER)
 public @interface QueryMap {
+
   /**
    * Specifies whether parameter names and values are already encoded.
    *

--- a/core/src/main/java/feign/Request.java
+++ b/core/src/main/java/feign/Request.java
@@ -13,83 +13,20 @@
  */
 package feign;
 
-import static feign.Util.checkNotNull;
-import static feign.Util.valuesOrEmpty;
 import java.net.HttpURLConnection;
 import java.nio.charset.Charset;
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import feign.template.BodyTemplate;
+import static feign.Util.checkNotNull;
+import static feign.Util.valuesOrEmpty;
 
 /**
  * An immutable request to an http server.
  */
 public final class Request {
-
-  public static class Body {
-
-    private final byte[] data;
-    private final Charset encoding;
-    private final BodyTemplate bodyTemplate;
-
-    private Body(byte[] data, Charset encoding, BodyTemplate bodyTemplate) {
-      super();
-      this.data = data;
-      this.encoding = encoding;
-      this.bodyTemplate = bodyTemplate;
-    }
-
-    public Request.Body expand(Map<String, ?> variables) {
-      if (bodyTemplate == null) {
-        return this;
-      }
-
-      return encoded(bodyTemplate.expand(variables).getBytes(encoding), encoding);
-    }
-
-    public List<String> getVariables() {
-      if (bodyTemplate == null) {
-        return Collections.emptyList();
-      }
-      return bodyTemplate.getVariables();
-    }
-
-    public static Request.Body encoded(byte[] bodyData, Charset encoding) {
-      return new Request.Body(bodyData, encoding, null);
-    }
-
-    public int length() {
-      /* calculate the content length based on the data provided */
-      return data != null ? data.length : 0;
-    }
-
-    public byte[] asBytes() {
-      return data;
-    }
-
-    public static Request.Body bodyTemplate(String bodyTemplate, Charset encoding) {
-      return new Request.Body(null, encoding, BodyTemplate.create(bodyTemplate));
-    }
-
-    public String bodyTemplate() {
-      return (bodyTemplate != null) ? bodyTemplate.toString() : null;
-    }
-
-    public String asString() {
-      return !isBinary()
-          ? new String(data, encoding)
-          : "Binary data";
-    }
-
-    public static Body empty() {
-      return new Request.Body(null, null, null);
-    }
-
-    public boolean isBinary() {
-      return encoding == null || data == null;
-    }
-
-  }
 
   public enum HttpMethod {
     GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH
@@ -128,7 +65,7 @@ public final class Request {
                                Map<String, Collection<String>> headers,
                                byte[] body,
                                Charset charset) {
-    return create(httpMethod, url, headers, Body.encoded(body, charset), null);
+    return create(httpMethod, url, headers, Body.create(body, charset), null);
   }
 
   /**
@@ -147,7 +84,7 @@ public final class Request {
                                byte[] body,
                                Charset charset,
                                RequestTemplate requestTemplate) {
-    return create(httpMethod, url, headers, Body.encoded(body, charset), requestTemplate);
+    return create(httpMethod, url, headers, Body.create(body, charset), requestTemplate);
   }
 
   /**
@@ -173,6 +110,15 @@ public final class Request {
   private final Body body;
   private final RequestTemplate requestTemplate;
 
+  /**
+   * Creates a new Request.
+   *
+   * @param method of the request.
+   * @param url for the request.
+   * @param headers for the request.
+   * @param body for the request, optional.
+   * @param requestTemplate used to build the request.
+   */
   Request(HttpMethod method,
       String url,
       Map<String, Collection<String>> headers,
@@ -205,24 +151,30 @@ public final class Request {
     return this.httpMethod;
   }
 
-  /* Fully resolved URL including query. */
+
+  /**
+   * URL for the request.
+   *
+   * @return URL as a String.
+   */
   public String url() {
     return url;
   }
 
-  /* Ordered list of headers that will be sent to the server. */
+  /**
+   * Request Headers.
+   *
+   * @return the request headers.
+   */
   public Map<String, Collection<String>> headers() {
-    return headers;
+    return Collections.unmodifiableMap(headers);
   }
 
   /**
-   * The character set with which the body is encoded, or null if unknown or not applicable. When
-   * this is present, you can use {@code new String(req.body(), req.charset())} to access the body
-   * as a String.
+   * Charset of the request.
    *
-   * @deprecated use {@link #requestBody()} instead
+   * @return the current character set for the request, may be {@literal null} for binary data.
    */
-  @Deprecated
   public Charset charset() {
     return body.encoding;
   }
@@ -232,17 +184,29 @@ public final class Request {
    * interpretable as text.
    *
    * @see #charset()
-   * @deprecated use {@link #requestBody()} instead
    */
-  @Deprecated
   public byte[] body() {
     return body.data;
   }
 
-  public Body requestBody() {
-    return body;
+  public boolean isBinary() {
+    return body.isBinary();
   }
 
+  /**
+   * Request Length.
+   *
+   * @return size of the request body.
+   */
+  public int length() {
+    return this.body.length();
+  }
+
+  /**
+   * Request as an HTTP/1.1 request.
+   *
+   * @return the request.
+   */
   @Override
   public String toString() {
     final StringBuilder builder = new StringBuilder();
@@ -258,7 +222,7 @@ public final class Request {
     return builder.toString();
   }
 
-  /*
+  /**
    * Controls the per-request settings currently required to be implemented by all {@link Client
    * clients}
    */
@@ -270,7 +234,31 @@ public final class Request {
     private final TimeUnit readTimeoutUnit;
     private final boolean followRedirects;
 
+    /**
+     * Creates a new Options instance.
+     *
+     * @param connectTimeoutMillis connection timeout in milliseconds.
+     * @param readTimeoutMillis read timeout in milliseconds.
+     * @param followRedirects if the request should follow 3xx redirections.
+     *
+     * @deprecated please use {@link #Options(long, TimeUnit, long, TimeUnit, boolean)}
+     */
+    @Deprecated
+    public Options(int connectTimeoutMillis, int readTimeoutMillis, boolean followRedirects) {
+      this(connectTimeoutMillis, TimeUnit.MILLISECONDS,
+          readTimeoutMillis, TimeUnit.MILLISECONDS,
+          followRedirects);
+    }
 
+    /**
+     * Creates a new Options Instance.
+     *
+     * @param connectTimeout value.
+     * @param connectTimeoutUnit with the TimeUnit for the timeout value.
+     * @param readTimeout value.
+     * @param readTimeoutUnit with the TimeUnit for the timeout value.
+     * @param followRedirects if the request should follow 3xx redirections.
+     */
     public Options(long connectTimeout, TimeUnit connectTimeoutUnit,
         long readTimeout, TimeUnit readTimeoutUnit,
         boolean followRedirects) {
@@ -282,18 +270,27 @@ public final class Request {
       this.followRedirects = followRedirects;
     }
 
-    @Deprecated
-    public Options(int connectTimeoutMillis, int readTimeoutMillis, boolean followRedirects) {
-      this(connectTimeoutMillis, TimeUnit.MILLISECONDS,
-          readTimeoutMillis, TimeUnit.MILLISECONDS,
-          followRedirects);
-    }
-
+    /**
+     * Creates a new Options instance that follows redirects by default.
+     *
+     * @param connectTimeoutMillis connection timeout in milliseconds.
+     * @param readTimeoutMillis read timeout in milliseconds.
+     *
+     * @deprecated please use {@link #Options(long, TimeUnit, long, TimeUnit, boolean)}
+     */
     @Deprecated
     public Options(int connectTimeoutMillis, int readTimeoutMillis) {
       this(connectTimeoutMillis, readTimeoutMillis, true);
     }
 
+    /**
+     * Creates the new Options instance using the following defaults:
+     * <ul>
+     * <li>Connect Timeout: 10 seconds</li>
+     * <li>Read Timeout: 60 seconds</li>
+     * <li>Follow all 3xx redirects</li>
+     * </ul>
+     */
     public Options() {
       this(10, TimeUnit.SECONDS, 60, TimeUnit.SECONDS, true);
     }
@@ -303,7 +300,6 @@ public final class Request {
      *
      * @see java.net.HttpURLConnection#getConnectTimeout()
      */
-    @Deprecated
     public int connectTimeoutMillis() {
       return (int) connectTimeoutUnit.toMillis(connectTimeout);
     }
@@ -313,7 +309,6 @@ public final class Request {
      *
      * @see java.net.HttpURLConnection#getReadTimeout()
      */
-    @Deprecated
     public int readTimeoutMillis() {
       return (int) readTimeoutUnit.toMillis(readTimeout);
     }
@@ -328,18 +323,38 @@ public final class Request {
       return followRedirects;
     }
 
+    /**
+     * Connect Timeout Value.
+     *
+     * @return current timeout value.
+     */
     public long connectTimeout() {
       return connectTimeout;
     }
 
+    /**
+     * TimeUnit for the Connection Timeout value.
+     *
+     * @return TimeUnit
+     */
     public TimeUnit connectTimeoutUnit() {
       return connectTimeoutUnit;
     }
 
+    /**
+     * Read Timeout value.
+     *
+     * @return current read timeout value.
+     */
     public long readTimeout() {
       return readTimeout;
     }
 
+    /**
+     * TimeUnit for the Read Timeout value.
+     *
+     * @return TimeUnit
+     */
     public TimeUnit readTimeoutUnit() {
       return readTimeoutUnit;
     }
@@ -349,5 +364,71 @@ public final class Request {
   @Experimental
   public RequestTemplate requestTemplate() {
     return this.requestTemplate;
+  }
+
+  /**
+   * Request Body.
+   */
+  public static class Body {
+
+    private Charset encoding;
+    private byte[] data;
+
+    private Body() {
+      super();
+    }
+
+    private Body(byte[] data) {
+      this.data = data;
+    }
+
+    private Body(byte[] data, Charset encoding) {
+      this.data = data;
+      this.encoding = encoding;
+    }
+
+    public Optional<Charset> getEncoding() {
+      return Optional.ofNullable(this.encoding);
+    }
+
+    public int length() {
+      /* calculate the content length based on the data provided */
+      return data != null ? data.length : 0;
+    }
+
+    public byte[] asBytes() {
+      return data;
+    }
+
+    public String asString() {
+      return !isBinary()
+          ? new String(data, encoding)
+          : "Binary data";
+    }
+
+    public boolean isBinary() {
+      return encoding == null || data == null;
+    }
+
+    public static Body create(String data) {
+      return new Body(data.getBytes());
+    }
+
+    public static Body create(String data, Charset charset) {
+      return new Body(data.getBytes(charset), charset);
+    }
+
+    public static Body create(byte[] data) {
+      return new Body(data);
+    }
+
+    public static Body create(byte[] data, Charset charset) {
+      return new Body(data, charset);
+    }
+
+    public static Body empty() {
+      return new Body();
+    }
+
   }
 }

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2019 The Feign Authors
+ * Copyright 2012-2020 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -33,7 +33,6 @@ import static feign.Util.*;
  * information also support template expressions.
  * </p>
  */
-// @SuppressWarnings({"WeakerAccess", "UnusedReturnValue"})
 public final class RequestTemplate implements Serializable {
 
   private static final Pattern QUERY_STRING_PATTERN = Pattern.compile("(?<!\\{)\\?");

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -13,20 +13,18 @@
  */
 package feign;
 
-import static feign.Util.CONTENT_LENGTH;
-import static feign.Util.UTF_8;
-import static feign.Util.checkNotNull;
+import feign.Request.HttpMethod;
+import feign.template.*;
 import java.io.Serializable;
 import java.net.URI;
 import java.nio.charset.Charset;
-import java.util.*;
 import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.*;
 import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import feign.Request.HttpMethod;
-import feign.template.*;
+import static feign.Util.*;
 
 /**
  * Request Builder for an HTTP Target.
@@ -35,7 +33,7 @@ import feign.template.*;
  * information also support template expressions.
  * </p>
  */
-@SuppressWarnings({"WeakerAccess", "UnusedReturnValue"})
+// @SuppressWarnings({"WeakerAccess", "UnusedReturnValue"})
 public final class RequestTemplate implements Serializable {
 
   private static final Pattern QUERY_STRING_PATTERN = Pattern.compile("(?<!\\{)\\?");
@@ -45,6 +43,7 @@ public final class RequestTemplate implements Serializable {
   private String fragment;
   private boolean resolved = false;
   private UriTemplate uriTemplate;
+  private BodyTemplate bodyTemplate;
   private HttpMethod method;
   private transient Charset charset = Util.UTF_8;
   private Request.Body body = Request.Body.empty();
@@ -63,19 +62,22 @@ public final class RequestTemplate implements Serializable {
   /**
    * Create a new Request Template.
    *
+   * @param fragment part of the request uri.
    * @param target for the template.
    * @param uriTemplate for the template.
+   * @param bodyTemplate for the template, may be {@literal null}
    * @param method of the request.
    * @param charset for the request.
-   * @param body of the request, may be null
+   * @param body of the request, may be {@literal null}
    * @param decodeSlash if the request uri should encode slash characters.
    * @param collectionFormat when expanding collection based variables.
-   * @param feignTarget
-   * @param methodMetadata
+   * @param feignTarget this template is targeted for.
+   * @param methodMetadata containing a reference to the method this template is built from.
    */
   private RequestTemplate(String target,
       String fragment,
       UriTemplate uriTemplate,
+      BodyTemplate bodyTemplate,
       HttpMethod method,
       Charset charset,
       Request.Body body,
@@ -86,6 +88,7 @@ public final class RequestTemplate implements Serializable {
     this.target = target;
     this.fragment = fragment;
     this.uriTemplate = uriTemplate;
+    this.bodyTemplate = bodyTemplate;
     this.method = method;
     this.charset = charset;
     this.body = body;
@@ -104,11 +107,18 @@ public final class RequestTemplate implements Serializable {
    */
   public static RequestTemplate from(RequestTemplate requestTemplate) {
     RequestTemplate template =
-        new RequestTemplate(requestTemplate.target, requestTemplate.fragment,
+        new RequestTemplate(
+            requestTemplate.target,
+            requestTemplate.fragment,
             requestTemplate.uriTemplate,
-            requestTemplate.method, requestTemplate.charset,
-            requestTemplate.body, requestTemplate.decodeSlash, requestTemplate.collectionFormat,
-            requestTemplate.methodMetadata, requestTemplate.feignTarget);
+            requestTemplate.bodyTemplate,
+            requestTemplate.method,
+            requestTemplate.charset,
+            requestTemplate.body,
+            requestTemplate.decodeSlash,
+            requestTemplate.collectionFormat,
+            requestTemplate.methodMetadata,
+            requestTemplate.feignTarget);
 
     if (!requestTemplate.queries().isEmpty()) {
       template.queries.putAll(requestTemplate.queries);
@@ -140,9 +150,11 @@ public final class RequestTemplate implements Serializable {
     this.collectionFormat =
         (toCopy.collectionFormat != null) ? toCopy.collectionFormat : CollectionFormat.EXPLODED;
     this.uriTemplate = toCopy.uriTemplate;
+    this.bodyTemplate = toCopy.bodyTemplate;
     this.resolved = false;
     this.methodMetadata = toCopy.methodMetadata;
     this.target = toCopy.target;
+    this.feignTarget = toCopy.feignTarget;
   }
 
   /**
@@ -228,7 +240,9 @@ public final class RequestTemplate implements Serializable {
       }
     }
 
-    resolved.body(this.body.expand(variables));
+    if (this.bodyTemplate != null) {
+      resolved.body(this.bodyTemplate.expand(variables));
+    }
 
     /* mark the new template resolved */
     resolved.resolved = true;
@@ -262,7 +276,7 @@ public final class RequestTemplate implements Serializable {
     if (!this.resolved) {
       throw new IllegalStateException("template has not been resolved.");
     }
-    return Request.create(this.method, this.url(), this.headers(), this.requestBody(), this);
+    return Request.create(this.method, this.url(), this.headers(), this.body, this);
   }
 
   /**
@@ -558,7 +572,9 @@ public final class RequestTemplate implements Serializable {
     }
 
     /* body */
-    variables.addAll(this.body.getVariables());
+    if (this.bodyTemplate != null) {
+      variables.addAll(this.bodyTemplate.getVariables());
+    }
 
     return variables;
   }
@@ -699,7 +715,6 @@ public final class RequestTemplate implements Serializable {
       throw new IllegalArgumentException("name is required.");
     }
     this.headers.remove(name);
-
     return this;
   }
 
@@ -762,15 +777,12 @@ public final class RequestTemplate implements Serializable {
   /**
    * Sets the Body and Charset for this request.
    *
-   * @param bodyData to send, can be null.
+   * @param data to send, can be null.
    * @param charset of the encoded data.
    * @return a RequestTemplate for chaining.
-   * @deprecated use {@link RequestTemplate#body(feign.Request.Body)} instead
    */
-  @Deprecated
-  public RequestTemplate body(byte[] bodyData, Charset charset) {
-    this.body(Request.Body.encoded(bodyData, charset));
-
+  public RequestTemplate body(byte[] data, Charset charset) {
+    this.body(Request.Body.create(data, charset));
     return this;
   }
 
@@ -779,12 +791,10 @@ public final class RequestTemplate implements Serializable {
    *
    * @param bodyText to send.
    * @return a RequestTemplate for chaining.
-   * @deprecated use {@link RequestTemplate#body(feign.Request.Body)} instead
    */
-  @Deprecated
   public RequestTemplate body(String bodyText) {
-    byte[] bodyData = bodyText != null ? bodyText.getBytes(UTF_8) : null;
-    return body(bodyData, UTF_8);
+    this.body(Request.Body.create(bodyText.getBytes(this.charset), this.charset));
+    return this;
   }
 
   /**
@@ -793,8 +803,11 @@ public final class RequestTemplate implements Serializable {
    * @param body to send.
    * @return a RequestTemplate for chaining.
    */
-  public RequestTemplate body(Request.Body body) {
+  private RequestTemplate body(Request.Body body) {
     this.body = body;
+
+    /* body template must be cleared to prevent double processing */
+    this.bodyTemplate = null;
 
     header(CONTENT_LENGTH);
     if (body.length() > 0) {
@@ -810,16 +823,18 @@ public final class RequestTemplate implements Serializable {
    * @return the currently applied Charset.
    */
   public Charset requestCharset() {
-    return charset;
+    if (this.body != null) {
+      return this.body.getEncoding()
+          .orElse(this.charset);
+    }
+    return this.charset;
   }
 
   /**
    * The Request Body.
    *
    * @return the request body.
-   * @deprecated replaced by {@link RequestTemplate#requestBody()}
    */
-  @Deprecated
   public byte[] body() {
     return body.asBytes();
   }
@@ -830,11 +845,21 @@ public final class RequestTemplate implements Serializable {
    *
    * @param bodyTemplate to use.
    * @return a RequestTemplate for chaining.
-   * @deprecated replaced by {@link RequestTemplate#body(feign.Request.Body)}
    */
-  @Deprecated
   public RequestTemplate bodyTemplate(String bodyTemplate) {
-    this.body(Request.Body.bodyTemplate(bodyTemplate, Util.UTF_8));
+    this.bodyTemplate = BodyTemplate.create(bodyTemplate, this.charset);
+    return this;
+  }
+
+  /**
+   * Specify the Body Template to use. Can contain literals and expressions.
+   *
+   * @param bodyTemplate to use.
+   * @return a RequestTemplate for chaining.
+   */
+  public RequestTemplate bodyTemplate(String bodyTemplate, Charset charset) {
+    this.bodyTemplate = BodyTemplate.create(bodyTemplate, charset);
+    this.charset = charset;
     return this;
   }
 
@@ -844,7 +869,10 @@ public final class RequestTemplate implements Serializable {
    * @return the unresolved body template.
    */
   public String bodyTemplate() {
-    return body.bodyTemplate();
+    if (this.bodyTemplate != null) {
+      return this.bodyTemplate.toString();
+    }
+    return null;
   }
 
   @Override
@@ -942,10 +970,6 @@ public final class RequestTemplate implements Serializable {
     final String name = (eq > 0) ? pair.substring(0, eq) : pair;
     final String value = (eq > 0 && eq < pair.length()) ? pair.substring(eq + 1) : null;
     return new SimpleImmutableEntry<>(name, value);
-  }
-
-  public Request.Body requestBody() {
-    return this.body;
   }
 
   @Experimental

--- a/core/src/main/java/feign/Response.java
+++ b/core/src/main/java/feign/Response.java
@@ -120,10 +120,10 @@ public final class Response implements Closeable {
     }
 
     /**
-     * @see Response#requestTemplate
+     * The Request Template used for the original request.
      *
-     *      NOTE: will add null check in version 12 which may require changes to custom feign.Client
-     *      or loggers
+     * @param requestTemplate used.
+     * @return builder reference.
      */
     @Experimental
     public Builder requestTemplate(RequestTemplate requestTemplate) {
@@ -263,12 +263,13 @@ public final class Response implements Closeable {
     }
 
     @Override
-    public InputStream asInputStream() throws IOException {
+    public InputStream asInputStream() {
       return inputStream;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
-    public Reader asReader() throws IOException {
+    public Reader asReader() {
       return new InputStreamReader(inputStream, UTF_8);
     }
 
@@ -331,6 +332,7 @@ public final class Response implements Closeable {
       return new ByteArrayInputStream(data);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public Reader asReader() throws IOException {
       return new InputStreamReader(asInputStream(), UTF_8);

--- a/core/src/main/java/feign/codec/StringDecoder.java
+++ b/core/src/main/java/feign/codec/StringDecoder.java
@@ -28,7 +28,7 @@ public class StringDecoder implements Decoder {
       return null;
     }
     if (String.class.equals(type)) {
-      return Util.toString(body.asReader());
+      return Util.toString(body.asReader(Util.UTF_8));
     }
     throw new DecodeException(response.status(),
         format("%s is not a type supported by this decoder.", type), response.request());

--- a/core/src/main/java/feign/template/BodyTemplate.java
+++ b/core/src/main/java/feign/template/BodyTemplate.java
@@ -39,6 +39,17 @@ public final class BodyTemplate extends Template {
     return new BodyTemplate(template, Util.UTF_8);
   }
 
+  /**
+   * Create a new Body Template.
+   *
+   * @param template to parse.
+   * @param charset to use when encoding the template.
+   * @return a Body Template instance.
+   */
+  public static BodyTemplate create(String template, Charset charset) {
+    return new BodyTemplate(template, charset);
+  }
+
   private BodyTemplate(String value, Charset charset) {
     super(value, ExpansionOptions.ALLOW_UNRESOLVED, EncodingOptions.NOT_REQUIRED, false, charset);
     if (value.startsWith(JSON_TOKEN_START_ENCODED) && value.endsWith(JSON_TOKEN_END_ENCODED)) {

--- a/core/src/test/java/feign/DefaultContractTest.java
+++ b/core/src/test/java/feign/DefaultContractTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2019 The Feign Authors
+ * Copyright 2012-2020 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/DefaultContractTest.java
+++ b/core/src/test/java/feign/DefaultContractTest.java
@@ -149,7 +149,7 @@ public class DefaultContractTest {
         .hasHeaders(
             entry("Content-Type", asList("application/xml")),
             entry("Content-Length",
-                asList(String.valueOf(md.template().requestBody().asBytes().length))));
+                asList(String.valueOf(md.template().body().length))));
   }
 
   @Test
@@ -160,7 +160,7 @@ public class DefaultContractTest {
         .hasHeaders(
             entry("Content-Type", asList("application/xml")),
             entry("Content-Length",
-                asList(String.valueOf(md.template().requestBody().asBytes().length))));
+                asList(String.valueOf(md.template().body().length))));
   }
 
   @Test
@@ -169,9 +169,9 @@ public class DefaultContractTest {
 
     assertThat(md.template())
         .hasHeaders(
-            entry("Content-Type", asList("application/xml")),
+            entry("Content-Type", Collections.singletonList("application/xml")),
             entry("Content-Length",
-                asList(String.valueOf(md.template().requestBody().asBytes().length))));
+                asList(String.valueOf(md.template().body().length))));
   }
 
   @Test

--- a/core/src/test/java/feign/DefaultQueryMapEncoderTest.java
+++ b/core/src/test/java/feign/DefaultQueryMapEncoderTest.java
@@ -13,6 +13,7 @@
  */
 package feign;
 
+import feign.querymap.FieldQueryMapEncoder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -26,7 +27,7 @@ public class DefaultQueryMapEncoderTest {
   @Rule
   public final ExpectedException thrown = ExpectedException.none();
 
-  private final QueryMapEncoder encoder = new QueryMapEncoder.Default();
+  private final QueryMapEncoder encoder = new FieldQueryMapEncoder();
 
   @Test
   public void testEncodesObject_visibleFields() {

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -46,6 +46,7 @@ import static org.hamcrest.CoreMatchers.isA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+@SuppressWarnings("deprecation")
 public class FeignTest {
 
   @Rule
@@ -79,7 +80,7 @@ public class FeignTest {
   }
 
   @Test
-  public void responseCoercesToStringBody() throws Exception {
+  public void responseCoercesToStringBody() {
     server.enqueue(new MockResponse().setBody("foo"));
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
@@ -123,7 +124,7 @@ public class FeignTest {
   public void bodyTypeCorrespondsWithParameterType() throws Exception {
     server.enqueue(new MockResponse().setBody("foo"));
 
-    final AtomicReference<Type> encodedType = new AtomicReference<Type>();
+    final AtomicReference<Type> encodedType = new AtomicReference<>();
     TestInterface api = new TestInterfaceBuilder()
         .encoder(new Encoder.Default() {
           @Override
@@ -202,7 +203,7 @@ public class FeignTest {
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
-    api.expand(new Date(1234l));
+    api.expand(new Date(1234L));
 
     assertThat(server.takeRequest())
         .hasPath("/?date=1234");
@@ -214,7 +215,7 @@ public class FeignTest {
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
-    api.expandList(Arrays.asList(new Date(1234l), new Date(12345l)));
+    api.expandList(Arrays.asList(new Date(1234L), new Date(12345L)));
 
     assertThat(server.takeRequest())
         .hasPath("/?date=1234&date=12345");
@@ -262,8 +263,8 @@ public class FeignTest {
     // header map should be additive for headers provided by annotations
     assertThat(server.takeRequest())
         .hasHeaders(
-            entry("Content-Encoding", Arrays.asList("deflate")),
-            entry("Custom-Header", Arrays.asList("fooValue")));
+            entry("Content-Encoding", Collections.singletonList("deflate")),
+            entry("Custom-Header", Collections.singletonList("fooValue")));
 
     server.enqueue(new MockResponse());
     headerMap.put("Content-Encoding", "overrideFromMap");
@@ -277,7 +278,7 @@ public class FeignTest {
     assertThat(server.takeRequest())
         .hasHeaders(
             entry("Content-Encoding", Arrays.asList("deflate", "overrideFromMap")),
-            entry("Custom-Header", Arrays.asList("fooValue")));
+            entry("Custom-Header", Collections.singletonList("fooValue")));
   }
 
   @Test
@@ -286,7 +287,7 @@ public class FeignTest {
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
-    Map<String, Object> queryMap = new LinkedHashMap<String, Object>();
+    Map<String, Object> queryMap = new LinkedHashMap<>();
     queryMap.put("name", "alice");
     queryMap.put("fooKey", "fooValue");
     api.queryMap(queryMap);
@@ -301,7 +302,7 @@ public class FeignTest {
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
-    Map<String, Object> queryMap = new LinkedHashMap<String, Object>();
+    Map<String, Object> queryMap = new LinkedHashMap<>();
     queryMap.put("name", Arrays.asList("Alice", "Bob"));
     queryMap.put("fooKey", "fooValue");
     queryMap.put("emptyListKey", new ArrayList<String>());
@@ -619,8 +620,8 @@ public class FeignTest {
 
   @Test
   public void whenReturnTypeIsResponseNoErrorHandling() {
-    Map<String, Collection<String>> headers = new LinkedHashMap<String, Collection<String>>();
-    headers.put("Location", Arrays.asList("http://bar.com"));
+    Map<String, Collection<String>> headers = new LinkedHashMap<>();
+    headers.put("Location", Collections.singletonList("http://bar.com"));
     final Response response = Response.builder()
         .status(302)
         .reason("Found")
@@ -810,7 +811,7 @@ public class FeignTest {
         try {
           return response
               .toBuilder()
-              .body(Util.toString(response.body().asReader()).toUpperCase().getBytes())
+              .body(Util.toString(response.body().asReader(UTF_8)).toUpperCase().getBytes())
               .build();
         } catch (IOException e) {
           throw new RuntimeException(e);
@@ -973,7 +974,7 @@ public class FeignTest {
                                  @QueryMap Map<String, Object> queryMap);
 
     @RequestLine("GET /?trim={trim}")
-    void encodedQueryParam(@Param(value = "trim", encoded = true) String trim);
+    void encodedQueryParam(@Param(value = "trim") String trim);
 
     @RequestLine("GET /")
     void queryMapPojo(@QueryMap CustomPojo object);

--- a/core/src/test/java/feign/LoggerTest.java
+++ b/core/src/test/java/feign/LoggerTest.java
@@ -27,9 +27,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.model.Statement;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import feign.Logger.Level;
@@ -70,7 +70,7 @@ public class LoggerTest {
     @Parameters
     public static Iterable<Object[]> data() {
       return Arrays.asList(new Object[][] {
-          {Level.NONE, Arrays.asList()},
+          {Level.NONE, Collections.emptyList()},
           {Level.BASIC, Arrays.asList(
               "\\[SendsStuff#login\\] ---> POST http://localhost:[0-9]+/ HTTP/1.1",
               "\\[SendsStuff#login\\] <--- HTTP/1.1 200 OK \\([0-9]+ms\\)")},
@@ -98,7 +98,7 @@ public class LoggerTest {
     }
 
     @Test
-    public void levelEmits() throws IOException, InterruptedException {
+    public void levelEmits() {
       server.enqueue(new MockResponse().setBody("foo"));
 
       SendsStuff api = Feign.builder()
@@ -130,7 +130,7 @@ public class LoggerTest {
     }
 
     @Test
-    public void reasonPhraseOptional() throws IOException, InterruptedException {
+    public void reasonPhraseOptional() {
       server.enqueue(new MockResponse().setStatus("HTTP/1.1 " + 200));
 
       SendsStuff api = Feign.builder()
@@ -155,7 +155,7 @@ public class LoggerTest {
     @Parameters
     public static Iterable<Object[]> data() {
       return Arrays.asList(new Object[][] {
-          {Level.NONE, Arrays.asList()},
+          {Level.NONE, Collections.emptyList()},
           {Level.BASIC, Arrays.asList(
               "\\[SendsStuff#login\\] ---> POST http://localhost:[0-9]+/ HTTP/1.1",
               "\\[SendsStuff#login\\] <--- ERROR SocketTimeoutException: Read timed out \\([0-9]+ms\\)")},
@@ -179,14 +179,15 @@ public class LoggerTest {
     }
 
     @Test
-    public void levelEmitsOnReadTimeout() throws IOException, InterruptedException {
+    public void levelEmitsOnReadTimeout() {
       server.enqueue(new MockResponse().throttleBody(1, 1, TimeUnit.SECONDS).setBody("foo"));
       thrown.expect(FeignException.class);
 
       SendsStuff api = Feign.builder()
           .logger(logger)
           .logLevel(logLevel)
-          .options(new Request.Options(10 * 1000, 50))
+          .options(new Request.Options(10 * 1000, TimeUnit.MILLISECONDS, 50, TimeUnit.MILLISECONDS,
+              true))
           .retryer(new Retryer() {
             @Override
             public void continueOrPropagate(RetryableException e) {
@@ -217,7 +218,7 @@ public class LoggerTest {
     @Parameters
     public static Iterable<Object[]> data() {
       return Arrays.asList(new Object[][] {
-          {Level.NONE, Arrays.asList()},
+          {Level.NONE, Collections.emptyList()},
           {Level.BASIC, Arrays.asList(
               "\\[SendsStuff#login\\] ---> POST http://robofu.abc/ HTTP/1.1",
               "\\[SendsStuff#login\\] <--- ERROR UnknownHostException: robofu.abc \\([0-9]+ms\\)")},
@@ -241,7 +242,7 @@ public class LoggerTest {
     }
 
     @Test
-    public void unknownHostEmits() throws IOException, InterruptedException {
+    public void unknownHostEmits() {
       SendsStuff api = Feign.builder()
           .logger(logger)
           .logLevel(logLevel)
@@ -279,7 +280,7 @@ public class LoggerTest {
     @Parameters
     public static Iterable<Object[]> data() {
       return Arrays.asList(new Object[][] {
-          {Level.NONE, Arrays.asList()},
+          {Level.NONE, Collections.emptyList()},
           {Level.BASIC, Arrays.asList(
               "\\[SendsStuff#login\\] ---> POST http://sna%fu.abc/ HTTP/1.1",
               "\\[SendsStuff#login\\] <--- ERROR UnknownHostException: sna%fu.abc \\([0-9]+ms\\)")},
@@ -303,7 +304,7 @@ public class LoggerTest {
     }
 
     @Test
-    public void formatCharacterEmits() throws IOException, InterruptedException {
+    public void formatCharacterEmits() {
       SendsStuff api = Feign.builder()
           .logger(logger)
           .logLevel(logLevel)
@@ -340,7 +341,7 @@ public class LoggerTest {
     @Parameters
     public static Iterable<Object[]> data() {
       return Arrays.asList(new Object[][] {
-          {Level.NONE, Arrays.asList()},
+          {Level.NONE, Collections.emptyList()},
           {Level.BASIC, Arrays.asList(
               "\\[SendsStuff#login\\] ---> POST http://robofu.abc/ HTTP/1.1",
               "\\[SendsStuff#login\\] <--- ERROR UnknownHostException: robofu.abc \\([0-9]+ms\\)",
@@ -351,7 +352,7 @@ public class LoggerTest {
     }
 
     @Test
-    public void retryEmits() throws IOException, InterruptedException {
+    public void retryEmits() {
       thrown.expect(FeignException.class);
 
       SendsStuff api = Feign.builder()
@@ -382,12 +383,11 @@ public class LoggerTest {
 
   private static final class RecordingLogger extends Logger implements TestRule {
 
-    private final List<String> messages = new ArrayList<String>();
-    private final List<String> expectedMessages = new ArrayList<String>();
+    private final List<String> messages = new ArrayList<>();
+    private final List<String> expectedMessages = new ArrayList<>();
 
-    RecordingLogger expectMessages(List<String> expectedMessages) {
+    void expectMessages(List<String> expectedMessages) {
       this.expectedMessages.addAll(expectedMessages);
-      return this;
     }
 
     @Override

--- a/core/src/test/java/feign/MethodMetadataPresenceTest.java
+++ b/core/src/test/java/feign/MethodMetadataPresenceTest.java
@@ -44,7 +44,7 @@ public class MethodMetadataPresenceTest {
         .target(TestInterface.class, url);
 
     final Response response = api.codecPost("request data");
-    assertEquals("response data", Util.toString(response.body().asReader()));
+    assertEquals("response data", Util.toString(response.body().asReader(Util.UTF_8)));
 
     assertThat(server.takeRequest())
         .hasBody("request data");
@@ -65,7 +65,7 @@ public class MethodMetadataPresenceTest {
         .target(TestInterface.class, url);
 
     final Response response = api.codecPost("request data");
-    assertEquals("response data", Util.toString(response.body().asReader()));
+    assertEquals("response data", Util.toString(response.body().asReader(Util.UTF_8)));
 
     assertThat(server.takeRequest())
         .hasBody("request data");
@@ -87,7 +87,7 @@ public class MethodMetadataPresenceTest {
         .target(TestInterface.class, url);
 
     final Response response = api.codecPost("request data");
-    assertEquals("response data", Util.toString(response.body().asReader()));
+    assertEquals("response data", Util.toString(response.body().asReader(Util.UTF_8)));
 
     assertThat(server.takeRequest())
         .hasBody("request data");

--- a/core/src/test/java/feign/MultipleLoggerTest.java
+++ b/core/src/test/java/feign/MultipleLoggerTest.java
@@ -30,6 +30,7 @@ public class MultipleLoggerTest {
     return (java.util.logging.Logger) inner.get(logger);
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void testAppendSeveralFilesToOneJavaLogger() throws Exception {
     Logger.JavaLogger logger = new Logger.JavaLogger()

--- a/core/src/test/java/feign/OptionsTest.java
+++ b/core/src/test/java/feign/OptionsTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author pengfei.zhao
  */
+@SuppressWarnings("deprecation")
 public class OptionsTest {
 
   interface OptionsInterface {

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -105,7 +105,7 @@ public class RequestTemplateTest {
   public void resolveTemplateWithBinaryBody() {
     RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)
         .uri("{zoneId}")
-        .body(Request.Body.encoded(new byte[] {7, 3, -3, -7}, null));
+        .body(new byte[] {7, 3, -3, -7}, null);
     template = template.resolve(mapOf("zoneId", "/hostedzone/Z1PA6795UKMFR9"));
 
     assertThat(template)
@@ -269,10 +269,10 @@ public class RequestTemplateTest {
   @Test
   public void resolveTemplateWithBodyTemplateSetsBodyAndContentLength() {
     RequestTemplate template = new RequestTemplate().method(HttpMethod.POST)
-        .body(Request.Body.bodyTemplate(
+        .bodyTemplate(
             "%7B\"customer_name\": \"{customer_name}\", \"user_name\": \"{user_name}\", " +
                 "\"password\": \"{password}\"%7D",
-            Util.UTF_8));
+            Util.UTF_8);
 
     template = template.resolve(
         mapOf(
@@ -285,15 +285,15 @@ public class RequestTemplateTest {
             "{\"customer_name\": \"netflix\", \"user_name\": \"denominator\", \"password\": \"password\"}")
         .hasHeaders(
             entry("Content-Length",
-                Collections.singletonList(String.valueOf(template.requestBody().length()))));
+                Collections.singletonList(String.valueOf(template.body().length))));
   }
 
   @Test
   public void resolveTemplateWithBodyTemplateDoesNotDoubleDecode() {
     RequestTemplate template = new RequestTemplate().method(HttpMethod.POST)
-        .body(Request.Body.bodyTemplate(
+        .bodyTemplate(
             "%7B\"customer_name\": \"{customer_name}\", \"user_name\": \"{user_name}\", \"password\": \"{password}\"%7D",
-            Util.UTF_8));
+            Util.UTF_8);
 
     template = template.resolve(
         mapOf(

--- a/core/src/test/java/feign/ResponseTest.java
+++ b/core/src/test/java/feign/ResponseTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import static feign.assertj.FeignAssertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
+@SuppressWarnings("deprecation")
 public class ResponseTest {
 
   @Test
@@ -42,7 +43,7 @@ public class ResponseTest {
 
   @Test
   public void canAccessHeadersCaseInsensitively() {
-    Map<String, Collection<String>> headersMap = new LinkedHashMap();
+    Map<String, Collection<String>> headersMap = new LinkedHashMap<>();
     List<String> valueList = Collections.singletonList("application/json");
     headersMap.put("Content-Type", valueList);
     Response response = Response.builder()
@@ -57,9 +58,9 @@ public class ResponseTest {
 
   @Test
   public void headerValuesWithSameNameOnlyVaryingInCaseAreMerged() {
-    Map<String, Collection<String>> headersMap = new LinkedHashMap();
+    Map<String, Collection<String>> headersMap = new LinkedHashMap<>();
     headersMap.put("Set-Cookie", Arrays.asList("Cookie-A=Value", "Cookie-B=Value"));
-    headersMap.put("set-cookie", Arrays.asList("Cookie-C=Value"));
+    headersMap.put("set-cookie", Collections.singletonList("Cookie-C=Value"));
 
     Response response = Response.builder()
         .status(200)

--- a/core/src/test/java/feign/RetryerTest.java
+++ b/core/src/test/java/feign/RetryerTest.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import feign.Retryer.Default;
 import static org.junit.Assert.assertEquals;
 
+@SuppressWarnings("deprecation")
 public class RetryerTest {
 
   @Rule
@@ -58,7 +59,7 @@ public class RetryerTest {
   }
 
   @Test
-  public void considersRetryAfterButNotMoreThanMaxPeriod() throws Exception {
+  public void considersRetryAfterButNotMoreThanMaxPeriod() {
     Default retryer = new Retryer.Default() {
       protected long currentTimeMillis() {
         return 0;

--- a/core/src/test/java/feign/TargetTest.java
+++ b/core/src/test/java/feign/TargetTest.java
@@ -21,6 +21,7 @@ import okhttp3.mockwebserver.MockWebServer;
 import org.junit.Rule;
 import org.junit.Test;
 
+@SuppressWarnings("deprecation")
 public class TargetTest {
 
   @Rule
@@ -61,7 +62,7 @@ public class TargetTest {
             urlEncoded.httpMethod(),
             urlEncoded.url().replace("%2F", "/"),
             urlEncoded.headers(),
-            urlEncoded.requestBody().asBytes(), urlEncoded.charset());
+            urlEncoded.body(), urlEncoded.charset());
       }
     };
 

--- a/core/src/test/java/feign/assertj/RequestTemplateAssert.java
+++ b/core/src/test/java/feign/assertj/RequestTemplateAssert.java
@@ -96,14 +96,14 @@ public final class RequestTemplateAssert
 
   public RequestTemplateAssert noRequestBody() {
     isNotNull();
-    if (actual.requestBody() != null) {
-      if (actual.requestBody().bodyTemplate() != null) {
+    if (actual.body() != null) {
+      if (actual.bodyTemplate() != null) {
         failWithMessage("\nExpecting requestBody.bodyTemplate to be null, but was:<%s>",
-            actual.requestBody().bodyTemplate());
+            actual.bodyTemplate());
       }
-      if (actual.requestBody().asBytes() != null) {
+      if (actual.body() != null) {
         failWithMessage("\nExpecting requestBody.data to be null, but was:<%s>",
-            actual.requestBody().asString());
+            new String(actual.body(), actual.requestCharset()));
       }
     }
     return this;

--- a/core/src/test/java/feign/client/AbstractClientTest.java
+++ b/core/src/test/java/feign/client/AbstractClientTest.java
@@ -274,7 +274,7 @@ public abstract class AbstractClientTest {
 
     Response response = api.postWithContentType("foo", "text/plain;charset=utf-8");
     // Response length should not be null
-    assertEquals("AAAAAAAA", Util.toString(response.body().asReader()));
+    assertEquals("AAAAAAAA", Util.toString(response.body().asReader(UTF_8)));
   }
 
   @Test
@@ -286,7 +286,7 @@ public abstract class AbstractClientTest {
 
     Response response = api.postWithContentType("foo", "text/plain");
     // Response length should not be null
-    assertEquals("AAAAAAAA", Util.toString(response.body().asReader()));
+    assertEquals("AAAAAAAA", Util.toString(response.body().asReader(UTF_8)));
   }
 
   @Test

--- a/core/src/test/java/feign/codec/DefaultDecoderTest.java
+++ b/core/src/test/java/feign/codec/DefaultDecoderTest.java
@@ -31,6 +31,7 @@ import feign.Request;
 import feign.Response;
 import feign.Util;
 
+@SuppressWarnings("deprecation")
 public class DefaultDecoderTest {
 
   @Rule

--- a/core/src/test/java/feign/codec/DefaultErrorDecoderHttpErrorTest.java
+++ b/core/src/test/java/feign/codec/DefaultErrorDecoderHttpErrorTest.java
@@ -27,6 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SuppressWarnings("deprecation")
 @RunWith(Parameterized.class)
 public class DefaultErrorDecoderHttpErrorTest {
 

--- a/core/src/test/java/feign/codec/DefaultErrorDecoderTest.java
+++ b/core/src/test/java/feign/codec/DefaultErrorDecoderTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.springframework.util.StringUtils;
 
+@SuppressWarnings("deprecation")
 public class DefaultErrorDecoderTest {
 
   @Rule

--- a/core/src/test/java/feign/examples/GitHubExample.java
+++ b/core/src/test/java/feign/examples/GitHubExample.java
@@ -25,6 +25,7 @@ import feign.Param;
 import feign.RequestLine;
 import feign.Response;
 import feign.codec.Decoder;
+import static feign.Util.UTF_8;
 import static feign.Util.ensureClosed;
 
 /**
@@ -70,7 +71,7 @@ public class GitHubExample {
       if (void.class == type || response.body() == null) {
         return null;
       }
-      Reader reader = response.body().asReader();
+      Reader reader = response.body().asReader(UTF_8);
       try {
         return gson.fromJson(reader, type);
       } catch (JsonIOException e) {

--- a/core/src/test/java/feign/stream/StreamDecoderTest.java
+++ b/core/src/test/java/feign/stream/StreamDecoderTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 import static feign.Util.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SuppressWarnings("deprecation")
 public class StreamDecoderTest {
 
   interface StreamInterface {
@@ -69,7 +70,8 @@ public class StreamDecoderTest {
 
     StreamInterface api = Feign.builder()
         .decoder(StreamDecoder.create(
-            (response, type) -> new BufferedReader(response.body().asReader()).lines().iterator()))
+            (response, type) -> new BufferedReader(response.body().asReader(UTF_8)).lines()
+                .iterator()))
         .doNotCloseAfterDecode()
         .target(StreamInterface.class, server.url("/").toString());
 

--- a/googlehttpclient/src/main/java/feign/googlehttpclient/GoogleHttpClient.java
+++ b/googlehttpclient/src/main/java/feign/googlehttpclient/GoogleHttpClient.java
@@ -69,7 +69,7 @@ public class GoogleHttpClient implements Client {
       throws IOException {
     // Setup the request body
     HttpContent content = null;
-    if (inputRequest.requestBody().length() > 0) {
+    if (inputRequest.length() > 0) {
       final Collection<String> contentTypeValues = inputRequest.headers().get("Content-Type");
       String contentType = null;
       if (contentTypeValues != null && contentTypeValues.size() > 0) {
@@ -77,7 +77,7 @@ public class GoogleHttpClient implements Client {
       } else {
         contentType = "application/octet-stream";
       }
-      content = new ByteArrayContent(contentType, inputRequest.requestBody().asBytes());
+      content = new ByteArrayContent(contentType, inputRequest.body());
     }
 
     // Build the request

--- a/gson/src/main/java/feign/gson/GsonDecoder.java
+++ b/gson/src/main/java/feign/gson/GsonDecoder.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import feign.Response;
 import feign.Util;
 import feign.codec.Decoder;
+import static feign.Util.UTF_8;
 import static feign.Util.ensureClosed;
 
 public class GsonDecoder implements Decoder {
@@ -45,7 +46,7 @@ public class GsonDecoder implements Decoder {
   public Object decode(Response response, Type type) throws IOException {
     if (response.body() == null)
       return null;
-    Reader reader = response.body().asReader();
+    Reader reader = response.body().asReader(UTF_8);
     try {
       return gson.fromJson(reader, type);
     } catch (JsonIOException e) {

--- a/gson/src/test/java/feign/gson/GsonCodecTest.java
+++ b/gson/src/test/java/feign/gson/GsonCodecTest.java
@@ -36,6 +36,7 @@ import static feign.assertj.FeignAssertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+@SuppressWarnings("deprecation")
 public class GsonCodecTest {
 
   @Test

--- a/hc5/src/main/java/feign/hc5/ApacheHttp5Client.java
+++ b/hc5/src/main/java/feign/hc5/ApacheHttp5Client.java
@@ -127,14 +127,15 @@ public final class ApacheHttp5Client implements Client {
     }
 
     // request body
-    final Body requestBody = request.requestBody();
-    if (requestBody.asBytes() != null) {
+    // final Body requestBody = request.requestBody();
+    byte[] data = request.body();
+    if (data != null) {
       HttpEntity entity;
-      if (requestBody.isBinary()) {
-        entity = new ByteArrayEntity(requestBody.asBytes(), null);
+      if (request.isBinary()) {
+        entity = new ByteArrayEntity(data, null);
       } else {
         final ContentType contentType = getContentType(request);
-        entity = new StringEntity(requestBody.asString(), contentType);
+        entity = new StringEntity(new String(data), contentType);
       }
 
       requestBuilder.setEntity(entity);
@@ -142,9 +143,7 @@ public final class ApacheHttp5Client implements Client {
       requestBuilder.setEntity(new ByteArrayEntity(new byte[0], null));
     }
 
-    final ClassicHttpRequest classicRequest = requestBuilder.build();
-
-    return classicRequest;
+    return requestBuilder.build();
   }
 
   private ContentType getContentType(Request request) {
@@ -215,6 +214,7 @@ public final class ApacheHttp5Client implements Client {
         return entity.getContent();
       }
 
+      @SuppressWarnings("deprecation")
       @Override
       public Reader asReader() throws IOException {
         return new InputStreamReader(asInputStream(), UTF_8);

--- a/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
+++ b/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
@@ -105,7 +105,7 @@ public final class ApacheHttpClient implements Client {
 
     // request query params
     List<NameValuePair> queryParams =
-        URLEncodedUtils.parse(uri, requestBuilder.getCharset().name());
+        URLEncodedUtils.parse(uri, requestBuilder.getCharset());
     for (NameValuePair queryParam : queryParams) {
       requestBuilder.addParameter(queryParam);
     }
@@ -134,14 +134,14 @@ public final class ApacheHttpClient implements Client {
     }
 
     // request body
-    if (request.requestBody().asBytes() != null) {
+    if (request.body() != null) {
       HttpEntity entity = null;
       if (request.charset() != null) {
         ContentType contentType = getContentType(request);
-        String content = new String(request.requestBody().asBytes(), request.charset());
+        String content = new String(request.body(), request.charset());
         entity = new StringEntity(content, contentType);
       } else {
-        entity = new ByteArrayEntity(request.requestBody().asBytes());
+        entity = new ByteArrayEntity(request.body());
       }
 
       requestBuilder.setEntity(entity);
@@ -220,6 +220,7 @@ public final class ApacheHttpClient implements Client {
         return entity.getContent();
       }
 
+      @SuppressWarnings("deprecation")
       @Override
       public Reader asReader() throws IOException {
         return new InputStreamReader(asInputStream(), UTF_8);

--- a/jackson-jaxb/src/test/java/feign/jackson/jaxb/JacksonJaxbCodecTest.java
+++ b/jackson-jaxb/src/test/java/feign/jackson/jaxb/JacksonJaxbCodecTest.java
@@ -27,6 +27,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import org.junit.Test;
 
+@SuppressWarnings("deprecation")
 public class JacksonJaxbCodecTest {
 
   @Test

--- a/jackson/src/main/java/feign/jackson/JacksonDecoder.java
+++ b/jackson/src/main/java/feign/jackson/JacksonDecoder.java
@@ -47,7 +47,7 @@ public class JacksonDecoder implements Decoder {
   public Object decode(Response response, Type type) throws IOException {
     if (response.body() == null)
       return null;
-    Reader reader = response.body().asReader();
+    Reader reader = response.body().asReader(Util.UTF_8);
     if (!reader.markSupported()) {
       reader = new BufferedReader(reader, 1);
     }

--- a/jackson/src/main/java/feign/jackson/JacksonIteratorDecoder.java
+++ b/jackson/src/main/java/feign/jackson/JacksonIteratorDecoder.java
@@ -29,6 +29,7 @@ import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import static feign.Util.UTF_8;
 import static feign.Util.ensureClosed;
 
 /**
@@ -65,7 +66,7 @@ public final class JacksonIteratorDecoder implements Decoder {
   public Object decode(Response response, Type type) throws IOException {
     if (response.body() == null)
       return null;
-    Reader reader = response.body().asReader();
+    Reader reader = response.body().asReader(UTF_8);
     if (!reader.markSupported()) {
       reader = new BufferedReader(reader, 1);
     }

--- a/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
+++ b/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
@@ -46,6 +46,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+@SuppressWarnings("deprecation")
 public class JacksonCodecTest {
 
   private String zonesJson = ""//

--- a/jackson/src/test/java/feign/jackson/JacksonIteratorTest.java
+++ b/jackson/src/test/java/feign/jackson/JacksonIteratorTest.java
@@ -35,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.core.Is.isA;
 
+@SuppressWarnings("deprecation")
 public class JacksonIteratorTest {
 
   @Rule

--- a/java11/src/main/java/feign/http2client/Http2Client.java
+++ b/java11/src/main/java/feign/http2client/Http2Client.java
@@ -80,10 +80,11 @@ public class Http2Client implements Client {
     }
 
     final BodyPublisher body;
-    if (request.requestBody().asBytes() == null) {
+    final byte[] data = request.body();
+    if (data == null) {
       body = BodyPublishers.noBody();
     } else {
-      body = BodyPublishers.ofByteArray(request.requestBody().asBytes());
+      body = BodyPublishers.ofByteArray(data);
     }
 
     final Builder requestBuilder = HttpRequest.newBuilder()

--- a/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
+++ b/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
@@ -34,6 +34,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+@SuppressWarnings("deprecation")
 public class JAXBCodecTest {
 
   @Rule

--- a/jaxb/src/test/java/feign/jaxb/examples/AWSSignatureVersion4.java
+++ b/jaxb/src/test/java/feign/jaxb/examples/AWSSignatureVersion4.java
@@ -75,7 +75,8 @@ public class AWSSignatureVersion4 {
     canonicalRequest.append("host").append('\n');
 
     // HexEncode(Hash(Payload))
-    String bodyText = input.requestBody().asString();
+    byte[] data = input.body();
+    String bodyText = (data != null) ? new String(data, input.requestCharset()) : null;
     if (bodyText != null) {
       canonicalRequest.append(hex(sha256(bodyText)));
     } else {

--- a/jaxrs2/src/main/java/feign/jaxrs2/JAXRSClient.java
+++ b/jaxrs2/src/main/java/feign/jaxrs2/JAXRSClient.java
@@ -69,12 +69,12 @@ public class JAXRSClient implements Client {
   }
 
   private Entity<byte[]> createRequestEntity(feign.Request request) {
-    if (request.requestBody().asBytes() == null) {
+    if (request.body() == null) {
       return null;
     }
 
     return Entity.entity(
-        request.requestBody().asBytes(),
+        request.body(),
         new Variant(mediaType(request.headers()), locale(request.headers()),
             encoding(request.charset())));
   }

--- a/jaxrs2/src/test/java/feign/jaxrs2/JAXRSClientTest.java
+++ b/jaxrs2/src/test/java/feign/jaxrs2/JAXRSClientTest.java
@@ -117,7 +117,7 @@ public class JAXRSClientTest extends AbstractClientTest {
 
     final Response response = api.getWithContentType();
     // Response length should not be null
-    assertEquals("AAAAAAAA", Util.toString(response.body().asReader()));
+    assertEquals("AAAAAAAA", Util.toString(response.body().asReader(UTF_8)));
 
     MockWebServerAssertions.assertThat(server.takeRequest())
         .hasHeaders(

--- a/mock/src/main/java/feign/mock/RequestKey.java
+++ b/mock/src/main/java/feign/mock/RequestKey.java
@@ -112,7 +112,7 @@ public class RequestKey {
     this.url = buildUrl(request);
     this.headers = RequestHeaders.of(request.headers());
     this.charset = request.charset();
-    this.body = request.requestBody().asBytes();
+    this.body = request.body();
   }
 
   public HttpMethod getMethod() {

--- a/mock/src/test/java/feign/mock/MockClientTest.java
+++ b/mock/src/test/java/feign/mock/MockClientTest.java
@@ -166,7 +166,7 @@ public class MockClientTest {
     assertThat(results, hasSize(1));
 
     byte[] body = mockClient.verifyOne(HttpMethod.POST, "/repos/netflix/feign/contributors")
-        .requestBody().asBytes();
+        .body();
     assertThat(body, notNullValue());
 
     String message = new String(body);

--- a/mock/src/test/java/feign/mock/RequestKeyTest.java
+++ b/mock/src/test/java/feign/mock/RequestKeyTest.java
@@ -53,6 +53,7 @@ public class RequestKeyTest {
     assertThat(requestKey.getCharset(), equalTo(StandardCharsets.UTF_16));
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void create() throws Exception {
     Map<String, Collection<String>> map = new HashMap<String, Collection<String>>();

--- a/okhttp/src/main/java/feign/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/feign/okhttp/OkHttpClient.java
@@ -71,7 +71,7 @@ public final class OkHttpClient implements Client {
       requestBuilder.addHeader("Accept", "*/*");
     }
 
-    byte[] inputBody = input.requestBody().asBytes();
+    byte[] inputBody = input.body();
     boolean isMethodWithBody =
         HttpMethod.POST == input.httpMethod() || HttpMethod.PUT == input.httpMethod()
             || HttpMethod.PATCH == input.httpMethod();
@@ -137,6 +137,7 @@ public final class OkHttpClient implements Client {
         return input.byteStream();
       }
 
+      @SuppressWarnings("deprecation")
       @Override
       public Reader asReader() throws IOException {
         return input.charStream();

--- a/okhttp/src/test/java/feign/okhttp/OkHttpClientTest.java
+++ b/okhttp/src/test/java/feign/okhttp/OkHttpClientTest.java
@@ -47,7 +47,7 @@ public class OkHttpClientTest extends AbstractClientTest {
 
     Response response = api.getWithContentType();
     // Response length should not be null
-    assertEquals("AAAAAAAA", Util.toString(response.body().asReader()));
+    assertEquals("AAAAAAAA", Util.toString(response.body().asReader(Util.UTF_8)));
 
     MockWebServerAssertions.assertThat(server.takeRequest())
         .hasHeaders(

--- a/ribbon/src/main/java/feign/ribbon/LBClient.java
+++ b/ribbon/src/main/java/feign/ribbon/LBClient.java
@@ -31,6 +31,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import feign.Client;
 import feign.Request;
 import feign.Response;
@@ -77,10 +78,13 @@ public final class LBClient extends
       options =
           new Request.Options(
               configOverride.get(CommonClientConfigKey.ConnectTimeout, connectTimeout),
+              TimeUnit.MILLISECONDS,
               (configOverride.get(CommonClientConfigKey.ReadTimeout, readTimeout)),
+              TimeUnit.MILLISECONDS,
               configOverride.get(CommonClientConfigKey.FollowRedirects, followRedirects));
     } else {
-      options = new Request.Options(connectTimeout, readTimeout);
+      options = new Request.Options(connectTimeout, TimeUnit.MILLISECONDS, readTimeout,
+          TimeUnit.MILLISECONDS, true);
     }
     Response response = request.client().execute(request.toRequest(), options);
     if (retryableStatusCodes.contains(response.status())) {
@@ -115,9 +119,10 @@ public final class LBClient extends
       setUri(uri);
     }
 
+    @SuppressWarnings("deprecation")
     Request toRequest() {
       // add header "Content-Length" according to the request body
-      final byte[] body = request.requestBody().asBytes();
+      final byte[] body = request.body();
       final int bodyLength = body != null ? body.length : 0;
       // create a new Map to avoid side effect, not to change the old headers
       Map<String, Collection<String>> headers = new LinkedHashMap<String, Collection<String>>();

--- a/ribbon/src/test/java/feign/ribbon/LBClientTest.java
+++ b/ribbon/src/test/java/feign/ribbon/LBClientTest.java
@@ -25,6 +25,7 @@ import feign.Request;
 import feign.ribbon.LBClient.RibbonRequest;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SuppressWarnings("deprecation")
 public class LBClientTest {
 
   @Test

--- a/ribbon/src/test/java/feign/ribbon/RibbonClientTest.java
+++ b/ribbon/src/test/java/feign/ribbon/RibbonClientTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 import java.util.Collection;
+import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -292,7 +293,8 @@ public class RibbonClientTest {
 
     getConfigInstance().setProperty(serverListKey(), hostAndPort(server1.url("").url()));
 
-    Request.Options options = new Request.Options(1000, 1000, false);
+    Request.Options options =
+        new Request.Options(1000, TimeUnit.MILLISECONDS, 1000, TimeUnit.MILLISECONDS, false);
     TestInterface api = Feign.builder()
         .options(options)
         .client(RibbonClient.create())
@@ -324,7 +326,8 @@ public class RibbonClientTest {
     getConfigInstance().setProperty(serverListKey(),
         hostAndPort(server1.url("").url()) + "," + hostAndPort(server2.url("").url()));
 
-    Request.Options options = new Request.Options(1000, 1000, true);
+    Request.Options options =
+        new Request.Options(1000, TimeUnit.MILLISECONDS, 1000, TimeUnit.MILLISECONDS, true);
     TestInterface api = Feign.builder()
         .options(options)
         .client(RibbonClient.create())
@@ -344,7 +347,8 @@ public class RibbonClientTest {
 
   @Test
   public void testFeignOptionsClientConfig() {
-    Request.Options options = new Request.Options(1111, 22222);
+    Request.Options options =
+        new Request.Options(1111, TimeUnit.MILLISECONDS, 22222, TimeUnit.MILLISECONDS, true);
     IClientConfig config = new RibbonClient.FeignOptionsClientConfig(options);
     assertThat(config.get(CommonClientConfigKey.ConnectTimeout),
         equalTo(options.connectTimeoutMillis()));

--- a/sax/src/test/java/feign/sax/SAXDecoderTest.java
+++ b/sax/src/test/java/feign/sax/SAXDecoderTest.java
@@ -31,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+@SuppressWarnings("deprecation")
 public class SAXDecoderTest {
 
   static String statusFailed = ""//

--- a/sax/src/test/java/feign/sax/examples/AWSSignatureVersion4.java
+++ b/sax/src/test/java/feign/sax/examples/AWSSignatureVersion4.java
@@ -75,7 +75,8 @@ public class AWSSignatureVersion4 {
     canonicalRequest.append("host").append('\n');
 
     // HexEncode(Hash(Payload))
-    String bodyText = input.requestBody().asString();
+    byte[] data = input.body();
+    String bodyText = (data != null) ? new String(data, input.requestCharset()) : null;
     if (bodyText != null) {
       canonicalRequest.append(hex(sha256(bodyText)));
     } else {

--- a/slf4j/src/test/java/feign/slf4j/Slf4jLoggerTest.java
+++ b/slf4j/src/test/java/feign/slf4j/Slf4jLoggerTest.java
@@ -26,6 +26,7 @@ import feign.Request;
 import feign.RequestTemplate;
 import feign.Response;
 
+@SuppressWarnings("deprecation")
 public class Slf4jLoggerTest {
 
   private static final String CONFIG_KEY = "someMethod()";

--- a/soap/src/test/java/feign/soap/SOAPCodecTest.java
+++ b/soap/src/test/java/feign/soap/SOAPCodecTest.java
@@ -39,6 +39,7 @@ import feign.codec.Encoder;
 import feign.jaxb.JAXBContextFactory;
 import feign.jaxb.JAXBDecoder;
 
+@SuppressWarnings("deprecation")
 public class SOAPCodecTest {
 
   @Rule

--- a/soap/src/test/java/feign/soap/SOAPFaultDecoderTest.java
+++ b/soap/src/test/java/feign/soap/SOAPFaultDecoderTest.java
@@ -31,6 +31,7 @@ import feign.Response;
 import feign.Util;
 import feign.jaxb.JAXBContextFactory;
 
+@SuppressWarnings("deprecation")
 public class SOAPFaultDecoderTest {
 
   @Rule

--- a/spring4/src/main/java/feign/spring/SpringContract.java
+++ b/spring4/src/main/java/feign/spring/SpringContract.java
@@ -30,7 +30,7 @@ public class SpringContract extends DeclarativeContract {
       appendMappings(data, requestMapping.value());
 
       if (requestMapping.method().length == 1)
-        data.template().method(requestMapping.method()[0].name());
+        data.template().method(Request.HttpMethod.valueOf(requestMapping.method()[0].name()));
 
       handleProducesAnnotation(data, requestMapping.produces());
       handleConsumesAnnotation(data, requestMapping.consumes());
@@ -41,7 +41,7 @@ public class SpringContract extends DeclarativeContract {
       appendMappings(data, mappings);
 
       if (requestMapping.method().length == 1)
-        data.template().method(requestMapping.method()[0].name());
+        data.template().method(Request.HttpMethod.valueOf(requestMapping.method()[0].name()));
     });
 
 


### PR DESCRIPTION
Fixes #857

To simply removal, Request.Body was returned back to an internal
component and additional methods were added to Request to expose
it's capabilities outside of the object.

All other deprecated usage in core modules has been removed.
Deprecated code still exists in the test cases and will be
removed once the deprecated methods are removed in our next
major release.

This is a very large PR that has very little changes.