### PR TITLE
GH-934: Update Default Client to handle Compression correctly

### DIFF
--- a/core/src/main/java/feign/Client.java
+++ b/core/src/main/java/feign/Client.java
@@ -21,7 +21,6 @@ import static feign.Util.checkArgument;
 import static feign.Util.checkNotNull;
 import static feign.Util.isNotBlank;
 import static java.lang.String.format;
-
 import feign.Request.Options;
 import java.io.IOException;
 import java.io.InputStream;

--- a/core/src/main/java/feign/Client.java
+++ b/core/src/main/java/feign/Client.java
@@ -19,9 +19,10 @@ import static feign.Util.ENCODING_DEFLATE;
 import static feign.Util.ENCODING_GZIP;
 import static feign.Util.checkArgument;
 import static feign.Util.checkNotNull;
-import static feign.Util.isBlank;
 import static feign.Util.isNotBlank;
 import static java.lang.String.format;
+
+import feign.Request.Options;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -34,7 +35,6 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.zip.DeflaterInputStream;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -42,7 +42,6 @@ import java.util.zip.InflaterInputStream;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
-import feign.Request.Options;
 
 /**
  * Submits HTTP {@link Request requests}. Implementations are expected to be thread-safe.
@@ -132,9 +131,9 @@ public interface Client {
       if (status >= 400) {
         stream = connection.getErrorStream();
       } else {
-        if (this.isGzip(connection)) {
+        if (this.isGzip(connection.getHeaderFields().get(CONTENT_ENCODING))) {
           stream = new GZIPInputStream(connection.getInputStream());
-        } else if (this.isDeflate(connection)) {
+        } else if (this.isDeflate(connection.getHeaderFields().get(CONTENT_ENCODING))) {
           stream = new InflaterInputStream(connection.getInputStream());
         } else {
           stream = connection.getInputStream();
@@ -172,10 +171,8 @@ public interface Client {
       connection.setRequestMethod(request.httpMethod().name());
 
       Collection<String> contentEncodingValues = request.headers().get(CONTENT_ENCODING);
-      boolean gzipEncodedRequest =
-          contentEncodingValues != null && contentEncodingValues.contains(ENCODING_GZIP);
-      boolean deflateEncodedRequest =
-          contentEncodingValues != null && contentEncodingValues.contains(ENCODING_DEFLATE);
+      boolean gzipEncodedRequest = this.isGzip(contentEncodingValues);
+      boolean deflateEncodedRequest = this.isDeflate(contentEncodingValues);
 
       boolean hasAcceptHeader = false;
       Integer contentLength = null;
@@ -226,20 +223,16 @@ public interface Client {
       return connection;
     }
 
-    private boolean isGzip(HttpURLConnection connection) {
-      String contentEncoding = connection.getHeaderField(CONTENT_ENCODING);
-      if (Util.isNotBlank(contentEncoding)) {
-        return contentEncoding.equalsIgnoreCase(ENCODING_GZIP);
-      }
-      return false;
+    private boolean isGzip(Collection<String> contentEncodingValues) {
+      return contentEncodingValues != null
+          && !contentEncodingValues.isEmpty()
+          && contentEncodingValues.contains(ENCODING_GZIP);
     }
 
-    private boolean isDeflate(HttpURLConnection connection) {
-      String contentEncoding = connection.getHeaderField(CONTENT_ENCODING);
-      if (Util.isNotBlank(contentEncoding)) {
-        return contentEncoding.equalsIgnoreCase(ENCODING_DEFLATE);
-      }
-      return false;
+    private boolean isDeflate(Collection<String> contentEncodingValues) {
+      return contentEncodingValues != null
+          && !contentEncodingValues.isEmpty()
+          && contentEncodingValues.contains(ENCODING_DEFLATE);
     }
   }
 

--- a/core/src/main/java/feign/Client.java
+++ b/core/src/main/java/feign/Client.java
@@ -35,6 +35,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.zip.DeflaterOutputStream;
+import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
@@ -129,7 +130,11 @@ public interface Client {
       if (status >= 400) {
         stream = connection.getErrorStream();
       } else {
-        stream = connection.getInputStream();
+        if (this.isGzip(connection)) {
+          stream = new GZIPInputStream(connection.getInputStream());
+        } else {
+          stream = connection.getInputStream();
+        }
       }
       return Response.builder()
           .status(status)
@@ -215,6 +220,14 @@ public interface Client {
         }
       }
       return connection;
+    }
+
+    private boolean isGzip(HttpURLConnection connection) {
+      String contentEncoding = connection.getHeaderField("Content-Encoding");
+      if (Util.isNotBlank(contentEncoding)) {
+        return contentEncoding.equalsIgnoreCase("gzip");
+      }
+      return false;
     }
   }
 

--- a/core/src/main/java/feign/Client.java
+++ b/core/src/main/java/feign/Client.java
@@ -34,9 +34,11 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.DeflaterInputStream;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
+import java.util.zip.InflaterInputStream;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
@@ -132,6 +134,8 @@ public interface Client {
       } else {
         if (this.isGzip(connection)) {
           stream = new GZIPInputStream(connection.getInputStream());
+        } else if (this.isDeflate(connection)) {
+          stream = new InflaterInputStream(connection.getInputStream());
         } else {
           stream = connection.getInputStream();
         }
@@ -223,9 +227,17 @@ public interface Client {
     }
 
     private boolean isGzip(HttpURLConnection connection) {
-      String contentEncoding = connection.getHeaderField("Content-Encoding");
+      String contentEncoding = connection.getHeaderField(CONTENT_ENCODING);
       if (Util.isNotBlank(contentEncoding)) {
-        return contentEncoding.equalsIgnoreCase("gzip");
+        return contentEncoding.equalsIgnoreCase(ENCODING_GZIP);
+      }
+      return false;
+    }
+
+    private boolean isDeflate(HttpURLConnection connection) {
+      String contentEncoding = connection.getHeaderField(CONTENT_ENCODING);
+      if (Util.isNotBlank(contentEncoding)) {
+        return contentEncoding.equalsIgnoreCase(ENCODING_DEFLATE);
       }
       return false;
     }

--- a/core/src/main/java/feign/Response.java
+++ b/core/src/main/java/feign/Response.java
@@ -284,14 +284,6 @@ public final class Response implements Closeable {
       inputStream.close();
     }
 
-    @Override
-    public String toString() {
-      try {
-        return new String(toByteArray(inputStream), UTF_8);
-      } catch (Exception e) {
-        return super.toString();
-      }
-    }
   }
 
   private static final class ByteArrayBody implements Response.Body {
@@ -347,10 +339,6 @@ public final class Response implements Closeable {
     @Override
     public void close() throws IOException {}
 
-    @Override
-    public String toString() {
-      return decodeOrDefault(data, UTF_8, "Binary data");
-    }
   }
 
   private static Map<String, Collection<String>> caseInsensitiveCopyOf(Map<String, Collection<String>> headers) {

--- a/core/src/test/java/feign/AsyncFeignTest.java
+++ b/core/src/test/java/feign/AsyncFeignTest.java
@@ -92,18 +92,6 @@ public class AsyncFeignTest {
   }
 
   @Test
-  public void responseCoercesToStringBody() throws Throwable {
-    server.enqueue(new MockResponse().setBody("foo"));
-
-    TestInterfaceAsync api =
-        new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
-
-    Response response = unwrap(api.response());
-    assertTrue(response.body().isRepeatable());
-    assertEquals("foo", response.body().toString());
-  }
-
-  @Test
   public void postFormParams() throws Exception {
     server.enqueue(new MockResponse().setBody("foo"));
 

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -93,17 +93,6 @@ public class FeignTest {
   }
 
   @Test
-  public void responseCoercesToStringBody() {
-    server.enqueue(new MockResponse().setBody("foo"));
-
-    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
-
-    Response response = api.response();
-    assertTrue(response.body().isRepeatable());
-    assertEquals("foo", response.body().toString());
-  }
-
-  @Test
   public void postFormParams() throws Exception {
     server.enqueue(new MockResponse().setBody("foo"));
 

--- a/core/src/test/java/feign/FeignUnderAsyncTest.java
+++ b/core/src/test/java/feign/FeignUnderAsyncTest.java
@@ -90,17 +90,6 @@ public class FeignUnderAsyncTest {
   }
 
   @Test
-  public void responseCoercesToStringBody() {
-    server.enqueue(new MockResponse().setBody("foo"));
-
-    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
-
-    Response response = api.response();
-    assertTrue(response.body().isRepeatable());
-    assertEquals("foo", response.body().toString());
-  }
-
-  @Test
   public void postFormParams() throws Exception {
     server.enqueue(new MockResponse().setBody("foo"));
 

--- a/core/src/test/java/feign/ResponseTest.java
+++ b/core/src/test/java/feign/ResponseTest.java
@@ -14,6 +14,7 @@
 package feign;
 
 import feign.Request.HttpMethod;
+import java.nio.charset.StandardCharsets;
 import org.assertj.core.util.Lists;
 import org.junit.Test;
 import java.util.Arrays;
@@ -38,7 +39,7 @@ public class ResponseTest {
         .build();
 
     assertThat(response.reason()).isNull();
-    assertThat(response.toString()).isEqualTo("HTTP/1.1 200\n\n");
+    assertThat(response.toString()).startsWith("HTTP/1.1 200");
   }
 
   @Test

--- a/hc5/src/test/java/feign/hc5/AsyncApacheHttp5ClientTest.java
+++ b/hc5/src/test/java/feign/hc5/AsyncApacheHttp5ClientTest.java
@@ -77,18 +77,6 @@ public class AsyncApacheHttp5ClientTest {
   }
 
   @Test
-  public void responseCoercesToStringBody() throws Throwable {
-    server.enqueue(new MockResponse().setBody("foo"));
-
-    final TestInterfaceAsync api =
-        new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
-
-    final Response response = unwrap(api.response());
-    assertTrue(response.body().isRepeatable());
-    assertEquals("foo", response.body().toString());
-  }
-
-  @Test
   public void postFormParams() throws Exception {
     server.enqueue(new MockResponse().setBody("foo"));
 

--- a/okhttp/src/test/java/feign/okhttp/OkHttpClientTest.java
+++ b/okhttp/src/test/java/feign/okhttp/OkHttpClientTest.java
@@ -22,6 +22,7 @@ import feign.Util;
 import feign.assertj.MockWebServerAssertions;
 import feign.client.AbstractClientTest;
 import feign.Feign;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import okhttp3.mockwebserver.MockResponse;
@@ -97,7 +98,8 @@ public class OkHttpClientTest extends AbstractClientTest {
     Response response = api.get();
     // Response length should not be null
     assertEquals(200, response.status());
-    assertEquals(expectedBody, response.body().toString());
+    String payload = Util.toString(response.body().asReader(StandardCharsets.UTF_8));
+    assertEquals(expectedBody, payload);
 
   }
 

--- a/scripts/no-git-changes.sh
+++ b/scripts/no-git-changes.sh
@@ -13,7 +13,6 @@
 # the License.
 #
 
-
 set -euo pipefail
 set -x
 
@@ -28,4 +27,3 @@ else
   echo "Please run 'mvn clean install' locally to format files"
   exit 1
 fi
-


### PR DESCRIPTION
Fixes: #934, #1208

This change updates the Input Stream handling when using the Default client implementation to detect when a response is `gzipped` and wrap it in a `GZipInputStream` and the same for `deflate` and `InflaterInputStream` respectively.

This addresses any issues related to compression when using the default client.

Additional Changes:

Removed the implicit parsing of the body during `toString`.  This was also brought up in #1208 and it came up
during testing of this change.  Users should be using our `asReader` and other methods to access the response body.
