### PR TITLE
#1210 attempt to fix null body issue

### DIFF
--- a/core/src/main/java/feign/Request.java
+++ b/core/src/main/java/feign/Request.java
@@ -128,7 +128,7 @@ public final class Request {
     this.httpMethod = checkNotNull(method, "httpMethod of %s", method.name());
     this.url = checkNotNull(url, "url");
     this.headers = checkNotNull(headers, "headers of %s %s", method, url);
-    this.body = body;
+    this.body = (body != null) ? body : Body.EMPTY;
     this.requestTemplate = requestTemplate;
   }
 
@@ -375,6 +375,8 @@ public final class Request {
    */
   @Experimental
   public static class Body {
+
+    public static final Body EMPTY = new Body(new byte[0]);
 
     private Charset encoding;
     private byte[] data;

--- a/core/src/main/java/feign/Request.java
+++ b/core/src/main/java/feign/Request.java
@@ -128,7 +128,7 @@ public final class Request {
     this.httpMethod = checkNotNull(method, "httpMethod of %s", method.name());
     this.url = checkNotNull(url, "url");
     this.headers = checkNotNull(headers, "headers of %s %s", method, url);
-    this.body = (body != null) ? body : Body.EMPTY;
+    this.body = body;
     this.requestTemplate = requestTemplate;
   }
 
@@ -177,7 +177,9 @@ public final class Request {
    * @return the current character set for the request, may be {@literal null} for binary data.
    */
   public Charset charset() {
-    return body.encoding;
+    return (body == null)
+        ? Body.EMPTY.encoding
+        : body.encoding;
   }
 
   /**
@@ -187,7 +189,9 @@ public final class Request {
    * @see #charset()
    */
   public byte[] body() {
-    return body.data;
+    return (body == null)
+        ? Body.EMPTY.data
+        : body.data;
   }
 
   public boolean isBinary() {

--- a/core/src/test/java/feign/RequestTest.java
+++ b/core/src/test/java/feign/RequestTest.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2012-2020 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign;
+
+import feign.Request.HttpMethod;
+import java.util.Collections;
+import org.junit.Test;
+import static feign.assertj.FeignAssertions.assertThat;
+
+public class RequestTest {
+
+  @Test
+  public void testNullBodyShouldBeReplacedByEmptyConstant() {
+    Request request = Request.create(HttpMethod.GET,
+        "https://github.com/OpenFeign/feign",
+        Collections.emptyMap(),
+        (Request.Body) null,
+        (RequestTemplate) null);
+    assertThat(request.body()).isEqualTo(Request.Body.EMPTY.asBytes());
+  }
+
+}


### PR DESCRIPTION
Hi all,
This is an attempt to fix an issue. I think if we have null-body for request it is better to provide null back if client ask Request#Body. But in fact we're sending back not Body but body's data. In that case I don't think null is ok for byte array. So I decided to create constant EMPTY body and when we have null body to create Request we can just put that constant instead null.