### PR TITLE
Fixes propagation of unchecked exceptions in feign-micrometer

### DIFF
--- a/micrometer/src/main/java/feign/micrometer/MeteredClient.java
+++ b/micrometer/src/main/java/feign/micrometer/MeteredClient.java
@@ -45,7 +45,7 @@ public class MeteredClient implements Client {
           metricName.name(),
           metricName.tag(template.methodMetadata(), template.feignTarget()))
           .recordCallable(() -> client.execute(request, options));
-    } catch (IOException e) {
+    } catch (IOException | RuntimeException e) {
       throw e;
     } catch (Exception e) {
       throw new IOException(e);

--- a/micrometer/src/main/java/feign/micrometer/MeteredDecoder.java
+++ b/micrometer/src/main/java/feign/micrometer/MeteredDecoder.java
@@ -55,7 +55,7 @@ public class MeteredDecoder implements Decoder {
           .timer(metricName.name(),
               metricName.tag(template.methodMetadata(), template.feignTarget()))
           .recordCallable(() -> decoder.decode(meteredResponse, type));
-    } catch (IOException e) {
+    } catch (IOException | RuntimeException e) {
       throw e;
     } catch (Exception e) {
       throw new IOException(e);


### PR DESCRIPTION
Both `MeteredClient` and `MeteredDecoder` now propagates all
unchecked exceptions as-is (they were previously wrapped in
`IOException` before rethrown).
Fixes #1281