### PR TITLE
Fix for #1339 (An extra space after commas)

### DIFF
--- a/core/src/main/java/feign/template/HeaderTemplate.java
+++ b/core/src/main/java/feign/template/HeaderTemplate.java
@@ -148,6 +148,7 @@ public final class HeaderTemplate extends Template {
     }
 
     /* space all the commas now */
+    result = result.replaceAll(", ", ",");
     result = result.replaceAll(",", ", ");
     return result;
   }


### PR DESCRIPTION
feign.template.HeaderTemplate#expand repaces ',' to ', ' (An extra space after commas)