### PR TITLE
Add support for Dropwizard Metrics 4.1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -909,6 +909,21 @@ But, it's possible to add metric collection capabilities to any feign client.
 
 Metric Capabilities provide a first-class Metrics API that users can tap into to gain insight into the request/response lifecycle.
 
+#### Dropwizard Metrics 4
+
+```
+public class MyApp {
+  public static void main(String[] args) {
+    GitHub github = Feign.builder()
+                         .addCapability(new Metrics4Capability())
+                         .target(GitHub.class, "https://api.github.com");
+
+    github.contributors("OpenFeign", "feign");
+    // metrics will be available from this point onwards
+  }
+}
+```
+
 #### Dropwizard Metrics 5
 
 ```

--- a/dropwizard-metrics4/pom.xml
+++ b/dropwizard-metrics4/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2012-2020 The Feign Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.github.openfeign</groupId>
+    <artifactId>parent</artifactId>
+    <version>10.10.2-SNAPSHOT</version>
+  </parent>
+  <artifactId>feign-dropwizard-metrics4</artifactId>
+  <name>Feign Dropwizard Metrics4</name>
+  <description>Feign Dropwizard Metrics 4</description>
+
+  <properties>
+    <main.basedir>${project.basedir}/..</main.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>feign-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>feign-mock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>4.1.9</version>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>java-hamcrest</artifactId>
+      <version>2.0.0.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/dropwizard-metrics4/src/main/java/feign/metrics4/CountingInputStream.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/CountingInputStream.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.metrics4;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import feign.Util;
+
+/**
+ * Copy from guava CountingInputStream
+ *
+ * An {@link InputStream} that counts the number of bytes read.
+ *
+ * @author Chris Nokleberg
+ * @since 1.0
+ */
+public final class CountingInputStream extends FilterInputStream {
+
+  private long count;
+  private long mark = -1;
+
+  /**
+   * Wraps another input stream, counting the number of bytes read.
+   *
+   * @param in the input stream to be wrapped
+   */
+  public CountingInputStream(InputStream in) {
+    super(Util.checkNotNull(in, "InputStream must not be null"));
+  }
+
+  /** Returns the number of bytes read. */
+  public long getCount() {
+    return count;
+  }
+
+  @Override
+  public int read() throws IOException {
+    final int result = in.read();
+    if (result != -1) {
+      count++;
+    }
+    return result;
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    final int result = in.read(b, off, len);
+    if (result != -1) {
+      count += result;
+    }
+    return result;
+  }
+
+  @Override
+  public long skip(long n) throws IOException {
+    final long result = in.skip(n);
+    count += result;
+    return result;
+  }
+
+  @Override
+  public synchronized void mark(int readlimit) {
+    in.mark(readlimit);
+    mark = count;
+    // it's okay to mark even if mark isn't supported, as reset won't work
+  }
+
+  @Override
+  public synchronized void reset() throws IOException {
+    if (!in.markSupported()) {
+      throw new IOException("Mark not supported");
+    }
+    if (mark == -1) {
+      throw new IOException("Mark not set");
+    }
+
+    in.reset();
+    count = mark;
+  }
+}

--- a/dropwizard-metrics4/src/main/java/feign/metrics4/FeignMetricName.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/FeignMetricName.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.metrics4;
+
+
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import com.codahale.metrics.MetricRegistry;
+import feign.MethodMetadata;
+import feign.Target;
+
+public final class FeignMetricName {
+
+  private final Class<?> meteredComponent;
+
+
+  public FeignMetricName(Class<?> meteredComponent) {
+    this.meteredComponent = meteredComponent;
+  }
+
+
+  public String metricName(MethodMetadata methodMetadata, Target<?> target, String suffix) {
+    return MetricRegistry.name(metricName(methodMetadata, target), suffix);
+  }
+
+  public String metricName(MethodMetadata methodMetadata, Target<?> target) {
+    return metricName(methodMetadata.targetType(), methodMetadata.method(), target.url());
+  }
+
+  public String metricName(Class<?> targetType, Method method, String url) {
+    return MetricRegistry.name(meteredComponent, targetType.getName(), method.getName(), extractHost(url));
+  }
+
+  private String extractHost(final String targetUrl) {
+    try {
+      return new URI(targetUrl).getHost();
+    } catch (final URISyntaxException e) {
+      // can't get the host, in that case, just read first 20 chars from url
+      return targetUrl.length() <= 20
+          ? targetUrl
+          : targetUrl.substring(0, 20);
+    }
+  }
+
+
+}

--- a/dropwizard-metrics4/src/main/java/feign/metrics4/FeignMetricName.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/FeignMetricName.java
@@ -17,7 +17,6 @@ package feign.metrics4;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URISyntaxException;
-
 import com.codahale.metrics.MetricRegistry;
 import feign.MethodMetadata;
 import feign.Target;
@@ -41,7 +40,8 @@ public final class FeignMetricName {
   }
 
   public String metricName(Class<?> targetType, Method method, String url) {
-    return MetricRegistry.name(meteredComponent, targetType.getName(), method.getName(), extractHost(url));
+    return MetricRegistry.name(meteredComponent, targetType.getName(), method.getName(),
+        extractHost(url));
   }
 
   private String extractHost(final String targetUrl) {

--- a/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredBody.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredBody.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.metrics4;
+
+import static feign.Util.UTF_8;
+import java.io.*;
+import java.nio.charset.Charset;
+import java.util.function.Supplier;
+import feign.Response.Body;
+
+/**
+ * {@link Body} implementation that keeps track of how many bytes are read.
+ */
+public final class MeteredBody implements Body {
+
+  private final Body delegate;
+  private Supplier<Long> count;
+
+  public MeteredBody(Body body) {
+    this.delegate = body;
+    count = () -> 0L;
+  }
+
+  @Override
+  public void close() throws IOException {
+    delegate.close();
+  }
+
+  @Override
+  public Integer length() {
+    return delegate.length();
+  }
+
+  @Override
+  public boolean isRepeatable() {
+    return delegate.isRepeatable();
+  }
+
+  @Override
+  public InputStream asInputStream() throws IOException {
+    // TODO, ideally, would like not to bring guava just for this
+    final CountingInputStream input = new CountingInputStream(delegate.asInputStream());
+    count = input::getCount;
+    return input;
+  }
+
+  @Override
+  public Reader asReader() throws IOException {
+    return new InputStreamReader(asInputStream(), UTF_8);
+  }
+
+  public long count() {
+    return count.get();
+  }
+
+  @Override
+  public Reader asReader(Charset charset) throws IOException {
+    return new InputStreamReader(asInputStream(), charset);
+  }
+
+}

--- a/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredClient.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredClient.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.metrics4;
+
+
+import java.io.IOException;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import feign.*;
+import feign.Request.Options;
+
+/**
+ * Warp feign {@link Client} with metrics.
+ */
+public class MeteredClient implements Client {
+
+  private final Client client;
+  private final MetricRegistry metricRegistry;
+  private final FeignMetricName metricName;
+  private final MetricSuppliers metricSuppliers;
+
+  public MeteredClient(Client client, MetricRegistry metricRegistry,
+      MetricSuppliers metricSuppliers) {
+    this.client = client;
+    this.metricRegistry = metricRegistry;
+    this.metricSuppliers = metricSuppliers;
+    this.metricName = new FeignMetricName(Client.class);
+  }
+
+  @Override
+  public Response execute(Request request, Options options) throws IOException {
+    final RequestTemplate template = request.requestTemplate();
+    try (final Timer.Context classTimer =
+        metricRegistry.timer(
+            metricName.metricName(template.methodMetadata(), template.feignTarget()),
+            metricSuppliers.timers()).time()) {
+      return client.execute(request, options);
+    }
+  }
+
+}

--- a/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredClient.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredClient.java
@@ -15,7 +15,6 @@ package feign.metrics4;
 
 
 import java.io.IOException;
-
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import feign.*;

--- a/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredDecoder.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredDecoder.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.metrics4;
+
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import feign.FeignException;
+import feign.RequestTemplate;
+import feign.Response;
+import feign.codec.DecodeException;
+import feign.codec.Decoder;
+
+/**
+ * Warp feign {@link Decoder} with metrics.
+ */
+public class MeteredDecoder implements Decoder {
+
+  private final Decoder decoder;
+  private final MetricRegistry metricRegistry;
+  private final MetricSuppliers metricSuppliers;
+  private final FeignMetricName metricName;
+
+  public MeteredDecoder(Decoder decoder, MetricRegistry metricRegistry,
+      MetricSuppliers metricSuppliers) {
+    this.decoder = decoder;
+    this.metricRegistry = metricRegistry;
+    this.metricSuppliers = metricSuppliers;
+    this.metricName = new FeignMetricName(Decoder.class);
+  }
+
+  @Override
+  public Object decode(Response response, Type type)
+      throws IOException, DecodeException, FeignException {
+    final RequestTemplate template = response.request().requestTemplate();
+    final MeteredBody body = response.body() == null
+        ? null
+        : new MeteredBody(response.body());
+
+    response = response.toBuilder().body(body).build();
+
+    final Object decoded;
+    try (final Timer.Context classTimer =
+        metricRegistry
+            .timer(metricName.metricName(template.methodMetadata(), template.feignTarget()),
+                metricSuppliers.timers())
+            .time()) {
+      decoded = decoder.decode(response, type);
+    }
+
+    if (body != null) {
+      metricRegistry.histogram(
+          metricName.metricName(template.methodMetadata(), template.feignTarget(),
+              "response_size"),
+          metricSuppliers.histograms()).update(body.count());
+    }
+
+    return decoded;
+  }
+
+}

--- a/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredDecoder.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredDecoder.java
@@ -16,7 +16,6 @@ package feign.metrics4;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
-
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import feign.FeignException;

--- a/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredEncoder.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredEncoder.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.metrics4;
+
+
+import java.lang.reflect.Type;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import feign.RequestTemplate;
+import feign.codec.EncodeException;
+import feign.codec.Encoder;
+
+/**
+ * Warp feign {@link Encoder} with metrics.
+ */
+public class MeteredEncoder implements Encoder {
+
+  private final Encoder encoder;
+  private final MetricRegistry metricRegistry;
+  private final MetricSuppliers metricSuppliers;
+  private final FeignMetricName metricName;
+
+  public MeteredEncoder(Encoder encoder, MetricRegistry metricRegistry,
+      MetricSuppliers metricSuppliers) {
+    this.encoder = encoder;
+    this.metricRegistry = metricRegistry;
+    this.metricSuppliers = metricSuppliers;
+    this.metricName = new FeignMetricName(Encoder.class);
+  }
+
+  @Override
+  public void encode(Object object, Type bodyType, RequestTemplate template)
+      throws EncodeException {
+    try (final Timer.Context classTimer =
+        metricRegistry.timer(
+            metricName.metricName(template.methodMetadata(), template.feignTarget()),
+            metricSuppliers.timers()).time()) {
+      encoder.encode(object, bodyType, template);
+    }
+
+    if (template.body() != null) {
+      metricRegistry.histogram(
+          metricName.metricName(template.methodMetadata(), template.feignTarget(), "request_size"),
+          metricSuppliers.histograms()).update(template.body().length);
+    }
+  }
+
+}

--- a/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredEncoder.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredEncoder.java
@@ -15,7 +15,6 @@ package feign.metrics4;
 
 
 import java.lang.reflect.Type;
-
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import feign.RequestTemplate;

--- a/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredInvocationHandleFactory.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredInvocationHandleFactory.java
@@ -84,7 +84,7 @@ public class MeteredInvocationHandleFactory implements InvocationHandlerFactory 
         metricRegistry.meter(
             MetricRegistry.name(metricName.metricName(clientClass, method, target.url()),
                 "exception", e.getClass().getSimpleName()),
-                metricSuppliers.meters())
+            metricSuppliers.meters())
             .mark();
 
         throw e;

--- a/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredInvocationHandleFactory.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredInvocationHandleFactory.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.metrics4;
+
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import feign.*;
+
+/**
+ * Warp feign {@link InvocationHandler} with metrics.
+ */
+public class MeteredInvocationHandleFactory implements InvocationHandlerFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MeteredInvocationHandleFactory.class);
+
+  /**
+   * Methods that are declared by super class object and, if invoked, we don't wanna record metrics
+   * for
+   */
+  private static final List<String> JAVA_OBJECT_METHODS =
+      Arrays.asList("equals", "toString", "hashCode");
+
+  private final InvocationHandlerFactory invocationHandler;
+
+  private final MetricRegistry metricRegistry;
+
+  private final FeignMetricName metricName;
+
+  private final MetricSuppliers metricSuppliers;
+
+  public MeteredInvocationHandleFactory(InvocationHandlerFactory invocationHandler,
+      MetricRegistry metricRegistry, MetricSuppliers metricSuppliers) {
+    this.invocationHandler = invocationHandler;
+    this.metricRegistry = metricRegistry;
+    this.metricSuppliers = metricSuppliers;
+    this.metricName = new FeignMetricName(Feign.class);
+  }
+
+  @Override
+  public InvocationHandler create(Target target, Map<Method, MethodHandler> dispatch) {
+    final Class clientClass = target.type();
+
+    final InvocationHandler invocationHandle = invocationHandler.create(target, dispatch);
+    return (proxy, method, args) -> {
+
+      if (JAVA_OBJECT_METHODS.contains(method.getName())
+          || Util.isDefault(method)) {
+        LOG.trace("Skipping metrics for method={}", method);
+        return invocationHandle.invoke(proxy, method, args);
+      }
+
+      try (final Timer.Context classTimer =
+          metricRegistry.timer(metricName.metricName(clientClass, method, target.url()),
+              metricSuppliers.timers()).time()) {
+
+        return invocationHandle.invoke(proxy, method, args);
+      } catch (final FeignException e) {
+        metricRegistry.meter(
+            MetricRegistry.name(metricName.metricName(clientClass, method, target.url()),
+                "http_error", e.status() / 100 + "xx", String.valueOf(e.status())),
+            metricSuppliers.meters()).mark();
+
+        throw e;
+      } catch (final Throwable e) {
+        metricRegistry.meter(
+            MetricRegistry.name(metricName.metricName(clientClass, method, target.url()),
+                "exception", e.getClass().getSimpleName()),
+                metricSuppliers.meters())
+            .mark();
+
+        throw e;
+      }
+    };
+  }
+
+
+}

--- a/dropwizard-metrics4/src/main/java/feign/metrics4/MetricSuppliers.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/MetricSuppliers.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.metrics4;
+
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SlidingTimeWindowArrayReservoir;
+import com.codahale.metrics.Timer;
+
+import java.util.concurrent.TimeUnit;
+
+public class MetricSuppliers {
+
+  public MetricRegistry.MetricSupplier<Timer> timers() {
+    // only keep timer data for 1 minute
+    return () -> new Timer(new SlidingTimeWindowArrayReservoir(1, TimeUnit.MINUTES));
+  }
+
+  public MetricRegistry.MetricSupplier<Meter> meters() {
+    return Meter::new;
+  }
+
+  public MetricRegistry.MetricSupplier<Histogram> histograms() {
+    // only keep timer data for 1 minute
+    return () -> new Histogram(new SlidingTimeWindowArrayReservoir(1, TimeUnit.MINUTES));
+  }
+
+}

--- a/dropwizard-metrics4/src/main/java/feign/metrics4/MetricSuppliers.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/MetricSuppliers.java
@@ -18,7 +18,6 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SlidingTimeWindowArrayReservoir;
 import com.codahale.metrics.Timer;
-
 import java.util.concurrent.TimeUnit;
 
 public class MetricSuppliers {

--- a/dropwizard-metrics4/src/main/java/feign/metrics4/Metrics4Capability.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/Metrics4Capability.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.metrics4;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SharedMetricRegistries;
+import feign.Capability;
+import feign.Client;
+import feign.InvocationHandlerFactory;
+import feign.codec.Decoder;
+import feign.codec.Encoder;
+
+public class Metrics4Capability implements Capability {
+
+  private final MetricRegistry metricRegistry;
+  private final MetricSuppliers metricSuppliers;
+
+  public Metrics4Capability() {
+    this(SharedMetricRegistries.getOrCreate("feign"), new MetricSuppliers());
+  }
+
+  public Metrics4Capability(MetricRegistry metricRegistry) {
+    this(metricRegistry, new MetricSuppliers());
+  }
+
+  public Metrics4Capability(MetricRegistry metricRegistry, MetricSuppliers metricSuppliers) {
+    this.metricRegistry = metricRegistry;
+    this.metricSuppliers = metricSuppliers;
+  }
+
+  @Override
+  public Client enrich(Client client) {
+    return new MeteredClient(client, metricRegistry, metricSuppliers);
+  }
+
+  @Override
+  public Encoder enrich(Encoder encoder) {
+    return new MeteredEncoder(encoder, metricRegistry, metricSuppliers);
+  }
+
+  @Override
+  public Decoder enrich(Decoder decoder) {
+    return new MeteredDecoder(decoder, metricRegistry, metricSuppliers);
+  }
+
+  @Override
+  public InvocationHandlerFactory enrich(InvocationHandlerFactory invocationHandlerFactory) {
+    return new MeteredInvocationHandleFactory(invocationHandlerFactory, metricRegistry,
+        metricSuppliers);
+  }
+
+}

--- a/dropwizard-metrics4/src/test/java/feign/metrics4/Metrics4CapabilityTest.java
+++ b/dropwizard-metrics4/src/test/java/feign/metrics4/Metrics4CapabilityTest.java
@@ -16,7 +16,6 @@ package feign.metrics4;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
-
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SharedMetricRegistries;
 import org.junit.Test;
@@ -56,7 +55,7 @@ public class Metrics4CapabilityTest {
     registry.getMetrics().keySet().forEach(metricName -> assertThat(
         "Expect all metric names to include method name:" + metricName,
         metricName,
-            containsString( "get")));
+        containsString("get")));
   }
 
 }

--- a/dropwizard-metrics4/src/test/java/feign/metrics4/Metrics4CapabilityTest.java
+++ b/dropwizard-metrics4/src/test/java/feign/metrics4/Metrics4CapabilityTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.metrics4;
+
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SharedMetricRegistries;
+import org.junit.Test;
+import feign.Feign;
+import feign.RequestLine;
+import feign.mock.HttpMethod;
+import feign.mock.MockClient;
+import feign.mock.MockTarget;
+
+public class Metrics4CapabilityTest {
+
+  public interface SimpleSource {
+
+    @RequestLine("GET /get")
+    String get(String body);
+
+  }
+
+  @Test
+  public void addMetricsCapability() {
+    final MetricRegistry registry = SharedMetricRegistries.getOrCreate("unit_test");
+
+    final SimpleSource source = Feign.builder()
+        .client(new MockClient()
+            .ok(HttpMethod.GET, "/get", "1234567890abcde"))
+        .addCapability(new Metrics4Capability(registry))
+        .target(new MockTarget<>(Metrics4CapabilityTest.SimpleSource.class));
+
+    source.get("0x3456789");
+
+    assertThat(registry.getMetrics(), aMapWithSize(6));
+
+    registry.getMetrics().keySet().forEach(metricName -> assertThat(
+        "Expect all metric names to include client name:" + metricName,
+        metricName,
+        containsString("feign.metrics4.Metrics4CapabilityTest$SimpleSource")));
+    registry.getMetrics().keySet().forEach(metricName -> assertThat(
+        "Expect all metric names to include method name:" + metricName,
+        metricName,
+            containsString( "get")));
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <module>spring4</module>
     <module>soap</module>
     <module>reactive</module>
+    <module>dropwizard-metrics4</module>
     <module>dropwizard-metrics5</module>
     <module>micrometer</module>
     <module>example-github</module>


### PR DESCRIPTION
Dropwizard Metrics 5.x is currently unmaintained, so there should be the option to use the currently maintained Dropwizard Metrics version.