### PR TITLE
GH-1246: Enable offline ci dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,17 @@
+#
+# Copyright 2012-2020 The Feign Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
 # Java Maven CircleCI 2.0 configuration file
 #
 # Check https://circleci.com/docs/2.0/language-java/ for more details

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
           paths:
             - ~/.m2
           key: feign-dependencies-{{ checksum "pom.xml" }}
-      - run: mvn -o install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+      - run: mvn -o test
 workflows:
   version: 2
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
           paths:
             - ~/.m2
           key: feign-dependencies-{{ checksum "pom.xml" }}
-      - run: mvn -o test
+      - run: mvn -o install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 workflows:
   version: 2
   build:

--- a/pom.xml
+++ b/pom.xml
@@ -580,8 +580,8 @@
           <dynamicDependencies>
             <DynamicDependency>
               <groupId>org.apache.maven.surefire</groupId>
-              <artifactId>surefire-junit-platform</artifactId>
-              <version>2.22.2</version>
+              <artifactId>surefire-junit4</artifactId>
+              <version>2.22.0</version>
               <repositoryType>PLUGIN</repositoryType>
             </DynamicDependency>
           </dynamicDependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -532,6 +532,7 @@
             <exclude>travis/**</exclude>
             <exclude>src/test/resources/**</exclude>
             <exclude>src/main/resources/**</exclude>
+            <exclude>.circleci/**</exclude>
           </excludes>
           <strictCheck>true</strictCheck>
         </configuration>
@@ -571,7 +572,21 @@
           </execution>
         </executions>
       </plugin>
-
+      <plugin>
+        <groupId>de.qaware.maven</groupId>
+        <artifactId>go-offline-maven-plugin</artifactId>
+        <version>1.1.0</version>
+        <configuration>
+          <dynamicDependencies>
+            <DynamicDependency>
+              <groupId>org.apache.maven.surefire</groupId>
+              <artifactId>surefire-junit-platform</artifactId>
+              <version>2.22.2</version>
+              <repositoryType>PLUGIN</repositoryType>
+            </DynamicDependency>
+          </dynamicDependencies>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>com.github.ekryd.sortpom</groupId>
         <artifactId>sortpom-maven-plugin</artifactId>


### PR DESCRIPTION
This change enabled Circle CI Caching of dependencies to speed up
builds and checks.