### PR TITLE
Use LinkedHashMap for deterministic iterations

### DIFF
--- a/mock/src/main/java/feign/mock/RequestHeaders.java
+++ b/mock/src/main/java/feign/mock/RequestHeaders.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2019 The Feign Authors
+ * Copyright 2012-2020 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,14 +17,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class RequestHeaders {
 
   public static class Builder {
 
-    private Map<String, Collection<String>> headers = new HashMap<String, Collection<String>>();
+    private Map<String, Collection<String>> headers =
+        new LinkedHashMap<String, Collection<String>>();
 
     private Builder() {}
 

--- a/mock/src/test/java/feign/mock/RequestHeadersTest.java
+++ b/mock/src/test/java/feign/mock/RequestHeadersTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2019 The Feign Authors
+ * Copyright 2012-2020 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -83,6 +83,6 @@ public class RequestHeadersTest {
         .add("other header", "val2")
         .add("header", Arrays.asList("val3", "val4"))
         .build();
-    assertThat(headers.toString()).isEqualTo("other header=[val2], header=[val, val3, val4]");
+    assertThat(headers.toString()).isEqualTo("header=[val, val3, val4], other header=[val2]");
   }
 }


### PR DESCRIPTION
Test `shouldPrintHeaders()` asserts the string version of `RequestHeader`. `RequestHeader` class uses a HashMap to store the headers. However, HashMap does not guarantee any specific order of entries. Test can fail if the iteration order changes.
This PR proposes to fix the test by changing HashMap to LinkedHashMap that makes the iteration order deterministic.