### PR TITLE
feat: java11 request options timeout.

### DIFF
--- a/java11/src/main/java/feign/http2client/Http2Client.java
+++ b/java11/src/main/java/feign/http2client/Http2Client.java
@@ -59,6 +59,7 @@ public class Http2Client implements Client {
     try {
       httpResponse = client.send(httpRequest, BodyHandlers.ofByteArray());
     } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new IOException("Invalid uri " + request.url(), e);
     }
 

--- a/java11/src/main/java/feign/http2client/Http2Client.java
+++ b/java11/src/main/java/feign/http2client/Http2Client.java
@@ -13,6 +13,11 @@
  */
 package feign.http2client;
 
+import feign.Client;
+import feign.Request;
+import feign.Request.Options;
+import feign.Response;
+import feign.Util;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
@@ -26,11 +31,10 @@ import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpRequest.Builder;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import feign.*;
-import feign.Request.Options;
 
 public class Http2Client implements Client {
 
@@ -49,7 +53,7 @@ public class Http2Client implements Client {
 
   @Override
   public Response execute(Request request, Options options) throws IOException {
-    final HttpRequest httpRequest = newRequestBuilder(request).build();
+    final HttpRequest httpRequest = newRequestBuilder(request, options).build();
 
     HttpResponse<byte[]> httpResponse;
     try {
@@ -71,7 +75,7 @@ public class Http2Client implements Client {
     return response;
   }
 
-  private Builder newRequestBuilder(Request request) throws IOException {
+  private Builder newRequestBuilder(Request request, Options options) throws IOException {
     URI uri;
     try {
       uri = new URI(request.url());
@@ -89,6 +93,7 @@ public class Http2Client implements Client {
 
     final Builder requestBuilder = HttpRequest.newBuilder()
         .uri(uri)
+        .timeout(Duration.ofMillis(options.readTimeoutMillis()))
         .version(Version.HTTP_2);
 
     final Map<String, Collection<String>> headers = filterRestrictedHeaders(request.headers());
@@ -152,8 +157,7 @@ public class Http2Client implements Client {
             .stream()
             .map(value -> Arrays.asList(entry.getKey(), value))
             .flatMap(List::stream))
-        .collect(Collectors.toList())
-        .toArray(new String[0]);
+        .toArray(String[]::new);
   }
 
 }

--- a/java11/src/test/java/feign/http2client/test/Http2ClientTest.java
+++ b/java11/src/test/java/feign/http2client/test/Http2ClientTest.java
@@ -15,9 +15,13 @@ package feign.http2client.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import org.assertj.core.api.Assertions;
+import org.hamcrest.CoreMatchers;
 import org.junit.Ignore;
 import org.junit.Test;
 import java.io.IOException;
+import java.net.http.HttpTimeoutException;
+import java.util.concurrent.TimeUnit;
+
 import feign.*;
 import feign.client.AbstractClientTest;
 import feign.http2client.Http2Client;
@@ -37,6 +41,10 @@ public class Http2ClientTest extends AbstractClientTest {
     @RequestLine("PATCH /patch")
     @Headers({"Accept: text/plain"})
     String patch();
+
+    @RequestLine("POST /timeout")
+    @Headers({"Accept: text/plain"})
+    String timeout();
   }
 
   @Override
@@ -78,6 +86,21 @@ public class Http2ClientTest extends AbstractClientTest {
   @Test
   public void testVeryLongResponseNullLength() {
     // client is too smart to fall for a body that is 8 bytes long
+  }
+
+  @Test
+  public void timeoutTest() {
+    server.enqueue(new MockResponse().setBody("foo").setBodyDelay(30, TimeUnit.SECONDS));
+
+    final TestInterface api = newBuilder()
+            .retryer(Retryer.NEVER_RETRY)
+            .options(new Request.Options(1, TimeUnit.SECONDS, 1, TimeUnit.SECONDS, true))
+            .target(TestInterface.class, server.url("/").toString());
+
+    thrown.expect(FeignException.class);
+    thrown.expectCause(CoreMatchers.isA(HttpTimeoutException.class));
+
+    api.timeout();
   }
 
   @Override

--- a/java11/src/test/java/feign/http2client/test/Http2ClientTest.java
+++ b/java11/src/test/java/feign/http2client/test/Http2ClientTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 import java.io.IOException;
 import java.net.http.HttpTimeoutException;
 import java.util.concurrent.TimeUnit;
-
 import feign.*;
 import feign.client.AbstractClientTest;
 import feign.http2client.Http2Client;
@@ -93,9 +92,9 @@ public class Http2ClientTest extends AbstractClientTest {
     server.enqueue(new MockResponse().setBody("foo").setBodyDelay(30, TimeUnit.SECONDS));
 
     final TestInterface api = newBuilder()
-            .retryer(Retryer.NEVER_RETRY)
-            .options(new Request.Options(1, TimeUnit.SECONDS, 1, TimeUnit.SECONDS, true))
-            .target(TestInterface.class, server.url("/").toString());
+        .retryer(Retryer.NEVER_RETRY)
+        .options(new Request.Options(1, TimeUnit.SECONDS, 1, TimeUnit.SECONDS, true))
+        .target(TestInterface.class, server.url("/").toString());
 
     thrown.expect(FeignException.class);
     thrown.expectCause(CoreMatchers.isA(HttpTimeoutException.class));


### PR DESCRIPTION
Config feign-java11 request timeout use feign `Request.options`.