### PR TITLE
Update documentation regarding decodeSlash

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ See [Advanced Usage](#advanced-usage) for more examples.
 
 > **What about slashes? `/`**
 >
-> `@RequestLine` and `@QueryMap` templates do not encode slash `/` characters by default.  To change this behavior, set the `decodeSlash` property on the `@RequestLine` to `false`.  
+> Templates do not encode slash `/` characters by default.  To change this behavior, set the `decodeSlash` property on the `@RequestLine` to `false`.  
 
 > **What about plus? `+`**
 >

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ See [Advanced Usage](#advanced-usage) for more examples.
 
 > **What about slashes? `/`**
 >
-> Templates do not encode slash `/` characters by default.  To change this behavior, set the `decodeSlash` property on the `@RequestLine` to `false`.  
+> @RequestLine and @QueryMap Templates do encode slash `/` characters by default.  To change this behavior, set the `decodeSlash` property on the `@RequestLine` to `false`.  
 
 > **What about plus? `+`**
 >

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ See [Advanced Usage](#advanced-usage) for more examples.
 
 > **What about slashes? `/`**
 >
-> @RequestLine and @QueryMap Templates do encode slash `/` characters by default.  To change this behavior, set the `decodeSlash` property on the `@RequestLine` to `false`.  
+> @RequestLine and @QueryMap Templates do encode slash `/` characters by default.  To change this behavior, set the `decodeSlash` property on the `@RequestLine` to `true`.  
 
 > **What about plus? `+`**
 >


### PR DESCRIPTION
Fixes #1131

Updating documentation around slahes to reflect that now encoding
is consistent across all areas and that `decodeSlash` is required
in all cases.