### PR TITLE
GH-1172: Store expanded Header Template values as Literals

### DIFF
--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -33,6 +33,7 @@ import static feign.Util.*;
  * information also support template expressions.
  * </p>
  */
+@SuppressWarnings("UnusedReturnValue")
 public final class RequestTemplate implements Serializable {
 
   private static final Pattern QUERY_STRING_PATTERN = Pattern.compile("(?<!\\{)\\?");
@@ -233,7 +234,8 @@ public final class RequestTemplate implements Serializable {
           /* split off the header values and add it to the resolved template */
           String headerValues = header.substring(header.indexOf(" ") + 1);
           if (!headerValues.isEmpty()) {
-            resolved.header(headerTemplate.getName(), headerValues);
+            /* append the header as a new literal as the value has already been expanded. */
+            resolved.header(headerTemplate.getName(), Literal.create(headerValues));
           }
         }
       }
@@ -693,6 +695,20 @@ public final class RequestTemplate implements Serializable {
   }
 
   /**
+   * Add a header using the supplied Chunks.
+   * 
+   * @param name of the header.
+   * @param chunks to add.
+   * @return a RequestTemplate for chaining.
+   */
+  private RequestTemplate header(String name, TemplateChunk... chunks) {
+    if (chunks == null) {
+      throw new IllegalArgumentException("chunks are required.");
+    }
+    return appendHeader(name, Arrays.asList(chunks));
+  }
+
+  /**
    * Specify a Header, with the specified values. Values can be literals or template expressions.
    *
    * @param name of the header.
@@ -742,6 +758,22 @@ public final class RequestTemplate implements Serializable {
         return HeaderTemplate.create(headerName, values);
       } else {
         return HeaderTemplate.append(headerTemplate, values);
+      }
+    });
+    return this;
+  }
+
+  private RequestTemplate appendHeader(String name, List<TemplateChunk> chunks) {
+    if (chunks.isEmpty()) {
+      this.headers.remove(name);
+      return this;
+    }
+
+    this.headers.compute(name, (headerName, headerTemplate) -> {
+      if (headerTemplate == null) {
+        return HeaderTemplate.from(name, chunks);
+      } else {
+        return HeaderTemplate.appendFrom(headerTemplate, chunks);
       }
     });
     return this;
@@ -817,7 +849,7 @@ public final class RequestTemplate implements Serializable {
     /* body template must be cleared to prevent double processing */
     this.bodyTemplate = null;
 
-    header(CONTENT_LENGTH);
+    header(CONTENT_LENGTH, Collections.emptyList());
     if (body.length() > 0) {
       header(CONTENT_LENGTH, String.valueOf(body.length()));
     }

--- a/core/src/main/java/feign/template/Literal.java
+++ b/core/src/main/java/feign/template/Literal.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2019 The Feign Authors
+ * Copyright 2012-2020 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,7 +16,7 @@ package feign.template;
 /**
  * URI Template Literal.
  */
-class Literal implements TemplateChunk {
+public class Literal implements TemplateChunk {
 
   private final String value;
 

--- a/core/src/main/java/feign/template/Template.java
+++ b/core/src/main/java/feign/template/Template.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2019 The Feign Authors
+ * Copyright 2012-2020 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,6 +15,7 @@ package feign.template;
 
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -58,6 +59,25 @@ public class Template {
     this.encodeSlash = encodeSlash;
     this.charset = charset;
     this.parseTemplate();
+  }
+
+  /**
+   * Create a new Template from the provided {@link TemplateChunk}s.
+   *
+   * @param allowUnresolved if unresolved expressions should remain.
+   * @param encode all values
+   * @param encodeSlash if slash characters should be encoded.
+   * @param charset of the result.
+   * @param chunks for this template.
+   */
+  Template(ExpansionOptions allowUnresolved, EncodingOptions encode, boolean encodeSlash,
+      Charset charset, List<TemplateChunk> chunks) {
+    this.templateChunks.addAll(chunks);
+    this.allowUnresolved = ExpansionOptions.ALLOW_UNRESOLVED == allowUnresolved;
+    this.encode = encode;
+    this.encodeSlash = encodeSlash;
+    this.charset = charset;
+    this.template = this.toString();
   }
 
   /**
@@ -158,6 +178,10 @@ public class Template {
         .map(TemplateChunk::toString)
         .filter(Objects::nonNull)
         .collect(Collectors.toList());
+  }
+
+  public List<TemplateChunk> getTemplateChunks() {
+    return Collections.unmodifiableList(this.templateChunks);
   }
 
   /**

--- a/core/src/main/java/feign/template/TemplateChunk.java
+++ b/core/src/main/java/feign/template/TemplateChunk.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2019 The Feign Authors
+ * Copyright 2012-2020 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,7 +17,7 @@ package feign.template;
  * Represents the parts of a URI Template.
  */
 @FunctionalInterface
-interface TemplateChunk {
+public interface TemplateChunk {
 
   String getValue();
 

--- a/core/src/test/java/feign/template/HeaderTemplateTest.java
+++ b/core/src/test/java/feign/template/HeaderTemplateTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2019 The Feign Authors
+ * Copyright 2012-2020 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -30,19 +30,25 @@ public class HeaderTemplateTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void it_should_throw_exception_when_name_is_null() {
-    HeaderTemplate.create(null, Arrays.asList("test"));
+    HeaderTemplate.create(null, Collections.singletonList("test"));
     exception.expectMessage("name is required.");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void it_should_throw_exception_when_name_is_empty() {
-    HeaderTemplate.create("", Arrays.asList("test"));
+    HeaderTemplate.create("", Collections.singletonList("test"));
     exception.expectMessage("name is required.");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void it_should_throw_exception_when_value_is_null() {
     HeaderTemplate.create("test", null);
+    exception.expectMessage("values are required");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void it_should_throw_exception_when_value_is_null_for_chunks() {
+    HeaderTemplate.from("test", null);
     exception.expectMessage("values are required");
   }
 
@@ -55,10 +61,19 @@ public class HeaderTemplateTest {
 
   @Test
   public void it_should_return_expanded() {
-    HeaderTemplate headerTemplate = HeaderTemplate.create("hello", Arrays.asList("emre", "savci"));
+    HeaderTemplate headerTemplate =
+        HeaderTemplate.create("hello", Arrays.asList("emre", "savci", "{name}", "{missing}"));
     assertEquals("hello emre, savci", headerTemplate.expand(Collections.emptyMap()));
-    assertEquals("hello emre, savci",
+    assertEquals("hello emre, savci, firsts",
         headerTemplate.expand(Collections.singletonMap("name", "firsts")));
+  }
+
+  @Test
+  public void it_should_return_expanded_literals() {
+    HeaderTemplate headerTemplate =
+        HeaderTemplate.create("hello", Arrays.asList("emre", "savci", "{replace_me}"));
+    assertEquals("hello emre, savci, {}",
+        headerTemplate.expand(Collections.singletonMap("replace_me", "{}")));
   }
 
   @Test
@@ -96,5 +111,4 @@ public class HeaderTemplateTest {
     assertThat(new ArrayList<>(headerTemplateWithSecondOrdering.getValues()),
         equalTo(Arrays.asList("test 2", "test 1")));
   }
-
 }


### PR DESCRIPTION
Fixes #1172

When a `HeaderTemplate` is expanded, the result is placed onto a new
`RequestTemplate` via it's `header` method.  This results in the expanded
result being turned back into a `HeaderTemplate`, simply out of
convenience.  This behavior, while fine more general use cases, is
problematic if the header value contains braces `{` `}`, as this will
cause the app to consider these values as new expressions.

At this point in the expansion process, there is no need to evaluate
the expanded values again, so this change allows a `Template` to be
created from an existing List of `TemplateChunks`, allowing for callers
to provide explicit `Literal` or `Expression` chunks directly into a
`Template`, by passing the template parsing algorithms.

`RequestTemplate#expand` has been updated to apply this logic for
`HeaderTemplate` values only.