### PR TITLE
Upgrade JUnit to 4.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <slf4j.version>1.7.13</slf4j.version>
     <bouncy.version>1.60</bouncy.version>
 
-    <junit.version>4.12</junit.version>
+    <junit.version>4.13.1</junit.version>
     <jackson.version>2.10.0.pr3</jackson.version>
     <jackson.databind.version>2.10.0.pr3</jackson.databind.version>
     <assertj.version>3.10.0</assertj.version>


### PR DESCRIPTION
This change updates JUnit to 4.13.1 to address a published security issue.