### PR TITLE
Headers overwrite

### DIFF
--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -696,7 +696,7 @@ public final class RequestTemplate implements Serializable {
 
   /**
    * Add a header using the supplied Chunks.
-   * 
+   *
    * @param name of the header.
    * @param chunks to add.
    * @return a RequestTemplate for chaining.
@@ -751,6 +751,14 @@ public final class RequestTemplate implements Serializable {
     if (!values.iterator().hasNext()) {
       /* empty value, clear the existing values */
       this.headers.remove(name);
+      return this;
+    }
+    if (name.equals("Content-Type")) {
+      // a client can only produce content of one single type, so always override Content-Type and
+      // only add a single type
+      this.headers.remove(name);
+      this.headers.put(name,
+          HeaderTemplate.create(name, Collections.singletonList(values.iterator().next())));
       return this;
     }
     this.headers.compute(name, (headerName, headerTemplate) -> {

--- a/jaxrs/src/main/java/feign/jaxrs/JAXRSContract.java
+++ b/jaxrs/src/main/java/feign/jaxrs/JAXRSContract.java
@@ -66,12 +66,12 @@ public class JAXRSContract extends DeclarativeContract {
     super.registerClassAnnotation(Produces.class, this::handleProducesAnnotation);
 
     registerMethodAnnotation(methodAnnotation -> {
-      Class<? extends Annotation> annotationType = methodAnnotation.annotationType();
-      HttpMethod http = annotationType.getAnnotation(HttpMethod.class);
+      final Class<? extends Annotation> annotationType = methodAnnotation.annotationType();
+      final HttpMethod http = annotationType.getAnnotation(HttpMethod.class);
       return http != null;
     }, (methodAnnotation, data) -> {
-      Class<? extends Annotation> annotationType = methodAnnotation.annotationType();
-      HttpMethod http = annotationType.getAnnotation(HttpMethod.class);
+      final Class<? extends Annotation> annotationType = methodAnnotation.annotationType();
+      final HttpMethod http = annotationType.getAnnotation(HttpMethod.class);
       checkState(data.template().method() == null,
           "Method %s contains multiple HTTP methods. Found: %s and %s", data.configKey(),
           data.template().method(), http.value());
@@ -103,7 +103,7 @@ public class JAXRSContract extends DeclarativeContract {
 
   private void handleProducesAnnotation(Produces produces, MethodMetadata data) {
     final String[] serverProduces =
-        removeValues(produces.value(), (mediaType) -> emptyToNull(mediaType) == null, String.class);
+        removeValues(produces.value(), mediaType -> emptyToNull(mediaType) == null, String.class);
     checkState(serverProduces.length > 0, "Produces.value() was empty on %s", data.configKey());
     data.template().header(ACCEPT, Collections.emptyList()); // remove any previous produces
     data.template().header(ACCEPT, serverProduces);
@@ -111,10 +111,9 @@ public class JAXRSContract extends DeclarativeContract {
 
   private void handleConsumesAnnotation(Consumes consumes, MethodMetadata data) {
     final String[] serverConsumes =
-        removeValues(consumes.value(), (mediaType) -> emptyToNull(mediaType) == null, String.class);
+        removeValues(consumes.value(), mediaType -> emptyToNull(mediaType) == null, String.class);
     checkState(serverConsumes.length > 0, "Consumes.value() was empty on %s", data.configKey());
-    data.template().header(CONTENT_TYPE, Collections.emptyList()); // remove any previous consumes
-    data.template().header(CONTENT_TYPE, serverConsumes[0]);
+    data.template().header(CONTENT_TYPE, serverConsumes);
   }
 
   protected void registerParamAnnotations() {

--- a/jaxrs2/src/test/java/feign/jaxrs2/JAXRSClientTest.java
+++ b/jaxrs2/src/test/java/feign/jaxrs2/JAXRSClientTest.java
@@ -33,7 +33,6 @@ import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.ProcessingException;
-
 import feign.jaxrs.JAXRSContract;
 import okhttp3.mockwebserver.MockResponse;
 import org.assertj.core.data.MapEntry;
@@ -136,15 +135,18 @@ public class JAXRSClientTest extends AbstractClientTest {
   public void testConsumesMultipleWithContentTypeHeaderAndBody() throws Exception {
     server.enqueue(new MockResponse().setBody("AAAAAAAA"));
     final JaxRSClientTestInterfaceWithJaxRsContract api = newBuilder()
-            .contract(new JAXRSContract()) // use JAXRSContract
-            .target(JaxRSClientTestInterfaceWithJaxRsContract.class, "http://localhost:" + server.getPort());
+        .contract(new JAXRSContract()) // use JAXRSContract
+        .target(JaxRSClientTestInterfaceWithJaxRsContract.class,
+            "http://localhost:" + server.getPort());
 
-    final Response response = api.consumesMultipleWithContentTypeHeaderAndBody("application/json;charset=utf-8", "body");
+    final Response response =
+        api.consumesMultipleWithContentTypeHeaderAndBody("application/json;charset=utf-8", "body");
     assertEquals("AAAAAAAA", Util.toString(response.body().asReader(UTF_8)));
 
     MockWebServerAssertions.assertThat(server.takeRequest())
-            .hasHeaders(MapEntry.entry("Content-Type", Collections.singletonList("application/json;charset=utf-8")))
-            .hasMethod("POST");
+        .hasHeaders(MapEntry.entry("Content-Type",
+            Collections.singletonList("application/json;charset=utf-8")))
+        .hasMethod("POST");
   }
 
   public interface JaxRSClientTestInterface {
@@ -158,6 +160,7 @@ public class JAXRSClientTest extends AbstractClientTest {
     @Path("/")
     @POST
     @Consumes({"application/xml", "application/json"})
-    Response consumesMultipleWithContentTypeHeaderAndBody(@HeaderParam("Content-Type") String contentType, String body);
+    Response consumesMultipleWithContentTypeHeaderAndBody(@HeaderParam("Content-Type") String contentType,
+                                                          String body);
   }
 }

--- a/jaxrs2/src/test/java/feign/jaxrs2/JAXRSClientTest.java
+++ b/jaxrs2/src/test/java/feign/jaxrs2/JAXRSClientTest.java
@@ -28,7 +28,13 @@ import feign.client.AbstractClientTest;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Collections;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
 import javax.ws.rs.ProcessingException;
+
+import feign.jaxrs.JAXRSContract;
 import okhttp3.mockwebserver.MockResponse;
 import org.assertj.core.data.MapEntry;
 import org.junit.Assume;
@@ -126,11 +132,32 @@ public class JAXRSClientTest extends AbstractClientTest {
         .hasMethod("GET");
   }
 
+  @Test
+  public void testConsumesMultipleWithContentTypeHeaderAndBody() throws Exception {
+    server.enqueue(new MockResponse().setBody("AAAAAAAA"));
+    final JaxRSClientTestInterfaceWithJaxRsContract api = newBuilder()
+            .contract(new JAXRSContract()) // use JAXRSContract
+            .target(JaxRSClientTestInterfaceWithJaxRsContract.class, "http://localhost:" + server.getPort());
+
+    final Response response = api.consumesMultipleWithContentTypeHeaderAndBody("application/json;charset=utf-8", "body");
+    assertEquals("AAAAAAAA", Util.toString(response.body().asReader(UTF_8)));
+
+    MockWebServerAssertions.assertThat(server.takeRequest())
+            .hasHeaders(MapEntry.entry("Content-Type", Collections.singletonList("application/json;charset=utf-8")))
+            .hasMethod("POST");
+  }
 
   public interface JaxRSClientTestInterface {
 
     @RequestLine("GET /")
     @Headers({"Accept: text/plain", "Content-Type: text/plain"})
     Response getWithContentType();
+  }
+
+  public interface JaxRSClientTestInterfaceWithJaxRsContract {
+    @Path("/")
+    @POST
+    @Consumes({"application/xml", "application/json"})
+    Response consumesMultipleWithContentTypeHeaderAndBody(@HeaderParam("Content-Type") String contentType, String body);
   }
 }


### PR DESCRIPTION
Fixes #1217

Specially when using contracts, there is more than one way to set some headers.

`Content-Type` seems to be the most special one, were client sends one.

This change will guarantee that only one value for this header will survive.

@kdavisk6 do you think there is any situation feign would wan't to send more than one Content-Type header?