### PR TITLE
Allow empty expression in header values

### DIFF
--- a/core/src/main/java/feign/template/BodyTemplate.java
+++ b/core/src/main/java/feign/template/BodyTemplate.java
@@ -51,7 +51,7 @@ public final class BodyTemplate extends Template {
   }
 
   private BodyTemplate(String value, Charset charset) {
-    super(value, ExpansionOptions.ALLOW_UNRESOLVED, EncodingOptions.NOT_REQUIRED, false, charset);
+    super(value, ExpansionOptions.ALLOW_UNRESOLVED, EncodingOptions.NOT_REQUIRED, false, false, charset);
     if (value.startsWith(JSON_TOKEN_START_ENCODED) && value.endsWith(JSON_TOKEN_END_ENCODED)) {
       this.json = true;
     }

--- a/core/src/main/java/feign/template/Expressions.java
+++ b/core/src/main/java/feign/template/Expressions.java
@@ -40,12 +40,17 @@ public final class Expressions {
         SimpleExpression.class);
   }
 
-  public static Expression create(final String value) {
+  public static Expression create(final String value, boolean allowEmpty) {
 
     /* remove the start and end braces */
     final String expression = stripBraces(value);
     if (expression == null || expression.isEmpty()) {
-      throw new IllegalArgumentException("an expression is required.");
+      if(allowEmpty) {
+        return null;
+      }
+      else {
+        throw new IllegalArgumentException("an expression is required.");
+      }
     }
 
     Optional<Entry<Pattern, Class<? extends Expression>>> matchedExpressionEntry =

--- a/core/src/main/java/feign/template/HeaderTemplate.java
+++ b/core/src/main/java/feign/template/HeaderTemplate.java
@@ -78,7 +78,7 @@ public final class HeaderTemplate extends Template {
    * @param template to parse.
    */
   private HeaderTemplate(String template, String name, Iterable<String> values, Charset charset) {
-    super(template, ExpansionOptions.REQUIRED, EncodingOptions.NOT_REQUIRED, false, charset);
+    super(template, ExpansionOptions.REQUIRED, EncodingOptions.NOT_REQUIRED, false, true, charset);
     this.values = StreamSupport.stream(values.spliterator(), false)
         .filter(Util::isNotBlank)
         .collect(Collectors.toCollection(LinkedHashSet::new));

--- a/core/src/main/java/feign/template/QueryTemplate.java
+++ b/core/src/main/java/feign/template/QueryTemplate.java
@@ -124,7 +124,7 @@ public final class QueryTemplate {
       boolean decodeSlash) {
     this.values = new CopyOnWriteArrayList<>();
     this.name = new Template(name, ExpansionOptions.ALLOW_UNRESOLVED, EncodingOptions.REQUIRED,
-        !decodeSlash, charset);
+        !decodeSlash, false, charset);
     this.collectionFormat = collectionFormat;
 
     /* parse each value into a template chunk for resolution later */
@@ -139,8 +139,7 @@ public final class QueryTemplate {
               value,
               ExpansionOptions.REQUIRED,
               EncodingOptions.REQUIRED,
-              !decodeSlash,
-              charset));
+              !decodeSlash, false, charset));
     }
 
     if (this.values.isEmpty()) {

--- a/core/src/main/java/feign/template/Template.java
+++ b/core/src/main/java/feign/template/Template.java
@@ -30,7 +30,6 @@ import java.util.stream.Collectors;
 public class Template {
 
   private static final Logger logger = Logger.getLogger(Template.class.getName());
-  private static final Pattern QUERY_STRING_PATTERN = Pattern.compile("(?<!\\{)(\\?)");
   private final String template;
   private final boolean allowUnresolved;
   private final EncodingOptions encode;

--- a/core/src/main/java/feign/template/Template.java
+++ b/core/src/main/java/feign/template/Template.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.logging.Logger;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -34,6 +33,7 @@ public class Template {
   private final boolean allowUnresolved;
   private final EncodingOptions encode;
   private final boolean encodeSlash;
+  private final boolean allowEmpty;
   private final Charset charset;
   private final List<TemplateChunk> templateChunks = new ArrayList<>();
 
@@ -44,10 +44,11 @@ public class Template {
    * @param allowUnresolved if unresolved expressions should remain.
    * @param encode all values.
    * @param encodeSlash if slash characters should be encoded.
+   * @param allowEmpty if empty expressions are allowed.
    */
   Template(
-      String value, ExpansionOptions allowUnresolved, EncodingOptions encode, boolean encodeSlash,
-      Charset charset) {
+          String value, ExpansionOptions allowUnresolved, EncodingOptions encode, boolean encodeSlash,
+          boolean allowEmpty, Charset charset) {
     if (value == null) {
       throw new IllegalArgumentException("template is required.");
     }
@@ -55,6 +56,7 @@ public class Template {
     this.allowUnresolved = ExpansionOptions.ALLOW_UNRESOLVED == allowUnresolved;
     this.encode = encode;
     this.encodeSlash = encodeSlash;
+    this.allowEmpty = allowEmpty;
     this.charset = charset;
     this.parseTemplate();
   }
@@ -190,7 +192,7 @@ public class Template {
       String chunk = tokenizer.next();
 
       if (chunk.startsWith("{")) {
-        Expression expression = Expressions.create(chunk);
+        Expression expression = Expressions.create(chunk, this.allowEmpty);
         if (expression == null) {
           this.templateChunks.add(Literal.create(this.encodeLiteral(chunk)));
         } else {

--- a/core/src/main/java/feign/template/UriTemplate.java
+++ b/core/src/main/java/feign/template/UriTemplate.java
@@ -70,6 +70,6 @@ public class UriTemplate extends Template {
    * @param charset to use when encoding.
    */
   private UriTemplate(String template, boolean encodeSlash, Charset charset) {
-    super(template, ExpansionOptions.REQUIRED, EncodingOptions.REQUIRED, encodeSlash, charset);
+    super(template, ExpansionOptions.REQUIRED, EncodingOptions.REQUIRED, encodeSlash, false, charset);
   }
 }

--- a/core/src/test/java/feign/template/HeaderTemplateTest.java
+++ b/core/src/test/java/feign/template/HeaderTemplateTest.java
@@ -62,6 +62,12 @@ public class HeaderTemplateTest {
   }
 
   @Test
+  public void allow_empty_expression() {
+    HeaderTemplate headerTemplate = HeaderTemplate.create("hello", Arrays.asList("{}"));
+    assertEquals("hello {}", headerTemplate.expand(Collections.emptyMap()));
+  }
+
+  @Test
   public void create_should_preserve_order() {
     /*
      * Since Java 7, HashSet order is stable within a since JVM process, so one of these assertions


### PR DESCRIPTION
Allow empty expression `{}` as a literal within header template values. In any other template (Uri, Body, Query), they're still not allowed (there the expression should be pct-encoded in those cases). 

Fixes #1172.