### PR TITLE
Fix expansion of @RequestParam empty lists

### DIFF
--- a/core/src/main/java/feign/template/Expressions.java
+++ b/core/src/main/java/feign/template/Expressions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2019 The Feign Authors
+ * Copyright 2012-2020 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -150,11 +150,6 @@ public final class Expressions {
           }
           result.append(expanded);
         }
-      }
-
-      if (result.length() == 0) {
-        /* completely unresolved */
-        return null;
       }
 
       /* return the expanded value */

--- a/core/src/test/java/feign/template/QueryTemplateTest.java
+++ b/core/src/test/java/feign/template/QueryTemplateTest.java
@@ -53,7 +53,7 @@ public class QueryTemplateTest {
     QueryTemplate template =
             QueryTemplate.create("name", Collections.singletonList("{value}"), Util.UTF_8);
     String expanded = template.expand(Collections.singletonMap("value", Collections.emptyList()));
-    assertThat(expanded).isEqualToIgnoringCase("name=null");
+    assertThat(expanded).isEqualToIgnoringCase("name=");
   }
 
   @Test

--- a/core/src/test/java/feign/template/QueryTemplateTest.java
+++ b/core/src/test/java/feign/template/QueryTemplateTest.java
@@ -34,7 +34,7 @@ public class QueryTemplateTest {
   @Test
   public void expandEmptyCollection() {
     QueryTemplate template =
-            QueryTemplate.create("people", Collections.singletonList("{people}"), Util.UTF_8);
+        QueryTemplate.create("people", Collections.singletonList("{people}"), Util.UTF_8);
     String expanded = template.expand(Collections.singletonMap("people", Collections.emptyList()));
     assertThat(expanded).isEqualToIgnoringCase("people=");
   }
@@ -42,8 +42,9 @@ public class QueryTemplateTest {
   @Test
   public void expandCollection() {
     QueryTemplate template =
-            QueryTemplate.create("people", Collections.singletonList("{people}"), Util.UTF_8);
-    String expanded = template.expand(Collections.singletonMap("people", Arrays.asList("Bob", "James", "Jason")));
+        QueryTemplate.create("people", Collections.singletonList("{people}"), Util.UTF_8);
+    String expanded =
+        template.expand(Collections.singletonMap("people", Arrays.asList("Bob", "James", "Jason")));
     assertThat(expanded).isEqualToIgnoringCase("people=Bob&people=James&people=Jason");
   }
 

--- a/core/src/test/java/feign/template/QueryTemplateTest.java
+++ b/core/src/test/java/feign/template/QueryTemplateTest.java
@@ -32,6 +32,22 @@ public class QueryTemplateTest {
   }
 
   @Test
+  public void expandEmptyCollection() {
+    QueryTemplate template =
+            QueryTemplate.create("people", Collections.singletonList("{people}"), Util.UTF_8);
+    String expanded = template.expand(Collections.singletonMap("people", Collections.emptyList()));
+    assertThat(expanded).isEqualToIgnoringCase("people=");
+  }
+
+  @Test
+  public void expandCollection() {
+    QueryTemplate template =
+            QueryTemplate.create("people", Collections.singletonList("{people}"), Util.UTF_8);
+    String expanded = template.expand(Collections.singletonMap("people", Arrays.asList("Bob", "James", "Jason")));
+    assertThat(expanded).isEqualToIgnoringCase("people=Bob&people=James&people=Jason");
+  }
+
+  @Test
   public void expandCollectionWithBlanks() {
     QueryTemplate template =
         QueryTemplate.create("people", Collections.singletonList("{people}"), Util.UTF_8);
@@ -48,29 +64,6 @@ public class QueryTemplateTest {
     assertThat(expanded).isEqualToIgnoringCase("name=Magnum%20P.I.");
   }
 
-  @Test
-  public void expandSingleValueEmptyList() {
-    QueryTemplate template =
-            QueryTemplate.create("name", Collections.singletonList("{value}"), Util.UTF_8);
-    String expanded = template.expand(Collections.singletonMap("value", Collections.emptyList()));
-    assertThat(expanded).isEqualToIgnoringCase("name=");
-  }
-
-  @Test
-  public void expandSingleValueSingletonList() {
-    QueryTemplate template =
-            QueryTemplate.create("name", Collections.singletonList("{value}"), Util.UTF_8);
-    String expanded = template.expand(Collections.singletonMap("value", Collections.singletonList("Magnum P.I.")));
-    assertThat(expanded).isEqualToIgnoringCase("name=Magnum%20P.I.");
-  }
-
-  @Test
-  public void expandSingleValueMultipleValueList() {
-    QueryTemplate template =
-            QueryTemplate.create("name", Collections.singletonList("{value}"), Util.UTF_8);
-    String expanded = template.expand(Collections.singletonMap("value", Arrays.asList("Bob", "James", "Jason")));
-    assertThat(expanded).isEqualToIgnoringCase("name=Bob&name=James&name=Jason");
-  }
 
   @Test
   public void expandMultipleValues() {

--- a/core/src/test/java/feign/template/QueryTemplateTest.java
+++ b/core/src/test/java/feign/template/QueryTemplateTest.java
@@ -17,6 +17,7 @@ package feign.template;
 import static org.assertj.core.api.Assertions.assertThat;
 import feign.CollectionFormat;
 import feign.Util;
+
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.Test;
@@ -45,6 +46,30 @@ public class QueryTemplateTest {
         QueryTemplate.create("name", Collections.singletonList("{value}"), Util.UTF_8);
     String expanded = template.expand(Collections.singletonMap("value", "Magnum P.I."));
     assertThat(expanded).isEqualToIgnoringCase("name=Magnum%20P.I.");
+  }
+
+  @Test
+  public void expandSingleValueEmptyList() {
+    QueryTemplate template =
+            QueryTemplate.create("name", Collections.singletonList("{value}"), Util.UTF_8);
+    String expanded = template.expand(Collections.singletonMap("value", Collections.emptyList()));
+    assertThat(expanded).isEqualToIgnoringCase("name=null");
+  }
+
+  @Test
+  public void expandSingleValueSingletonList() {
+    QueryTemplate template =
+            QueryTemplate.create("name", Collections.singletonList("{value}"), Util.UTF_8);
+    String expanded = template.expand(Collections.singletonMap("value", Collections.singletonList("Magnum P.I.")));
+    assertThat(expanded).isEqualToIgnoringCase("name=Magnum%20P.I.");
+  }
+
+  @Test
+  public void expandSingleValueMultipleValueList() {
+    QueryTemplate template =
+            QueryTemplate.create("name", Collections.singletonList("{value}"), Util.UTF_8);
+    String expanded = template.expand(Collections.singletonMap("value", Arrays.asList("Bob", "James", "Jason")));
+    assertThat(expanded).isEqualToIgnoringCase("name=Bob&name=James&name=Jason");
   }
 
   @Test

--- a/core/src/test/java/feign/template/QueryTemplateTest.java
+++ b/core/src/test/java/feign/template/QueryTemplateTest.java
@@ -17,7 +17,6 @@ package feign.template;
 import static org.assertj.core.api.Assertions.assertThat;
 import feign.CollectionFormat;
 import feign.Util;
-
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.Test;
@@ -64,7 +63,6 @@ public class QueryTemplateTest {
     String expanded = template.expand(Collections.singletonMap("value", "Magnum P.I."));
     assertThat(expanded).isEqualToIgnoringCase("name=Magnum%20P.I.");
   }
-
 
   @Test
   public void expandMultipleValues() {


### PR DESCRIPTION
This PR addresses #1194.

`Expressions.expandIterable()` ([link](https://github.com/OpenFeign/feign/blob/master/core/src/main/java/feign/template/Expressions.java#L132)), expands an empty list into `null`, which gets returned to `expand()`, whose `StringBuilder` appends a `null`. `StringBuilder` will append a literal `null` to the internal string buffer, resulting in an expansion of an empty list into something like `/items?manufacturer=null`, which will be serialized by the caller as a singleton list with a single `null`.

This PR modifies `expandIterable()` to return an empty string instead of `null` in the case of an empty list.