### PR TITLE
issue 361 - async feign variant supporting CompleteableFutures

### DIFF
--- a/core/src/main/java/feign/AsyncClient.java
+++ b/core/src/main/java/feign/AsyncClient.java
@@ -68,4 +68,28 @@ public interface AsyncClient<C> {
     }
   }
 
+  /**
+   * A synchronous implementation of {@link AsyncClient}
+   * @param <C> - unused context; synchronous clients handle context internally
+   */
+  class Pseudo<C> implements AsyncClient<C> {
+
+    private final Client client;
+
+    public Pseudo(Client client) {
+      this.client = client;
+    }
+
+    @Override
+    public CompletableFuture<Response> execute(Request request, Options options, Optional<C> requestContext) {
+      CompletableFuture<Response> result = new CompletableFuture<>();
+      try {
+        result.complete(client.execute(request, options));
+      }catch(Exception e) {
+        result.completeExceptionally(e);
+      }
+
+      return result;
+    }
+  }
 }

--- a/core/src/main/java/feign/AsyncClient.java
+++ b/core/src/main/java/feign/AsyncClient.java
@@ -1,5 +1,15 @@
 /**
- * 
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package feign;
 
@@ -7,7 +17,6 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-
 import feign.Request.Options;
 
 /**
@@ -15,45 +24,48 @@ import feign.Request.Options;
  */
 public interface AsyncClient<C> {
 
-	/**
-	 * Executes the request asynchronously. Calling {@link CompletableFuture#cancel(boolean)} on the result
-	 * may cause the execution to be cancelled / aborted, but this is not guaranteed.
-	 * 
-	 * @param request safe to replay
-	 * @param options options to apply to this request
-	 * @param contextOpt - the optional context. The client should update this appropriately based
-	 * on the received response before completing the result.
-	 * @return a {@link CompletableFuture} to be completed with the response, or completed exceptionally
-	 * otherwise, for example with an {@link java.io.IOException} on a network error connecting to {@link Request#url()}.
-	 */
-	CompletableFuture<Response> execute(Request request, Options options, Optional<C> contextOpt);
+  /**
+   * Executes the request asynchronously. Calling {@link CompletableFuture#cancel(boolean)} on the
+   * result may cause the execution to be cancelled / aborted, but this is not guaranteed.
+   * 
+   * @param request safe to replay
+   * @param options options to apply to this request
+   * @param requestContext - the optional context, for example for storing session cookies. The client should update
+   *                       this appropriately based on the received response before completing the result.
+   * @return a {@link CompletableFuture} to be completed with the response, or completed
+   *         exceptionally otherwise, for example with an {@link java.io.IOException} on a network
+   *         error connecting to {@link Request#url()}.
+   */
+  CompletableFuture<Response> execute(Request request, Options options, Optional<C> requestContext);
 
-	class Default<C> implements AsyncClient<C> {
-		
-		private final Client client;
-		private final ExecutorService executorService;
-		
-		public Default(Client client, ExecutorService executorService) {
-			this.client = client;
-			this.executorService = executorService;
-		}
+  class Default<C> implements AsyncClient<C> {
 
-		@Override
-		public CompletableFuture<Response> execute(Request request, Options options, Optional<C> contextOpt) {
-			CompletableFuture<Response> result = new CompletableFuture<>();
-			Future<?> future = executorService.submit(() -> {
-				try {
-					result.complete(client.execute(request, options));
-				}catch(Exception e) {
-					result.completeExceptionally(e);
-				}
-			});
-			result.whenComplete( (response, throwable) -> {
-				if (result.isCancelled())
-					future.cancel(true);
-			});
-			return result;
-		}
-	}
-	
+    private final Client client;
+    private final ExecutorService executorService;
+
+    public Default(Client client, ExecutorService executorService) {
+      this.client = client;
+      this.executorService = executorService;
+    }
+
+    @Override
+    public CompletableFuture<Response> execute(Request request,
+                                               Options options,
+                                               Optional<C> requestContext) {
+      CompletableFuture<Response> result = new CompletableFuture<>();
+      Future<?> future = executorService.submit(() -> {
+        try {
+          result.complete(client.execute(request, options));
+        } catch (Exception e) {
+          result.completeExceptionally(e);
+        }
+      });
+      result.whenComplete((response, throwable) -> {
+        if (result.isCancelled())
+          future.cancel(true);
+      });
+      return result;
+    }
+  }
+
 }

--- a/core/src/main/java/feign/AsyncClient.java
+++ b/core/src/main/java/feign/AsyncClient.java
@@ -1,0 +1,59 @@
+/**
+ * 
+ */
+package feign;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import feign.Request.Options;
+
+/**
+ * Submits HTTP {@link Request requests} asynchronously, with an optional context.
+ */
+public interface AsyncClient<C> {
+
+	/**
+	 * Executes the request asynchronously. Calling {@link CompletableFuture#cancel(boolean)} on the result
+	 * may cause the execution to be cancelled / aborted, but this is not guaranteed.
+	 * 
+	 * @param request safe to replay
+	 * @param options options to apply to this request
+	 * @param contextOpt - the optional context. The client should update this appropriately based
+	 * on the received response before completing the result.
+	 * @return a {@link CompletableFuture} to be completed with the response, or completed exceptionally
+	 * otherwise, for example with an {@link java.io.IOException} on a network error connecting to {@link Request#url()}.
+	 */
+	CompletableFuture<Response> execute(Request request, Options options, Optional<C> contextOpt);
+
+	class Default<C> implements AsyncClient<C> {
+		
+		private final Client client;
+		private final ExecutorService executorService;
+		
+		public Default(Client client, ExecutorService executorService) {
+			this.client = client;
+			this.executorService = executorService;
+		}
+
+		@Override
+		public CompletableFuture<Response> execute(Request request, Options options, Optional<C> contextOpt) {
+			CompletableFuture<Response> result = new CompletableFuture<>();
+			Future<?> future = executorService.submit(() -> {
+				try {
+					result.complete(client.execute(request, options));
+				}catch(Exception e) {
+					result.completeExceptionally(e);
+				}
+			});
+			result.whenComplete( (response, throwable) -> {
+				if (result.isCancelled())
+					future.cancel(true);
+			});
+			return result;
+		}
+	}
+	
+}

--- a/core/src/main/java/feign/AsyncFeign.java
+++ b/core/src/main/java/feign/AsyncFeign.java
@@ -1,0 +1,328 @@
+
+package feign;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import feign.Logger.NoOpLogger;
+import feign.Request.Options;
+import feign.Target.HardCodedTarget;
+import feign.codec.Decoder;
+import feign.codec.Encoder;
+import feign.codec.ErrorDecoder;
+
+/**
+ * Enhances {@link Feign} to provide support for asynchronous clients.
+ * Context (for example for session cookies or tokens) is explicit,
+ * as calls for the same session may be done across several threads.
+ * <br><br>
+ * {@link Retryer} is not supported in this model, as that is a blocking API.
+ * {@link ExceptionPropagationPolicy} is made redundant as
+ * {@link RetryableException} is never thrown.
+ * <br>
+ * Alternative approaches to retrying can be handled through {@link AsyncClient clients}.
+ * <br><br>
+ * Target interface methods must return {@link CompletableFuture} with a non-wildcard type.
+ * As the completion is done by the {@link AsyncClient}, it is important that any subsequent
+ * processing on the thread be short - generally, this should involve notifying some other
+ * thread of the work to be done (for example, creating and submitting a task to an {@link ExecutorService}).
+ *
+ */
+public abstract class AsyncFeign<C> extends Feign {
+
+	public static <C> AsyncBuilder<C> asyncBuilder() {
+		return new AsyncBuilder<>();
+	}
+
+	private static class LazyInitializedExecutorService {
+
+		private static final ExecutorService instance = Executors.newCachedThreadPool(r -> {
+			Thread result = new Thread(r);
+			result.setDaemon(true);
+			return result;
+		});
+	}
+
+	public static class AsyncBuilder<C> {
+
+		private final Builder builder;
+		private Supplier<C> defaultContextSupplier = () -> null;
+		private AsyncClient<C> client;
+
+		private Logger.Level logLevel = Logger.Level.NONE;
+		private Logger logger = new NoOpLogger();
+
+		private Decoder decoder = new Decoder.Default();
+		private ErrorDecoder errorDecoder = new ErrorDecoder.Default();
+		private boolean decode404;
+		private boolean closeAfterDecode = true;
+
+		public AsyncBuilder() {
+			super();
+			this.builder = Feign.builder();								
+		}		
+		
+		public AsyncBuilder<C> defaultContextSupplier(Supplier<C> supplier) {
+			this.defaultContextSupplier = supplier;
+			return this;
+		}
+
+		public AsyncBuilder<C> client(AsyncClient<C> client) {
+			this.client = client;
+			return this;
+		}
+		
+		/**
+		 * @see Builder#mapAndDecode(ResponseMapper, Decoder)
+		 */
+		public AsyncBuilder<C> mapAndDecode(ResponseMapper mapper, Decoder decoder) {
+			this.decoder = (response, type) -> decoder.decode(mapper.map(response, type), type);
+			return this;
+		}
+		
+		/**
+		 * @see Builder#decoder(Decoder)
+		 */
+		public AsyncBuilder<C> decoder(Decoder decoder) {
+			this.decoder = decoder;
+			return this;
+		}
+
+		/**
+		 * @see Builder#decode404()
+		 */
+		public AsyncBuilder<C> decode404() {
+			this.decode404 = true;
+			return this;
+		}
+
+		/**
+		 * @see Builder#errorDecoder(ErrorDecoder)
+		 */
+		public AsyncBuilder<C> errorDecoder(ErrorDecoder errorDecoder) {
+			this.errorDecoder = errorDecoder;
+			return this;
+		}
+		
+		public AsyncBuilder<C> doNotCloseAfterDecode() {
+			this.closeAfterDecode = false;
+			return this;
+		}
+
+		public <T> T target(Class<T> apiType, String url) {
+			return target(new HardCodedTarget<>(apiType, url));
+		}
+		
+		public <T> T target(Class<T> apiType, String url, C context) {
+			return target(new HardCodedTarget<>(apiType, url), context);
+		}
+		
+		public <T> T target(Target<T> target) {
+			return build().newInstance(target);
+		}
+
+		public <T> T target(Target<T> target, C context) {
+			return build().newInstance(target, context);
+		}
+		
+		private static <C> AsyncClient<C> initDefaultClient() {
+			return new AsyncClient.Default<>(new Client.Default(null, null), LazyInitializedExecutorService.instance);
+		}
+		
+		private AsyncBuilder<C> lazyInits() {
+			if (client == null) {
+				client = initDefaultClient(); 
+			}
+			
+			return this;
+		}
+		
+		public AsyncFeign<C> build() {			
+			return new ReflectiveAsyncFeign<>(lazyInits());
+		}
+		
+		// start of builder delgates
+		
+		/**
+		 * @see Builder#logLevel(Logger.Level)
+		 */
+		public AsyncBuilder<C> logLevel(Logger.Level logLevel) {
+			builder.logLevel(logLevel);
+			return this;
+		}
+
+		/**
+		 * @see Builder#contract(Contract)
+		 */
+		public AsyncBuilder<C> contract(Contract contract) {
+			builder.contract(contract);
+			return this;
+		}
+
+		/**
+		 * @see Builder#logLevel(Logger.Level)
+		 */		
+		public AsyncBuilder<C> logger(Logger logger) {
+			builder.logger(logger);
+			return this;
+		}
+		
+		/**
+		 * @see Builder#encoder(Encoder)
+		 */
+		public AsyncBuilder<C> encoder(Encoder encoder) {
+			builder.encoder(encoder);
+			return this;
+		}
+	
+		/**
+		 * @see Builder#queryMapEncoder(QueryMapEncoder)
+		 */
+		public AsyncBuilder<C> queryMapEncoder(QueryMapEncoder queryMapEncoder) {
+			builder.queryMapEncoder(queryMapEncoder);
+			return this;
+		}
+
+
+		/**
+		 * @see Builder#options(Options)
+		 */
+		public AsyncBuilder<C> options(Options options) {
+			builder.options(options);
+			return this;
+		}
+
+		/**
+		 * @see Builder#requestInterceptor(RequestInterceptor)
+		 */
+		public AsyncBuilder<C> requestInterceptor(RequestInterceptor requestInterceptor) {
+			builder.requestInterceptor(requestInterceptor);
+			return this;
+		}
+
+		/**
+		 * @see Builder#requestInterceptors(Iterable)
+		 */
+		public AsyncBuilder<C> requestInterceptors(Iterable<RequestInterceptor> requestInterceptors) {
+			builder.requestInterceptors(requestInterceptors);
+			return this;
+		}
+
+		/**
+		 * @see Builder#invocationHandlerFactory(InvocationHandlerFactory)
+		 */
+		public AsyncBuilder<C> invocationHandlerFactory(InvocationHandlerFactory invocationHandlerFactory) {
+			builder.invocationHandlerFactory(invocationHandlerFactory);
+			return this;
+		}
+	}
+		
+	private final ThreadLocal<AsyncInvocation<C>> activeContext;
+	
+	private final Feign feign;
+
+	private final Supplier<C> defaultContextSupplier;
+	private final AsyncClient<C> client;
+	
+	private final Logger.Level logLevel;
+	private final Logger logger;
+
+	private final AsyncResponseHandler responseHandler;
+
+	protected AsyncFeign(AsyncBuilder<C> asyncBuilder) {
+		this.activeContext = new ThreadLocal<>();
+		
+		this.defaultContextSupplier = asyncBuilder.defaultContextSupplier;
+		this.client = asyncBuilder.client;
+		
+		this.logLevel = asyncBuilder.logLevel;
+		this.logger = asyncBuilder.logger;
+		
+		this.responseHandler = new AsyncResponseHandler(
+				asyncBuilder.logLevel,
+				asyncBuilder.logger,
+				asyncBuilder.decoder,
+				asyncBuilder.errorDecoder,
+				asyncBuilder.decode404,
+				asyncBuilder.closeAfterDecode);
+		
+		asyncBuilder.builder.client(this::stageExecution);
+		asyncBuilder.builder.decoder(this::stageDecode);
+				
+		this.feign = asyncBuilder.builder.build();
+	}
+	
+	private Response stageExecution(Request request, Options options) {
+		Response result = Response.builder()
+								.status(200)
+								.request(request)
+								.build();
+		
+		AsyncInvocation<C> invocationContext = activeContext.get();
+		
+		invocationContext.setResponseFuture(client.execute(request, options, Optional.ofNullable(invocationContext.context())));
+				
+		
+		return result;
+	}
+	
+	// from SynchronousMethodHandler
+	long elapsedTime(long start) {
+		return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+	}
+
+	
+	private Object stageDecode(Response response, Type type) {
+		AsyncInvocation<C> invocationContext = activeContext.get();
+		
+		CompletableFuture<Object> result = new CompletableFuture<>();
+		
+		invocationContext.responseFuture().whenComplete( (r,t) -> {
+			long elapsedTime = elapsedTime(invocationContext.startNanos());
+			
+			if (t != null) {
+				if (logLevel != Logger.Level.NONE && t instanceof IOException) {
+					IOException e = (IOException)t;					
+					logger.logIOException(invocationContext.configKey(), logLevel, e, elapsedTime);
+				}
+				result.completeExceptionally(t);
+			}
+			else {
+				responseHandler.handleResponse(result, invocationContext, r, invocationContext.underlyingType(), elapsedTime);
+			}
+		});
+		
+		result.whenComplete( (r,t) -> {
+			if (result.isCancelled())
+				invocationContext.responseFuture().cancel(true);
+		});
+		
+		return result;
+	}
+	
+
+	protected void setInvocationContext(AsyncInvocation<C> invocationContext) {
+		activeContext.set(invocationContext);
+	}
+	
+	protected void clearInvocationContext() {
+		activeContext.remove();
+	}
+
+	@Override
+	public <T> T newInstance(Target<T> target) {
+		return newInstance(target, defaultContextSupplier.get());
+	}
+	
+	public <T> T newInstance(Target<T> target, C context) {
+		return wrap(target.type(), feign.newInstance(target), context);
+	}
+	
+	protected abstract <T> T wrap(Class<T> type, T instance, C context);
+}

--- a/core/src/main/java/feign/AsyncFeign.java
+++ b/core/src/main/java/feign/AsyncFeign.java
@@ -1,4 +1,16 @@
-
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package feign;
 
 import java.io.IOException;
@@ -9,7 +21,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-
 import feign.Logger.NoOpLogger;
 import feign.Request.Options;
 import feign.Target.HardCodedTarget;
@@ -18,311 +29,307 @@ import feign.codec.Encoder;
 import feign.codec.ErrorDecoder;
 
 /**
- * Enhances {@link Feign} to provide support for asynchronous clients.
- * Context (for example for session cookies or tokens) is explicit,
- * as calls for the same session may be done across several threads.
- * <br><br>
- * {@link Retryer} is not supported in this model, as that is a blocking API.
- * {@link ExceptionPropagationPolicy} is made redundant as
- * {@link RetryableException} is never thrown.
+ * Enhances {@link Feign} to provide support for asynchronous clients. Context (for example for
+ * session cookies or tokens) is explicit, as calls for the same session may be done across several
+ * threads. <br>
  * <br>
- * Alternative approaches to retrying can be handled through {@link AsyncClient clients}.
- * <br><br>
- * Target interface methods must return {@link CompletableFuture} with a non-wildcard type.
- * As the completion is done by the {@link AsyncClient}, it is important that any subsequent
- * processing on the thread be short - generally, this should involve notifying some other
- * thread of the work to be done (for example, creating and submitting a task to an {@link ExecutorService}).
+ * {@link Retryer} is not supported in this model, as that is a blocking API.
+ * {@link ExceptionPropagationPolicy} is made redundant as {@link RetryableException} is never
+ * thrown. <br>
+ * Alternative approaches to retrying can be handled through {@link AsyncClient clients}. <br>
+ * <br>
+ * Target interface methods must return {@link CompletableFuture} with a non-wildcard type. As the
+ * completion is done by the {@link AsyncClient}, it is important that any subsequent processing on
+ * the thread be short - generally, this should involve notifying some other thread of the work to
+ * be done (for example, creating and submitting a task to an {@link ExecutorService}).
  *
  */
 public abstract class AsyncFeign<C> extends Feign {
 
-	public static <C> AsyncBuilder<C> asyncBuilder() {
-		return new AsyncBuilder<>();
-	}
+  public static <C> AsyncBuilder<C> asyncBuilder() {
+    return new AsyncBuilder<>();
+  }
 
-	private static class LazyInitializedExecutorService {
+  private static class LazyInitializedExecutorService {
 
-		private static final ExecutorService instance = Executors.newCachedThreadPool(r -> {
-			Thread result = new Thread(r);
-			result.setDaemon(true);
-			return result;
-		});
-	}
+    private static final ExecutorService instance = Executors.newCachedThreadPool(r -> {
+      Thread result = new Thread(r);
+      result.setDaemon(true);
+      return result;
+    });
+  }
 
-	public static class AsyncBuilder<C> {
+  public static class AsyncBuilder<C> {
 
-		private final Builder builder;
-		private Supplier<C> defaultContextSupplier = () -> null;
-		private AsyncClient<C> client;
+    private final Builder builder;
+    private Supplier<C> defaultContextSupplier = () -> null;
+    private AsyncClient<C> client;
 
-		private Logger.Level logLevel = Logger.Level.NONE;
-		private Logger logger = new NoOpLogger();
+    private Logger.Level logLevel = Logger.Level.NONE;
+    private Logger logger = new NoOpLogger();
 
-		private Decoder decoder = new Decoder.Default();
-		private ErrorDecoder errorDecoder = new ErrorDecoder.Default();
-		private boolean decode404;
-		private boolean closeAfterDecode = true;
+    private Decoder decoder = new Decoder.Default();
+    private ErrorDecoder errorDecoder = new ErrorDecoder.Default();
+    private boolean decode404;
+    private boolean closeAfterDecode = true;
 
-		public AsyncBuilder() {
-			super();
-			this.builder = Feign.builder();								
-		}		
-		
-		public AsyncBuilder<C> defaultContextSupplier(Supplier<C> supplier) {
-			this.defaultContextSupplier = supplier;
-			return this;
-		}
+    public AsyncBuilder() {
+      super();
+      this.builder = Feign.builder();
+    }
 
-		public AsyncBuilder<C> client(AsyncClient<C> client) {
-			this.client = client;
-			return this;
-		}
-		
-		/**
-		 * @see Builder#mapAndDecode(ResponseMapper, Decoder)
-		 */
-		public AsyncBuilder<C> mapAndDecode(ResponseMapper mapper, Decoder decoder) {
-			this.decoder = (response, type) -> decoder.decode(mapper.map(response, type), type);
-			return this;
-		}
-		
-		/**
-		 * @see Builder#decoder(Decoder)
-		 */
-		public AsyncBuilder<C> decoder(Decoder decoder) {
-			this.decoder = decoder;
-			return this;
-		}
+    public AsyncBuilder<C> defaultContextSupplier(Supplier<C> supplier) {
+      this.defaultContextSupplier = supplier;
+      return this;
+    }
 
-		/**
-		 * @see Builder#decode404()
-		 */
-		public AsyncBuilder<C> decode404() {
-			this.decode404 = true;
-			return this;
-		}
+    public AsyncBuilder<C> client(AsyncClient<C> client) {
+      this.client = client;
+      return this;
+    }
 
-		/**
-		 * @see Builder#errorDecoder(ErrorDecoder)
-		 */
-		public AsyncBuilder<C> errorDecoder(ErrorDecoder errorDecoder) {
-			this.errorDecoder = errorDecoder;
-			return this;
-		}
-		
-		public AsyncBuilder<C> doNotCloseAfterDecode() {
-			this.closeAfterDecode = false;
-			return this;
-		}
+    /**
+     * @see Builder#mapAndDecode(ResponseMapper, Decoder)
+     */
+    public AsyncBuilder<C> mapAndDecode(ResponseMapper mapper, Decoder decoder) {
+      this.decoder = (response, type) -> decoder.decode(mapper.map(response, type), type);
+      return this;
+    }
 
-		public <T> T target(Class<T> apiType, String url) {
-			return target(new HardCodedTarget<>(apiType, url));
-		}
-		
-		public <T> T target(Class<T> apiType, String url, C context) {
-			return target(new HardCodedTarget<>(apiType, url), context);
-		}
-		
-		public <T> T target(Target<T> target) {
-			return build().newInstance(target);
-		}
+    /**
+     * @see Builder#decoder(Decoder)
+     */
+    public AsyncBuilder<C> decoder(Decoder decoder) {
+      this.decoder = decoder;
+      return this;
+    }
 
-		public <T> T target(Target<T> target, C context) {
-			return build().newInstance(target, context);
-		}
-		
-		private static <C> AsyncClient<C> initDefaultClient() {
-			return new AsyncClient.Default<>(new Client.Default(null, null), LazyInitializedExecutorService.instance);
-		}
-		
-		private AsyncBuilder<C> lazyInits() {
-			if (client == null) {
-				client = initDefaultClient(); 
-			}
-			
-			return this;
-		}
-		
-		public AsyncFeign<C> build() {			
-			return new ReflectiveAsyncFeign<>(lazyInits());
-		}
-		
-		// start of builder delgates
-		
-		/**
-		 * @see Builder#logLevel(Logger.Level)
-		 */
-		public AsyncBuilder<C> logLevel(Logger.Level logLevel) {
-			builder.logLevel(logLevel);
-			return this;
-		}
+    /**
+     * @see Builder#decode404()
+     */
+    public AsyncBuilder<C> decode404() {
+      this.decode404 = true;
+      return this;
+    }
 
-		/**
-		 * @see Builder#contract(Contract)
-		 */
-		public AsyncBuilder<C> contract(Contract contract) {
-			builder.contract(contract);
-			return this;
-		}
+    /**
+     * @see Builder#errorDecoder(ErrorDecoder)
+     */
+    public AsyncBuilder<C> errorDecoder(ErrorDecoder errorDecoder) {
+      this.errorDecoder = errorDecoder;
+      return this;
+    }
 
-		/**
-		 * @see Builder#logLevel(Logger.Level)
-		 */		
-		public AsyncBuilder<C> logger(Logger logger) {
-			builder.logger(logger);
-			return this;
-		}
-		
-		/**
-		 * @see Builder#encoder(Encoder)
-		 */
-		public AsyncBuilder<C> encoder(Encoder encoder) {
-			builder.encoder(encoder);
-			return this;
-		}
-	
-		/**
-		 * @see Builder#queryMapEncoder(QueryMapEncoder)
-		 */
-		public AsyncBuilder<C> queryMapEncoder(QueryMapEncoder queryMapEncoder) {
-			builder.queryMapEncoder(queryMapEncoder);
-			return this;
-		}
+    public AsyncBuilder<C> doNotCloseAfterDecode() {
+      this.closeAfterDecode = false;
+      return this;
+    }
+
+    public <T> T target(Class<T> apiType, String url) {
+      return target(new HardCodedTarget<>(apiType, url));
+    }
+
+    public <T> T target(Class<T> apiType, String url, C context) {
+      return target(new HardCodedTarget<>(apiType, url), context);
+    }
+
+    public <T> T target(Target<T> target) {
+      return build().newInstance(target);
+    }
+
+    public <T> T target(Target<T> target, C context) {
+      return build().newInstance(target, context);
+    }
+
+    private AsyncBuilder<C> lazyInits() {
+      if (client == null) {
+        client = new AsyncClient.Default<>(new Client.Default(null, null), LazyInitializedExecutorService.instance);
+      }
+
+      return this;
+    }
+
+    public AsyncFeign<C> build() {
+      return new ReflectiveAsyncFeign<>(lazyInits());
+    }
+
+    // start of builder delgates
+
+    /**
+     * @see Builder#logLevel(Logger.Level)
+     */
+    public AsyncBuilder<C> logLevel(Logger.Level logLevel) {
+      builder.logLevel(logLevel);
+      return this;
+    }
+
+    /**
+     * @see Builder#contract(Contract)
+     */
+    public AsyncBuilder<C> contract(Contract contract) {
+      builder.contract(contract);
+      return this;
+    }
+
+    /**
+     * @see Builder#logLevel(Logger.Level)
+     */
+    public AsyncBuilder<C> logger(Logger logger) {
+      builder.logger(logger);
+      return this;
+    }
+
+    /**
+     * @see Builder#encoder(Encoder)
+     */
+    public AsyncBuilder<C> encoder(Encoder encoder) {
+      builder.encoder(encoder);
+      return this;
+    }
+
+    /**
+     * @see Builder#queryMapEncoder(QueryMapEncoder)
+     */
+    public AsyncBuilder<C> queryMapEncoder(QueryMapEncoder queryMapEncoder) {
+      builder.queryMapEncoder(queryMapEncoder);
+      return this;
+    }
 
 
-		/**
-		 * @see Builder#options(Options)
-		 */
-		public AsyncBuilder<C> options(Options options) {
-			builder.options(options);
-			return this;
-		}
+    /**
+     * @see Builder#options(Options)
+     */
+    public AsyncBuilder<C> options(Options options) {
+      builder.options(options);
+      return this;
+    }
 
-		/**
-		 * @see Builder#requestInterceptor(RequestInterceptor)
-		 */
-		public AsyncBuilder<C> requestInterceptor(RequestInterceptor requestInterceptor) {
-			builder.requestInterceptor(requestInterceptor);
-			return this;
-		}
+    /**
+     * @see Builder#requestInterceptor(RequestInterceptor)
+     */
+    public AsyncBuilder<C> requestInterceptor(RequestInterceptor requestInterceptor) {
+      builder.requestInterceptor(requestInterceptor);
+      return this;
+    }
 
-		/**
-		 * @see Builder#requestInterceptors(Iterable)
-		 */
-		public AsyncBuilder<C> requestInterceptors(Iterable<RequestInterceptor> requestInterceptors) {
-			builder.requestInterceptors(requestInterceptors);
-			return this;
-		}
+    /**
+     * @see Builder#requestInterceptors(Iterable)
+     */
+    public AsyncBuilder<C> requestInterceptors(Iterable<RequestInterceptor> requestInterceptors) {
+      builder.requestInterceptors(requestInterceptors);
+      return this;
+    }
 
-		/**
-		 * @see Builder#invocationHandlerFactory(InvocationHandlerFactory)
-		 */
-		public AsyncBuilder<C> invocationHandlerFactory(InvocationHandlerFactory invocationHandlerFactory) {
-			builder.invocationHandlerFactory(invocationHandlerFactory);
-			return this;
-		}
-	}
-		
-	private final ThreadLocal<AsyncInvocation<C>> activeContext;
-	
-	private final Feign feign;
+    /**
+     * @see Builder#invocationHandlerFactory(InvocationHandlerFactory)
+     */
+    public AsyncBuilder<C> invocationHandlerFactory(InvocationHandlerFactory invocationHandlerFactory) {
+      builder.invocationHandlerFactory(invocationHandlerFactory);
+      return this;
+    }
+  }
 
-	private final Supplier<C> defaultContextSupplier;
-	private final AsyncClient<C> client;
-	
-	private final Logger.Level logLevel;
-	private final Logger logger;
+  private final ThreadLocal<AsyncInvocation<C>> activeContext;
 
-	private final AsyncResponseHandler responseHandler;
+  private final Feign feign;
 
-	protected AsyncFeign(AsyncBuilder<C> asyncBuilder) {
-		this.activeContext = new ThreadLocal<>();
-		
-		this.defaultContextSupplier = asyncBuilder.defaultContextSupplier;
-		this.client = asyncBuilder.client;
-		
-		this.logLevel = asyncBuilder.logLevel;
-		this.logger = asyncBuilder.logger;
-		
-		this.responseHandler = new AsyncResponseHandler(
-				asyncBuilder.logLevel,
-				asyncBuilder.logger,
-				asyncBuilder.decoder,
-				asyncBuilder.errorDecoder,
-				asyncBuilder.decode404,
-				asyncBuilder.closeAfterDecode);
-		
-		asyncBuilder.builder.client(this::stageExecution);
-		asyncBuilder.builder.decoder(this::stageDecode);
-				
-		this.feign = asyncBuilder.builder.build();
-	}
-	
-	private Response stageExecution(Request request, Options options) {
-		Response result = Response.builder()
-								.status(200)
-								.request(request)
-								.build();
-		
-		AsyncInvocation<C> invocationContext = activeContext.get();
-		
-		invocationContext.setResponseFuture(client.execute(request, options, Optional.ofNullable(invocationContext.context())));
-				
-		
-		return result;
-	}
-	
-	// from SynchronousMethodHandler
-	long elapsedTime(long start) {
-		return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
-	}
+  private final Supplier<C> defaultContextSupplier;
+  private final AsyncClient<C> client;
 
-	
-	private Object stageDecode(Response response, Type type) {
-		AsyncInvocation<C> invocationContext = activeContext.get();
-		
-		CompletableFuture<Object> result = new CompletableFuture<>();
-		
-		invocationContext.responseFuture().whenComplete( (r,t) -> {
-			long elapsedTime = elapsedTime(invocationContext.startNanos());
-			
-			if (t != null) {
-				if (logLevel != Logger.Level.NONE && t instanceof IOException) {
-					IOException e = (IOException)t;					
-					logger.logIOException(invocationContext.configKey(), logLevel, e, elapsedTime);
-				}
-				result.completeExceptionally(t);
-			}
-			else {
-				responseHandler.handleResponse(result, invocationContext, r, invocationContext.underlyingType(), elapsedTime);
-			}
-		});
-		
-		result.whenComplete( (r,t) -> {
-			if (result.isCancelled())
-				invocationContext.responseFuture().cancel(true);
-		});
-		
-		return result;
-	}
-	
+  private final Logger.Level logLevel;
+  private final Logger logger;
 
-	protected void setInvocationContext(AsyncInvocation<C> invocationContext) {
-		activeContext.set(invocationContext);
-	}
-	
-	protected void clearInvocationContext() {
-		activeContext.remove();
-	}
+  private final AsyncResponseHandler responseHandler;
 
-	@Override
-	public <T> T newInstance(Target<T> target) {
-		return newInstance(target, defaultContextSupplier.get());
-	}
-	
-	public <T> T newInstance(Target<T> target, C context) {
-		return wrap(target.type(), feign.newInstance(target), context);
-	}
-	
-	protected abstract <T> T wrap(Class<T> type, T instance, C context);
+  protected AsyncFeign(AsyncBuilder<C> asyncBuilder) {
+    this.activeContext = new ThreadLocal<>();
+
+    this.defaultContextSupplier = asyncBuilder.defaultContextSupplier;
+    this.client = asyncBuilder.client;
+
+    this.logLevel = asyncBuilder.logLevel;
+    this.logger = asyncBuilder.logger;
+
+    this.responseHandler = new AsyncResponseHandler(
+        asyncBuilder.logLevel,
+        asyncBuilder.logger,
+        asyncBuilder.decoder,
+        asyncBuilder.errorDecoder,
+        asyncBuilder.decode404,
+        asyncBuilder.closeAfterDecode);
+
+    asyncBuilder.builder.client(this::stageExecution);
+    asyncBuilder.builder.decoder(this::stageDecode);
+
+    this.feign = asyncBuilder.builder.build();
+  }
+
+  private Response stageExecution(Request request, Options options) {
+    Response result = Response.builder()
+        .status(200)
+        .request(request)
+        .build();
+
+    AsyncInvocation<C> invocationContext = activeContext.get();
+
+    invocationContext.setResponseFuture(
+        client.execute(request, options, Optional.ofNullable(invocationContext.context())));
+
+
+    return result;
+  }
+
+  // from SynchronousMethodHandler
+  long elapsedTime(long start) {
+    return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+  }
+
+
+  private Object stageDecode(Response response, Type type) {
+    AsyncInvocation<C> invocationContext = activeContext.get();
+
+    CompletableFuture<Object> result = new CompletableFuture<>();
+
+    invocationContext.responseFuture().whenComplete((r, t) -> {
+      long elapsedTime = elapsedTime(invocationContext.startNanos());
+
+      if (t != null) {
+        if (logLevel != Logger.Level.NONE && t instanceof IOException) {
+          IOException e = (IOException) t;
+          logger.logIOException(invocationContext.configKey(), logLevel, e, elapsedTime);
+        }
+        result.completeExceptionally(t);
+      } else {
+        responseHandler.handleResponse(result, invocationContext, r,
+            invocationContext.underlyingType(), elapsedTime);
+      }
+    });
+
+    result.whenComplete((r, t) -> {
+      if (result.isCancelled())
+        invocationContext.responseFuture().cancel(true);
+    });
+
+    return result;
+  }
+
+
+  protected void setInvocationContext(AsyncInvocation<C> invocationContext) {
+    activeContext.set(invocationContext);
+  }
+
+  protected void clearInvocationContext() {
+    activeContext.remove();
+  }
+
+  @Override
+  public <T> T newInstance(Target<T> target) {
+    return newInstance(target, defaultContextSupplier.get());
+  }
+
+  public <T> T newInstance(Target<T> target, C context) {
+    return wrap(target.type(), feign.newInstance(target), context);
+  }
+
+  protected abstract <T> T wrap(Class<T> type, T instance, C context);
 }

--- a/core/src/main/java/feign/AsyncInvocation.java
+++ b/core/src/main/java/feign/AsyncInvocation.java
@@ -13,6 +13,7 @@
  */
 package feign;
 
+import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.concurrent.CompletableFuture;
 
@@ -22,16 +23,14 @@ import java.util.concurrent.CompletableFuture;
 class AsyncInvocation<C> {
 
   private final C context;
-  private final String configKey;
-  private final Type underlyingType;
+  private final MethodInfo methodInfo;
   private final long startNanos;
   private CompletableFuture<Response> responseFuture;
 
-  AsyncInvocation(C context, String configKey, Type underlyingType) {
+  AsyncInvocation(C context, MethodInfo methodInfo) {
     super();
     this.context = context;
-    this.configKey = configKey;
-    this.underlyingType = underlyingType;
+    this.methodInfo = methodInfo;
     this.startNanos = System.nanoTime();
   }
 
@@ -40,7 +39,7 @@ class AsyncInvocation<C> {
   }
 
   String configKey() {
-    return configKey;
+    return methodInfo.configKey();
   }
 
   long startNanos() {
@@ -48,7 +47,11 @@ class AsyncInvocation<C> {
   }
 
   Type underlyingType() {
-    return underlyingType;
+    return methodInfo.underlyingReturnType();
+  }
+
+  boolean isAsyncReturnType() {
+    return methodInfo.isAsyncReturnType();
   }
 
   void setResponseFuture(CompletableFuture<Response> responseFuture) {

--- a/core/src/main/java/feign/AsyncInvocation.java
+++ b/core/src/main/java/feign/AsyncInvocation.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package feign;
 
 import java.lang.reflect.Type;
@@ -7,42 +20,42 @@ import java.util.concurrent.CompletableFuture;
  * A specific invocation of an APU
  */
 class AsyncInvocation<C> {
-	
-	private final C context;
-	private final String configKey;
-	private final Type underlyingType;
-	private final long startNanos;
-	private CompletableFuture<Response> responseFuture;
-	
-	AsyncInvocation(C context, String configKey, Type underlyingType) {
-		super();
-		this.context = context;
-		this.configKey = configKey;
-		this.underlyingType = underlyingType;
-		this.startNanos = System.nanoTime();
-	}
 
-	C context() {
-		return context;
-	}
+  private final C context;
+  private final String configKey;
+  private final Type underlyingType;
+  private final long startNanos;
+  private CompletableFuture<Response> responseFuture;
 
-	String configKey() {
-		return configKey;
-	}
+  AsyncInvocation(C context, String configKey, Type underlyingType) {
+    super();
+    this.context = context;
+    this.configKey = configKey;
+    this.underlyingType = underlyingType;
+    this.startNanos = System.nanoTime();
+  }
 
-	long startNanos() {
-		return startNanos;
-	}
-	
-	Type underlyingType() {
-		return underlyingType;
-	}
-	
-	void setResponseFuture(CompletableFuture<Response> responseFuture) {
-		this.responseFuture = responseFuture;		
-	}
-	
-	CompletableFuture<Response> responseFuture() {
-		return responseFuture;
-	}
+  C context() {
+    return context;
+  }
+
+  String configKey() {
+    return configKey;
+  }
+
+  long startNanos() {
+    return startNanos;
+  }
+
+  Type underlyingType() {
+    return underlyingType;
+  }
+
+  void setResponseFuture(CompletableFuture<Response> responseFuture) {
+    this.responseFuture = responseFuture;
+  }
+
+  CompletableFuture<Response> responseFuture() {
+    return responseFuture;
+  }
 }

--- a/core/src/main/java/feign/AsyncInvocation.java
+++ b/core/src/main/java/feign/AsyncInvocation.java
@@ -1,0 +1,48 @@
+package feign;
+
+import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A specific invocation of an APU
+ */
+class AsyncInvocation<C> {
+	
+	private final C context;
+	private final String configKey;
+	private final Type underlyingType;
+	private final long startNanos;
+	private CompletableFuture<Response> responseFuture;
+	
+	AsyncInvocation(C context, String configKey, Type underlyingType) {
+		super();
+		this.context = context;
+		this.configKey = configKey;
+		this.underlyingType = underlyingType;
+		this.startNanos = System.nanoTime();
+	}
+
+	C context() {
+		return context;
+	}
+
+	String configKey() {
+		return configKey;
+	}
+
+	long startNanos() {
+		return startNanos;
+	}
+	
+	Type underlyingType() {
+		return underlyingType;
+	}
+	
+	void setResponseFuture(CompletableFuture<Response> responseFuture) {
+		this.responseFuture = responseFuture;		
+	}
+	
+	CompletableFuture<Response> responseFuture() {
+		return responseFuture;
+	}
+}

--- a/core/src/main/java/feign/AsyncJoinException.java
+++ b/core/src/main/java/feign/AsyncJoinException.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2012-2019 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign;
+
+import java.util.concurrent.CompletableFuture;
+
+import static feign.Util.*;
+
+/**
+ * Thrown to encapsulate an underlying cause when using {@link CompletableFuture#join()}
+ * to convert an asynchronous call to a synchronous one.
+ */
+public class AsyncJoinException extends FeignException {
+
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * @param message possibly null reason for the failure.
+   * @param cause the cause of the error.
+   */
+  public AsyncJoinException(int status, String message, Request request, Throwable cause) {
+    super(status, message, request, checkNotNull(cause, "cause"));
+  }
+}

--- a/core/src/main/java/feign/AsyncResponseHandler.java
+++ b/core/src/main/java/feign/AsyncResponseHandler.java
@@ -50,14 +50,6 @@ class AsyncResponseHandler {
     this.closeAfterDecode = closeAfterDecode;
   }
 
-  void handleResponse(CompletableFuture<Object> resultFuture,
-                      AsyncInvocation<?> invocationContext,
-                      Response response,
-                      Type returnType,
-                      long elapsedTime) {
-    handleResponse(resultFuture, invocationContext.configKey(), response, returnType, elapsedTime);
-  }
-
   boolean isVoidType(Type returnType) {
     return Void.class == returnType || void.class == returnType;
   }

--- a/core/src/main/java/feign/AsyncResponseHandler.java
+++ b/core/src/main/java/feign/AsyncResponseHandler.java
@@ -1,102 +1,128 @@
-
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package feign;
 
 import static feign.FeignException.*;
 import static feign.Util.*;
-
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.concurrent.CompletableFuture;
-
 import feign.Logger.Level;
 import feign.codec.DecodeException;
 import feign.codec.Decoder;
 import feign.codec.ErrorDecoder;
 
 /**
- * The response handler that is used to provide asynchronous support on top of standard
- * response handling
+ * The response handler that is used to provide asynchronous support on top of standard response
+ * handling
  */
 class AsyncResponseHandler {
 
-	private static final long MAX_RESPONSE_BUFFER_SIZE = 8192L;
+  private static final long MAX_RESPONSE_BUFFER_SIZE = 8192L;
 
-	private final Level logLevel;
-	private final Logger logger;
+  private final Level logLevel;
+  private final Logger logger;
 
-	private final Decoder decoder;
-	private final ErrorDecoder errorDecoder;
-	private final boolean decode404;
-	private final boolean closeAfterDecode;
+  private final Decoder decoder;
+  private final ErrorDecoder errorDecoder;
+  private final boolean decode404;
+  private final boolean closeAfterDecode;
 
-	AsyncResponseHandler(Level logLevel, Logger logger, Decoder decoder, ErrorDecoder errorDecoder,
-			boolean decode404, boolean closeAfterDecode) {
-		super();
-		this.logLevel = logLevel;
-		this.logger = logger;
-		this.decoder = decoder;
-		this.errorDecoder = errorDecoder;
-		this.decode404 = decode404;
-		this.closeAfterDecode = closeAfterDecode;
-	}
-	
-	void handleResponse(CompletableFuture<Object> resultFuture, AsyncInvocation<?> invocationContext,
-			Response response, Type type, long elapsedTime) {
-		// copied fairly liberally from SynchronousMethodHandler
-		boolean shouldClose = true;
-		try {
-			if (logLevel != Level.NONE) {
-				response = logger.logAndRebufferResponse(invocationContext.configKey(), logLevel, response,
-						elapsedTime);
-			}
-			if (Response.class == type) {
-				if (response.body() == null) {
-					resultFuture.complete(response);
-				} else if (response.body().length() == null || response.body().length() > MAX_RESPONSE_BUFFER_SIZE) {
-					shouldClose = false;
-					resultFuture.complete(response);
-				} else {
-					// Ensure the response body is disconnected
-					byte[] bodyData = Util.toByteArray(response.body().asInputStream());
-					resultFuture.complete(response.toBuilder().body(bodyData).build());
-				}
-			} else if (response.status() >= 200 && response.status() < 300) {
-				if (Void.class == type) {
-					resultFuture.complete(null);
-				} else {
-					Object result = decode(response, type);
-					shouldClose = closeAfterDecode;
-					resultFuture.complete(result);
-				}
-			} else if (decode404 && response.status() == 404 && Void.class != type) {
-				Object result = decode(response, type);
-				shouldClose = closeAfterDecode;
-				resultFuture.complete(result);
-			} else {
-				resultFuture.completeExceptionally(errorDecoder.decode(invocationContext.configKey(), response));
-			}
-		} catch (IOException e) {
-			if (logLevel != Level.NONE) {
-				logger.logIOException(invocationContext.configKey(), logLevel, e, elapsedTime);
-			}
-			resultFuture.completeExceptionally(errorReading(response.request(), response, e));
-		} catch (Exception e) {
-			resultFuture.completeExceptionally(e);
-		} finally {
-			if (shouldClose) {
-				ensureClosed(response.body());
-			}
-		}
+  AsyncResponseHandler(Level logLevel, Logger logger, Decoder decoder, ErrorDecoder errorDecoder,
+      boolean decode404, boolean closeAfterDecode) {
+    super();
+    this.logLevel = logLevel;
+    this.logger = logger;
+    this.decoder = decoder;
+    this.errorDecoder = errorDecoder;
+    this.decode404 = decode404;
+    this.closeAfterDecode = closeAfterDecode;
+  }
 
-	}
+  void handleResponse(CompletableFuture<Object> resultFuture,
+                      AsyncInvocation<?> invocationContext,
+                      Response response,
+                      Type returnType,
+                      long elapsedTime) {
+    handleResponse(resultFuture, invocationContext.configKey(), response, returnType, elapsedTime);
+  }
 
-	Object decode(Response response, Type type) throws IOException {
-		try {
-			return decoder.decode(response, type);
-		} catch (FeignException e) {
-			throw e;
-		} catch (RuntimeException e) {
-			throw new DecodeException(response.status(), e.getMessage(), response.request(), e);
-		}
-	}
+  boolean isVoidType(Type returnType) {
+    return Void.class == returnType || void.class == returnType;
+  }
+
+  void handleResponse(CompletableFuture<Object> resultFuture,
+                      String configKey,
+                      Response response,
+                      Type returnType,
+                      long elapsedTime) {
+    // copied fairly liberally from SynchronousMethodHandler
+    boolean shouldClose = true;
+
+    try {
+      if (logLevel != Level.NONE) {
+        response = logger.logAndRebufferResponse(configKey, logLevel, response,
+            elapsedTime);
+      }
+      if (Response.class == returnType) {
+        if (response.body() == null) {
+          resultFuture.complete(response);
+        } else if (response.body().length() == null || response.body().length() > MAX_RESPONSE_BUFFER_SIZE) {
+          shouldClose = false;
+          resultFuture.complete(response);
+        } else {
+          // Ensure the response body is disconnected
+          byte[] bodyData = Util.toByteArray(response.body().asInputStream());
+          resultFuture.complete(response.toBuilder().body(bodyData).build());
+        }
+      } else if (response.status() >= 200 && response.status() < 300) {
+        if (isVoidType(returnType)) {
+          resultFuture.complete(null);
+        } else {
+          Object result = decode(response, returnType);
+          shouldClose = closeAfterDecode;
+          resultFuture.complete(result);
+        }
+      } else if (decode404 && response.status() == 404 && !isVoidType(returnType)) {
+        Object result = decode(response, returnType);
+        shouldClose = closeAfterDecode;
+        resultFuture.complete(result);
+      } else {
+        resultFuture.completeExceptionally(errorDecoder.decode(configKey, response));
+      }
+    } catch (IOException e) {
+      if (logLevel != Level.NONE) {
+        logger.logIOException(configKey, logLevel, e, elapsedTime);
+      }
+      resultFuture.completeExceptionally(errorReading(response.request(), response, e));
+    } catch (Exception e) {
+      resultFuture.completeExceptionally(e);
+    } finally {
+      if (shouldClose) {
+        ensureClosed(response.body());
+      }
+    }
+
+  }
+
+  Object decode(Response response, Type type) throws IOException {
+    try {
+      return decoder.decode(response, type);
+    } catch (FeignException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      throw new DecodeException(response.status(), e.getMessage(), response.request(), e);
+    }
+  }
 }

--- a/core/src/main/java/feign/AsyncResponseHandler.java
+++ b/core/src/main/java/feign/AsyncResponseHandler.java
@@ -1,0 +1,102 @@
+
+package feign;
+
+import static feign.FeignException.*;
+import static feign.Util.*;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+
+import feign.Logger.Level;
+import feign.codec.DecodeException;
+import feign.codec.Decoder;
+import feign.codec.ErrorDecoder;
+
+/**
+ * The response handler that is used to provide asynchronous support on top of standard
+ * response handling
+ */
+class AsyncResponseHandler {
+
+	private static final long MAX_RESPONSE_BUFFER_SIZE = 8192L;
+
+	private final Level logLevel;
+	private final Logger logger;
+
+	private final Decoder decoder;
+	private final ErrorDecoder errorDecoder;
+	private final boolean decode404;
+	private final boolean closeAfterDecode;
+
+	AsyncResponseHandler(Level logLevel, Logger logger, Decoder decoder, ErrorDecoder errorDecoder,
+			boolean decode404, boolean closeAfterDecode) {
+		super();
+		this.logLevel = logLevel;
+		this.logger = logger;
+		this.decoder = decoder;
+		this.errorDecoder = errorDecoder;
+		this.decode404 = decode404;
+		this.closeAfterDecode = closeAfterDecode;
+	}
+	
+	void handleResponse(CompletableFuture<Object> resultFuture, AsyncInvocation<?> invocationContext,
+			Response response, Type type, long elapsedTime) {
+		// copied fairly liberally from SynchronousMethodHandler
+		boolean shouldClose = true;
+		try {
+			if (logLevel != Level.NONE) {
+				response = logger.logAndRebufferResponse(invocationContext.configKey(), logLevel, response,
+						elapsedTime);
+			}
+			if (Response.class == type) {
+				if (response.body() == null) {
+					resultFuture.complete(response);
+				} else if (response.body().length() == null || response.body().length() > MAX_RESPONSE_BUFFER_SIZE) {
+					shouldClose = false;
+					resultFuture.complete(response);
+				} else {
+					// Ensure the response body is disconnected
+					byte[] bodyData = Util.toByteArray(response.body().asInputStream());
+					resultFuture.complete(response.toBuilder().body(bodyData).build());
+				}
+			} else if (response.status() >= 200 && response.status() < 300) {
+				if (Void.class == type) {
+					resultFuture.complete(null);
+				} else {
+					Object result = decode(response, type);
+					shouldClose = closeAfterDecode;
+					resultFuture.complete(result);
+				}
+			} else if (decode404 && response.status() == 404 && Void.class != type) {
+				Object result = decode(response, type);
+				shouldClose = closeAfterDecode;
+				resultFuture.complete(result);
+			} else {
+				resultFuture.completeExceptionally(errorDecoder.decode(invocationContext.configKey(), response));
+			}
+		} catch (IOException e) {
+			if (logLevel != Level.NONE) {
+				logger.logIOException(invocationContext.configKey(), logLevel, e, elapsedTime);
+			}
+			resultFuture.completeExceptionally(errorReading(response.request(), response, e));
+		} catch (Exception e) {
+			resultFuture.completeExceptionally(e);
+		} finally {
+			if (shouldClose) {
+				ensureClosed(response.body());
+			}
+		}
+
+	}
+
+	Object decode(Response response, Type type) throws IOException {
+		try {
+			return decoder.decode(response, type);
+		} catch (FeignException e) {
+			throw e;
+		} catch (RuntimeException e) {
+			throw new DecodeException(response.status(), e.getMessage(), response.request(), e);
+		}
+	}
+}

--- a/core/src/main/java/feign/Feign.java
+++ b/core/src/main/java/feign/Feign.java
@@ -112,6 +112,7 @@ public abstract class Feign {
     private boolean decode404;
     private boolean closeAfterDecode = true;
     private ExceptionPropagationPolicy propagationPolicy = NONE;
+    private boolean forceDecoding = false;
 
     public Builder logLevel(Logger.Level logLevel) {
       this.logLevel = logLevel;
@@ -244,6 +245,14 @@ public abstract class Feign {
       return this;
     }
 
+    /**
+     * Internal - used to indicate that the decoder should be immediately called
+     */
+    Builder forceDecoding() {
+      this.forceDecoding = true;
+      return this;
+    }
+
     public <T> T target(Class<T> apiType, String url) {
       return target(new HardCodedTarget<T>(apiType, url));
     }
@@ -255,7 +264,7 @@ public abstract class Feign {
     public Feign build() {
       SynchronousMethodHandler.Factory synchronousMethodHandlerFactory =
           new SynchronousMethodHandler.Factory(client, retryer, requestInterceptors, logger,
-              logLevel, decode404, closeAfterDecode, propagationPolicy);
+              logLevel, decode404, closeAfterDecode, propagationPolicy, forceDecoding);
       ParseHandlersByName handlersByName =
           new ParseHandlersByName(contract, options, encoder, decoder, queryMapEncoder,
               errorDecoder, synchronousMethodHandlerFactory);

--- a/core/src/main/java/feign/MethodInfo.java
+++ b/core/src/main/java/feign/MethodInfo.java
@@ -1,0 +1,39 @@
+package feign;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+
+class MethodInfo {
+  private final String configKey;
+  private final Type underlyingReturnType;
+  private final boolean asyncReturnType;
+
+  MethodInfo(String configKey, Type underlyingReturnType, boolean asyncReturnType) {
+    this.configKey = configKey;
+    this.underlyingReturnType = underlyingReturnType;
+    this.asyncReturnType = asyncReturnType;
+  }
+
+  MethodInfo(Class<?> targetType, Method method) {
+    this.configKey = Feign.configKey(targetType, method);
+
+    Type type = method.getGenericReturnType();
+
+    if (method.getReturnType() != CompletableFuture.class) {
+      this.asyncReturnType = false;
+      this.underlyingReturnType = type;
+    }
+    else {
+      this.asyncReturnType = true;
+      this.underlyingReturnType = ((ParameterizedType) type).getActualTypeArguments()[0];
+    }
+  }
+
+  String configKey() { return configKey; }
+
+  Type underlyingReturnType() { return underlyingReturnType; }
+
+  boolean isAsyncReturnType() { return asyncReturnType; }
+}

--- a/core/src/main/java/feign/ReflectiveAsyncFeign.java
+++ b/core/src/main/java/feign/ReflectiveAsyncFeign.java
@@ -1,0 +1,126 @@
+
+package feign;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Proxy;
+import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+
+public class ReflectiveAsyncFeign<C> extends AsyncFeign<C> {
+
+	private static class MethodInfo {
+		private final String configKey;
+		private final Type underlyingType;
+
+		MethodInfo(Class<?> targetType, Method method) {
+			this.configKey = Feign.configKey(targetType, method);
+
+			Type type = method.getGenericReturnType();
+		
+			this.underlyingType = ((ParameterizedType) type).getActualTypeArguments()[0];
+		}
+	}
+
+	private class AsyncFeignInvocationHandler<T> implements InvocationHandler {
+
+		private final Map<Method, MethodInfo> methodInfoLookup = new ConcurrentHashMap<>();
+
+		private final Class<T> type;
+		private final T instance;
+		private final C context;
+
+		AsyncFeignInvocationHandler(Class<T> type, T instance, C context) {
+			this.type = type;
+			this.instance = instance;
+			this.context = context;
+		}
+
+		@Override
+		public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+			if ("equals".equals(method.getName()) && method.getParameterCount() == 1) {
+				try {
+					Object otherHandler = args.length > 0 && args[0] != null ? Proxy.getInvocationHandler(args[0])
+							: null;
+					return equals(otherHandler);
+				} catch (IllegalArgumentException e) {
+					return false;
+				}
+			} else if ("hashCode".equals(method.getName()) && method.getParameterCount() == 0) {
+				return hashCode();
+			} else if ("toString".equals(method.getName()) && method.getParameterCount() == 0) {
+				return toString();
+			}
+
+			MethodInfo methodInfo = methodInfoLookup.computeIfAbsent(method, m -> new MethodInfo(type, m));
+
+			setInvocationContext(new AsyncInvocation<C>(context, methodInfo.configKey, methodInfo.underlyingType));
+			try {
+				return method.invoke(instance, args);
+			} catch(InvocationTargetException e) {
+				// unwrap
+				throw e.getCause();
+			} finally {
+				clearInvocationContext();
+			}
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public boolean equals(Object obj) {
+			if (obj instanceof AsyncFeignInvocationHandler) {
+				AsyncFeignInvocationHandler<?> other = (AsyncFeignInvocationHandler<?>) obj;
+				return instance.equals(other.instance);
+			}
+			return false;
+		}
+
+		@Override
+		public int hashCode() {
+			return instance.hashCode();
+		}
+
+		@Override
+		public String toString() {
+			return instance.toString();
+		}
+	}
+
+	public ReflectiveAsyncFeign(AsyncBuilder<C> asyncBuilder) {
+		super(asyncBuilder);
+	}
+	
+	private String getFullMethodName(Class<?> type, Type retType, Method m) {
+		return retType.getTypeName() + " " + type.toGenericString() + "." + m.getName();
+	}
+
+	@Override
+	protected <T> T wrap(Class<T> type, T instance, C context) {
+		if (!type.isInterface())
+			throw new IllegalArgumentException("Type must be an interface: " + type);
+
+		for (Method m : type.getMethods()) {
+			Type retType = m.getGenericReturnType();
+			if (m.getReturnType() != CompletableFuture.class)
+				throw new IllegalArgumentException("Method return type is not CompleteableFuture: "
+						+ getFullMethodName(type, retType, m));
+			
+			if (!ParameterizedType.class.isInstance(retType))
+				throw new IllegalArgumentException("Method return type is not parameterized: "
+						+ getFullMethodName(type, retType, m));
+			
+			if (WildcardType.class.isInstance(ParameterizedType.class.cast(retType).getActualTypeArguments()[0]))
+				throw new IllegalArgumentException("Wildcards are not supported for return-type parameters: "
+						+ getFullMethodName(type, retType, m));
+		}
+
+		return type.cast(Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[] { type },
+							new AsyncFeignInvocationHandler<>(type, instance, context)));
+	}
+}

--- a/core/src/main/java/feign/ReflectiveAsyncFeign.java
+++ b/core/src/main/java/feign/ReflectiveAsyncFeign.java
@@ -107,8 +107,7 @@ public class ReflectiveAsyncFeign<C> extends AsyncFeign<C> {
     for (final Method m : type.getMethods()) {
       final Class<?> retType = m.getReturnType();
 
-      if (!CompletableFuture.class.isAssignableFrom(retType))
-       {
+      if (!CompletableFuture.class.isAssignableFrom(retType)) {
         continue; // synchronous case
       }
 

--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2019 The Feign Authors
+ * Copyright 2012-2020 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,20 +15,19 @@ package feign;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import feign.InvocationHandlerFactory.MethodHandler;
 import feign.Request.Options;
-import feign.codec.DecodeException;
 import feign.codec.Decoder;
 import feign.codec.ErrorDecoder;
 import static feign.ExceptionPropagationPolicy.UNWRAP;
 import static feign.FeignException.errorExecuting;
-import static feign.FeignException.errorReading;
 import static feign.Util.checkNotNull;
-import static feign.Util.ensureClosed;
 
-final class SynchronousMethodHandler implements MethodHandler {
+final class SynchronousMethodHandler extends AsyncResponseHandler implements MethodHandler {
 
   private static final long MAX_RESPONSE_BUFFER_SIZE = 8192L;
 
@@ -41,10 +40,6 @@ final class SynchronousMethodHandler implements MethodHandler {
   private final Logger.Level logLevel;
   private final RequestTemplate.Factory buildTemplateFromArgs;
   private final Options options;
-  private final Decoder decoder;
-  private final ErrorDecoder errorDecoder;
-  private final boolean decode404;
-  private final boolean closeAfterDecode;
   private final ExceptionPropagationPolicy propagationPolicy;
 
   private SynchronousMethodHandler(Target<?> target, Client client, Retryer retryer,
@@ -53,6 +48,9 @@ final class SynchronousMethodHandler implements MethodHandler {
       RequestTemplate.Factory buildTemplateFromArgs, Options options,
       Decoder decoder, ErrorDecoder errorDecoder, boolean decode404,
       boolean closeAfterDecode, ExceptionPropagationPolicy propagationPolicy) {
+
+    super(logLevel, logger, decoder, errorDecoder, decode404, closeAfterDecode);
+
     this.target = checkNotNull(target, "target");
     this.client = checkNotNull(client, "client for %s", target);
     this.retryer = checkNotNull(retryer, "retryer for %s", target);
@@ -63,10 +61,6 @@ final class SynchronousMethodHandler implements MethodHandler {
     this.metadata = checkNotNull(metadata, "metadata for %s", target);
     this.buildTemplateFromArgs = checkNotNull(buildTemplateFromArgs, "metadata for %s", target);
     this.options = checkNotNull(options, "options for %s", target);
-    this.errorDecoder = checkNotNull(errorDecoder, "errorDecoder for %s", target);
-    this.decoder = checkNotNull(decoder, "decoder for %s", target);
-    this.decode404 = decode404;
-    this.closeAfterDecode = closeAfterDecode;
     this.propagationPolicy = propagationPolicy;
   }
 
@@ -121,49 +115,20 @@ final class SynchronousMethodHandler implements MethodHandler {
     }
     long elapsedTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
 
-    boolean shouldClose = true;
+    CompletableFuture<Object> resultFuture = new CompletableFuture<>();
+    super.handleResponse(resultFuture, metadata.configKey(), response, metadata.returnType(),
+        elapsedTime);
+
     try {
-      if (logLevel != Logger.Level.NONE) {
-        response =
-            logger.logAndRebufferResponse(metadata.configKey(), logLevel, response, elapsedTime);
-      }
-      if (Response.class == metadata.returnType()) {
-        if (response.body() == null) {
-          return response;
-        }
-        if (response.body().length() == null ||
-            response.body().length() > MAX_RESPONSE_BUFFER_SIZE) {
-          shouldClose = false;
-          return response;
-        }
-        // Ensure the response body is disconnected
-        byte[] bodyData = Util.toByteArray(response.body().asInputStream());
-        return response.toBuilder().body(bodyData).build();
-      }
-      if (response.status() >= 200 && response.status() < 300) {
-        if (void.class == metadata.returnType()) {
-          return null;
-        } else {
-          Object result = decode(response);
-          shouldClose = closeAfterDecode;
-          return result;
-        }
-      } else if (decode404 && response.status() == 404 && void.class != metadata.returnType()) {
-        Object result = decode(response);
-        shouldClose = closeAfterDecode;
-        return result;
-      } else {
-        throw errorDecoder.decode(metadata.configKey(), response);
-      }
-    } catch (IOException e) {
-      if (logLevel != Logger.Level.NONE) {
-        logger.logIOException(metadata.configKey(), logLevel, e, elapsedTime);
-      }
-      throw errorReading(request, response, e);
-    } finally {
-      if (shouldClose) {
-        ensureClosed(response.body());
-      }
+      if (!resultFuture.isDone())
+        throw new IllegalStateException("Response handling not done");
+
+      return resultFuture.join();
+    } catch (CompletionException e) {
+      Throwable cause = e.getCause();
+      if (cause != null)
+        throw cause;
+      throw e;
     }
   }
 
@@ -176,16 +141,6 @@ final class SynchronousMethodHandler implements MethodHandler {
       interceptor.apply(template);
     }
     return target.apply(template);
-  }
-
-  Object decode(Response response) throws Throwable {
-    try {
-      return decoder.decode(response, metadata.returnType());
-    } catch (FeignException e) {
-      throw e;
-    } catch (RuntimeException e) {
-      throw new DecodeException(response.status(), e.getMessage(), response.request(), e);
-    }
   }
 
   Options findOptions(Object[] argv) {

--- a/core/src/test/java/feign/AsyncFeignTest.java
+++ b/core/src/test/java/feign/AsyncFeignTest.java
@@ -997,12 +997,6 @@ public class AsyncFeignTest {
 		thrown.expect(IllegalArgumentException.class);
 		AsyncFeign.asyncBuilder().target(NonInterface.class, "http://localhost");
 	}
-
-	@Test
-	public void testNonCFReturnType() {
-		thrown.expect(IllegalArgumentException.class);
-		AsyncFeign.asyncBuilder().target(NonCFApi.class, "http://localhost");
-	}
 	
 	@Test
 	public void testExtendedCFReturnType() {

--- a/core/src/test/java/feign/AsyncFeignTest.java
+++ b/core/src/test/java/feign/AsyncFeignTest.java
@@ -1,0 +1,1067 @@
+/**
+ * Copyright 2012-2019 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign;
+
+import static feign.Util.*;
+import static feign.assertj.MockWebServerAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import feign.Feign.ResponseMappingDecoder;
+import feign.Request.HttpMethod;
+import feign.Target.HardCodedTarget;
+import feign.codec.DecodeException;
+import feign.codec.Decoder;
+import feign.codec.EncodeException;
+import feign.codec.Encoder;
+import feign.codec.ErrorDecoder;
+import feign.codec.StringDecoder;
+import feign.querymap.BeanQueryMapEncoder;
+import feign.querymap.FieldQueryMapEncoder;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okio.Buffer;
+
+public class AsyncFeignTest {
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+	@Rule
+	public final MockWebServer server = new MockWebServer();
+
+	@Test
+	public void iterableQueryParams() throws Exception {
+		server.enqueue(new MockResponse().setBody("foo"));
+
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+
+		api.queryParams("user", Arrays.asList("apple", "pear"));
+
+		assertThat(server.takeRequest()).hasPath("/?1=user&2=apple&2=pear");
+	}
+
+	@Test
+	public void postTemplateParamsResolve() throws Exception {
+		server.enqueue(new MockResponse().setBody("foo"));
+
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+
+		api.login("netflix", "denominator", "password");
+
+		assertThat(server.takeRequest()).hasBody(
+				"{\"customer_name\": \"netflix\", \"user_name\": \"denominator\", \"password\": \"password\"}");
+	}
+
+	@Test
+	public void responseCoercesToStringBody() throws Throwable {
+		server.enqueue(new MockResponse().setBody("foo"));
+
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+
+		Response response = unwrap(api.response());
+		assertTrue(response.body().isRepeatable());
+		assertEquals("foo", response.body().toString());
+	}
+
+	@Test
+	public void postFormParams() throws Exception {
+		server.enqueue(new MockResponse().setBody("foo"));
+
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+
+		CompletableFuture<?> cf = api.form("netflix", "denominator", "password");
+
+		assertThat(server.takeRequest())
+				.hasBody("{\"customer_name\":\"netflix\",\"user_name\":\"denominator\",\"password\":\"password\"}");
+
+		checkCFCompletedSoon(cf);
+	}
+
+	@Test
+	public void postBodyParam() throws Exception {
+		server.enqueue(new MockResponse().setBody("foo"));
+
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+
+		CompletableFuture<?> cf = api.body(Arrays.asList("netflix", "denominator", "password"));
+
+		assertThat(server.takeRequest()).hasHeaders(entry("Content-Length", Collections.singletonList("32")))
+				.hasBody("[netflix, denominator, password]");
+
+		checkCFCompletedSoon(cf);
+	}
+
+	/**
+	 * The type of a parameter value may not be the desired type to encode as.
+	 * Prefer the interface type.
+	 */
+	@Test
+	public void bodyTypeCorrespondsWithParameterType() throws Exception {
+		server.enqueue(new MockResponse().setBody("foo"));
+
+		final AtomicReference<Type> encodedType = new AtomicReference<Type>();
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().encoder(new Encoder.Default() {
+			@Override
+			public void encode(Object object, Type bodyType, RequestTemplate template) {
+				encodedType.set(bodyType);
+			}
+		}).target("http://localhost:" + server.getPort());
+
+		CompletableFuture<?> cf = api.body(Arrays.asList("netflix", "denominator", "password"));
+
+		server.takeRequest();
+
+		assertThat(encodedType.get()).isEqualTo(new TypeToken<List<String>>() {
+		}.getType());
+
+		checkCFCompletedSoon(cf);
+	}
+
+	@Test
+	public void postGZIPEncodedBodyParam() throws Exception {
+		server.enqueue(new MockResponse().setBody("foo"));
+
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+
+		CompletableFuture<?> cf = api.gzipBody(Arrays.asList("netflix", "denominator", "password"));
+
+		assertThat(server.takeRequest()).hasNoHeaderNamed("Content-Length")
+				.hasGzippedBody("[netflix, denominator, password]".getBytes(UTF_8));
+
+		checkCFCompletedSoon(cf);
+	}
+
+	@Test
+	public void postDeflateEncodedBodyParam() throws Exception {
+		server.enqueue(new MockResponse().setBody("foo"));
+
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+
+		CompletableFuture<?> cf = api.deflateBody(Arrays.asList("netflix", "denominator", "password"));
+
+		assertThat(server.takeRequest()).hasNoHeaderNamed("Content-Length")
+				.hasDeflatedBody("[netflix, denominator, password]".getBytes(UTF_8));
+
+		checkCFCompletedSoon(cf);
+	}
+
+	@Test
+	public void singleInterceptor() throws Exception {
+		server.enqueue(new MockResponse().setBody("foo"));
+
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().requestInterceptor(new ForwardedForInterceptor())
+				.target("http://localhost:" + server.getPort());
+
+		CompletableFuture<?> cf = api.post();
+
+		assertThat(server.takeRequest())
+				.hasHeaders(entry("X-Forwarded-For", Collections.singletonList("origin.host.com")));
+
+		checkCFCompletedSoon(cf);
+	}
+
+	@Test
+	public void multipleInterceptor() throws Exception {
+		server.enqueue(new MockResponse().setBody("foo"));
+
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().requestInterceptor(new ForwardedForInterceptor())
+				.requestInterceptor(new UserAgentInterceptor()).target("http://localhost:" + server.getPort());
+
+		CompletableFuture<?> cf = api.post();
+
+		assertThat(server.takeRequest()).hasHeaders(
+				entry("X-Forwarded-For", Collections.singletonList("origin.host.com")),
+				entry("User-Agent", Collections.singletonList("Feign")));
+
+		checkCFCompletedSoon(cf);
+	}
+
+	@Test
+	public void customExpander() throws Exception {
+		server.enqueue(new MockResponse());
+
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+
+		CompletableFuture<?> cf = api.expand(new Date(1234l));
+
+		assertThat(server.takeRequest()).hasPath("/?date=1234");
+
+		checkCFCompletedSoon(cf);
+	}
+
+	@Test
+	public void customExpanderListParam() throws Exception {
+		server.enqueue(new MockResponse());
+
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+
+		CompletableFuture<?> cf = api.expandList(Arrays.asList(new Date(1234l), new Date(12345l)));
+
+		assertThat(server.takeRequest()).hasPath("/?date=1234&date=12345");
+
+		checkCFCompletedSoon(cf);
+	}
+
+	@Test
+	public void customExpanderNullParam() throws Exception {
+		server.enqueue(new MockResponse());
+
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+
+		CompletableFuture<?> cf = api.expandList(Arrays.asList(new Date(1234l), null));
+
+		assertThat(server.takeRequest()).hasPath("/?date=1234");
+
+		checkCFCompletedSoon(cf);
+	}
+
+	@Test
+	public void headerMap() throws Exception {
+		server.enqueue(new MockResponse());
+
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+
+		Map<String, Object> headerMap = new LinkedHashMap<String, Object>();
+		headerMap.put("Content-Type", "myContent");
+		headerMap.put("Custom-Header", "fooValue");
+		CompletableFuture<?> cf = api.headerMap(headerMap);
+
+		assertThat(server.takeRequest()).hasHeaders(entry("Content-Type", Arrays.asList("myContent")),
+				entry("Custom-Header", Arrays.asList("fooValue")));
+
+		checkCFCompletedSoon(cf);
+	}
+
+	@Test
+	public void headerMapWithHeaderAnnotations() throws Exception {
+		server.enqueue(new MockResponse());
+
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+
+		Map<String, Object> headerMap = new LinkedHashMap<String, Object>();
+		headerMap.put("Custom-Header", "fooValue");
+		api.headerMapWithHeaderAnnotations(headerMap);
+
+		// header map should be additive for headers provided by annotations
+		assertThat(server.takeRequest()).hasHeaders(entry("Content-Encoding", Arrays.asList("deflate")),
+				entry("Custom-Header", Arrays.asList("fooValue")));
+
+		server.enqueue(new MockResponse());
+		headerMap.put("Content-Encoding", "overrideFromMap");
+
+		CompletableFuture<?> cf = api.headerMapWithHeaderAnnotations(headerMap);
+
+		/*
+		 * @HeaderMap map values no longer override @Header parameters. This caused
+		 * confusion as it is valid to have more than one value for a header.
+		 */
+		assertThat(server.takeRequest()).hasHeaders(
+				entry("Content-Encoding", Arrays.asList("deflate", "overrideFromMap")),
+				entry("Custom-Header", Arrays.asList("fooValue")));
+
+		checkCFCompletedSoon(cf);
+	}
+
+	@Test
+	public void queryMap() throws Exception {
+		server.enqueue(new MockResponse());
+
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+
+		Map<String, Object> queryMap = new LinkedHashMap<String, Object>();
+		queryMap.put("name", "alice");
+		queryMap.put("fooKey", "fooValue");
+		CompletableFuture<?> cf = api.queryMap(queryMap);
+
+		assertThat(server.takeRequest()).hasPath("/?name=alice&fooKey=fooValue");
+
+		checkCFCompletedSoon(cf);
+	}
+
+	@Test
+	public void queryMapIterableValuesExpanded() throws Exception {
+		server.enqueue(new MockResponse());
+
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+
+		Map<String, Object> queryMap = new LinkedHashMap<String, Object>();
+		queryMap.put("name", Arrays.asList("Alice", "Bob"));
+		queryMap.put("fooKey", "fooValue");
+		queryMap.put("emptyListKey", new ArrayList<String>());
+		queryMap.put("emptyStringKey", ""); // empty values are ignored.
+		CompletableFuture<?> cf = api.queryMap(queryMap);
+
+		assertThat(server.takeRequest()).hasPath("/?name=Alice&name=Bob&fooKey=fooValue&emptyStringKey");
+
+		checkCFCompletedSoon(cf);
+	}
+
+	@Test
+	public void queryMapWithQueryParams() throws Exception {
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+
+		server.enqueue(new MockResponse());
+		Map<String, Object> queryMap = new LinkedHashMap<String, Object>();
+		queryMap.put("fooKey", "fooValue");
+		api.queryMapWithQueryParams("alice", queryMap);
+		// query map should be expanded after built-in parameters
+		assertThat(server.takeRequest()).hasPath("/?name=alice&fooKey=fooValue");
+
+		server.enqueue(new MockResponse());
+		queryMap = new LinkedHashMap<String, Object>();
+		queryMap.put("name", "bob");
+		api.queryMapWithQueryParams("alice", queryMap);
+		// queries are additive
+		assertThat(server.takeRequest()).hasPath("/?name=alice&name=bob");
+
+		server.enqueue(new MockResponse());
+		queryMap = new LinkedHashMap<String, Object>();
+		queryMap.put("name", null);
+		api.queryMapWithQueryParams("alice", queryMap);
+		// null value for a query map key removes query parameter
+		assertThat(server.takeRequest()).hasPath("/?name=alice");
+	}
+
+	@Test
+	public void queryMapValueStartingWithBrace() throws Exception {
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+
+		server.enqueue(new MockResponse());
+		Map<String, Object> queryMap = new LinkedHashMap<String, Object>();
+		queryMap.put("name", "{alice");
+		api.queryMap(queryMap);
+		assertThat(server.takeRequest()).hasPath("/?name=%7Balice");
+
+		server.enqueue(new MockResponse());
+		queryMap = new LinkedHashMap<String, Object>();
+		queryMap.put("{name", "alice");
+		api.queryMap(queryMap);
+		assertThat(server.takeRequest()).hasPath("/?%7Bname=alice");
+
+		server.enqueue(new MockResponse());
+		queryMap = new LinkedHashMap<String, Object>();
+		queryMap.put("name", "%7Balice");
+		api.queryMapEncoded(queryMap);
+		assertThat(server.takeRequest()).hasPath("/?name=%7Balice");
+
+		server.enqueue(new MockResponse());
+		queryMap = new LinkedHashMap<String, Object>();
+		queryMap.put("%7Bname", "%7Balice");
+		api.queryMapEncoded(queryMap);
+		assertThat(server.takeRequest()).hasPath("/?%7Bname=%7Balice");
+	}
+
+	@Test
+	public void queryMapPojoWithFullParams() throws Exception {
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+
+		CustomPojo customPojo = new CustomPojo("Name", 3);
+
+		server.enqueue(new MockResponse());
+		CompletableFuture<?> cf = api.queryMapPojo(customPojo);
+		assertThat(server.takeRequest()).hasQueryParams(Arrays.asList("name=Name", "number=3"));
+		checkCFCompletedSoon(cf);
+	}
+
+	@Test
+	public void queryMapPojoWithPartialParams() throws Exception {
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+
+		CustomPojo customPojo = new CustomPojo("Name", null);
+
+		server.enqueue(new MockResponse());
+		CompletableFuture<?> cf = api.queryMapPojo(customPojo);
+		assertThat(server.takeRequest()).hasPath("/?name=Name");
+
+		checkCFCompletedSoon(cf);
+	}
+
+	@Test
+	public void queryMapPojoWithEmptyParams() throws Exception {
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+
+		CustomPojo customPojo = new CustomPojo(null, null);
+
+		server.enqueue(new MockResponse());
+		api.queryMapPojo(customPojo);
+		assertThat(server.takeRequest()).hasPath("/");
+	}
+
+	@Test
+	public void configKeyFormatsAsExpected() throws Exception {
+		assertEquals("TestInterfaceAsync#post()",
+				Feign.configKey(TestInterfaceAsync.class, TestInterfaceAsync.class.getDeclaredMethod("post")));
+		assertEquals("TestInterfaceAsync#uriParam(String,URI,String)", Feign.configKey(TestInterfaceAsync.class,
+				TestInterfaceAsync.class.getDeclaredMethod("uriParam", String.class, URI.class, String.class)));
+	}
+
+	@Test
+	public void configKeyUsesChildType() throws Exception {
+		assertEquals("List#iterator()", Feign.configKey(List.class, Iterable.class.getDeclaredMethod("iterator")));
+	}
+
+	private <T> T unwrap(CompletableFuture<T> cf) throws Throwable {
+		try {
+			return cf.get(1, TimeUnit.SECONDS);
+		} catch (ExecutionException e) {
+			throw e.getCause();
+		}
+	}
+
+	@Test
+	public void canOverrideErrorDecoder() throws Throwable {
+		server.enqueue(new MockResponse().setResponseCode(400).setBody("foo"));
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage("bad zone name");
+
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().errorDecoder(new IllegalArgumentExceptionOn400())
+				.target("http://localhost:" + server.getPort());
+
+		unwrap(api.post());
+	}
+
+	@Test
+	public void overrideTypeSpecificDecoder() throws Throwable {
+		server.enqueue(new MockResponse().setBody("success!"));
+
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().decoder(new Decoder() {
+			@Override
+			public Object decode(Response response, Type type) {
+				return "fail";
+			}
+		}).target("http://localhost:" + server.getPort());
+
+		assertEquals("fail", unwrap(api.post()));
+	}
+
+	@Test
+	public void doesntRetryAfterResponseIsSent() throws Throwable {
+		server.enqueue(new MockResponse().setBody("success!"));
+		thrown.expect(FeignException.class);
+		thrown.expectMessage("timeout reading POST http://");
+
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().decoder(new Decoder() {
+			@Override
+			public Object decode(Response response, Type type) throws IOException {
+				throw new IOException("timeout");
+			}
+		}).target("http://localhost:" + server.getPort());
+
+		CompletableFuture<?> cf = api.post();
+		server.takeRequest();
+		unwrap(cf);
+	}
+
+	@Test
+	public void throwsFeignExceptionIncludingBody() throws Throwable {
+		server.enqueue(new MockResponse().setBody("success!"));
+
+		TestInterfaceAsync api = AsyncFeign.asyncBuilder().decoder((response, type) -> {
+			throw new IOException("timeout");
+		}).target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
+
+		CompletableFuture<?> cf = api.body("Request body");
+		server.takeRequest();
+		try {
+			unwrap(cf);
+		} catch (FeignException e) {
+			assertThat(e.getMessage()).isEqualTo("timeout reading POST http://localhost:" + server.getPort() + "/");
+			assertThat(e.contentUTF8()).isEqualTo("Request body");
+			return;
+		}
+		fail();
+	}
+
+	@Test
+	public void throwsFeignExceptionWithoutBody() {
+		server.enqueue(new MockResponse().setBody("success!"));
+
+		TestInterfaceAsync api = AsyncFeign.asyncBuilder().decoder((response, type) -> {
+			throw new IOException("timeout");
+		}).target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
+
+		try {
+			api.noContent();
+		} catch (FeignException e) {
+			assertThat(e.getMessage()).isEqualTo("timeout reading POST http://localhost:" + server.getPort() + "/");
+			assertThat(e.contentUTF8()).isEqualTo("");
+		}
+	}
+
+	@SuppressWarnings("deprecation")
+	@Test
+	public void whenReturnTypeIsResponseNoErrorHandling() throws Throwable {
+		Map<String, Collection<String>> headers = new LinkedHashMap<String, Collection<String>>();
+		headers.put("Location", Arrays.asList("http://bar.com"));
+		final Response response = Response.builder().status(302).reason("Found").headers(headers)
+				.request(Request.create(HttpMethod.GET, "/", Collections.emptyMap(), null, Util.UTF_8))
+				.body(new byte[0]).build();
+
+		ExecutorService execs = Executors.newSingleThreadExecutor();
+
+		// fake client as Client.Default follows redirects.
+		TestInterfaceAsync api = AsyncFeign.<Void>asyncBuilder()
+				.client(new AsyncClient.Default<>((request, options) -> response, execs))
+				.target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
+
+		assertEquals(Collections.singletonList("http://bar.com"), unwrap(api.response()).headers().get("Location"));
+
+		execs.shutdown();
+	}
+
+	@Test
+	public void okIfDecodeRootCauseHasNoMessage() throws Throwable {
+		server.enqueue(new MockResponse().setBody("success!"));
+		thrown.expect(DecodeException.class);
+
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().decoder(new Decoder() {
+			@Override
+			public Object decode(Response response, Type type) throws IOException {
+				throw new RuntimeException();
+			}
+		}).target("http://localhost:" + server.getPort());
+
+		unwrap(api.post());
+	}
+
+	@Test
+	public void decodingExceptionGetWrappedInDecode404Mode() throws Throwable {
+		server.enqueue(new MockResponse().setResponseCode(404));
+		thrown.expect(DecodeException.class);
+		thrown.expectCause(isA(NoSuchElementException.class));
+		;
+
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().decode404().decoder(new Decoder() {
+			@Override
+			public Object decode(Response response, Type type) throws IOException {
+				assertEquals(404, response.status());
+				throw new NoSuchElementException();
+			}
+		}).target("http://localhost:" + server.getPort());
+
+		unwrap(api.post());
+	}
+
+	@Test
+	public void decodingDoesNotSwallow404ErrorsInDecode404Mode() throws Throwable {
+		server.enqueue(new MockResponse().setResponseCode(404));
+		thrown.expect(IllegalArgumentException.class);
+
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().decode404()
+				.errorDecoder(new IllegalArgumentExceptionOn404()).target("http://localhost:" + server.getPort());
+
+		CompletableFuture<Void> cf = api.queryMap(Collections.<String, Object>emptyMap());
+		server.takeRequest();
+		unwrap(cf);
+	}
+
+	@Test
+	public void okIfEncodeRootCauseHasNoMessage() throws Throwable {
+		server.enqueue(new MockResponse().setBody("success!"));
+		thrown.expect(EncodeException.class);
+
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().encoder(new Encoder() {
+			@Override
+			public void encode(Object object, Type bodyType, RequestTemplate template) {
+				throw new RuntimeException();
+			}
+		}).target("http://localhost:" + server.getPort());
+
+		unwrap(api.body(Arrays.asList("foo")));
+	}
+
+	@Test
+	public void equalsHashCodeAndToStringWork() {
+		Target<TestInterfaceAsync> t1 = new HardCodedTarget<TestInterfaceAsync>(TestInterfaceAsync.class,
+				"http://localhost:8080");
+		Target<TestInterfaceAsync> t2 = new HardCodedTarget<TestInterfaceAsync>(TestInterfaceAsync.class,
+				"http://localhost:8888");
+		Target<OtherTestInterfaceAsync> t3 = new HardCodedTarget<OtherTestInterfaceAsync>(OtherTestInterfaceAsync.class,
+				"http://localhost:8080");
+		TestInterfaceAsync i1 = AsyncFeign.asyncBuilder().target(t1);
+		TestInterfaceAsync i2 = AsyncFeign.asyncBuilder().target(t1);
+		TestInterfaceAsync i3 = AsyncFeign.asyncBuilder().target(t2);
+		OtherTestInterfaceAsync i4 = AsyncFeign.asyncBuilder().target(t3);
+
+		assertThat(i1).isEqualTo(i2).isNotEqualTo(i3).isNotEqualTo(i4);
+
+		assertThat(i1.hashCode()).isEqualTo(i2.hashCode()).isNotEqualTo(i3.hashCode()).isNotEqualTo(i4.hashCode());
+
+		assertThat(i1.toString()).isEqualTo(i2.toString()).isNotEqualTo(i3.toString()).isNotEqualTo(i4.toString());
+
+		assertThat(t1).isNotEqualTo(i1);
+
+		assertThat(t1.hashCode()).isEqualTo(i1.hashCode());
+
+		assertThat(t1.toString()).isEqualTo(i1.toString());
+	}
+
+	@SuppressWarnings("resource")
+	@Test
+	public void decodeLogicSupportsByteArray() throws Throwable {
+		byte[] expectedResponse = { 12, 34, 56 };
+		server.enqueue(new MockResponse().setBody(new Buffer().write(expectedResponse)));
+
+		OtherTestInterfaceAsync api = AsyncFeign.asyncBuilder().target(OtherTestInterfaceAsync.class,
+				"http://localhost:" + server.getPort());
+
+		assertThat(unwrap(api.binaryResponseBody())).containsExactly(expectedResponse);
+	}
+
+	@Test
+	public void encodeLogicSupportsByteArray() throws Exception {
+		byte[] expectedRequest = { 12, 34, 56 };
+		server.enqueue(new MockResponse());
+
+		OtherTestInterfaceAsync api = AsyncFeign.asyncBuilder().target(OtherTestInterfaceAsync.class,
+				"http://localhost:" + server.getPort());
+
+		CompletableFuture<?> cf = api.binaryRequestBody(expectedRequest);
+
+		assertThat(server.takeRequest()).hasBody(expectedRequest);
+
+		checkCFCompletedSoon(cf);
+	}
+
+	@Test
+	public void encodedQueryParam() throws Exception {
+		server.enqueue(new MockResponse());
+
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+
+		CompletableFuture<?> cf = api.encodedQueryParam("5.2FSi+");
+
+		assertThat(server.takeRequest()).hasPath("/?trim=5.2FSi%2B");
+
+		checkCFCompletedSoon(cf);
+	}
+
+	private void checkCFCompletedSoon(CompletableFuture<?> cf) {
+		try {
+			unwrap(cf);
+		}catch(RuntimeException e) {
+			throw e;
+		}catch(Throwable t) {
+			throw new RuntimeException(t);
+		}
+	}
+
+	@Test
+	public void responseMapperIsAppliedBeforeDelegate() throws IOException {
+		ResponseMappingDecoder decoder = new ResponseMappingDecoder(upperCaseResponseMapper(), new StringDecoder());
+		String output = (String) decoder.decode(responseWithText("response"), String.class);
+
+		assertThat(output).isEqualTo("RESPONSE");
+	}
+
+	private ResponseMapper upperCaseResponseMapper() {
+		return new ResponseMapper() {
+			@SuppressWarnings("deprecation")
+			@Override
+			public Response map(Response response, Type type) {
+				try {
+					return response.toBuilder().body(Util.toString(response.body().asReader()).toUpperCase().getBytes())
+							.build();
+				} catch (IOException e) {
+					throw new RuntimeException(e);
+				}
+			}
+		};
+	}
+
+	@SuppressWarnings("deprecation")
+	private Response responseWithText(String text) {
+		return Response.builder().body(text, Util.UTF_8).status(200)
+				.request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+				.headers(new HashMap<>()).build();
+	}
+
+	@Test
+	public void mapAndDecodeExecutesMapFunction() throws Throwable {
+		server.enqueue(new MockResponse().setBody("response!"));
+
+		TestInterfaceAsync api = AsyncFeign.asyncBuilder().mapAndDecode(upperCaseResponseMapper(), new StringDecoder())
+				.target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
+
+		assertEquals("RESPONSE!", unwrap(api.post()));
+	}
+
+	@Test
+	public void beanQueryMapEncoderWithPrivateGetterIgnored() throws Exception {
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().queryMapEndcoder(new BeanQueryMapEncoder())
+				.target("http://localhost:" + server.getPort());
+
+		PropertyPojo.ChildPojoClass propertyPojo = new PropertyPojo.ChildPojoClass();
+		propertyPojo.setPrivateGetterProperty("privateGetterProperty");
+		propertyPojo.setName("Name");
+		propertyPojo.setNumber(1);
+
+		server.enqueue(new MockResponse());
+		CompletableFuture<?> cf = api.queryMapPropertyPojo(propertyPojo);
+		assertThat(server.takeRequest()).hasQueryParams(Arrays.asList("name=Name", "number=1"));
+		checkCFCompletedSoon(cf);
+	}
+
+	@Test
+	public void queryMap_with_child_pojo() throws Exception {
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().queryMapEndcoder(new FieldQueryMapEncoder())
+				.target("http://localhost:" + server.getPort());
+
+		ChildPojo childPojo = new ChildPojo();
+		childPojo.setChildPrivateProperty("first");
+		childPojo.setParentProtectedProperty("second");
+		childPojo.setParentPublicProperty("third");
+
+		server.enqueue(new MockResponse());
+		CompletableFuture<?> cf = api.queryMapPropertyInheritence(childPojo);
+		assertThat(server.takeRequest()).hasQueryParams("parentPublicProperty=third", "parentProtectedProperty=second",
+				"childPrivateProperty=first");
+		checkCFCompletedSoon(cf);
+	}
+
+	@Test
+	public void beanQueryMapEncoderWithNullValueIgnored() throws Exception {
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().queryMapEndcoder(new BeanQueryMapEncoder())
+				.target("http://localhost:" + server.getPort());
+
+		PropertyPojo.ChildPojoClass propertyPojo = new PropertyPojo.ChildPojoClass();
+		propertyPojo.setName(null);
+		propertyPojo.setNumber(1);
+
+		server.enqueue(new MockResponse());
+		CompletableFuture<?> cf = api.queryMapPropertyPojo(propertyPojo);
+
+		assertThat(server.takeRequest()).hasQueryParams("number=1");
+
+		checkCFCompletedSoon(cf);
+	}
+
+	@Test
+	public void beanQueryMapEncoderWithEmptyParams() throws Exception {
+		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().queryMapEndcoder(new BeanQueryMapEncoder())
+				.target("http://localhost:" + server.getPort());
+
+		PropertyPojo.ChildPojoClass propertyPojo = new PropertyPojo.ChildPojoClass();
+
+		server.enqueue(new MockResponse());
+		CompletableFuture<?> cf = api.queryMapPropertyPojo(propertyPojo);
+		assertThat(server.takeRequest()).hasQueryParams("/");
+
+		checkCFCompletedSoon(cf);
+	}
+
+	interface TestInterfaceAsync {
+
+		@RequestLine("POST /")
+		CompletableFuture<Response> response();
+
+		@RequestLine("POST /")
+		CompletableFuture<String> post() throws TestInterfaceException;
+
+		@RequestLine("POST /")
+		@Body("%7B\"customer_name\": \"{customer_name}\", \"user_name\": \"{user_name}\", \"password\": \"{password}\"%7D")
+		CompletableFuture<Void> login(@Param("customer_name") String customer, @Param("user_name") String user,
+                                      @Param("password") String password);
+
+		@RequestLine("POST /")
+		CompletableFuture<Void> body(List<String> contents);
+
+		@RequestLine("POST /")
+		CompletableFuture<String> body(String content);
+
+		@RequestLine("POST /")
+		CompletableFuture<String> noContent();
+
+		@RequestLine("POST /")
+		@Headers("Content-Encoding: gzip")
+		CompletableFuture<Void> gzipBody(List<String> contents);
+
+		@RequestLine("POST /")
+		@Headers("Content-Encoding: deflate")
+		CompletableFuture<Void> deflateBody(List<String> contents);
+
+		@RequestLine("POST /")
+		CompletableFuture<Void> form(@Param("customer_name") String customer, @Param("user_name") String user,
+                                     @Param("password") String password);
+
+		@RequestLine("GET /{1}/{2}")
+		CompletableFuture<Response> uriParam(@Param("1") String one, URI endpoint, @Param("2") String two);
+
+		@RequestLine("GET /?1={1}&2={2}")
+		CompletableFuture<Response> queryParams(@Param("1") String one, @Param("2") Iterable<String> twos);
+
+		@RequestLine("POST /?date={date}")
+		CompletableFuture<Void> expand(@Param(value = "date", expander = DateToMillis.class) Date date);
+
+		@RequestLine("GET /?date={date}")
+		CompletableFuture<Void> expandList(@Param(value = "date", expander = DateToMillis.class) List<Date> dates);
+
+		@RequestLine("GET /?date={date}")
+		CompletableFuture<Void> expandArray(@Param(value = "date", expander = DateToMillis.class) Date[] dates);
+
+		@RequestLine("GET /")
+		CompletableFuture<Void> headerMap(@HeaderMap Map<String, Object> headerMap);
+
+		@RequestLine("GET /")
+		@Headers("Content-Encoding: deflate")
+		CompletableFuture<Void> headerMapWithHeaderAnnotations(@HeaderMap Map<String, Object> headerMap);
+
+		@RequestLine("GET /")
+		CompletableFuture<Void> queryMap(@QueryMap Map<String, Object> queryMap);
+
+		@RequestLine("GET /")
+		CompletableFuture<Void> queryMapEncoded(@QueryMap(encoded = true) Map<String, Object> queryMap);
+
+		@RequestLine("GET /?name={name}")
+		CompletableFuture<Void> queryMapWithQueryParams(@Param("name") String name,
+                                                        @QueryMap Map<String, Object> queryMap);
+
+		@RequestLine("GET /?trim={trim}")
+		CompletableFuture<Void> encodedQueryParam(@Param(value = "trim", encoded = true) String trim);
+
+		@RequestLine("GET /")
+		CompletableFuture<Void> queryMapPojo(@QueryMap CustomPojo object);
+
+		@RequestLine("GET /")
+		CompletableFuture<Void> queryMapPropertyPojo(@QueryMap PropertyPojo object);
+
+		@RequestLine("GET /")
+		CompletableFuture<Void> queryMapPropertyInheritence(@QueryMap ChildPojo object);
+
+		class DateToMillis implements Param.Expander {
+
+			@Override
+			public String expand(Object value) {
+				return String.valueOf(((Date) value).getTime());
+			}
+		}
+	}
+
+	class TestInterfaceException extends Exception {
+		private static final long serialVersionUID = 1L;
+
+		TestInterfaceException(String message) {
+			super(message);
+		}
+	}
+
+	interface OtherTestInterfaceAsync {
+
+		@RequestLine("POST /")
+		CompletableFuture<String> post();
+
+		@RequestLine("POST /")
+		CompletableFuture<byte[]> binaryResponseBody();
+
+		@RequestLine("POST /")
+		CompletableFuture<Void> binaryRequestBody(byte[] contents);
+	}
+
+	static class ForwardedForInterceptor implements RequestInterceptor {
+
+		@Override
+		public void apply(RequestTemplate template) {
+			template.header("X-Forwarded-For", "origin.host.com");
+		}
+	}
+
+	static class UserAgentInterceptor implements RequestInterceptor {
+
+		@Override
+		public void apply(RequestTemplate template) {
+			template.header("User-Agent", "Feign");
+		}
+	}
+
+	static class IllegalArgumentExceptionOn400 extends ErrorDecoder.Default {
+
+		@Override
+		public Exception decode(String methodKey, Response response) {
+			if (response.status() == 400) {
+				return new IllegalArgumentException("bad zone name");
+			}
+			return super.decode(methodKey, response);
+		}
+	}
+
+	static class IllegalArgumentExceptionOn404 extends ErrorDecoder.Default {
+
+		@Override
+		public Exception decode(String methodKey, Response response) {
+			if (response.status() == 404) {
+				return new IllegalArgumentException("bad zone name");
+			}
+			return super.decode(methodKey, response);
+		}
+	}
+
+	static final class TestInterfaceAsyncBuilder {
+
+		private final AsyncFeign.AsyncBuilder<Void> delegate = AsyncFeign.<Void>asyncBuilder()
+				.decoder(new Decoder.Default()).encoder(new Encoder() {
+
+					@SuppressWarnings("deprecation")
+					@Override
+					public void encode(Object object, Type bodyType, RequestTemplate template) {
+						if (object instanceof Map) {
+							template.body(new Gson().toJson(object));
+						} else {
+							template.body(object.toString());
+						}
+					}
+				});
+
+		TestInterfaceAsyncBuilder requestInterceptor(RequestInterceptor requestInterceptor) {
+			delegate.requestInterceptor(requestInterceptor);
+			return this;
+		}
+
+		TestInterfaceAsyncBuilder encoder(Encoder encoder) {
+			delegate.encoder(encoder);
+			return this;
+		}
+
+		TestInterfaceAsyncBuilder decoder(Decoder decoder) {
+			delegate.decoder(decoder);
+			return this;
+		}
+
+		TestInterfaceAsyncBuilder errorDecoder(ErrorDecoder errorDecoder) {
+			delegate.errorDecoder(errorDecoder);
+			return this;
+		}
+
+		TestInterfaceAsyncBuilder decode404() {
+			delegate.decode404();
+			return this;
+		}
+
+		TestInterfaceAsyncBuilder queryMapEndcoder(QueryMapEncoder queryMapEncoder) {
+			delegate.queryMapEncoder(queryMapEncoder);
+			return this;
+		}
+
+		TestInterfaceAsync target(String url) {
+			return delegate.target(TestInterfaceAsync.class, url);
+		}
+	}
+	
+	/* ====
+	 * new tests not related to standard Feign begin here
+	 * ====
+	 */
+	
+	@Test
+	public void testNonInterface() {
+		thrown.expect(IllegalArgumentException.class);
+		AsyncFeign.asyncBuilder().target(NonInterface.class, "http://localhost");
+	}
+
+	@Test
+	public void testNonCFReturnType() {
+		thrown.expect(IllegalArgumentException.class);
+		AsyncFeign.asyncBuilder().target(NonCFApi.class, "http://localhost");
+	}
+	
+	@Test
+	public void testExtendedCFReturnType() {
+		thrown.expect(IllegalArgumentException.class);
+		AsyncFeign.asyncBuilder().target(ExtendedCFApi.class, "http://localhost");
+	}
+
+	@Test
+	public void testLowerWildReturnType() {
+		thrown.expect(IllegalArgumentException.class);
+		AsyncFeign.asyncBuilder().target(LowerWildApi.class, "http://localhost");
+	}
+	
+	@Test
+	public void testUpperWildReturnType() {
+		thrown.expect(IllegalArgumentException.class);
+		AsyncFeign.asyncBuilder().target(UpperWildApi.class, "http://localhost");
+	}
+	
+	@Test
+	public void testrWildReturnType() {
+		thrown.expect(IllegalArgumentException.class);
+		AsyncFeign.asyncBuilder().target(WildApi.class, "http://localhost");
+	}
+	
+	
+	static final class ExtendedCF<T> extends CompletableFuture<T> {
+		
+	}
+	
+	static abstract class NonInterface {
+		@RequestLine("GET /")
+		abstract CompletableFuture<Void> x();
+	}
+	
+	static interface NonCFApi {
+		@RequestLine("GET /")
+		void x();
+	}
+	
+	static interface ExtendedCFApi {
+		@RequestLine("GET /")
+		ExtendedCF<Void> x();
+	}
+	
+	static interface LowerWildApi {
+		@RequestLine("GET /")
+		CompletableFuture<? extends Object> x();
+	}
+	
+	static interface UpperWildApi {
+		@RequestLine("GET /")
+		CompletableFuture<? super Object> x();
+	}
+	
+	static interface WildApi {
+		@RequestLine("GET /")
+		CompletableFuture<? extends Object> x();
+	}
+
+
+}

--- a/core/src/test/java/feign/AsyncFeignTest.java
+++ b/core/src/test/java/feign/AsyncFeignTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2019 The Feign Authors
+ * Copyright 2012-2020 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -20,7 +20,6 @@ import static org.assertj.core.data.MapEntry.entry;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 import static org.junit.Assert.fail;
-
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.net.URI;
@@ -40,14 +39,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-
 import feign.Feign.ResponseMappingDecoder;
 import feign.Request.HttpMethod;
 import feign.Target.HardCodedTarget;
@@ -65,1003 +61,1055 @@ import okio.Buffer;
 
 public class AsyncFeignTest {
 
-	@Rule
-	public final ExpectedException thrown = ExpectedException.none();
-	@Rule
-	public final MockWebServer server = new MockWebServer();
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+  @Rule
+  public final MockWebServer server = new MockWebServer();
 
-	@Test
-	public void iterableQueryParams() throws Exception {
-		server.enqueue(new MockResponse().setBody("foo"));
+  @Test
+  public void iterableQueryParams() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
 
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+    TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
 
-		api.queryParams("user", Arrays.asList("apple", "pear"));
+    api.queryParams("user", Arrays.asList("apple", "pear"));
 
-		assertThat(server.takeRequest()).hasPath("/?1=user&2=apple&2=pear");
-	}
+    assertThat(server.takeRequest()).hasPath("/?1=user&2=apple&2=pear");
+  }
 
-	@Test
-	public void postTemplateParamsResolve() throws Exception {
-		server.enqueue(new MockResponse().setBody("foo"));
+  @Test
+  public void postTemplateParamsResolve() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
 
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+    TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
 
-		api.login("netflix", "denominator", "password");
+    api.login("netflix", "denominator", "password");
 
-		assertThat(server.takeRequest()).hasBody(
-				"{\"customer_name\": \"netflix\", \"user_name\": \"denominator\", \"password\": \"password\"}");
-	}
+    assertThat(server.takeRequest()).hasBody(
+        "{\"customer_name\": \"netflix\", \"user_name\": \"denominator\", \"password\": \"password\"}");
+  }
 
-	@Test
-	public void responseCoercesToStringBody() throws Throwable {
-		server.enqueue(new MockResponse().setBody("foo"));
+  @Test
+  public void responseCoercesToStringBody() throws Throwable {
+    server.enqueue(new MockResponse().setBody("foo"));
 
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+    TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
 
-		Response response = unwrap(api.response());
-		assertTrue(response.body().isRepeatable());
-		assertEquals("foo", response.body().toString());
-	}
+    Response response = unwrap(api.response());
+    assertTrue(response.body().isRepeatable());
+    assertEquals("foo", response.body().toString());
+  }
 
-	@Test
-	public void postFormParams() throws Exception {
-		server.enqueue(new MockResponse().setBody("foo"));
+  @Test
+  public void postFormParams() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
 
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+    TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
 
-		CompletableFuture<?> cf = api.form("netflix", "denominator", "password");
+    CompletableFuture<?> cf = api.form("netflix", "denominator", "password");
 
-		assertThat(server.takeRequest())
-				.hasBody("{\"customer_name\":\"netflix\",\"user_name\":\"denominator\",\"password\":\"password\"}");
+    assertThat(server.takeRequest())
+        .hasBody(
+            "{\"customer_name\":\"netflix\",\"user_name\":\"denominator\",\"password\":\"password\"}");
 
-		checkCFCompletedSoon(cf);
-	}
+    checkCFCompletedSoon(cf);
+  }
 
-	@Test
-	public void postBodyParam() throws Exception {
-		server.enqueue(new MockResponse().setBody("foo"));
+  @Test
+  public void postBodyParam() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
 
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+    TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
 
-		CompletableFuture<?> cf = api.body(Arrays.asList("netflix", "denominator", "password"));
+    CompletableFuture<?> cf = api.body(Arrays.asList("netflix", "denominator", "password"));
 
-		assertThat(server.takeRequest()).hasHeaders(entry("Content-Length", Collections.singletonList("32")))
-				.hasBody("[netflix, denominator, password]");
+    assertThat(server.takeRequest())
+        .hasHeaders(entry("Content-Length", Collections.singletonList("32")))
+        .hasBody("[netflix, denominator, password]");
 
-		checkCFCompletedSoon(cf);
-	}
+    checkCFCompletedSoon(cf);
+  }
 
-	/**
-	 * The type of a parameter value may not be the desired type to encode as.
-	 * Prefer the interface type.
-	 */
-	@Test
-	public void bodyTypeCorrespondsWithParameterType() throws Exception {
-		server.enqueue(new MockResponse().setBody("foo"));
+  /**
+   * The type of a parameter value may not be the desired type to encode as. Prefer the interface
+   * type.
+   */
+  @Test
+  public void bodyTypeCorrespondsWithParameterType() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
 
-		final AtomicReference<Type> encodedType = new AtomicReference<Type>();
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().encoder(new Encoder.Default() {
-			@Override
-			public void encode(Object object, Type bodyType, RequestTemplate template) {
-				encodedType.set(bodyType);
-			}
-		}).target("http://localhost:" + server.getPort());
+    final AtomicReference<Type> encodedType = new AtomicReference<Type>();
+    TestInterfaceAsync api = new TestInterfaceAsyncBuilder().encoder(new Encoder.Default() {
+      @Override
+      public void encode(Object object, Type bodyType, RequestTemplate template) {
+        encodedType.set(bodyType);
+      }
+    }).target("http://localhost:" + server.getPort());
 
-		CompletableFuture<?> cf = api.body(Arrays.asList("netflix", "denominator", "password"));
+    CompletableFuture<?> cf = api.body(Arrays.asList("netflix", "denominator", "password"));
 
-		server.takeRequest();
+    server.takeRequest();
 
-		assertThat(encodedType.get()).isEqualTo(new TypeToken<List<String>>() {
-		}.getType());
+    assertThat(encodedType.get()).isEqualTo(new TypeToken<List<String>>() {}.getType());
 
-		checkCFCompletedSoon(cf);
-	}
+    checkCFCompletedSoon(cf);
+  }
 
-	@Test
-	public void postGZIPEncodedBodyParam() throws Exception {
-		server.enqueue(new MockResponse().setBody("foo"));
+  @Test
+  public void postGZIPEncodedBodyParam() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
 
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+    TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
 
-		CompletableFuture<?> cf = api.gzipBody(Arrays.asList("netflix", "denominator", "password"));
+    CompletableFuture<?> cf = api.gzipBody(Arrays.asList("netflix", "denominator", "password"));
 
-		assertThat(server.takeRequest()).hasNoHeaderNamed("Content-Length")
-				.hasGzippedBody("[netflix, denominator, password]".getBytes(UTF_8));
+    assertThat(server.takeRequest()).hasNoHeaderNamed("Content-Length")
+        .hasGzippedBody("[netflix, denominator, password]".getBytes(UTF_8));
 
-		checkCFCompletedSoon(cf);
-	}
+    checkCFCompletedSoon(cf);
+  }
 
-	@Test
-	public void postDeflateEncodedBodyParam() throws Exception {
-		server.enqueue(new MockResponse().setBody("foo"));
+  @Test
+  public void postDeflateEncodedBodyParam() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
 
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+    TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
 
-		CompletableFuture<?> cf = api.deflateBody(Arrays.asList("netflix", "denominator", "password"));
+    CompletableFuture<?> cf = api.deflateBody(Arrays.asList("netflix", "denominator", "password"));
 
-		assertThat(server.takeRequest()).hasNoHeaderNamed("Content-Length")
-				.hasDeflatedBody("[netflix, denominator, password]".getBytes(UTF_8));
+    assertThat(server.takeRequest()).hasNoHeaderNamed("Content-Length")
+        .hasDeflatedBody("[netflix, denominator, password]".getBytes(UTF_8));
 
-		checkCFCompletedSoon(cf);
-	}
+    checkCFCompletedSoon(cf);
+  }
 
-	@Test
-	public void singleInterceptor() throws Exception {
-		server.enqueue(new MockResponse().setBody("foo"));
+  @Test
+  public void singleInterceptor() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
 
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().requestInterceptor(new ForwardedForInterceptor())
-				.target("http://localhost:" + server.getPort());
+    TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().requestInterceptor(new ForwardedForInterceptor())
+            .target("http://localhost:" + server.getPort());
 
-		CompletableFuture<?> cf = api.post();
+    CompletableFuture<?> cf = api.post();
 
-		assertThat(server.takeRequest())
-				.hasHeaders(entry("X-Forwarded-For", Collections.singletonList("origin.host.com")));
+    assertThat(server.takeRequest())
+        .hasHeaders(entry("X-Forwarded-For", Collections.singletonList("origin.host.com")));
 
-		checkCFCompletedSoon(cf);
-	}
+    checkCFCompletedSoon(cf);
+  }
 
-	@Test
-	public void multipleInterceptor() throws Exception {
-		server.enqueue(new MockResponse().setBody("foo"));
+  @Test
+  public void multipleInterceptor() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
 
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().requestInterceptor(new ForwardedForInterceptor())
-				.requestInterceptor(new UserAgentInterceptor()).target("http://localhost:" + server.getPort());
+    TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().requestInterceptor(new ForwardedForInterceptor())
+            .requestInterceptor(new UserAgentInterceptor())
+            .target("http://localhost:" + server.getPort());
 
-		CompletableFuture<?> cf = api.post();
+    CompletableFuture<?> cf = api.post();
 
-		assertThat(server.takeRequest()).hasHeaders(
-				entry("X-Forwarded-For", Collections.singletonList("origin.host.com")),
-				entry("User-Agent", Collections.singletonList("Feign")));
+    assertThat(server.takeRequest()).hasHeaders(
+        entry("X-Forwarded-For", Collections.singletonList("origin.host.com")),
+        entry("User-Agent", Collections.singletonList("Feign")));
 
-		checkCFCompletedSoon(cf);
-	}
+    checkCFCompletedSoon(cf);
+  }
 
-	@Test
-	public void customExpander() throws Exception {
-		server.enqueue(new MockResponse());
+  @Test
+  public void customExpander() throws Exception {
+    server.enqueue(new MockResponse());
 
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+    TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
 
-		CompletableFuture<?> cf = api.expand(new Date(1234l));
+    CompletableFuture<?> cf = api.expand(new Date(1234l));
 
-		assertThat(server.takeRequest()).hasPath("/?date=1234");
+    assertThat(server.takeRequest()).hasPath("/?date=1234");
 
-		checkCFCompletedSoon(cf);
-	}
+    checkCFCompletedSoon(cf);
+  }
 
-	@Test
-	public void customExpanderListParam() throws Exception {
-		server.enqueue(new MockResponse());
+  @Test
+  public void customExpanderListParam() throws Exception {
+    server.enqueue(new MockResponse());
 
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+    TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
 
-		CompletableFuture<?> cf = api.expandList(Arrays.asList(new Date(1234l), new Date(12345l)));
+    CompletableFuture<?> cf = api.expandList(Arrays.asList(new Date(1234l), new Date(12345l)));
 
-		assertThat(server.takeRequest()).hasPath("/?date=1234&date=12345");
+    assertThat(server.takeRequest()).hasPath("/?date=1234&date=12345");
 
-		checkCFCompletedSoon(cf);
-	}
+    checkCFCompletedSoon(cf);
+  }
 
-	@Test
-	public void customExpanderNullParam() throws Exception {
-		server.enqueue(new MockResponse());
+  @Test
+  public void customExpanderNullParam() throws Exception {
+    server.enqueue(new MockResponse());
 
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+    TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
 
-		CompletableFuture<?> cf = api.expandList(Arrays.asList(new Date(1234l), null));
+    CompletableFuture<?> cf = api.expandList(Arrays.asList(new Date(1234l), null));
 
-		assertThat(server.takeRequest()).hasPath("/?date=1234");
+    assertThat(server.takeRequest()).hasPath("/?date=1234");
 
-		checkCFCompletedSoon(cf);
-	}
+    checkCFCompletedSoon(cf);
+  }
 
-	@Test
-	public void headerMap() throws Exception {
-		server.enqueue(new MockResponse());
+  @Test
+  public void headerMap() throws Exception {
+    server.enqueue(new MockResponse());
 
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+    TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
 
-		Map<String, Object> headerMap = new LinkedHashMap<String, Object>();
-		headerMap.put("Content-Type", "myContent");
-		headerMap.put("Custom-Header", "fooValue");
-		CompletableFuture<?> cf = api.headerMap(headerMap);
+    Map<String, Object> headerMap = new LinkedHashMap<String, Object>();
+    headerMap.put("Content-Type", "myContent");
+    headerMap.put("Custom-Header", "fooValue");
+    CompletableFuture<?> cf = api.headerMap(headerMap);
 
-		assertThat(server.takeRequest()).hasHeaders(entry("Content-Type", Arrays.asList("myContent")),
-				entry("Custom-Header", Arrays.asList("fooValue")));
+    assertThat(server.takeRequest()).hasHeaders(entry("Content-Type", Arrays.asList("myContent")),
+        entry("Custom-Header", Arrays.asList("fooValue")));
 
-		checkCFCompletedSoon(cf);
-	}
+    checkCFCompletedSoon(cf);
+  }
 
-	@Test
-	public void headerMapWithHeaderAnnotations() throws Exception {
-		server.enqueue(new MockResponse());
+  @Test
+  public void headerMapWithHeaderAnnotations() throws Exception {
+    server.enqueue(new MockResponse());
 
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+    TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
 
-		Map<String, Object> headerMap = new LinkedHashMap<String, Object>();
-		headerMap.put("Custom-Header", "fooValue");
-		api.headerMapWithHeaderAnnotations(headerMap);
+    Map<String, Object> headerMap = new LinkedHashMap<String, Object>();
+    headerMap.put("Custom-Header", "fooValue");
+    api.headerMapWithHeaderAnnotations(headerMap);
 
-		// header map should be additive for headers provided by annotations
-		assertThat(server.takeRequest()).hasHeaders(entry("Content-Encoding", Arrays.asList("deflate")),
-				entry("Custom-Header", Arrays.asList("fooValue")));
+    // header map should be additive for headers provided by annotations
+    assertThat(server.takeRequest()).hasHeaders(entry("Content-Encoding", Arrays.asList("deflate")),
+        entry("Custom-Header", Arrays.asList("fooValue")));
 
-		server.enqueue(new MockResponse());
-		headerMap.put("Content-Encoding", "overrideFromMap");
+    server.enqueue(new MockResponse());
+    headerMap.put("Content-Encoding", "overrideFromMap");
 
-		CompletableFuture<?> cf = api.headerMapWithHeaderAnnotations(headerMap);
+    CompletableFuture<?> cf = api.headerMapWithHeaderAnnotations(headerMap);
 
-		/*
-		 * @HeaderMap map values no longer override @Header parameters. This caused
-		 * confusion as it is valid to have more than one value for a header.
-		 */
-		assertThat(server.takeRequest()).hasHeaders(
-				entry("Content-Encoding", Arrays.asList("deflate", "overrideFromMap")),
-				entry("Custom-Header", Arrays.asList("fooValue")));
+    /*
+     * @HeaderMap map values no longer override @Header parameters. This caused confusion as it is
+     * valid to have more than one value for a header.
+     */
+    assertThat(server.takeRequest()).hasHeaders(
+        entry("Content-Encoding", Arrays.asList("deflate", "overrideFromMap")),
+        entry("Custom-Header", Arrays.asList("fooValue")));
 
-		checkCFCompletedSoon(cf);
-	}
+    checkCFCompletedSoon(cf);
+  }
 
-	@Test
-	public void queryMap() throws Exception {
-		server.enqueue(new MockResponse());
+  @Test
+  public void queryMap() throws Exception {
+    server.enqueue(new MockResponse());
 
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+    TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
 
-		Map<String, Object> queryMap = new LinkedHashMap<String, Object>();
-		queryMap.put("name", "alice");
-		queryMap.put("fooKey", "fooValue");
-		CompletableFuture<?> cf = api.queryMap(queryMap);
+    Map<String, Object> queryMap = new LinkedHashMap<String, Object>();
+    queryMap.put("name", "alice");
+    queryMap.put("fooKey", "fooValue");
+    CompletableFuture<?> cf = api.queryMap(queryMap);
 
-		assertThat(server.takeRequest()).hasPath("/?name=alice&fooKey=fooValue");
+    assertThat(server.takeRequest()).hasPath("/?name=alice&fooKey=fooValue");
 
-		checkCFCompletedSoon(cf);
-	}
+    checkCFCompletedSoon(cf);
+  }
 
-	@Test
-	public void queryMapIterableValuesExpanded() throws Exception {
-		server.enqueue(new MockResponse());
+  @Test
+  public void queryMapIterableValuesExpanded() throws Exception {
+    server.enqueue(new MockResponse());
 
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+    TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
 
-		Map<String, Object> queryMap = new LinkedHashMap<String, Object>();
-		queryMap.put("name", Arrays.asList("Alice", "Bob"));
-		queryMap.put("fooKey", "fooValue");
-		queryMap.put("emptyListKey", new ArrayList<String>());
-		queryMap.put("emptyStringKey", ""); // empty values are ignored.
-		CompletableFuture<?> cf = api.queryMap(queryMap);
+    Map<String, Object> queryMap = new LinkedHashMap<String, Object>();
+    queryMap.put("name", Arrays.asList("Alice", "Bob"));
+    queryMap.put("fooKey", "fooValue");
+    queryMap.put("emptyListKey", new ArrayList<String>());
+    queryMap.put("emptyStringKey", ""); // empty values are ignored.
+    CompletableFuture<?> cf = api.queryMap(queryMap);
 
-		assertThat(server.takeRequest()).hasPath("/?name=Alice&name=Bob&fooKey=fooValue&emptyStringKey");
+    assertThat(server.takeRequest())
+        .hasPath("/?name=Alice&name=Bob&fooKey=fooValue&emptyStringKey");
 
-		checkCFCompletedSoon(cf);
-	}
+    checkCFCompletedSoon(cf);
+  }
 
-	@Test
-	public void queryMapWithQueryParams() throws Exception {
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+  @Test
+  public void queryMapWithQueryParams() throws Exception {
+    TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
 
-		server.enqueue(new MockResponse());
-		Map<String, Object> queryMap = new LinkedHashMap<String, Object>();
-		queryMap.put("fooKey", "fooValue");
-		api.queryMapWithQueryParams("alice", queryMap);
-		// query map should be expanded after built-in parameters
-		assertThat(server.takeRequest()).hasPath("/?name=alice&fooKey=fooValue");
+    server.enqueue(new MockResponse());
+    Map<String, Object> queryMap = new LinkedHashMap<String, Object>();
+    queryMap.put("fooKey", "fooValue");
+    api.queryMapWithQueryParams("alice", queryMap);
+    // query map should be expanded after built-in parameters
+    assertThat(server.takeRequest()).hasPath("/?name=alice&fooKey=fooValue");
 
-		server.enqueue(new MockResponse());
-		queryMap = new LinkedHashMap<String, Object>();
-		queryMap.put("name", "bob");
-		api.queryMapWithQueryParams("alice", queryMap);
-		// queries are additive
-		assertThat(server.takeRequest()).hasPath("/?name=alice&name=bob");
+    server.enqueue(new MockResponse());
+    queryMap = new LinkedHashMap<String, Object>();
+    queryMap.put("name", "bob");
+    api.queryMapWithQueryParams("alice", queryMap);
+    // queries are additive
+    assertThat(server.takeRequest()).hasPath("/?name=alice&name=bob");
 
-		server.enqueue(new MockResponse());
-		queryMap = new LinkedHashMap<String, Object>();
-		queryMap.put("name", null);
-		api.queryMapWithQueryParams("alice", queryMap);
-		// null value for a query map key removes query parameter
-		assertThat(server.takeRequest()).hasPath("/?name=alice");
-	}
+    server.enqueue(new MockResponse());
+    queryMap = new LinkedHashMap<String, Object>();
+    queryMap.put("name", null);
+    api.queryMapWithQueryParams("alice", queryMap);
+    // null value for a query map key removes query parameter
+    assertThat(server.takeRequest()).hasPath("/?name=alice");
+  }
 
-	@Test
-	public void queryMapValueStartingWithBrace() throws Exception {
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+  @Test
+  public void queryMapValueStartingWithBrace() throws Exception {
+    TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
 
-		server.enqueue(new MockResponse());
-		Map<String, Object> queryMap = new LinkedHashMap<String, Object>();
-		queryMap.put("name", "{alice");
-		api.queryMap(queryMap);
-		assertThat(server.takeRequest()).hasPath("/?name=%7Balice");
+    server.enqueue(new MockResponse());
+    Map<String, Object> queryMap = new LinkedHashMap<String, Object>();
+    queryMap.put("name", "{alice");
+    api.queryMap(queryMap);
+    assertThat(server.takeRequest()).hasPath("/?name=%7Balice");
 
-		server.enqueue(new MockResponse());
-		queryMap = new LinkedHashMap<String, Object>();
-		queryMap.put("{name", "alice");
-		api.queryMap(queryMap);
-		assertThat(server.takeRequest()).hasPath("/?%7Bname=alice");
+    server.enqueue(new MockResponse());
+    queryMap = new LinkedHashMap<String, Object>();
+    queryMap.put("{name", "alice");
+    api.queryMap(queryMap);
+    assertThat(server.takeRequest()).hasPath("/?%7Bname=alice");
 
-		server.enqueue(new MockResponse());
-		queryMap = new LinkedHashMap<String, Object>();
-		queryMap.put("name", "%7Balice");
-		api.queryMapEncoded(queryMap);
-		assertThat(server.takeRequest()).hasPath("/?name=%7Balice");
+    server.enqueue(new MockResponse());
+    queryMap = new LinkedHashMap<String, Object>();
+    queryMap.put("name", "%7Balice");
+    api.queryMapEncoded(queryMap);
+    assertThat(server.takeRequest()).hasPath("/?name=%7Balice");
 
-		server.enqueue(new MockResponse());
-		queryMap = new LinkedHashMap<String, Object>();
-		queryMap.put("%7Bname", "%7Balice");
-		api.queryMapEncoded(queryMap);
-		assertThat(server.takeRequest()).hasPath("/?%7Bname=%7Balice");
-	}
+    server.enqueue(new MockResponse());
+    queryMap = new LinkedHashMap<String, Object>();
+    queryMap.put("%7Bname", "%7Balice");
+    api.queryMapEncoded(queryMap);
+    assertThat(server.takeRequest()).hasPath("/?%7Bname=%7Balice");
+  }
 
-	@Test
-	public void queryMapPojoWithFullParams() throws Exception {
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+  @Test
+  public void queryMapPojoWithFullParams() throws Exception {
+    TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
 
-		CustomPojo customPojo = new CustomPojo("Name", 3);
-
-		server.enqueue(new MockResponse());
-		CompletableFuture<?> cf = api.queryMapPojo(customPojo);
-		assertThat(server.takeRequest()).hasQueryParams(Arrays.asList("name=Name", "number=3"));
-		checkCFCompletedSoon(cf);
-	}
-
-	@Test
-	public void queryMapPojoWithPartialParams() throws Exception {
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
-
-		CustomPojo customPojo = new CustomPojo("Name", null);
-
-		server.enqueue(new MockResponse());
-		CompletableFuture<?> cf = api.queryMapPojo(customPojo);
-		assertThat(server.takeRequest()).hasPath("/?name=Name");
-
-		checkCFCompletedSoon(cf);
-	}
-
-	@Test
-	public void queryMapPojoWithEmptyParams() throws Exception {
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
-
-		CustomPojo customPojo = new CustomPojo(null, null);
-
-		server.enqueue(new MockResponse());
-		api.queryMapPojo(customPojo);
-		assertThat(server.takeRequest()).hasPath("/");
-	}
-
-	@Test
-	public void configKeyFormatsAsExpected() throws Exception {
-		assertEquals("TestInterfaceAsync#post()",
-				Feign.configKey(TestInterfaceAsync.class, TestInterfaceAsync.class.getDeclaredMethod("post")));
-		assertEquals("TestInterfaceAsync#uriParam(String,URI,String)", Feign.configKey(TestInterfaceAsync.class,
-				TestInterfaceAsync.class.getDeclaredMethod("uriParam", String.class, URI.class, String.class)));
-	}
-
-	@Test
-	public void configKeyUsesChildType() throws Exception {
-		assertEquals("List#iterator()", Feign.configKey(List.class, Iterable.class.getDeclaredMethod("iterator")));
-	}
-
-	private <T> T unwrap(CompletableFuture<T> cf) throws Throwable {
-		try {
-			return cf.get(1, TimeUnit.SECONDS);
-		} catch (ExecutionException e) {
-			throw e.getCause();
-		}
-	}
-
-	@Test
-	public void canOverrideErrorDecoder() throws Throwable {
-		server.enqueue(new MockResponse().setResponseCode(400).setBody("foo"));
-		thrown.expect(IllegalArgumentException.class);
-		thrown.expectMessage("bad zone name");
-
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().errorDecoder(new IllegalArgumentExceptionOn400())
-				.target("http://localhost:" + server.getPort());
-
-		unwrap(api.post());
-	}
-
-	@Test
-	public void overrideTypeSpecificDecoder() throws Throwable {
-		server.enqueue(new MockResponse().setBody("success!"));
-
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().decoder(new Decoder() {
-			@Override
-			public Object decode(Response response, Type type) {
-				return "fail";
-			}
-		}).target("http://localhost:" + server.getPort());
-
-		assertEquals("fail", unwrap(api.post()));
-	}
-
-	@Test
-	public void doesntRetryAfterResponseIsSent() throws Throwable {
-		server.enqueue(new MockResponse().setBody("success!"));
-		thrown.expect(FeignException.class);
-		thrown.expectMessage("timeout reading POST http://");
-
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().decoder(new Decoder() {
-			@Override
-			public Object decode(Response response, Type type) throws IOException {
-				throw new IOException("timeout");
-			}
-		}).target("http://localhost:" + server.getPort());
-
-		CompletableFuture<?> cf = api.post();
-		server.takeRequest();
-		unwrap(cf);
-	}
-
-	@Test
-	public void throwsFeignExceptionIncludingBody() throws Throwable {
-		server.enqueue(new MockResponse().setBody("success!"));
-
-		TestInterfaceAsync api = AsyncFeign.asyncBuilder().decoder((response, type) -> {
-			throw new IOException("timeout");
-		}).target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
-
-		CompletableFuture<?> cf = api.body("Request body");
-		server.takeRequest();
-		try {
-			unwrap(cf);
-		} catch (FeignException e) {
-			assertThat(e.getMessage()).isEqualTo("timeout reading POST http://localhost:" + server.getPort() + "/");
-			assertThat(e.contentUTF8()).isEqualTo("Request body");
-			return;
-		}
-		fail();
-	}
-
-	@Test
-	public void throwsFeignExceptionWithoutBody() {
-		server.enqueue(new MockResponse().setBody("success!"));
-
-		TestInterfaceAsync api = AsyncFeign.asyncBuilder().decoder((response, type) -> {
-			throw new IOException("timeout");
-		}).target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
-
-		try {
-			api.noContent();
-		} catch (FeignException e) {
-			assertThat(e.getMessage()).isEqualTo("timeout reading POST http://localhost:" + server.getPort() + "/");
-			assertThat(e.contentUTF8()).isEqualTo("");
-		}
-	}
-
-	@SuppressWarnings("deprecation")
-	@Test
-	public void whenReturnTypeIsResponseNoErrorHandling() throws Throwable {
-		Map<String, Collection<String>> headers = new LinkedHashMap<String, Collection<String>>();
-		headers.put("Location", Arrays.asList("http://bar.com"));
-		final Response response = Response.builder().status(302).reason("Found").headers(headers)
-				.request(Request.create(HttpMethod.GET, "/", Collections.emptyMap(), null, Util.UTF_8))
-				.body(new byte[0]).build();
-
-		ExecutorService execs = Executors.newSingleThreadExecutor();
-
-		// fake client as Client.Default follows redirects.
-		TestInterfaceAsync api = AsyncFeign.<Void>asyncBuilder()
-				.client(new AsyncClient.Default<>((request, options) -> response, execs))
-				.target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
-
-		assertEquals(Collections.singletonList("http://bar.com"), unwrap(api.response()).headers().get("Location"));
-
-		execs.shutdown();
-	}
-
-	@Test
-	public void okIfDecodeRootCauseHasNoMessage() throws Throwable {
-		server.enqueue(new MockResponse().setBody("success!"));
-		thrown.expect(DecodeException.class);
-
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().decoder(new Decoder() {
-			@Override
-			public Object decode(Response response, Type type) throws IOException {
-				throw new RuntimeException();
-			}
-		}).target("http://localhost:" + server.getPort());
-
-		unwrap(api.post());
-	}
-
-	@Test
-	public void decodingExceptionGetWrappedInDecode404Mode() throws Throwable {
-		server.enqueue(new MockResponse().setResponseCode(404));
-		thrown.expect(DecodeException.class);
-		thrown.expectCause(isA(NoSuchElementException.class));
-		;
-
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().decode404().decoder(new Decoder() {
-			@Override
-			public Object decode(Response response, Type type) throws IOException {
-				assertEquals(404, response.status());
-				throw new NoSuchElementException();
-			}
-		}).target("http://localhost:" + server.getPort());
-
-		unwrap(api.post());
-	}
-
-	@Test
-	public void decodingDoesNotSwallow404ErrorsInDecode404Mode() throws Throwable {
-		server.enqueue(new MockResponse().setResponseCode(404));
-		thrown.expect(IllegalArgumentException.class);
-
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().decode404()
-				.errorDecoder(new IllegalArgumentExceptionOn404()).target("http://localhost:" + server.getPort());
-
-		CompletableFuture<Void> cf = api.queryMap(Collections.<String, Object>emptyMap());
-		server.takeRequest();
-		unwrap(cf);
-	}
-
-	@Test
-	public void okIfEncodeRootCauseHasNoMessage() throws Throwable {
-		server.enqueue(new MockResponse().setBody("success!"));
-		thrown.expect(EncodeException.class);
-
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().encoder(new Encoder() {
-			@Override
-			public void encode(Object object, Type bodyType, RequestTemplate template) {
-				throw new RuntimeException();
-			}
-		}).target("http://localhost:" + server.getPort());
-
-		unwrap(api.body(Arrays.asList("foo")));
-	}
-
-	@Test
-	public void equalsHashCodeAndToStringWork() {
-		Target<TestInterfaceAsync> t1 = new HardCodedTarget<TestInterfaceAsync>(TestInterfaceAsync.class,
-				"http://localhost:8080");
-		Target<TestInterfaceAsync> t2 = new HardCodedTarget<TestInterfaceAsync>(TestInterfaceAsync.class,
-				"http://localhost:8888");
-		Target<OtherTestInterfaceAsync> t3 = new HardCodedTarget<OtherTestInterfaceAsync>(OtherTestInterfaceAsync.class,
-				"http://localhost:8080");
-		TestInterfaceAsync i1 = AsyncFeign.asyncBuilder().target(t1);
-		TestInterfaceAsync i2 = AsyncFeign.asyncBuilder().target(t1);
-		TestInterfaceAsync i3 = AsyncFeign.asyncBuilder().target(t2);
-		OtherTestInterfaceAsync i4 = AsyncFeign.asyncBuilder().target(t3);
-
-		assertThat(i1).isEqualTo(i2).isNotEqualTo(i3).isNotEqualTo(i4);
-
-		assertThat(i1.hashCode()).isEqualTo(i2.hashCode()).isNotEqualTo(i3.hashCode()).isNotEqualTo(i4.hashCode());
-
-		assertThat(i1.toString()).isEqualTo(i2.toString()).isNotEqualTo(i3.toString()).isNotEqualTo(i4.toString());
-
-		assertThat(t1).isNotEqualTo(i1);
-
-		assertThat(t1.hashCode()).isEqualTo(i1.hashCode());
-
-		assertThat(t1.toString()).isEqualTo(i1.toString());
-	}
-
-	@SuppressWarnings("resource")
-	@Test
-	public void decodeLogicSupportsByteArray() throws Throwable {
-		byte[] expectedResponse = { 12, 34, 56 };
-		server.enqueue(new MockResponse().setBody(new Buffer().write(expectedResponse)));
-
-		OtherTestInterfaceAsync api = AsyncFeign.asyncBuilder().target(OtherTestInterfaceAsync.class,
-				"http://localhost:" + server.getPort());
-
-		assertThat(unwrap(api.binaryResponseBody())).containsExactly(expectedResponse);
-	}
-
-	@Test
-	public void encodeLogicSupportsByteArray() throws Exception {
-		byte[] expectedRequest = { 12, 34, 56 };
-		server.enqueue(new MockResponse());
-
-		OtherTestInterfaceAsync api = AsyncFeign.asyncBuilder().target(OtherTestInterfaceAsync.class,
-				"http://localhost:" + server.getPort());
-
-		CompletableFuture<?> cf = api.binaryRequestBody(expectedRequest);
-
-		assertThat(server.takeRequest()).hasBody(expectedRequest);
-
-		checkCFCompletedSoon(cf);
-	}
-
-	@Test
-	public void encodedQueryParam() throws Exception {
-		server.enqueue(new MockResponse());
-
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
-
-		CompletableFuture<?> cf = api.encodedQueryParam("5.2FSi+");
-
-		assertThat(server.takeRequest()).hasPath("/?trim=5.2FSi%2B");
-
-		checkCFCompletedSoon(cf);
-	}
-
-	private void checkCFCompletedSoon(CompletableFuture<?> cf) {
-		try {
-			unwrap(cf);
-		}catch(RuntimeException e) {
-			throw e;
-		}catch(Throwable t) {
-			throw new RuntimeException(t);
-		}
-	}
-
-	@Test
-	public void responseMapperIsAppliedBeforeDelegate() throws IOException {
-		ResponseMappingDecoder decoder = new ResponseMappingDecoder(upperCaseResponseMapper(), new StringDecoder());
-		String output = (String) decoder.decode(responseWithText("response"), String.class);
-
-		assertThat(output).isEqualTo("RESPONSE");
-	}
-
-	private ResponseMapper upperCaseResponseMapper() {
-		return new ResponseMapper() {
-			@SuppressWarnings("deprecation")
-			@Override
-			public Response map(Response response, Type type) {
-				try {
-					return response.toBuilder().body(Util.toString(response.body().asReader()).toUpperCase().getBytes())
-							.build();
-				} catch (IOException e) {
-					throw new RuntimeException(e);
-				}
-			}
-		};
-	}
-
-	@SuppressWarnings("deprecation")
-	private Response responseWithText(String text) {
-		return Response.builder().body(text, Util.UTF_8).status(200)
-				.request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
-				.headers(new HashMap<>()).build();
-	}
-
-	@Test
-	public void mapAndDecodeExecutesMapFunction() throws Throwable {
-		server.enqueue(new MockResponse().setBody("response!"));
-
-		TestInterfaceAsync api = AsyncFeign.asyncBuilder().mapAndDecode(upperCaseResponseMapper(), new StringDecoder())
-				.target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
-
-		assertEquals("RESPONSE!", unwrap(api.post()));
-	}
-
-	@Test
-	public void beanQueryMapEncoderWithPrivateGetterIgnored() throws Exception {
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().queryMapEndcoder(new BeanQueryMapEncoder())
-				.target("http://localhost:" + server.getPort());
-
-		PropertyPojo.ChildPojoClass propertyPojo = new PropertyPojo.ChildPojoClass();
-		propertyPojo.setPrivateGetterProperty("privateGetterProperty");
-		propertyPojo.setName("Name");
-		propertyPojo.setNumber(1);
-
-		server.enqueue(new MockResponse());
-		CompletableFuture<?> cf = api.queryMapPropertyPojo(propertyPojo);
-		assertThat(server.takeRequest()).hasQueryParams(Arrays.asList("name=Name", "number=1"));
-		checkCFCompletedSoon(cf);
-	}
-
-	@Test
-	public void queryMap_with_child_pojo() throws Exception {
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().queryMapEndcoder(new FieldQueryMapEncoder())
-				.target("http://localhost:" + server.getPort());
-
-		ChildPojo childPojo = new ChildPojo();
-		childPojo.setChildPrivateProperty("first");
-		childPojo.setParentProtectedProperty("second");
-		childPojo.setParentPublicProperty("third");
-
-		server.enqueue(new MockResponse());
-		CompletableFuture<?> cf = api.queryMapPropertyInheritence(childPojo);
-		assertThat(server.takeRequest()).hasQueryParams("parentPublicProperty=third", "parentProtectedProperty=second",
-				"childPrivateProperty=first");
-		checkCFCompletedSoon(cf);
-	}
-
-	@Test
-	public void beanQueryMapEncoderWithNullValueIgnored() throws Exception {
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().queryMapEndcoder(new BeanQueryMapEncoder())
-				.target("http://localhost:" + server.getPort());
-
-		PropertyPojo.ChildPojoClass propertyPojo = new PropertyPojo.ChildPojoClass();
-		propertyPojo.setName(null);
-		propertyPojo.setNumber(1);
-
-		server.enqueue(new MockResponse());
-		CompletableFuture<?> cf = api.queryMapPropertyPojo(propertyPojo);
-
-		assertThat(server.takeRequest()).hasQueryParams("number=1");
-
-		checkCFCompletedSoon(cf);
-	}
-
-	@Test
-	public void beanQueryMapEncoderWithEmptyParams() throws Exception {
-		TestInterfaceAsync api = new TestInterfaceAsyncBuilder().queryMapEndcoder(new BeanQueryMapEncoder())
-				.target("http://localhost:" + server.getPort());
-
-		PropertyPojo.ChildPojoClass propertyPojo = new PropertyPojo.ChildPojoClass();
-
-		server.enqueue(new MockResponse());
-		CompletableFuture<?> cf = api.queryMapPropertyPojo(propertyPojo);
-		assertThat(server.takeRequest()).hasQueryParams("/");
-
-		checkCFCompletedSoon(cf);
-	}
-
-	interface TestInterfaceAsync {
-
-		@RequestLine("POST /")
-		CompletableFuture<Response> response();
-
-		@RequestLine("POST /")
-		CompletableFuture<String> post() throws TestInterfaceException;
-
-		@RequestLine("POST /")
-		@Body("%7B\"customer_name\": \"{customer_name}\", \"user_name\": \"{user_name}\", \"password\": \"{password}\"%7D")
-		CompletableFuture<Void> login(@Param("customer_name") String customer, @Param("user_name") String user,
-                                      @Param("password") String password);
-
-		@RequestLine("POST /")
-		CompletableFuture<Void> body(List<String> contents);
-
-		@RequestLine("POST /")
-		CompletableFuture<String> body(String content);
-
-		@RequestLine("POST /")
-		CompletableFuture<String> noContent();
-
-		@RequestLine("POST /")
-		@Headers("Content-Encoding: gzip")
-		CompletableFuture<Void> gzipBody(List<String> contents);
-
-		@RequestLine("POST /")
-		@Headers("Content-Encoding: deflate")
-		CompletableFuture<Void> deflateBody(List<String> contents);
-
-		@RequestLine("POST /")
-		CompletableFuture<Void> form(@Param("customer_name") String customer, @Param("user_name") String user,
-                                     @Param("password") String password);
-
-		@RequestLine("GET /{1}/{2}")
-		CompletableFuture<Response> uriParam(@Param("1") String one, URI endpoint, @Param("2") String two);
-
-		@RequestLine("GET /?1={1}&2={2}")
-		CompletableFuture<Response> queryParams(@Param("1") String one, @Param("2") Iterable<String> twos);
-
-		@RequestLine("POST /?date={date}")
-		CompletableFuture<Void> expand(@Param(value = "date", expander = DateToMillis.class) Date date);
-
-		@RequestLine("GET /?date={date}")
-		CompletableFuture<Void> expandList(@Param(value = "date", expander = DateToMillis.class) List<Date> dates);
-
-		@RequestLine("GET /?date={date}")
-		CompletableFuture<Void> expandArray(@Param(value = "date", expander = DateToMillis.class) Date[] dates);
-
-		@RequestLine("GET /")
-		CompletableFuture<Void> headerMap(@HeaderMap Map<String, Object> headerMap);
-
-		@RequestLine("GET /")
-		@Headers("Content-Encoding: deflate")
-		CompletableFuture<Void> headerMapWithHeaderAnnotations(@HeaderMap Map<String, Object> headerMap);
-
-		@RequestLine("GET /")
-		CompletableFuture<Void> queryMap(@QueryMap Map<String, Object> queryMap);
-
-		@RequestLine("GET /")
-		CompletableFuture<Void> queryMapEncoded(@QueryMap(encoded = true) Map<String, Object> queryMap);
-
-		@RequestLine("GET /?name={name}")
-		CompletableFuture<Void> queryMapWithQueryParams(@Param("name") String name,
-                                                        @QueryMap Map<String, Object> queryMap);
-
-		@RequestLine("GET /?trim={trim}")
-		CompletableFuture<Void> encodedQueryParam(@Param(value = "trim", encoded = true) String trim);
-
-		@RequestLine("GET /")
-		CompletableFuture<Void> queryMapPojo(@QueryMap CustomPojo object);
-
-		@RequestLine("GET /")
-		CompletableFuture<Void> queryMapPropertyPojo(@QueryMap PropertyPojo object);
-
-		@RequestLine("GET /")
-		CompletableFuture<Void> queryMapPropertyInheritence(@QueryMap ChildPojo object);
-
-		class DateToMillis implements Param.Expander {
-
-			@Override
-			public String expand(Object value) {
-				return String.valueOf(((Date) value).getTime());
-			}
-		}
-	}
-
-	class TestInterfaceException extends Exception {
-		private static final long serialVersionUID = 1L;
-
-		TestInterfaceException(String message) {
-			super(message);
-		}
-	}
-
-	interface OtherTestInterfaceAsync {
-
-		@RequestLine("POST /")
-		CompletableFuture<String> post();
-
-		@RequestLine("POST /")
-		CompletableFuture<byte[]> binaryResponseBody();
-
-		@RequestLine("POST /")
-		CompletableFuture<Void> binaryRequestBody(byte[] contents);
-	}
-
-	static class ForwardedForInterceptor implements RequestInterceptor {
-
-		@Override
-		public void apply(RequestTemplate template) {
-			template.header("X-Forwarded-For", "origin.host.com");
-		}
-	}
-
-	static class UserAgentInterceptor implements RequestInterceptor {
-
-		@Override
-		public void apply(RequestTemplate template) {
-			template.header("User-Agent", "Feign");
-		}
-	}
-
-	static class IllegalArgumentExceptionOn400 extends ErrorDecoder.Default {
-
-		@Override
-		public Exception decode(String methodKey, Response response) {
-			if (response.status() == 400) {
-				return new IllegalArgumentException("bad zone name");
-			}
-			return super.decode(methodKey, response);
-		}
-	}
-
-	static class IllegalArgumentExceptionOn404 extends ErrorDecoder.Default {
-
-		@Override
-		public Exception decode(String methodKey, Response response) {
-			if (response.status() == 404) {
-				return new IllegalArgumentException("bad zone name");
-			}
-			return super.decode(methodKey, response);
-		}
-	}
-
-	static final class TestInterfaceAsyncBuilder {
-
-		private final AsyncFeign.AsyncBuilder<Void> delegate = AsyncFeign.<Void>asyncBuilder()
-				.decoder(new Decoder.Default()).encoder(new Encoder() {
-
-					@SuppressWarnings("deprecation")
-					@Override
-					public void encode(Object object, Type bodyType, RequestTemplate template) {
-						if (object instanceof Map) {
-							template.body(new Gson().toJson(object));
-						} else {
-							template.body(object.toString());
-						}
-					}
-				});
-
-		TestInterfaceAsyncBuilder requestInterceptor(RequestInterceptor requestInterceptor) {
-			delegate.requestInterceptor(requestInterceptor);
-			return this;
-		}
-
-		TestInterfaceAsyncBuilder encoder(Encoder encoder) {
-			delegate.encoder(encoder);
-			return this;
-		}
-
-		TestInterfaceAsyncBuilder decoder(Decoder decoder) {
-			delegate.decoder(decoder);
-			return this;
-		}
-
-		TestInterfaceAsyncBuilder errorDecoder(ErrorDecoder errorDecoder) {
-			delegate.errorDecoder(errorDecoder);
-			return this;
-		}
-
-		TestInterfaceAsyncBuilder decode404() {
-			delegate.decode404();
-			return this;
-		}
-
-		TestInterfaceAsyncBuilder queryMapEndcoder(QueryMapEncoder queryMapEncoder) {
-			delegate.queryMapEncoder(queryMapEncoder);
-			return this;
-		}
-
-		TestInterfaceAsync target(String url) {
-			return delegate.target(TestInterfaceAsync.class, url);
-		}
-	}
-	
-	/* ====
-	 * new tests not related to standard Feign begin here
-	 * ====
-	 */
-	
-	@Test
-	public void testNonInterface() {
-		thrown.expect(IllegalArgumentException.class);
-		AsyncFeign.asyncBuilder().target(NonInterface.class, "http://localhost");
-	}
-
-	@Test
-	public void testNonCFReturnType() {
-		thrown.expect(IllegalArgumentException.class);
-		AsyncFeign.asyncBuilder().target(NonCFApi.class, "http://localhost");
-	}
-	
-	@Test
-	public void testExtendedCFReturnType() {
-		thrown.expect(IllegalArgumentException.class);
-		AsyncFeign.asyncBuilder().target(ExtendedCFApi.class, "http://localhost");
-	}
-
-	@Test
-	public void testLowerWildReturnType() {
-		thrown.expect(IllegalArgumentException.class);
-		AsyncFeign.asyncBuilder().target(LowerWildApi.class, "http://localhost");
-	}
-	
-	@Test
-	public void testUpperWildReturnType() {
-		thrown.expect(IllegalArgumentException.class);
-		AsyncFeign.asyncBuilder().target(UpperWildApi.class, "http://localhost");
-	}
-	
-	@Test
-	public void testrWildReturnType() {
-		thrown.expect(IllegalArgumentException.class);
-		AsyncFeign.asyncBuilder().target(WildApi.class, "http://localhost");
-	}
-	
-	
-	static final class ExtendedCF<T> extends CompletableFuture<T> {
-		
-	}
-	
-	static abstract class NonInterface {
-		@RequestLine("GET /")
-		abstract CompletableFuture<Void> x();
-	}
-	
-	static interface NonCFApi {
-		@RequestLine("GET /")
-		void x();
-	}
-	
-	static interface ExtendedCFApi {
-		@RequestLine("GET /")
-		ExtendedCF<Void> x();
-	}
-	
-	static interface LowerWildApi {
-		@RequestLine("GET /")
-		CompletableFuture<? extends Object> x();
-	}
-	
-	static interface UpperWildApi {
-		@RequestLine("GET /")
-		CompletableFuture<? super Object> x();
-	}
-	
-	static interface WildApi {
-		@RequestLine("GET /")
-		CompletableFuture<? extends Object> x();
-	}
+    CustomPojo customPojo = new CustomPojo("Name", 3);
+
+    server.enqueue(new MockResponse());
+    CompletableFuture<?> cf = api.queryMapPojo(customPojo);
+    assertThat(server.takeRequest()).hasQueryParams(Arrays.asList("name=Name", "number=3"));
+    checkCFCompletedSoon(cf);
+  }
+
+  @Test
+  public void queryMapPojoWithPartialParams() throws Exception {
+    TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+
+    CustomPojo customPojo = new CustomPojo("Name", null);
+
+    server.enqueue(new MockResponse());
+    CompletableFuture<?> cf = api.queryMapPojo(customPojo);
+    assertThat(server.takeRequest()).hasPath("/?name=Name");
+
+    checkCFCompletedSoon(cf);
+  }
+
+  @Test
+  public void queryMapPojoWithEmptyParams() throws Exception {
+    TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+
+    CustomPojo customPojo = new CustomPojo(null, null);
+
+    server.enqueue(new MockResponse());
+    api.queryMapPojo(customPojo);
+    assertThat(server.takeRequest()).hasPath("/");
+  }
+
+  @Test
+  public void configKeyFormatsAsExpected() throws Exception {
+    assertEquals("TestInterfaceAsync#post()",
+        Feign.configKey(TestInterfaceAsync.class,
+            TestInterfaceAsync.class.getDeclaredMethod("post")));
+    assertEquals("TestInterfaceAsync#uriParam(String,URI,String)",
+        Feign.configKey(TestInterfaceAsync.class,
+            TestInterfaceAsync.class.getDeclaredMethod("uriParam", String.class, URI.class,
+                String.class)));
+  }
+
+  @Test
+  public void configKeyUsesChildType() throws Exception {
+    assertEquals("List#iterator()",
+        Feign.configKey(List.class, Iterable.class.getDeclaredMethod("iterator")));
+  }
+
+  private <T> T unwrap(CompletableFuture<T> cf) throws Throwable {
+    try {
+      return cf.get(1, TimeUnit.SECONDS);
+    } catch (ExecutionException e) {
+      throw e.getCause();
+    }
+  }
+
+  @Test
+  public void canOverrideErrorDecoder() throws Throwable {
+    server.enqueue(new MockResponse().setResponseCode(400).setBody("foo"));
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("bad zone name");
+
+    TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().errorDecoder(new IllegalArgumentExceptionOn400())
+            .target("http://localhost:" + server.getPort());
+
+    unwrap(api.post());
+  }
+
+  @Test
+  public void overrideTypeSpecificDecoder() throws Throwable {
+    server.enqueue(new MockResponse().setBody("success!"));
+
+    TestInterfaceAsync api = new TestInterfaceAsyncBuilder().decoder(new Decoder() {
+      @Override
+      public Object decode(Response response, Type type) {
+        return "fail";
+      }
+    }).target("http://localhost:" + server.getPort());
+
+    assertEquals("fail", unwrap(api.post()));
+  }
+
+  @Test
+  public void doesntRetryAfterResponseIsSent() throws Throwable {
+    server.enqueue(new MockResponse().setBody("success!"));
+    thrown.expect(FeignException.class);
+    thrown.expectMessage("timeout reading POST http://");
+
+    TestInterfaceAsync api = new TestInterfaceAsyncBuilder().decoder(new Decoder() {
+      @Override
+      public Object decode(Response response, Type type) throws IOException {
+        throw new IOException("timeout");
+      }
+    }).target("http://localhost:" + server.getPort());
+
+    CompletableFuture<?> cf = api.post();
+    server.takeRequest();
+    unwrap(cf);
+  }
+
+  @Test
+  public void throwsFeignExceptionIncludingBody() throws Throwable {
+    server.enqueue(new MockResponse().setBody("success!"));
+
+    TestInterfaceAsync api = AsyncFeign.asyncBuilder().decoder((response, type) -> {
+      throw new IOException("timeout");
+    }).target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
+
+    CompletableFuture<?> cf = api.body("Request body");
+    server.takeRequest();
+    try {
+      unwrap(cf);
+    } catch (FeignException e) {
+      assertThat(e.getMessage())
+          .isEqualTo("timeout reading POST http://localhost:" + server.getPort() + "/");
+      assertThat(e.contentUTF8()).isEqualTo("Request body");
+      return;
+    }
+    fail();
+  }
+
+  @Test
+  public void throwsFeignExceptionWithoutBody() {
+    server.enqueue(new MockResponse().setBody("success!"));
+
+    TestInterfaceAsync api = AsyncFeign.asyncBuilder().decoder((response, type) -> {
+      throw new IOException("timeout");
+    }).target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
+
+    try {
+      api.noContent();
+    } catch (FeignException e) {
+      assertThat(e.getMessage())
+          .isEqualTo("timeout reading POST http://localhost:" + server.getPort() + "/");
+      assertThat(e.contentUTF8()).isEqualTo("");
+    }
+  }
+
+  @SuppressWarnings("deprecation")
+  @Test
+  public void whenReturnTypeIsResponseNoErrorHandling() throws Throwable {
+    Map<String, Collection<String>> headers = new LinkedHashMap<String, Collection<String>>();
+    headers.put("Location", Arrays.asList("http://bar.com"));
+    final Response response = Response.builder().status(302).reason("Found").headers(headers)
+        .request(Request.create(HttpMethod.GET, "/", Collections.emptyMap(), null, Util.UTF_8))
+        .body(new byte[0]).build();
+
+    ExecutorService execs = Executors.newSingleThreadExecutor();
+
+    // fake client as Client.Default follows redirects.
+    TestInterfaceAsync api = AsyncFeign.<Void>asyncBuilder()
+        .client(new AsyncClient.Default<>((request, options) -> response, execs))
+        .target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
+
+    assertEquals(Collections.singletonList("http://bar.com"),
+        unwrap(api.response()).headers().get("Location"));
+
+    execs.shutdown();
+  }
+
+  @Test
+  public void okIfDecodeRootCauseHasNoMessage() throws Throwable {
+    server.enqueue(new MockResponse().setBody("success!"));
+    thrown.expect(DecodeException.class);
+
+    TestInterfaceAsync api = new TestInterfaceAsyncBuilder().decoder(new Decoder() {
+      @Override
+      public Object decode(Response response, Type type) throws IOException {
+        throw new RuntimeException();
+      }
+    }).target("http://localhost:" + server.getPort());
+
+    unwrap(api.post());
+  }
+
+  @Test
+  public void decodingExceptionGetWrappedInDecode404Mode() throws Throwable {
+    server.enqueue(new MockResponse().setResponseCode(404));
+    thrown.expect(DecodeException.class);
+    thrown.expectCause(isA(NoSuchElementException.class));;
+
+    TestInterfaceAsync api = new TestInterfaceAsyncBuilder().decode404().decoder(new Decoder() {
+      @Override
+      public Object decode(Response response, Type type) throws IOException {
+        assertEquals(404, response.status());
+        throw new NoSuchElementException();
+      }
+    }).target("http://localhost:" + server.getPort());
+
+    unwrap(api.post());
+  }
+
+  @Test
+  public void decodingDoesNotSwallow404ErrorsInDecode404Mode() throws Throwable {
+    server.enqueue(new MockResponse().setResponseCode(404));
+    thrown.expect(IllegalArgumentException.class);
+
+    TestInterfaceAsync api = new TestInterfaceAsyncBuilder().decode404()
+        .errorDecoder(new IllegalArgumentExceptionOn404())
+        .target("http://localhost:" + server.getPort());
+
+    CompletableFuture<Void> cf = api.queryMap(Collections.<String, Object>emptyMap());
+    server.takeRequest();
+    unwrap(cf);
+  }
+
+  @Test
+  public void okIfEncodeRootCauseHasNoMessage() throws Throwable {
+    server.enqueue(new MockResponse().setBody("success!"));
+    thrown.expect(EncodeException.class);
+
+    TestInterfaceAsync api = new TestInterfaceAsyncBuilder().encoder(new Encoder() {
+      @Override
+      public void encode(Object object, Type bodyType, RequestTemplate template) {
+        throw new RuntimeException();
+      }
+    }).target("http://localhost:" + server.getPort());
+
+    unwrap(api.body(Arrays.asList("foo")));
+  }
+
+  @Test
+  public void equalsHashCodeAndToStringWork() {
+    Target<TestInterfaceAsync> t1 =
+        new HardCodedTarget<TestInterfaceAsync>(TestInterfaceAsync.class,
+            "http://localhost:8080");
+    Target<TestInterfaceAsync> t2 =
+        new HardCodedTarget<TestInterfaceAsync>(TestInterfaceAsync.class,
+            "http://localhost:8888");
+    Target<OtherTestInterfaceAsync> t3 =
+        new HardCodedTarget<OtherTestInterfaceAsync>(OtherTestInterfaceAsync.class,
+            "http://localhost:8080");
+    TestInterfaceAsync i1 = AsyncFeign.asyncBuilder().target(t1);
+    TestInterfaceAsync i2 = AsyncFeign.asyncBuilder().target(t1);
+    TestInterfaceAsync i3 = AsyncFeign.asyncBuilder().target(t2);
+    OtherTestInterfaceAsync i4 = AsyncFeign.asyncBuilder().target(t3);
+
+    assertThat(i1).isEqualTo(i2).isNotEqualTo(i3).isNotEqualTo(i4);
+
+    assertThat(i1.hashCode()).isEqualTo(i2.hashCode()).isNotEqualTo(i3.hashCode())
+        .isNotEqualTo(i4.hashCode());
+
+    assertThat(i1.toString()).isEqualTo(i2.toString()).isNotEqualTo(i3.toString())
+        .isNotEqualTo(i4.toString());
+
+    assertThat(t1).isNotEqualTo(i1);
+
+    assertThat(t1.hashCode()).isEqualTo(i1.hashCode());
+
+    assertThat(t1.toString()).isEqualTo(i1.toString());
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  public void decodeLogicSupportsByteArray() throws Throwable {
+    byte[] expectedResponse = {12, 34, 56};
+    server.enqueue(new MockResponse().setBody(new Buffer().write(expectedResponse)));
+
+    OtherTestInterfaceAsync api = AsyncFeign.asyncBuilder().target(OtherTestInterfaceAsync.class,
+        "http://localhost:" + server.getPort());
+
+    assertThat(unwrap(api.binaryResponseBody())).containsExactly(expectedResponse);
+  }
+
+  @Test
+  public void encodeLogicSupportsByteArray() throws Exception {
+    byte[] expectedRequest = {12, 34, 56};
+    server.enqueue(new MockResponse());
+
+    OtherTestInterfaceAsync api = AsyncFeign.asyncBuilder().target(OtherTestInterfaceAsync.class,
+        "http://localhost:" + server.getPort());
+
+    CompletableFuture<?> cf = api.binaryRequestBody(expectedRequest);
+
+    assertThat(server.takeRequest()).hasBody(expectedRequest);
+
+    checkCFCompletedSoon(cf);
+  }
+
+  @Test
+  public void encodedQueryParam() throws Exception {
+    server.enqueue(new MockResponse());
+
+    TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+
+    CompletableFuture<?> cf = api.encodedQueryParam("5.2FSi+");
+
+    assertThat(server.takeRequest()).hasPath("/?trim=5.2FSi%2B");
+
+    checkCFCompletedSoon(cf);
+  }
+
+  private void checkCFCompletedSoon(CompletableFuture<?> cf) {
+    try {
+      unwrap(cf);
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
+  @Test
+  public void responseMapperIsAppliedBeforeDelegate() throws IOException {
+    ResponseMappingDecoder decoder =
+        new ResponseMappingDecoder(upperCaseResponseMapper(), new StringDecoder());
+    String output = (String) decoder.decode(responseWithText("response"), String.class);
+
+    assertThat(output).isEqualTo("RESPONSE");
+  }
+
+  private ResponseMapper upperCaseResponseMapper() {
+    return new ResponseMapper() {
+      @SuppressWarnings("deprecation")
+      @Override
+      public Response map(Response response, Type type) {
+        try {
+          return response.toBuilder()
+              .body(Util.toString(response.body().asReader()).toUpperCase().getBytes())
+              .build();
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    };
+  }
+
+  @SuppressWarnings("deprecation")
+  private Response responseWithText(String text) {
+    return Response.builder().body(text, Util.UTF_8).status(200)
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(new HashMap<>()).build();
+  }
+
+  @Test
+  public void mapAndDecodeExecutesMapFunction() throws Throwable {
+    server.enqueue(new MockResponse().setBody("response!"));
+
+    TestInterfaceAsync api =
+        AsyncFeign.asyncBuilder().mapAndDecode(upperCaseResponseMapper(), new StringDecoder())
+            .target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
+
+    assertEquals("RESPONSE!", unwrap(api.post()));
+  }
+
+  @Test
+  public void beanQueryMapEncoderWithPrivateGetterIgnored() throws Exception {
+    TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().queryMapEndcoder(new BeanQueryMapEncoder())
+            .target("http://localhost:" + server.getPort());
+
+    PropertyPojo.ChildPojoClass propertyPojo = new PropertyPojo.ChildPojoClass();
+    propertyPojo.setPrivateGetterProperty("privateGetterProperty");
+    propertyPojo.setName("Name");
+    propertyPojo.setNumber(1);
+
+    server.enqueue(new MockResponse());
+    CompletableFuture<?> cf = api.queryMapPropertyPojo(propertyPojo);
+    assertThat(server.takeRequest()).hasQueryParams(Arrays.asList("name=Name", "number=1"));
+    checkCFCompletedSoon(cf);
+  }
+
+  @Test
+  public void queryMap_with_child_pojo() throws Exception {
+    TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().queryMapEndcoder(new FieldQueryMapEncoder())
+            .target("http://localhost:" + server.getPort());
+
+    ChildPojo childPojo = new ChildPojo();
+    childPojo.setChildPrivateProperty("first");
+    childPojo.setParentProtectedProperty("second");
+    childPojo.setParentPublicProperty("third");
+
+    server.enqueue(new MockResponse());
+    CompletableFuture<?> cf = api.queryMapPropertyInheritence(childPojo);
+    assertThat(server.takeRequest()).hasQueryParams("parentPublicProperty=third",
+        "parentProtectedProperty=second",
+        "childPrivateProperty=first");
+    checkCFCompletedSoon(cf);
+  }
+
+  @Test
+  public void beanQueryMapEncoderWithNullValueIgnored() throws Exception {
+    TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().queryMapEndcoder(new BeanQueryMapEncoder())
+            .target("http://localhost:" + server.getPort());
+
+    PropertyPojo.ChildPojoClass propertyPojo = new PropertyPojo.ChildPojoClass();
+    propertyPojo.setName(null);
+    propertyPojo.setNumber(1);
+
+    server.enqueue(new MockResponse());
+    CompletableFuture<?> cf = api.queryMapPropertyPojo(propertyPojo);
+
+    assertThat(server.takeRequest()).hasQueryParams("number=1");
+
+    checkCFCompletedSoon(cf);
+  }
+
+  @Test
+  public void beanQueryMapEncoderWithEmptyParams() throws Exception {
+    TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().queryMapEndcoder(new BeanQueryMapEncoder())
+            .target("http://localhost:" + server.getPort());
+
+    PropertyPojo.ChildPojoClass propertyPojo = new PropertyPojo.ChildPojoClass();
+
+    server.enqueue(new MockResponse());
+    CompletableFuture<?> cf = api.queryMapPropertyPojo(propertyPojo);
+    assertThat(server.takeRequest()).hasQueryParams("/");
+
+    checkCFCompletedSoon(cf);
+  }
+
+  interface TestInterfaceAsync {
+
+    @RequestLine("POST /")
+    CompletableFuture<Response> response();
+
+    @RequestLine("POST /")
+    CompletableFuture<String> post() throws TestInterfaceException;
+
+    @RequestLine("POST /")
+    @Body("%7B\"customer_name\": \"{customer_name}\", \"user_name\": \"{user_name}\", \"password\": \"{password}\"%7D")
+    CompletableFuture<Void> login(@Param("customer_name") String customer,
+                                  @Param("user_name") String user,
+                                  @Param("password") String password);
+
+    @RequestLine("POST /")
+    CompletableFuture<Void> body(List<String> contents);
+
+    @RequestLine("POST /")
+    CompletableFuture<String> body(String content);
+
+    @RequestLine("POST /")
+    CompletableFuture<String> noContent();
+
+    @RequestLine("POST /")
+    @Headers("Content-Encoding: gzip")
+    CompletableFuture<Void> gzipBody(List<String> contents);
+
+    @RequestLine("POST /")
+    @Headers("Content-Encoding: deflate")
+    CompletableFuture<Void> deflateBody(List<String> contents);
+
+    @RequestLine("POST /")
+    CompletableFuture<Void> form(@Param("customer_name") String customer,
+                                 @Param("user_name") String user,
+                                 @Param("password") String password);
+
+    @RequestLine("GET /{1}/{2}")
+    CompletableFuture<Response> uriParam(@Param("1") String one,
+                                         URI endpoint,
+                                         @Param("2") String two);
+
+    @RequestLine("GET /?1={1}&2={2}")
+    CompletableFuture<Response> queryParams(@Param("1") String one,
+                                            @Param("2") Iterable<String> twos);
+
+    @RequestLine("POST /?date={date}")
+    CompletableFuture<Void> expand(@Param(value = "date", expander = DateToMillis.class) Date date);
+
+    @RequestLine("GET /?date={date}")
+    CompletableFuture<Void> expandList(@Param(value = "date",
+        expander = DateToMillis.class) List<Date> dates);
+
+    @RequestLine("GET /?date={date}")
+    CompletableFuture<Void> expandArray(@Param(value = "date",
+        expander = DateToMillis.class) Date[] dates);
+
+    @RequestLine("GET /")
+    CompletableFuture<Void> headerMap(@HeaderMap Map<String, Object> headerMap);
+
+    @RequestLine("GET /")
+    @Headers("Content-Encoding: deflate")
+    CompletableFuture<Void> headerMapWithHeaderAnnotations(@HeaderMap Map<String, Object> headerMap);
+
+    @RequestLine("GET /")
+    CompletableFuture<Void> queryMap(@QueryMap Map<String, Object> queryMap);
+
+    @RequestLine("GET /")
+    CompletableFuture<Void> queryMapEncoded(@QueryMap(encoded = true) Map<String, Object> queryMap);
+
+    @RequestLine("GET /?name={name}")
+    CompletableFuture<Void> queryMapWithQueryParams(@Param("name") String name,
+                                                    @QueryMap Map<String, Object> queryMap);
+
+    @RequestLine("GET /?trim={trim}")
+    CompletableFuture<Void> encodedQueryParam(@Param(value = "trim", encoded = true) String trim);
+
+    @RequestLine("GET /")
+    CompletableFuture<Void> queryMapPojo(@QueryMap CustomPojo object);
+
+    @RequestLine("GET /")
+    CompletableFuture<Void> queryMapPropertyPojo(@QueryMap PropertyPojo object);
+
+    @RequestLine("GET /")
+    CompletableFuture<Void> queryMapPropertyInheritence(@QueryMap ChildPojo object);
+
+    class DateToMillis implements Param.Expander {
+
+      @Override
+      public String expand(Object value) {
+        return String.valueOf(((Date) value).getTime());
+      }
+    }
+  }
+
+  class TestInterfaceException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    TestInterfaceException(String message) {
+      super(message);
+    }
+  }
+
+  interface OtherTestInterfaceAsync {
+
+    @RequestLine("POST /")
+    CompletableFuture<String> post();
+
+    @RequestLine("POST /")
+    CompletableFuture<byte[]> binaryResponseBody();
+
+    @RequestLine("POST /")
+    CompletableFuture<Void> binaryRequestBody(byte[] contents);
+  }
+
+  static class ForwardedForInterceptor implements RequestInterceptor {
+
+    @Override
+    public void apply(RequestTemplate template) {
+      template.header("X-Forwarded-For", "origin.host.com");
+    }
+  }
+
+  static class UserAgentInterceptor implements RequestInterceptor {
+
+    @Override
+    public void apply(RequestTemplate template) {
+      template.header("User-Agent", "Feign");
+    }
+  }
+
+  static class IllegalArgumentExceptionOn400 extends ErrorDecoder.Default {
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+      if (response.status() == 400) {
+        return new IllegalArgumentException("bad zone name");
+      }
+      return super.decode(methodKey, response);
+    }
+  }
+
+  static class IllegalArgumentExceptionOn404 extends ErrorDecoder.Default {
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+      if (response.status() == 404) {
+        return new IllegalArgumentException("bad zone name");
+      }
+      return super.decode(methodKey, response);
+    }
+  }
+
+  static final class TestInterfaceAsyncBuilder {
+
+    private final AsyncFeign.AsyncBuilder<Void> delegate = AsyncFeign.<Void>asyncBuilder()
+        .decoder(new Decoder.Default()).encoder(new Encoder() {
+
+          @SuppressWarnings("deprecation")
+          @Override
+          public void encode(Object object, Type bodyType, RequestTemplate template) {
+            if (object instanceof Map) {
+              template.body(new Gson().toJson(object));
+            } else {
+              template.body(object.toString());
+            }
+          }
+        });
+
+    TestInterfaceAsyncBuilder requestInterceptor(RequestInterceptor requestInterceptor) {
+      delegate.requestInterceptor(requestInterceptor);
+      return this;
+    }
+
+    TestInterfaceAsyncBuilder encoder(Encoder encoder) {
+      delegate.encoder(encoder);
+      return this;
+    }
+
+    TestInterfaceAsyncBuilder decoder(Decoder decoder) {
+      delegate.decoder(decoder);
+      return this;
+    }
+
+    TestInterfaceAsyncBuilder errorDecoder(ErrorDecoder errorDecoder) {
+      delegate.errorDecoder(errorDecoder);
+      return this;
+    }
+
+    TestInterfaceAsyncBuilder decode404() {
+      delegate.decode404();
+      return this;
+    }
+
+    TestInterfaceAsyncBuilder queryMapEndcoder(QueryMapEncoder queryMapEncoder) {
+      delegate.queryMapEncoder(queryMapEncoder);
+      return this;
+    }
+
+    TestInterfaceAsync target(String url) {
+      return delegate.target(TestInterfaceAsync.class, url);
+    }
+  }
+
+  /*
+   * ==== new tests not related to standard Feign begin here ====
+   */
+
+  @Test
+  public void testNonInterface() {
+    thrown.expect(IllegalArgumentException.class);
+    AsyncFeign.asyncBuilder().target(NonInterface.class, "http://localhost");
+  }
+
+  @Test
+  public void testNonCFReturnType() {
+    thrown.expect(IllegalArgumentException.class);
+    AsyncFeign.asyncBuilder().target(NonCFApi.class, "http://localhost");
+  }
+
+  @Test
+  public void testExtendedCFReturnType() {
+    thrown.expect(IllegalArgumentException.class);
+    AsyncFeign.asyncBuilder().target(ExtendedCFApi.class, "http://localhost");
+  }
+
+  @Test
+  public void testLowerWildReturnType() {
+    thrown.expect(IllegalArgumentException.class);
+    AsyncFeign.asyncBuilder().target(LowerWildApi.class, "http://localhost");
+  }
+
+  @Test
+  public void testUpperWildReturnType() {
+    thrown.expect(IllegalArgumentException.class);
+    AsyncFeign.asyncBuilder().target(UpperWildApi.class, "http://localhost");
+  }
+
+  @Test
+  public void testrWildReturnType() {
+    thrown.expect(IllegalArgumentException.class);
+    AsyncFeign.asyncBuilder().target(WildApi.class, "http://localhost");
+  }
+
+
+  static final class ExtendedCF<T> extends CompletableFuture<T> {
+
+  }
+
+  static abstract class NonInterface {
+    @RequestLine("GET /")
+    abstract CompletableFuture<Void> x();
+  }
+
+  static interface NonCFApi {
+    @RequestLine("GET /")
+    void x();
+  }
+
+  static interface ExtendedCFApi {
+    @RequestLine("GET /")
+    ExtendedCF<Void> x();
+  }
+
+  static interface LowerWildApi {
+    @RequestLine("GET /")
+    CompletableFuture<? extends Object> x();
+  }
+
+  static interface UpperWildApi {
+    @RequestLine("GET /")
+    CompletableFuture<? super Object> x();
+  }
+
+  static interface WildApi {
+    @RequestLine("GET /")
+    CompletableFuture<?> x();
+  }
 
 
 }

--- a/core/src/test/java/feign/FeignUnderAsyncTest.java
+++ b/core/src/test/java/feign/FeignUnderAsyncTest.java
@@ -1,0 +1,1028 @@
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import feign.Feign.ResponseMappingDecoder;
+import feign.Request.HttpMethod;
+import feign.Target.HardCodedTarget;
+import feign.codec.DecodeException;
+import feign.codec.Decoder;
+import feign.codec.EncodeException;
+import feign.codec.Encoder;
+import feign.codec.ErrorDecoder;
+import feign.codec.StringDecoder;
+import feign.querymap.BeanQueryMapEncoder;
+import feign.querymap.FieldQueryMapEncoder;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.SocketPolicy;
+import okio.Buffer;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static feign.ExceptionPropagationPolicy.*;
+import static feign.Util.*;
+import static feign.assertj.MockWebServerAssertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+@SuppressWarnings("deprecation")
+public class FeignUnderAsyncTest {
+
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+  @Rule
+  public final MockWebServer server = new MockWebServer();
+
+  @Test
+  public void iterableQueryParams() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
+
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+
+    api.queryParams("user", Arrays.asList("apple", "pear"));
+
+    assertThat(server.takeRequest())
+        .hasPath("/?1=user&2=apple&2=pear");
+  }
+
+  @Test
+  public void postTemplateParamsResolve() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
+
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+
+    api.login("netflix", "denominator", "password");
+
+    assertThat(server.takeRequest())
+        .hasBody(
+            "{\"customer_name\": \"netflix\", \"user_name\": \"denominator\", \"password\": \"password\"}");
+  }
+
+  @Test
+  public void responseCoercesToStringBody() {
+    server.enqueue(new MockResponse().setBody("foo"));
+
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+
+    Response response = api.response();
+    assertTrue(response.body().isRepeatable());
+    assertEquals("foo", response.body().toString());
+  }
+
+  @Test
+  public void postFormParams() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
+
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+
+    api.form("netflix", "denominator", "password");
+
+    assertThat(server.takeRequest())
+        .hasBody(
+            "{\"customer_name\":\"netflix\",\"user_name\":\"denominator\",\"password\":\"password\"}");
+  }
+
+  @Test
+  public void postBodyParam() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
+
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+
+    api.body(Arrays.asList("netflix", "denominator", "password"));
+
+    assertThat(server.takeRequest())
+        .hasHeaders(entry("Content-Length", Collections.singletonList("32")))
+        .hasBody("[netflix, denominator, password]");
+  }
+
+  /**
+   * The type of a parameter value may not be the desired type to encode as. Prefer the interface
+   * type.
+   */
+  @Test
+  public void bodyTypeCorrespondsWithParameterType() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
+
+    final AtomicReference<Type> encodedType = new AtomicReference<>();
+    TestInterface api = new TestInterfaceBuilder()
+        .encoder(new Encoder.Default() {
+          @Override
+          public void encode(Object object, Type bodyType, RequestTemplate template) {
+            encodedType.set(bodyType);
+          }
+        })
+        .target("http://localhost:" + server.getPort());
+
+    api.body(Arrays.asList("netflix", "denominator", "password"));
+
+    server.takeRequest();
+
+    assertThat(encodedType.get()).isEqualTo(new TypeToken<List<String>>() {}.getType());
+  }
+
+  @Test
+  public void postGZIPEncodedBodyParam() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
+
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+
+    api.gzipBody(Arrays.asList("netflix", "denominator", "password"));
+
+    assertThat(server.takeRequest())
+        .hasNoHeaderNamed("Content-Length")
+        .hasGzippedBody("[netflix, denominator, password]".getBytes(UTF_8));
+  }
+
+  @Test
+  public void postDeflateEncodedBodyParam() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
+
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+
+    api.deflateBody(Arrays.asList("netflix", "denominator", "password"));
+
+    assertThat(server.takeRequest())
+        .hasNoHeaderNamed("Content-Length")
+        .hasDeflatedBody("[netflix, denominator, password]".getBytes(UTF_8));
+  }
+
+  @Test
+  public void singleInterceptor() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
+
+    TestInterface api = new TestInterfaceBuilder()
+        .requestInterceptor(new ForwardedForInterceptor())
+        .target("http://localhost:" + server.getPort());
+
+    api.post();
+
+    assertThat(server.takeRequest())
+        .hasHeaders(entry("X-Forwarded-For", Collections.singletonList("origin.host.com")));
+  }
+
+  @Test
+  public void multipleInterceptor() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
+
+    TestInterface api = new TestInterfaceBuilder()
+        .requestInterceptor(new ForwardedForInterceptor())
+        .requestInterceptor(new UserAgentInterceptor())
+        .target("http://localhost:" + server.getPort());
+
+    api.post();
+
+    assertThat(server.takeRequest())
+        .hasHeaders(entry("X-Forwarded-For", Collections.singletonList("origin.host.com")),
+            entry("User-Agent", Collections.singletonList("Feign")));
+  }
+
+  @Test
+  public void customExpander() throws Exception {
+    server.enqueue(new MockResponse());
+
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+
+    api.expand(new Date(1234L));
+
+    assertThat(server.takeRequest())
+        .hasPath("/?date=1234");
+  }
+
+  @Test
+  public void customExpanderListParam() throws Exception {
+    server.enqueue(new MockResponse());
+
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+
+    api.expandList(Arrays.asList(new Date(1234L), new Date(12345L)));
+
+    assertThat(server.takeRequest())
+        .hasPath("/?date=1234&date=12345");
+  }
+
+  @Test
+  public void customExpanderNullParam() throws Exception {
+    server.enqueue(new MockResponse());
+
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+
+    api.expandList(Arrays.asList(new Date(1234l), null));
+
+    assertThat(server.takeRequest())
+        .hasPath("/?date=1234");
+  }
+
+  @Test
+  public void headerMap() throws Exception {
+    server.enqueue(new MockResponse());
+
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+
+    Map<String, Object> headerMap = new LinkedHashMap<String, Object>();
+    headerMap.put("Content-Type", "myContent");
+    headerMap.put("Custom-Header", "fooValue");
+    api.headerMap(headerMap);
+
+    assertThat(server.takeRequest())
+        .hasHeaders(
+            entry("Content-Type", Arrays.asList("myContent")),
+            entry("Custom-Header", Arrays.asList("fooValue")));
+  }
+
+  @Test
+  public void headerMapWithHeaderAnnotations() throws Exception {
+    server.enqueue(new MockResponse());
+
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+
+    Map<String, Object> headerMap = new LinkedHashMap<String, Object>();
+    headerMap.put("Custom-Header", "fooValue");
+    api.headerMapWithHeaderAnnotations(headerMap);
+
+    // header map should be additive for headers provided by annotations
+    assertThat(server.takeRequest())
+        .hasHeaders(
+            entry("Content-Encoding", Collections.singletonList("deflate")),
+            entry("Custom-Header", Collections.singletonList("fooValue")));
+
+    server.enqueue(new MockResponse());
+    headerMap.put("Content-Encoding", "overrideFromMap");
+
+    api.headerMapWithHeaderAnnotations(headerMap);
+
+    /*
+     * @HeaderMap map values no longer override @Header parameters. This caused confusion as it is
+     * valid to have more than one value for a header.
+     */
+    assertThat(server.takeRequest())
+        .hasHeaders(
+            entry("Content-Encoding", Arrays.asList("deflate", "overrideFromMap")),
+            entry("Custom-Header", Collections.singletonList("fooValue")));
+  }
+
+  @Test
+  public void queryMap() throws Exception {
+    server.enqueue(new MockResponse());
+
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+
+    Map<String, Object> queryMap = new LinkedHashMap<>();
+    queryMap.put("name", "alice");
+    queryMap.put("fooKey", "fooValue");
+    api.queryMap(queryMap);
+
+    assertThat(server.takeRequest())
+        .hasPath("/?name=alice&fooKey=fooValue");
+  }
+
+  @Test
+  public void queryMapIterableValuesExpanded() throws Exception {
+    server.enqueue(new MockResponse());
+
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+
+    Map<String, Object> queryMap = new LinkedHashMap<>();
+    queryMap.put("name", Arrays.asList("Alice", "Bob"));
+    queryMap.put("fooKey", "fooValue");
+    queryMap.put("emptyListKey", new ArrayList<String>());
+    queryMap.put("emptyStringKey", ""); // empty values are ignored.
+    api.queryMap(queryMap);
+
+    assertThat(server.takeRequest())
+        .hasPath("/?name=Alice&name=Bob&fooKey=fooValue&emptyStringKey");
+  }
+
+  @Test
+  public void queryMapWithQueryParams() throws Exception {
+    TestInterface api = new TestInterfaceBuilder()
+        .target("http://localhost:" + server.getPort());
+
+    server.enqueue(new MockResponse());
+    Map<String, Object> queryMap = new LinkedHashMap<String, Object>();
+    queryMap.put("fooKey", "fooValue");
+    api.queryMapWithQueryParams("alice", queryMap);
+    // query map should be expanded after built-in parameters
+    assertThat(server.takeRequest())
+        .hasPath("/?name=alice&fooKey=fooValue");
+
+    server.enqueue(new MockResponse());
+    queryMap = new LinkedHashMap<String, Object>();
+    queryMap.put("name", "bob");
+    api.queryMapWithQueryParams("alice", queryMap);
+    // queries are additive
+    assertThat(server.takeRequest())
+        .hasPath("/?name=alice&name=bob");
+
+    server.enqueue(new MockResponse());
+    queryMap = new LinkedHashMap<String, Object>();
+    queryMap.put("name", null);
+    api.queryMapWithQueryParams("alice", queryMap);
+    // null value for a query map key removes query parameter
+    assertThat(server.takeRequest())
+        .hasPath("/?name=alice");
+  }
+
+  @Test
+  public void queryMapValueStartingWithBrace() throws Exception {
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+
+    server.enqueue(new MockResponse());
+    Map<String, Object> queryMap = new LinkedHashMap<String, Object>();
+    queryMap.put("name", "{alice");
+    api.queryMap(queryMap);
+    assertThat(server.takeRequest())
+        .hasPath("/?name=%7Balice");
+
+    server.enqueue(new MockResponse());
+    queryMap = new LinkedHashMap<String, Object>();
+    queryMap.put("{name", "alice");
+    api.queryMap(queryMap);
+    assertThat(server.takeRequest())
+        .hasPath("/?%7Bname=alice");
+
+    server.enqueue(new MockResponse());
+    queryMap = new LinkedHashMap<String, Object>();
+    queryMap.put("name", "%7Balice");
+    api.queryMapEncoded(queryMap);
+    assertThat(server.takeRequest())
+        .hasPath("/?name=%7Balice");
+
+    server.enqueue(new MockResponse());
+    queryMap = new LinkedHashMap<String, Object>();
+    queryMap.put("%7Bname", "%7Balice");
+    api.queryMapEncoded(queryMap);
+    assertThat(server.takeRequest())
+        .hasPath("/?%7Bname=%7Balice");
+  }
+
+  @Test
+  public void queryMapPojoWithFullParams() throws Exception {
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+
+    CustomPojo customPojo = new CustomPojo("Name", 3);
+
+    server.enqueue(new MockResponse());
+    api.queryMapPojo(customPojo);
+    assertThat(server.takeRequest())
+        .hasQueryParams(Arrays.asList("name=Name", "number=3"));
+  }
+
+  @Test
+  public void queryMapPojoWithPartialParams() throws Exception {
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+
+    CustomPojo customPojo = new CustomPojo("Name", null);
+
+    server.enqueue(new MockResponse());
+    api.queryMapPojo(customPojo);
+    assertThat(server.takeRequest())
+        .hasPath("/?name=Name");
+  }
+
+  @Test
+  public void queryMapPojoWithEmptyParams() throws Exception {
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+
+    CustomPojo customPojo = new CustomPojo(null, null);
+
+    server.enqueue(new MockResponse());
+    api.queryMapPojo(customPojo);
+    assertThat(server.takeRequest())
+        .hasPath("/");
+  }
+
+  @Test
+  public void configKeyFormatsAsExpected() throws Exception {
+    assertEquals("TestInterface#post()",
+        Feign.configKey(TestInterface.class, TestInterface.class.getDeclaredMethod("post")));
+    assertEquals("TestInterface#uriParam(String,URI,String)",
+        Feign.configKey(TestInterface.class, TestInterface.class
+            .getDeclaredMethod("uriParam", String.class, URI.class,
+                String.class)));
+  }
+
+  @Test
+  public void configKeyUsesChildType() throws Exception {
+    assertEquals("List#iterator()",
+        Feign.configKey(List.class, Iterable.class.getDeclaredMethod("iterator")));
+  }
+
+  @Test
+  public void canOverrideErrorDecoder() throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(400).setBody("foo"));
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("bad zone name");
+
+    TestInterface api = new TestInterfaceBuilder()
+        .errorDecoder(new IllegalArgumentExceptionOn400())
+        .target("http://localhost:" + server.getPort());
+
+    api.post();
+  }
+
+  @Test
+  public void retriesLostConnectionBeforeRead() throws Exception {
+    server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+    server.enqueue(new MockResponse().setBody("success!"));
+
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+
+    api.post();
+
+    assertEquals(2, server.getRequestCount());
+  }
+
+  @Test
+  public void overrideTypeSpecificDecoder() throws Exception {
+    server.enqueue(new MockResponse().setBody("success!"));
+
+    TestInterface api = new TestInterfaceBuilder()
+        .decoder(new Decoder() {
+          @Override
+          public Object decode(Response response, Type type) {
+            return "fail";
+          }
+        }).target("http://localhost:" + server.getPort());
+
+    assertEquals(api.post(), "fail");
+  }
+
+  @Test
+  public void doesntRetryAfterResponseIsSent() throws Exception {
+    server.enqueue(new MockResponse().setBody("success!"));
+    thrown.expect(FeignException.class);
+    thrown.expectMessage("timeout reading POST http://");
+
+    TestInterface api = new TestInterfaceBuilder()
+        .decoder(new Decoder() {
+          @Override
+          public Object decode(Response response, Type type) throws IOException {
+            throw new IOException("timeout");
+          }
+        }).target("http://localhost:" + server.getPort());
+
+    api.post();
+  }
+
+  @Test
+  public void throwsFeignExceptionIncludingBody() {
+    server.enqueue(new MockResponse().setBody("success!"));
+
+    TestInterface api = AsyncFeign.asyncBuilder()
+        .decoder((response, type) -> {
+          throw new IOException("timeout");
+        })
+        .target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    try {
+      api.body("Request body");
+    } catch (FeignException e) {
+      assertThat(e.getMessage())
+          .isEqualTo("timeout reading POST http://localhost:" + server.getPort() + "/");
+      assertThat(e.contentUTF8()).isEqualTo("Request body");
+    }
+  }
+
+  @Test
+  public void throwsFeignExceptionWithoutBody() {
+    server.enqueue(new MockResponse().setBody("success!"));
+
+    TestInterface api = AsyncFeign.asyncBuilder()
+        .decoder((response, type) -> {
+          throw new IOException("timeout");
+        })
+        .target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    try {
+      api.noContent();
+    } catch (FeignException e) {
+      assertThat(e.getMessage())
+          .isEqualTo("timeout reading POST http://localhost:" + server.getPort() + "/");
+      assertThat(e.contentUTF8()).isEqualTo("");
+    }
+  }
+
+  @Test
+  public void whenReturnTypeIsResponseNoErrorHandling() {
+    Map<String, Collection<String>> headers = new LinkedHashMap<>();
+    headers.put("Location", Collections.singletonList("http://bar.com"));
+    final Response response = Response.builder()
+        .status(302)
+        .reason("Found")
+        .headers(headers)
+        .request(Request.create(HttpMethod.GET, "/", Collections.emptyMap(), null, Util.UTF_8))
+        .body(new byte[0])
+        .build();
+
+    ExecutorService execs = Executors.newSingleThreadExecutor();
+
+    // fake client as Client.Default follows redirects.
+    TestInterface api = AsyncFeign.<Void>asyncBuilder()
+        .client(new AsyncClient.Default<>((request, options) -> response, execs))
+        .target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    assertEquals(api.response().headers().get("Location"),
+        Collections.singletonList("http://bar.com"));
+
+    execs.shutdown();
+  }
+
+  private static class MockRetryer implements Retryer {
+    boolean tripped;
+
+    @Override
+    public void continueOrPropagate(RetryableException e) {
+      if (tripped) {
+        throw new RuntimeException("retryer instance should never be reused");
+      }
+      tripped = true;
+      return;
+    }
+
+    @Override
+    public Retryer clone() {
+      return new MockRetryer();
+    }
+  }
+
+  @Test
+  public void okIfDecodeRootCauseHasNoMessage() throws Exception {
+    server.enqueue(new MockResponse().setBody("success!"));
+    thrown.expect(DecodeException.class);
+
+    TestInterface api = new TestInterfaceBuilder()
+        .decoder(new Decoder() {
+          @Override
+          public Object decode(Response response, Type type) throws IOException {
+            throw new RuntimeException();
+          }
+        }).target("http://localhost:" + server.getPort());
+
+    api.post();
+  }
+
+  @Test
+  public void decodingExceptionGetWrappedInDecode404Mode() throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(404));
+    thrown.expect(DecodeException.class);
+    thrown.expectCause(isA(NoSuchElementException.class));;
+
+    TestInterface api = new TestInterfaceBuilder()
+        .decode404()
+        .decoder(new Decoder() {
+          @Override
+          public Object decode(Response response, Type type) throws IOException {
+            assertEquals(404, response.status());
+            throw new NoSuchElementException();
+          }
+        }).target("http://localhost:" + server.getPort());
+    api.post();
+  }
+
+  @Test
+  public void decodingDoesNotSwallow404ErrorsInDecode404Mode() throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(404));
+    thrown.expect(IllegalArgumentException.class);
+
+    TestInterface api = new TestInterfaceBuilder()
+        .decode404()
+        .errorDecoder(new IllegalArgumentExceptionOn404())
+        .target("http://localhost:" + server.getPort());
+    api.queryMap(Collections.<String, Object>emptyMap());
+  }
+
+  @Test
+  public void okIfEncodeRootCauseHasNoMessage() throws Exception {
+    server.enqueue(new MockResponse().setBody("success!"));
+    thrown.expect(EncodeException.class);
+
+    TestInterface api = new TestInterfaceBuilder()
+        .encoder(new Encoder() {
+          @Override
+          public void encode(Object object, Type bodyType, RequestTemplate template) {
+            throw new RuntimeException();
+          }
+        }).target("http://localhost:" + server.getPort());
+
+    api.body(Arrays.asList("foo"));
+  }
+
+  @Test
+  public void equalsHashCodeAndToStringWork() {
+    Target<TestInterface> t1 =
+        new HardCodedTarget<TestInterface>(TestInterface.class, "http://localhost:8080");
+    Target<TestInterface> t2 =
+        new HardCodedTarget<TestInterface>(TestInterface.class, "http://localhost:8888");
+    Target<OtherTestInterface> t3 =
+        new HardCodedTarget<OtherTestInterface>(OtherTestInterface.class, "http://localhost:8080");
+    TestInterface i1 = AsyncFeign.asyncBuilder().target(t1);
+    TestInterface i2 = AsyncFeign.asyncBuilder().target(t1);
+    TestInterface i3 = AsyncFeign.asyncBuilder().target(t2);
+    OtherTestInterface i4 = AsyncFeign.asyncBuilder().target(t3);
+
+    assertThat(i1)
+        .isEqualTo(i2)
+        .isNotEqualTo(i3)
+        .isNotEqualTo(i4);
+
+    assertThat(i1.hashCode())
+        .isEqualTo(i2.hashCode())
+        .isNotEqualTo(i3.hashCode())
+        .isNotEqualTo(i4.hashCode());
+
+    assertThat(i1.toString())
+        .isEqualTo(i2.toString())
+        .isNotEqualTo(i3.toString())
+        .isNotEqualTo(i4.toString());
+
+    assertThat(t1)
+        .isNotEqualTo(i1);
+
+    assertThat(t1.hashCode())
+        .isEqualTo(i1.hashCode());
+
+    assertThat(t1.toString())
+        .isEqualTo(i1.toString());
+  }
+
+  @Test
+  public void decodeLogicSupportsByteArray() throws Exception {
+    byte[] expectedResponse = {12, 34, 56};
+    server.enqueue(new MockResponse().setBody(new Buffer().write(expectedResponse)));
+
+    OtherTestInterface api =
+            AsyncFeign.asyncBuilder().target(OtherTestInterface.class, "http://localhost:" + server.getPort());
+
+    assertThat(api.binaryResponseBody())
+        .containsExactly(expectedResponse);
+  }
+
+  @Test
+  public void encodeLogicSupportsByteArray() throws Exception {
+    byte[] expectedRequest = {12, 34, 56};
+    server.enqueue(new MockResponse());
+
+    OtherTestInterface api =
+            AsyncFeign.asyncBuilder().target(OtherTestInterface.class, "http://localhost:" + server.getPort());
+
+    api.binaryRequestBody(expectedRequest);
+
+    assertThat(server.takeRequest())
+        .hasBody(expectedRequest);
+  }
+
+  @Test
+  public void encodedQueryParam() throws Exception {
+    server.enqueue(new MockResponse());
+
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+
+    api.encodedQueryParam("5.2FSi+");
+
+    assertThat(server.takeRequest())
+        .hasPath("/?trim=5.2FSi%2B");
+  }
+
+  @Test
+  public void responseMapperIsAppliedBeforeDelegate() throws IOException {
+    ResponseMappingDecoder decoder =
+        new ResponseMappingDecoder(upperCaseResponseMapper(), new StringDecoder());
+    String output = (String) decoder.decode(responseWithText("response"), String.class);
+
+    assertThat(output).isEqualTo("RESPONSE");
+  }
+
+  private ResponseMapper upperCaseResponseMapper() {
+    return new ResponseMapper() {
+      @Override
+      public Response map(Response response, Type type) {
+        try {
+          return response
+              .toBuilder()
+              .body(Util.toString(response.body().asReader(UTF_8)).toUpperCase().getBytes())
+              .build();
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    };
+  }
+
+  private Response responseWithText(String text) {
+    return Response.builder()
+        .body(text, Util.UTF_8)
+        .status(200)
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(new HashMap<>())
+        .build();
+  }
+
+  @Test
+  public void mapAndDecodeExecutesMapFunction() throws Exception {
+    server.enqueue(new MockResponse().setBody("response!"));
+
+    TestInterface api = AsyncFeign.asyncBuilder()
+        .mapAndDecode(upperCaseResponseMapper(), new StringDecoder())
+        .target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    assertEquals(api.post(), "RESPONSE!");
+  }
+
+  @Test
+  public void beanQueryMapEncoderWithPrivateGetterIgnored() throws Exception {
+    TestInterface api = new TestInterfaceBuilder().queryMapEndcoder(new BeanQueryMapEncoder())
+        .target("http://localhost:" + server.getPort());
+
+    PropertyPojo.ChildPojoClass propertyPojo = new PropertyPojo.ChildPojoClass();
+    propertyPojo.setPrivateGetterProperty("privateGetterProperty");
+    propertyPojo.setName("Name");
+    propertyPojo.setNumber(1);
+
+    server.enqueue(new MockResponse());
+    api.queryMapPropertyPojo(propertyPojo);
+    assertThat(server.takeRequest())
+        .hasQueryParams(Arrays.asList("name=Name", "number=1"));
+  }
+
+  @Test
+  public void queryMap_with_child_pojo() throws Exception {
+    TestInterface api = new TestInterfaceBuilder().queryMapEndcoder(new FieldQueryMapEncoder())
+        .target("http://localhost:" + server.getPort());
+
+    ChildPojo childPojo = new ChildPojo();
+    childPojo.setChildPrivateProperty("first");
+    childPojo.setParentProtectedProperty("second");
+    childPojo.setParentPublicProperty("third");
+
+    server.enqueue(new MockResponse());
+    api.queryMapPropertyInheritence(childPojo);
+    assertThat(server.takeRequest())
+        .hasQueryParams(
+            "parentPublicProperty=third",
+            "parentProtectedProperty=second",
+            "childPrivateProperty=first");
+  }
+
+  @Test
+  public void beanQueryMapEncoderWithNullValueIgnored() throws Exception {
+    TestInterface api = new TestInterfaceBuilder().queryMapEndcoder(new BeanQueryMapEncoder())
+        .target("http://localhost:" + server.getPort());
+
+    PropertyPojo.ChildPojoClass propertyPojo = new PropertyPojo.ChildPojoClass();
+    propertyPojo.setName(null);
+    propertyPojo.setNumber(1);
+
+    server.enqueue(new MockResponse());
+    api.queryMapPropertyPojo(propertyPojo);
+    assertThat(server.takeRequest())
+        .hasQueryParams("number=1");
+  }
+
+  @Test
+  public void beanQueryMapEncoderWithEmptyParams() throws Exception {
+    TestInterface api = new TestInterfaceBuilder().queryMapEndcoder(new BeanQueryMapEncoder())
+        .target("http://localhost:" + server.getPort());
+
+    PropertyPojo.ChildPojoClass propertyPojo = new PropertyPojo.ChildPojoClass();
+
+    server.enqueue(new MockResponse());
+    api.queryMapPropertyPojo(propertyPojo);
+    assertThat(server.takeRequest())
+        .hasQueryParams("/");
+  }
+
+  interface TestInterface {
+
+    @RequestLine("POST /")
+    Response response();
+
+    @RequestLine("POST /")
+    String post() throws TestInterfaceException;
+
+    @RequestLine("POST /")
+    @Body("%7B\"customer_name\": \"{customer_name}\", \"user_name\": \"{user_name}\", \"password\": \"{password}\"%7D")
+    void login(
+            @Param("customer_name") String customer,
+            @Param("user_name") String user,
+            @Param("password") String password);
+
+    @RequestLine("POST /")
+    void body(List<String> contents);
+
+    @RequestLine("POST /")
+    String body(String content);
+
+    @RequestLine("POST /")
+    String noContent();
+
+    @RequestLine("POST /")
+    @Headers("Content-Encoding: gzip")
+    void gzipBody(List<String> contents);
+
+    @RequestLine("POST /")
+    @Headers("Content-Encoding: deflate")
+    void deflateBody(List<String> contents);
+
+    @RequestLine("POST /")
+    void form(
+            @Param("customer_name") String customer,
+            @Param("user_name") String user,
+            @Param("password") String password);
+
+    @RequestLine("GET /{1}/{2}")
+    Response uriParam(@Param("1") String one, URI endpoint, @Param("2") String two);
+
+    @RequestLine("GET /?1={1}&2={2}")
+    Response queryParams(@Param("1") String one, @Param("2") Iterable<String> twos);
+
+    @RequestLine("POST /?date={date}")
+    void expand(@Param(value = "date", expander = DateToMillis.class) Date date);
+
+    @RequestLine("GET /?date={date}")
+    void expandList(@Param(value = "date", expander = DateToMillis.class) List<Date> dates);
+
+    @RequestLine("GET /?date={date}")
+    void expandArray(@Param(value = "date", expander = DateToMillis.class) Date[] dates);
+
+    @RequestLine("GET /")
+    void headerMap(@HeaderMap Map<String, Object> headerMap);
+
+    @RequestLine("GET /")
+    @Headers("Content-Encoding: deflate")
+    void headerMapWithHeaderAnnotations(@HeaderMap Map<String, Object> headerMap);
+
+    @RequestLine("GET /")
+    void queryMap(@QueryMap Map<String, Object> queryMap);
+
+    @RequestLine("GET /")
+    void queryMapEncoded(@QueryMap(encoded = true) Map<String, Object> queryMap);
+
+    @RequestLine("GET /?name={name}")
+    void queryMapWithQueryParams(@Param("name") String name,
+                                 @QueryMap Map<String, Object> queryMap);
+
+    @RequestLine("GET /?trim={trim}")
+    void encodedQueryParam(@Param(value = "trim") String trim);
+
+    @RequestLine("GET /")
+    void queryMapPojo(@QueryMap CustomPojo object);
+
+    @RequestLine("GET /")
+    void queryMapPropertyPojo(@QueryMap PropertyPojo object);
+
+    @RequestLine("GET /")
+    void queryMapPropertyInheritence(@QueryMap ChildPojo object);
+
+    class DateToMillis implements Param.Expander {
+
+      @Override
+      public String expand(Object value) {
+        return String.valueOf(((Date) value).getTime());
+      }
+    }
+  }
+
+  class TestInterfaceException extends Exception {
+    TestInterfaceException(String message) {
+      super(message);
+    }
+  }
+
+  interface OtherTestInterface {
+
+    @RequestLine("POST /")
+    String post();
+
+    @RequestLine("POST /")
+    byte[] binaryResponseBody();
+
+    @RequestLine("POST /")
+    void binaryRequestBody(byte[] contents);
+  }
+
+
+  static class ForwardedForInterceptor implements RequestInterceptor {
+
+    @Override
+    public void apply(RequestTemplate template) {
+      template.header("X-Forwarded-For", "origin.host.com");
+    }
+  }
+
+
+  static class UserAgentInterceptor implements RequestInterceptor {
+
+    @Override
+    public void apply(RequestTemplate template) {
+      template.header("User-Agent", "Feign");
+    }
+  }
+
+
+  static class IllegalArgumentExceptionOn400 extends ErrorDecoder.Default {
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+      if (response.status() == 400) {
+        return new IllegalArgumentException("bad zone name");
+      }
+      return super.decode(methodKey, response);
+    }
+  }
+
+
+  static class IllegalArgumentExceptionOn404 extends ErrorDecoder.Default {
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+      if (response.status() == 404) {
+        return new IllegalArgumentException("bad zone name");
+      }
+      return super.decode(methodKey, response);
+    }
+  }
+
+
+  static final class TestInterfaceBuilder {
+
+    private final AsyncFeign.AsyncBuilder<Void> delegate = AsyncFeign.<Void>asyncBuilder()
+        .decoder(new Decoder.Default())
+        .encoder(new Encoder() {
+          @Override
+          public void encode(Object object, Type bodyType, RequestTemplate template) {
+            if (object instanceof Map) {
+              template.body(new Gson().toJson(object));
+            } else {
+              template.body(object.toString());
+            }
+          }
+        });
+
+    TestInterfaceBuilder requestInterceptor(RequestInterceptor requestInterceptor) {
+      delegate.requestInterceptor(requestInterceptor);
+      return this;
+    }
+
+    TestInterfaceBuilder encoder(Encoder encoder) {
+      delegate.encoder(encoder);
+      return this;
+    }
+
+    TestInterfaceBuilder decoder(Decoder decoder) {
+      delegate.decoder(decoder);
+      return this;
+    }
+
+    TestInterfaceBuilder errorDecoder(ErrorDecoder errorDecoder) {
+      delegate.errorDecoder(errorDecoder);
+      return this;
+    }
+
+    TestInterfaceBuilder decode404() {
+      delegate.decode404();
+      return this;
+    }
+
+    TestInterfaceBuilder queryMapEndcoder(QueryMapEncoder queryMapEncoder) {
+      delegate.queryMapEncoder(queryMapEncoder);
+      return this;
+    }
+
+    TestInterface target(String url) {
+      return delegate.target(TestInterface.class, url);
+    }
+  }
+}


### PR DESCRIPTION
Adds CompleteableFuture support.
The targeted API must be an interface, where each method has a return type of CompleteableFuture<T> for some type T which can be decoded by the configured decoder.

Context is explicit, providing support for sessions.
A default synchronous -> asynchronous client is provided, although the different modules should add their own implementations of AsyncClient.

Retry is not supported - in particular, there can be many different ways one could handle the threading (scheduling the try on an appropriate thread). resilience4j could be an option, in particular to provide a wrapper to AsyncClient.
