### PR TITLE
Configurable to disable streaming mode for Default client

### DIFF
--- a/core/src/main/java/feign/Client.java
+++ b/core/src/main/java/feign/Client.java
@@ -19,8 +19,10 @@ import static feign.Util.ENCODING_DEFLATE;
 import static feign.Util.ENCODING_GZIP;
 import static feign.Util.checkArgument;
 import static feign.Util.checkNotNull;
+import static feign.Util.isBlank;
 import static feign.Util.isNotBlank;
 import static java.lang.String.format;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -35,9 +37,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.GZIPOutputStream;
+
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
+
 import feign.Request.Options;
 
 /**
@@ -161,10 +165,12 @@ public interface Client {
       }
 
       if (request.body() != null) {
-        if (contentLength != null) {
-          connection.setFixedLengthStreamingMode(contentLength);
-        } else {
-          connection.setChunkedStreamingMode(8196);
+        if (options.isAllowStreamingMode()) {
+          if (contentLength != null) {
+            connection.setFixedLengthStreamingMode(contentLength);
+          } else {
+            connection.setChunkedStreamingMode(8196);
+          }
         }
         connection.setDoOutput(true);
         OutputStream out = connection.getOutputStream();

--- a/core/src/main/java/feign/Request.java
+++ b/core/src/main/java/feign/Request.java
@@ -234,6 +234,7 @@ public final class Request {
     private final long readTimeout;
     private final TimeUnit readTimeoutUnit;
     private final boolean followRedirects;
+    private final boolean allowStreamingMode;
 
     /**
      * Creates a new Options instance.
@@ -249,6 +250,27 @@ public final class Request {
       this(connectTimeoutMillis, TimeUnit.MILLISECONDS,
           readTimeoutMillis, TimeUnit.MILLISECONDS,
           followRedirects);
+    }
+    
+    /**
+     * Creates a new Options Instance.
+     *
+     * @param connectTimeout value.
+     * @param connectTimeoutUnit with the TimeUnit for the timeout value.
+     * @param readTimeout value.
+     * @param readTimeoutUnit with the TimeUnit for the timeout value.
+     * @param followRedirects if the request should follow 3xx redirections.
+     * @param allowStreamingMode if the request should allow using streaming mode.
+     */
+    public Options(long connectTimeout, TimeUnit connectTimeoutUnit, long readTimeout,
+        TimeUnit readTimeoutUnit, boolean followRedirects, boolean allowStreamingMode) {
+      super();
+      this.connectTimeout = connectTimeout;
+      this.connectTimeoutUnit = connectTimeoutUnit;
+      this.readTimeout = readTimeout;
+      this.readTimeoutUnit = readTimeoutUnit;
+      this.followRedirects = followRedirects;
+      this.allowStreamingMode = allowStreamingMode;
     }
 
     /**
@@ -269,6 +291,7 @@ public final class Request {
       this.readTimeout = readTimeout;
       this.readTimeoutUnit = readTimeoutUnit;
       this.followRedirects = followRedirects;
+      this.allowStreamingMode = true;
     }
 
     /**
@@ -314,7 +337,6 @@ public final class Request {
       return (int) readTimeoutUnit.toMillis(readTimeout);
     }
 
-
     /**
      * Defaults to true. {@code false} tells the client to not follow the redirections.
      *
@@ -322,6 +344,13 @@ public final class Request {
      */
     public boolean isFollowRedirects() {
       return followRedirects;
+    }
+
+    /**
+     * Defaults to true. {@code false} tells the client to disable streaming mode.
+     */
+    public boolean isAllowStreamingMode() {
+      return allowStreamingMode;
     }
 
     /**

--- a/core/src/test/java/feign/client/AbstractClientTest.java
+++ b/core/src/test/java/feign/client/AbstractClientTest.java
@@ -147,6 +147,22 @@ public abstract class AbstractClientTest {
   }
 
   @Test
+  public void parsesUnauthorizedResponseBody() {
+    String expectedResponseBody = "ARGHH";
+
+    server.enqueue(new MockResponse().setResponseCode(401).setBody("ARGHH"));
+
+    TestInterface api = newBuilder()
+        .target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    try {
+      api.postForString("HELLO");
+    } catch (FeignException e) {
+      assertThat(e.contentUTF8()).isEqualTo(expectedResponseBody);
+    }
+  }
+
+  @Test
   public void safeRebuffering() {
     server.enqueue(new MockResponse().setBody("foo"));
 
@@ -377,6 +393,10 @@ public abstract class AbstractClientTest {
     @RequestLine("POST /path/{to}/resource")
     @Headers("Accept: text/plain")
     Response post(@Param("to") String to, String body);
+
+    @RequestLine("POST /?foo=bar&foo=baz&qux=")
+    @Headers({"Foo: Bar", "Foo: Baz", "Qux: ", "Content-Type: text/plain"})
+    String postForString(String body);
 
     @RequestLine("GET /")
     @Headers("Accept: text/plain")


### PR DESCRIPTION
* Add a property `allowStramingMode` in `Request.Option`.

* Optional to disable the streaming mode for `HttpURLConnection`.

* The property is default to `true` for compatibility.

Fix #260