### PR TITLE
Adds logging level to documentation. Fixes #1142

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ public class Example {
   public static void main(String[] args) {
     GitHub github = Feign.builder()
                      .logger(new Slf4jLogger())
+                     .logLevel(Level.FULL)
                      .target(GitHub.class, "https://api.github.com");
   }
 }

--- a/slf4j/README.md
+++ b/slf4j/README.md
@@ -8,5 +8,6 @@ To use SLF4J with Feign, add both the SLF4J module and an SLF4J binding of your 
 ```java
 GitHub github = Feign.builder()
                      .logger(new Slf4jLogger())
+                     .logLevel(Level.FULL)
                      .target(GitHub.class, "https://api.github.com");
 ```


### PR DESCRIPTION
Using the logger without setting the correct logging level results in no logging at all.