### PR TITLE
Metric API

### DIFF
--- a/core/src/main/java/feign/Capability.java
+++ b/core/src/main/java/feign/Capability.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.List;
+import feign.Logger.Level;
+import feign.Request.Options;
+import feign.codec.Decoder;
+import feign.codec.Encoder;
+
+public interface Capability {
+
+  static <E> E enrich(E target, List<Capability> capabilities) {
+    return capabilities.stream()
+        .reduce(
+            target,
+            (c, capability) -> invoke(c, capability),
+            (a, b) -> b);
+  }
+
+  static <E> E invoke(E target, Capability capability) {
+    return Arrays.stream(capability.getClass().getMethods())
+        .filter(method -> method.getName().equals("enrich"))
+        .filter(method -> method.getReturnType().isInstance(target))
+        .findFirst()
+        .map(method -> {
+          try {
+            return (E) method.invoke(capability, target);
+          } catch (IllegalAccessException | IllegalArgumentException
+              | InvocationTargetException e) {
+            throw new RuntimeException("Unable to enrich " + target, e);
+          }
+        })
+        .orElse(target);
+  }
+
+  default Client enrich(Client client) {
+    return client;
+  }
+
+  default Retryer enrich(Retryer retryer) {
+    return retryer;
+  }
+
+  default RequestInterceptor enrich(RequestInterceptor requestInterceptor) {
+    return requestInterceptor;
+  }
+
+  default Logger enrich(Logger logger) {
+    return logger;
+  }
+
+  default Level enrich(Level level) {
+    return level;
+  }
+
+  default Contract enrich(Contract contract) {
+    return contract;
+  }
+
+  default Options enrich(Options options) {
+    return options;
+  }
+
+  default Encoder enrich(Encoder encoder) {
+    return encoder;
+  }
+
+  default Decoder enrich(Decoder decoder) {
+    return decoder;
+  }
+
+  default InvocationHandlerFactory enrich(InvocationHandlerFactory invocationHandlerFactory) {
+    return invocationHandlerFactory;
+  }
+
+  default QueryMapEncoder enrich(QueryMapEncoder queryMapEncoder) {
+    return queryMapEncoder;
+  }
+
+}

--- a/core/src/main/java/feign/Capability.java
+++ b/core/src/main/java/feign/Capability.java
@@ -21,14 +21,35 @@ import feign.Request.Options;
 import feign.codec.Decoder;
 import feign.codec.Encoder;
 
+/**
+ * Capabilities expose core feign artifacts to implementations so parts of core can be customized
+ * around the time the client being built.
+ *
+ * For instance, capabilities take the {@link Client}, make changes to it and feed the modified
+ * version back to feign.
+ *
+ * @see Metrics5Capability
+ */
 public interface Capability {
 
-  static <E> E enrich(E target, List<Capability> capabilities) {
+
+  static <E> E enrich(E componentToEnrich, List<Capability> capabilities) {
     return capabilities.stream()
+        // invoke each individual capability and feed the result to the next one.
+        // This is equivalent to:
+        // Capability cap1 = ...;
+        // Capability cap2 = ...;
+        // Capability cap2 = ...;
+        // Contract contract = ...;
+        // Contract contract1 = cap1.enrich(contract);
+        // Contract contract2 = cap2.enrich(contract1);
+        // Contract contract3 = cap3.enrich(contract2);
+        // or in a more compact version
+        // Contract enrichedContract = cap3.enrich(cap2.enrich(cap1.enrich(contract)));
         .reduce(
-            target,
-            (c, capability) -> invoke(c, capability),
-            (a, b) -> b);
+            componentToEnrich,
+            (component, capability) -> invoke(component, capability),
+            (component, enrichedComponent) -> enrichedComponent);
   }
 
   static <E> E invoke(E target, Capability capability) {

--- a/core/src/test/java/feign/CapabilityTest.java
+++ b/core/src/test/java/feign/CapabilityTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+import java.io.IOException;
+import java.util.Arrays;
+import feign.Request.Options;
+
+public class CapabilityTest {
+
+  private class AClient implements Client {
+
+    public AClient(Client client) {}
+
+    @Override
+    public Response execute(Request request, Options options) throws IOException {
+      return null;
+    }
+
+  }
+  private class BClient implements Client {
+
+    public BClient(Client client) {
+      if (!(client instanceof AClient)) {
+        throw new RuntimeException("Test is chaing invokations, expected AClient instace here");
+      }
+    }
+
+    @Override
+    public Response execute(Request request, Options options) throws IOException {
+      return null;
+    }
+
+  }
+
+  @Test
+  public void enrichClient() {
+    Client enriched = Capability.enrich(new Client.Default(null, null), Arrays.asList(
+        new Capability() {
+          @Override
+          public Client enrich(Client client) {
+            return new AClient(client);
+          }
+        }, new Capability() {
+          @Override
+          public Client enrich(Client client) {
+            return new BClient(client);
+          }
+        }));
+
+    assertThat(enriched, CoreMatchers.instanceOf(BClient.class));
+  }
+
+}

--- a/hystrix/src/main/java/feign/hystrix/HystrixCapability.java
+++ b/hystrix/src/main/java/feign/hystrix/HystrixCapability.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.hystrix;
+
+import com.netflix.hystrix.HystrixCommand;
+import java.util.HashMap;
+import java.util.Map;
+import feign.Capability;
+import feign.Contract;
+import feign.InvocationHandlerFactory;
+
+/**
+ * Allows Feign interfaces to return HystrixCommand or rx.Observable or rx.Single objects. Also
+ * decorates normal Feign methods with circuit breakers, but calls {@link HystrixCommand#execute()}
+ * directly.
+ */
+public final class HystrixCapability implements Capability {
+
+  private SetterFactory setterFactory = new SetterFactory.Default();
+  private final Map<Class, Object> fallbacks = new HashMap<>();
+
+  /**
+   * Allows you to override hystrix properties such as thread pools and command keys.
+   */
+  public HystrixCapability setterFactory(SetterFactory setterFactory) {
+    this.setterFactory = setterFactory;
+    return this;
+  }
+
+  @Override
+  public Contract enrich(Contract contract) {
+    return new HystrixDelegatingContract(contract);
+  }
+
+  @Override
+  public InvocationHandlerFactory enrich(InvocationHandlerFactory invocationHandlerFactory) {
+    return (target, dispatch) -> new HystrixInvocationHandler(target, dispatch, setterFactory,
+        fallbacks.containsKey(target.type())
+            ? new FallbackFactory.Default<>(fallbacks.get(target.type()))
+            : null);
+  }
+
+  public <E> Capability fallback(Class<E> api, E fallback) {
+    fallbacks.put(api, fallback);
+
+    return this;
+  }
+
+}

--- a/hystrix/src/test/java/feign/hystrix/HystrixCapabilityTest.java
+++ b/hystrix/src/test/java/feign/hystrix/HystrixCapabilityTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.hystrix;
+
+import feign.Feign;
+import feign.Target;
+import feign.gson.GsonDecoder;
+
+public class HystrixCapabilityTest extends HystrixBuilderTest {
+
+  @Override
+  protected <E> E target(Class<E> api, String url) {
+    return Feign.builder()
+        .addCapability(
+            new HystrixCapability())
+        .target(api, url);
+  }
+
+  @Override
+  protected <E> E target(Target<E> api) {
+    return Feign.builder()
+        .addCapability(
+            new HystrixCapability())
+        .target(api);
+  }
+
+  @Override
+  protected <E> E target(Class<E> api, String url, E fallback) {
+    return Feign.builder()
+        .addCapability(new HystrixCapability()
+            .fallback(api, fallback))
+        .target(api, url);
+  }
+
+  @Override
+  protected TestInterface target() {
+    return Feign.builder()
+        .addCapability(new HystrixCapability()
+            .fallback(TestInterface.class,
+                new FallbackTestInterface()))
+        .decoder(new GsonDecoder())
+        .target(TestInterface.class, "http://localhost:" + server.getPort());
+  }
+
+  @Override
+  protected TestInterface targetWithoutFallback() {
+    return Feign.builder()
+        .addCapability(
+            new HystrixCapability())
+        .decoder(new GsonDecoder())
+        .target(TestInterface.class, "http://localhost:" + server.getPort());
+  }
+
+}

--- a/metrics5/pom.xml
+++ b/metrics5/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2012-2020 The Feign Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.github.openfeign</groupId>
+    <artifactId>parent</artifactId>
+    <version>10.7.5-SNAPSHOT</version>
+  </parent>
+  <artifactId>feign-metrics5</artifactId>
+  <name>Feign Metrics5</name>
+  <description>Feign Dropwizard Metrics 5</description>
+
+  <properties>
+    <main.basedir>${project.basedir}/..</main.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>feign-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>feign-mock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics5</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>5.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>28.0-jre</version>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>java-hamcrest</artifactId>
+      <version>2.0.0.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/metrics5/pom.xml
+++ b/metrics5/pom.xml
@@ -45,11 +45,6 @@
       <version>5.0.0</version>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>28.0-jre</version>
-    </dependency>
-    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>java-hamcrest</artifactId>
       <version>2.0.0.0</version>

--- a/metrics5/src/main/java/feign/metrics5/CountingInputStream.java
+++ b/metrics5/src/main/java/feign/metrics5/CountingInputStream.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+/*
+ * Copyright (C) 2007 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.metrics5;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import feign.Util;
+
+/**
+ * Copy from guava CountingInputStream
+ *
+ * An {@link InputStream} that counts the number of bytes read.
+ *
+ * @author Chris Nokleberg
+ * @since 1.0
+ */
+public final class CountingInputStream extends FilterInputStream {
+
+  private long count;
+  private long mark = -1;
+
+  /**
+   * Wraps another input stream, counting the number of bytes read.
+   *
+   * @param in the input stream to be wrapped
+   */
+  public CountingInputStream(InputStream in) {
+    super(Util.checkNotNull(in, "InputStream must not be null"));
+  }
+
+  /** Returns the number of bytes read. */
+  public long getCount() {
+    return count;
+  }
+
+  @Override
+  public int read() throws IOException {
+    final int result = in.read();
+    if (result != -1) {
+      count++;
+    }
+    return result;
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    final int result = in.read(b, off, len);
+    if (result != -1) {
+      count += result;
+    }
+    return result;
+  }
+
+  @Override
+  public long skip(long n) throws IOException {
+    final long result = in.skip(n);
+    count += result;
+    return result;
+  }
+
+  @Override
+  public synchronized void mark(int readlimit) {
+    in.mark(readlimit);
+    mark = count;
+    // it's okay to mark even if mark isn't supported, as reset won't work
+  }
+
+  @Override
+  public synchronized void reset() throws IOException {
+    if (!in.markSupported()) {
+      throw new IOException("Mark not supported");
+    }
+    if (mark == -1) {
+      throw new IOException("Mark not set");
+    }
+
+    in.reset();
+    count = mark;
+  }
+}

--- a/metrics5/src/main/java/feign/metrics5/FeignMetricName.java
+++ b/metrics5/src/main/java/feign/metrics5/FeignMetricName.java
@@ -22,26 +22,26 @@ import feign.Target;
 import io.dropwizard.metrics5.MetricName;
 import io.dropwizard.metrics5.MetricRegistry;
 
-final class FeignMetricName {
+public final class FeignMetricName {
 
   private final Class<?> meteredComponent;
 
 
-  FeignMetricName(Class<?> meteredComponent) {
+  public FeignMetricName(Class<?> meteredComponent) {
     this.meteredComponent = meteredComponent;
   }
 
 
-  MetricName metricName(MethodMetadata methodMetadata, Target<?> target, String suffix) {
+  public MetricName metricName(MethodMetadata methodMetadata, Target<?> target, String suffix) {
     return metricName(methodMetadata, target)
         .resolve(suffix);
   }
 
-  MetricName metricName(MethodMetadata methodMetadata, Target<?> target) {
+  public MetricName metricName(MethodMetadata methodMetadata, Target<?> target) {
     return metricName(methodMetadata.targetType(), methodMetadata.method(), target.url());
   }
 
-  MetricName metricName(Class<?> targetType, Method method, String url) {
+  public MetricName metricName(Class<?> targetType, Method method, String url) {
     return MetricRegistry.name(meteredComponent)
         .tagged("client", targetType.getName())
         .tagged("method", method.getName())

--- a/metrics5/src/main/java/feign/metrics5/FeignMetricName.java
+++ b/metrics5/src/main/java/feign/metrics5/FeignMetricName.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.metrics5;
+
+
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.URISyntaxException;
+import feign.MethodMetadata;
+import feign.Target;
+import io.dropwizard.metrics5.MetricName;
+import io.dropwizard.metrics5.MetricRegistry;
+
+final class FeignMetricName {
+
+  private final Class<?> meteredComponent;
+
+
+  FeignMetricName(Class<?> meteredComponent) {
+    this.meteredComponent = meteredComponent;
+  }
+
+
+  MetricName metricName(MethodMetadata methodMetadata, Target<?> target, String suffix) {
+    return metricName(methodMetadata, target)
+        .resolve(suffix);
+  }
+
+  MetricName metricName(MethodMetadata methodMetadata, Target<?> target) {
+    return metricName(methodMetadata.targetType(), methodMetadata.method(), target.url());
+  }
+
+  MetricName metricName(Class<?> targetType, Method method, String url) {
+    return MetricRegistry.name(meteredComponent)
+        .tagged("client", targetType.getName())
+        .tagged("method", method.getName())
+        .tagged("host", extractHost(url));
+  }
+
+  private String extractHost(final String targetUrl) {
+    try {
+      return new URI(targetUrl).getHost();
+    } catch (final URISyntaxException e) {
+      // can't get the host, in that case, just read first 20 chars from url
+      return targetUrl.length() <= 20
+          ? targetUrl
+          : targetUrl.substring(0, 20);
+    }
+  }
+
+
+}

--- a/metrics5/src/main/java/feign/metrics5/MeteredBody.java
+++ b/metrics5/src/main/java/feign/metrics5/MeteredBody.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.metrics5;
+
+import static feign.Util.UTF_8;
+import com.google.common.io.CountingInputStream;
+import java.io.*;
+import java.nio.charset.Charset;
+import java.util.function.Supplier;
+import feign.Response.Body;
+
+/**
+ * {@link Body} implementation that keeps track of how many bytes are read.
+ */
+final class MeteredBody implements Body {
+
+  private final Body delegate;
+  private Supplier<Long> count;
+
+  MeteredBody(Body body) {
+    this.delegate = body;
+    count = () -> 0L;
+  }
+
+  @Override
+  public void close() throws IOException {
+    delegate.close();
+  }
+
+  @Override
+  public Integer length() {
+    return delegate.length();
+  }
+
+  @Override
+  public boolean isRepeatable() {
+    return delegate.isRepeatable();
+  }
+
+  @Override
+  public InputStream asInputStream() throws IOException {
+    // TODO, ideally, would like not to bring guava just for this
+    final CountingInputStream input = new CountingInputStream(delegate.asInputStream());
+    count = input::getCount;
+    return input;
+  }
+
+  @Override
+  public Reader asReader() throws IOException {
+    return new InputStreamReader(asInputStream(), UTF_8);
+  }
+
+  public long count() {
+    return count.get();
+  }
+
+  @Override
+  public Reader asReader(Charset charset) throws IOException {
+    return new InputStreamReader(asInputStream(), charset);
+  }
+
+}

--- a/metrics5/src/main/java/feign/metrics5/MeteredBody.java
+++ b/metrics5/src/main/java/feign/metrics5/MeteredBody.java
@@ -14,7 +14,6 @@
 package feign.metrics5;
 
 import static feign.Util.UTF_8;
-import com.google.common.io.CountingInputStream;
 import java.io.*;
 import java.nio.charset.Charset;
 import java.util.function.Supplier;
@@ -23,12 +22,12 @@ import feign.Response.Body;
 /**
  * {@link Body} implementation that keeps track of how many bytes are read.
  */
-final class MeteredBody implements Body {
+public final class MeteredBody implements Body {
 
   private final Body delegate;
   private Supplier<Long> count;
 
-  MeteredBody(Body body) {
+  public MeteredBody(Body body) {
     this.delegate = body;
     count = () -> 0L;
   }

--- a/metrics5/src/main/java/feign/metrics5/MeteredClient.java
+++ b/metrics5/src/main/java/feign/metrics5/MeteredClient.java
@@ -23,7 +23,7 @@ import io.dropwizard.metrics5.Timer.Context;
 /**
  * Warp feign {@link Client} with metrics.
  */
-final class MeteredClient implements Client {
+public class MeteredClient implements Client {
 
   private final Client client;
   private final MetricRegistry metricRegistry;

--- a/metrics5/src/main/java/feign/metrics5/MeteredClient.java
+++ b/metrics5/src/main/java/feign/metrics5/MeteredClient.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.metrics5;
+
+
+import java.io.IOException;
+import feign.*;
+import feign.Request.Options;
+import io.dropwizard.metrics5.MetricRegistry;
+import io.dropwizard.metrics5.Timer.Context;
+
+/**
+ * Warp feign {@link Client} with metrics.
+ */
+final class MeteredClient implements Client {
+
+  private final Client client;
+  private final MetricRegistry metricRegistry;
+  private final FeignMetricName metricName;
+  private final MetricSuppliers metricSuppliers;
+
+  public MeteredClient(Client client, MetricRegistry metricRegistry,
+      MetricSuppliers metricSuppliers) {
+    this.client = client;
+    this.metricRegistry = metricRegistry;
+    this.metricSuppliers = metricSuppliers;
+    this.metricName = new FeignMetricName(Client.class);
+  }
+
+  @Override
+  public Response execute(Request request, Options options) throws IOException {
+    final RequestTemplate template = request.requestTemplate();
+    try (final Context classTimer =
+        metricRegistry.timer(
+            metricName.metricName(template.methodMetadata(), template.feignTarget()),
+            metricSuppliers.timers()).time()) {
+      return client.execute(request, options);
+    }
+  }
+
+}

--- a/metrics5/src/main/java/feign/metrics5/MeteredDecoder.java
+++ b/metrics5/src/main/java/feign/metrics5/MeteredDecoder.java
@@ -16,19 +16,18 @@ package feign.metrics5;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
-import java.util.concurrent.TimeUnit;
 import feign.FeignException;
 import feign.RequestTemplate;
 import feign.Response;
 import feign.codec.DecodeException;
 import feign.codec.Decoder;
-import io.dropwizard.metrics5.*;
+import io.dropwizard.metrics5.MetricRegistry;
 import io.dropwizard.metrics5.Timer.Context;
 
 /**
  * Warp feign {@link Decoder} with metrics.
  */
-final class MeteredDecoder implements Decoder {
+public class MeteredDecoder implements Decoder {
 
   private final Decoder decoder;
   private final MetricRegistry metricRegistry;

--- a/metrics5/src/main/java/feign/metrics5/MeteredDecoder.java
+++ b/metrics5/src/main/java/feign/metrics5/MeteredDecoder.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.metrics5;
+
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.concurrent.TimeUnit;
+import feign.FeignException;
+import feign.RequestTemplate;
+import feign.Response;
+import feign.codec.DecodeException;
+import feign.codec.Decoder;
+import io.dropwizard.metrics5.*;
+import io.dropwizard.metrics5.Timer.Context;
+
+/**
+ * Warp feign {@link Decoder} with metrics.
+ */
+final class MeteredDecoder implements Decoder {
+
+  private final Decoder decoder;
+  private final MetricRegistry metricRegistry;
+  private final MetricSuppliers metricSuppliers;
+  private final FeignMetricName metricName;
+
+  public MeteredDecoder(Decoder decoder, MetricRegistry metricRegistry,
+      MetricSuppliers metricSuppliers) {
+    this.decoder = decoder;
+    this.metricRegistry = metricRegistry;
+    this.metricSuppliers = metricSuppliers;
+    this.metricName = new FeignMetricName(Decoder.class);
+  }
+
+  @Override
+  public Object decode(Response response, Type type)
+      throws IOException, DecodeException, FeignException {
+    final RequestTemplate template = response.request().requestTemplate();
+    final MeteredBody body = response.body() == null
+        ? null
+        : new MeteredBody(response.body());
+
+    response = response.toBuilder().body(body).build();
+
+    final Object decoded;
+    try (final Context classTimer =
+        metricRegistry
+            .timer(metricName.metricName(template.methodMetadata(), template.feignTarget()),
+                metricSuppliers.timers())
+            .time()) {
+      decoded = decoder.decode(response, type);
+    }
+
+    if (body != null) {
+      metricRegistry.histogram(
+          metricName.metricName(template.methodMetadata(), template.feignTarget(),
+              "response_size"),
+          metricSuppliers.histograms()).update(body.count());
+    }
+
+    return decoded;
+  }
+
+}

--- a/metrics5/src/main/java/feign/metrics5/MeteredEncoder.java
+++ b/metrics5/src/main/java/feign/metrics5/MeteredEncoder.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.metrics5;
+
+
+import java.lang.reflect.Type;
+import feign.RequestTemplate;
+import feign.codec.EncodeException;
+import feign.codec.Encoder;
+import io.dropwizard.metrics5.MetricRegistry;
+import io.dropwizard.metrics5.Timer.Context;
+
+/**
+ * Warp feign {@link Encoder} with metrics.
+ */
+final class MeteredEncoder implements Encoder {
+
+  private final Encoder encoder;
+  private final MetricRegistry metricRegistry;
+  private final MetricSuppliers metricSuppliers;
+  private final FeignMetricName metricName;
+
+  public MeteredEncoder(Encoder encoder, MetricRegistry metricRegistry,
+      MetricSuppliers metricSuppliers) {
+    this.encoder = encoder;
+    this.metricRegistry = metricRegistry;
+    this.metricSuppliers = metricSuppliers;
+    this.metricName = new FeignMetricName(Encoder.class);
+  }
+
+  @Override
+  public void encode(Object object, Type bodyType, RequestTemplate template)
+      throws EncodeException {
+    try (final Context classTimer =
+        metricRegistry.timer(
+            metricName.metricName(template.methodMetadata(), template.feignTarget()),
+            metricSuppliers.timers()).time()) {
+      encoder.encode(object, bodyType, template);
+    }
+
+    if (template.body() != null) {
+      metricRegistry.histogram(
+          metricName.metricName(template.methodMetadata(), template.feignTarget(), "request_size"),
+          metricSuppliers.histograms()).update(template.body().length);
+    }
+  }
+
+}

--- a/metrics5/src/main/java/feign/metrics5/MeteredEncoder.java
+++ b/metrics5/src/main/java/feign/metrics5/MeteredEncoder.java
@@ -24,7 +24,7 @@ import io.dropwizard.metrics5.Timer.Context;
 /**
  * Warp feign {@link Encoder} with metrics.
  */
-final class MeteredEncoder implements Encoder {
+public class MeteredEncoder implements Encoder {
 
   private final Encoder encoder;
   private final MetricRegistry metricRegistry;

--- a/metrics5/src/main/java/feign/metrics5/MeteredInvocationHandleFactory.java
+++ b/metrics5/src/main/java/feign/metrics5/MeteredInvocationHandleFactory.java
@@ -28,7 +28,7 @@ import io.dropwizard.metrics5.Timer.Context;
 /**
  * Warp feign {@link InvocationHandler} with metrics.
  */
-final class MeteredInvocationHandleFactory implements InvocationHandlerFactory {
+public class MeteredInvocationHandleFactory implements InvocationHandlerFactory {
 
   private static final Logger LOG = LoggerFactory.getLogger(MeteredInvocationHandleFactory.class);
 
@@ -47,7 +47,7 @@ final class MeteredInvocationHandleFactory implements InvocationHandlerFactory {
 
   private final MetricSuppliers metricSuppliers;
 
-  MeteredInvocationHandleFactory(InvocationHandlerFactory invocationHandler,
+  public MeteredInvocationHandleFactory(InvocationHandlerFactory invocationHandler,
       MetricRegistry metricRegistry, MetricSuppliers metricSuppliers) {
     this.invocationHandler = invocationHandler;
     this.metricRegistry = metricRegistry;

--- a/metrics5/src/main/java/feign/metrics5/MeteredInvocationHandleFactory.java
+++ b/metrics5/src/main/java/feign/metrics5/MeteredInvocationHandleFactory.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.metrics5;
+
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import feign.*;
+import io.dropwizard.metrics5.MetricRegistry;
+import io.dropwizard.metrics5.Timer.Context;
+
+/**
+ * Warp feign {@link InvocationHandler} with metrics.
+ */
+final class MeteredInvocationHandleFactory implements InvocationHandlerFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MeteredInvocationHandleFactory.class);
+
+  /**
+   * Methods that are declared by super class object and, if invoked, we don't wanna record metrics
+   * for
+   */
+  private static final List<String> JAVA_OBJECT_METHODS =
+      Arrays.asList("equals", "toString", "hashCode");
+
+  private final InvocationHandlerFactory invocationHandler;
+
+  private final MetricRegistry metricRegistry;
+
+  private final FeignMetricName metricName;
+
+  private final MetricSuppliers metricSuppliers;
+
+  MeteredInvocationHandleFactory(InvocationHandlerFactory invocationHandler,
+      MetricRegistry metricRegistry, MetricSuppliers metricSuppliers) {
+    this.invocationHandler = invocationHandler;
+    this.metricRegistry = metricRegistry;
+    this.metricSuppliers = metricSuppliers;
+    this.metricName = new FeignMetricName(Feign.class);
+  }
+
+  @Override
+  public InvocationHandler create(Target target, Map<Method, MethodHandler> dispatch) {
+    final Class clientClass = target.type();
+
+    final InvocationHandler invocationHandle = invocationHandler.create(target, dispatch);
+    return (proxy, method, args) -> {
+
+      if (JAVA_OBJECT_METHODS.contains(method.getName())
+          || Util.isDefault(method)) {
+        LOG.trace("Skipping metrics for method={}", method);
+        return invocationHandle.invoke(proxy, method, args);
+      }
+
+      try (final Context classTimer =
+          metricRegistry.timer(metricName.metricName(clientClass, method, target.url()),
+              metricSuppliers.timers()).time()) {
+
+        return invocationHandle.invoke(proxy, method, args);
+      } catch (final FeignException e) {
+        metricRegistry.meter(
+            metricName.metricName(clientClass, method, target.url())
+                .resolve("http_error")
+                .tagged("http_status", String.valueOf(e.status()))
+                .tagged("error_group", e.status() / 100 + "xx"),
+            metricSuppliers.meters()).mark();
+
+        throw e;
+      } catch (final Throwable e) {
+        metricRegistry
+            .meter(metricName.metricName(clientClass, method, target.url())
+                .resolve("exception")
+                .tagged("exception_name", e.getClass().getSimpleName()),
+                metricSuppliers.meters())
+            .mark();
+
+        throw e;
+      }
+    };
+  }
+
+
+}

--- a/metrics5/src/main/java/feign/metrics5/MetricSuppliers.java
+++ b/metrics5/src/main/java/feign/metrics5/MetricSuppliers.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.metrics5;
+
+import java.util.concurrent.TimeUnit;
+import io.dropwizard.metrics5.*;
+import io.dropwizard.metrics5.MetricRegistry.MetricSupplier;
+
+public class MetricSuppliers {
+
+  public MetricSupplier<Timer> timers() {
+    // only keep timer data for 1 minute
+    return () -> new Timer(new SlidingTimeWindowArrayReservoir(1, TimeUnit.MINUTES));
+  }
+
+  public MetricSupplier<Meter> meters() {
+    return () -> new Meter();
+  }
+
+  public MetricSupplier<Histogram> histograms() {
+    // only keep timer data for 1 minute
+    return () -> new Histogram(new SlidingTimeWindowArrayReservoir(1, TimeUnit.MINUTES));
+  }
+
+}

--- a/metrics5/src/main/java/feign/metrics5/Metrics5Capability.java
+++ b/metrics5/src/main/java/feign/metrics5/Metrics5Capability.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.metrics5;
+
+import feign.Capability;
+import feign.Client;
+import feign.InvocationHandlerFactory;
+import feign.codec.Decoder;
+import feign.codec.Encoder;
+import io.dropwizard.metrics5.MetricRegistry;
+import io.dropwizard.metrics5.SharedMetricRegistries;
+
+public class Metrics5Capability implements Capability {
+
+  private final MetricRegistry metricRegistry;
+  private final MetricSuppliers metricSuppliers;
+
+  public Metrics5Capability() {
+    this(SharedMetricRegistries.getOrCreate("feign"), new MetricSuppliers());
+  }
+
+  public Metrics5Capability(MetricRegistry metricRegistry) {
+    this(metricRegistry, new MetricSuppliers());
+  }
+
+  public Metrics5Capability(MetricRegistry metricRegistry, MetricSuppliers metricSuppliers) {
+    this.metricRegistry = metricRegistry;
+    this.metricSuppliers = metricSuppliers;
+  }
+
+  @Override
+  public Client enrich(Client client) {
+    return new MeteredClient(client, metricRegistry, metricSuppliers);
+  }
+
+  @Override
+  public Encoder enrich(Encoder encoder) {
+    return new MeteredEncoder(encoder, metricRegistry, metricSuppliers);
+  }
+
+  @Override
+  public Decoder enrich(Decoder decoder) {
+    return new MeteredDecoder(decoder, metricRegistry, metricSuppliers);
+  }
+
+  @Override
+  public InvocationHandlerFactory enrich(InvocationHandlerFactory invocationHandlerFactory) {
+    return new MeteredInvocationHandleFactory(invocationHandlerFactory, metricRegistry,
+        metricSuppliers);
+  }
+
+}

--- a/metrics5/src/test/java/feign/metrics5/Metrics5CapabilityTest.java
+++ b/metrics5/src/test/java/feign/metrics5/Metrics5CapabilityTest.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.metrics5;
+
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.junit.Assert.assertThat;
+import org.junit.Test;
+import feign.Feign;
+import feign.RequestLine;
+import feign.mock.HttpMethod;
+import feign.mock.MockClient;
+import feign.mock.MockTarget;
+import io.dropwizard.metrics5.MetricRegistry;
+import io.dropwizard.metrics5.SharedMetricRegistries;
+
+public class Metrics5CapabilityTest {
+
+  public interface SimpleSource {
+
+    @RequestLine("GET /get")
+    String get(String body);
+
+  }
+
+  @Test
+  public void addMetricsCapability() {
+    final MetricRegistry registry = SharedMetricRegistries.getOrCreate("unit_test");
+
+    final SimpleSource source = Feign.builder()
+        .client(new MockClient()
+            .ok(HttpMethod.GET, "/get", "1234567890abcde"))
+        .addCapability(new Metrics5Capability(registry))
+        .target(new MockTarget<>(Metrics5CapabilityTest.SimpleSource.class));
+
+    source.get("0x3456789");
+
+    assertThat(registry.getMetrics(), aMapWithSize(6));
+
+    registry.getMetrics().keySet().forEach(metricName -> assertThat(
+        "Expect all metric names to include client name:" + metricName,
+        metricName.getTags(),
+        hasEntry("client", "feign.metrics5.Metrics5CapabilityTest$SimpleSource")));
+    registry.getMetrics().keySet().forEach(metricName -> assertThat(
+        "Expect all metric names to include method name:" + metricName,
+        metricName.getTags(),
+        hasEntry("method", "get")));
+    registry.getMetrics().keySet().forEach(
+        metricName -> assertThat(
+            "Expect all metric names to include host name:" + metricName,
+            metricName.getTags(),
+            // hostname is null due to feign-mock shortfalls
+            hasEntry("host", null)));
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
     <module>mock</module>
     <module>apt-test-generator</module>
     <module>benchmark</module>
+    <module>metrics5</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
Provide a first-class Metrics API that users can tap into to gain insight into the request/response lifecycle. 

My plan is:
Extend the capabilities to Async and Reactive (before 10.8 release)
Add metrics support for OpenTracing

After this, I feel we are in a good place to cut 10.8 and being 11 branch
