### PR TITLE
feat: added validation for duplicated keys on header

### DIFF
--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -736,7 +736,7 @@ public final class RequestTemplate implements Serializable {
       return this;
     }
 
-    if (this.headers.containsKey(name)) {
+    if (headerIsPresentOnHeaders(name)) {
       // a client can only produce content of one single type, so always override an present header and
       // only add a single type
       this.headers.remove(name);
@@ -755,7 +755,12 @@ public final class RequestTemplate implements Serializable {
     return this;
   }
 
-  /**
+	private boolean headerIsPresentOnHeaders(String name) {
+		return !name.equalsIgnoreCase("Content-Encoding") &&
+				this.headers.keySet().stream().anyMatch(name::equalsIgnoreCase);
+	}
+
+	/**
    * Headers for this Request.
    *
    * @param headers to use.

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -758,11 +758,22 @@ public final class RequestTemplate implements Serializable {
   /**
    *
    * @param headerName
-   * @return true when header has that key and is not Content-Encoding
+   * @return true when header is equal to Authorization or Content-Type and
+   * is already present on headers
    */
   private boolean headerIsPresentOnHeaders(String headerName) {
-      return !headerName.equalsIgnoreCase("Content-Encoding") &&
+      return isAuthorizationOrContentType(headerName) &&
               this.headers.keySet().stream().anyMatch(headerName::equalsIgnoreCase);
+  }
+
+  /**
+   *
+   * @param headerName
+   * @return true when header is equal to Authorization or Content-Type
+   */
+  private boolean isAuthorizationOrContentType(String headerName) {
+ 	return headerName.equalsIgnoreCase( "Authorization") ||
+			headerName.equalsIgnoreCase("Content-Type");
   }
 
 	/**

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -735,16 +735,14 @@ public final class RequestTemplate implements Serializable {
       this.headers.remove(name);
       return this;
     }
-
-    if (headerIsPresentOnHeaders(name)) {
-      // a client can only produce content of one single type of Authorization and content-type
-      // so always override an present header and only add a single type
+    if (name.equals("Content-Type") || name.equals("Authorization")) {
+      // a client can only produce content of one single type, so always override Content-Type or
+      // Authorization and only add a single type
       this.headers.remove(name);
       this.headers.put(name,
           HeaderTemplate.create(name, Collections.singletonList(values.iterator().next())));
       return this;
     }
-
     this.headers.compute(name, (headerName, headerTemplate) -> {
       if (headerTemplate == null) {
         return HeaderTemplate.create(headerName, values);
@@ -753,27 +751,6 @@ public final class RequestTemplate implements Serializable {
       }
     });
     return this;
-  }
-
-  /**
-   *
-   * @param headerName
-   * @return true when header is equal to Authorization or Content-Type and is already present on
-   *         headers
-   */
-  private boolean headerIsPresentOnHeaders(String headerName) {
-    return isAuthorizationOrContentType(headerName) &&
-        this.headers.keySet().stream().anyMatch(headerName::equalsIgnoreCase);
-  }
-
-  /**
-   *
-   * @param headerName
-   * @return true when header is equal to Authorization or Content-Type
-   */
-  private boolean isAuthorizationOrContentType(String headerName) {
-    return headerName.equalsIgnoreCase("Authorization") ||
-        headerName.equalsIgnoreCase("Content-Type");
   }
 
   /**

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -760,10 +760,10 @@ public final class RequestTemplate implements Serializable {
    * @param headerName
    * @return true when header has that key and is not Content-Encoding
    */
-	private boolean headerIsPresentOnHeaders(String headerName) {
-		return !headerName.equalsIgnoreCase("Content-Encoding") &&
-				this.headers.keySet().stream().anyMatch(headerName::equalsIgnoreCase);
-	}
+  private boolean headerIsPresentOnHeaders(String headerName) {
+      return !headerName.equalsIgnoreCase("Content-Encoding") &&
+              this.headers.keySet().stream().anyMatch(headerName::equalsIgnoreCase);
+  }
 
 	/**
    * Headers for this Request.

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -735,14 +735,16 @@ public final class RequestTemplate implements Serializable {
       this.headers.remove(name);
       return this;
     }
-    if (name.equals("Content-Type")) {
-      // a client can only produce content of one single type, so always override Content-Type and
+
+    if (this.headers.containsKey(name)) {
+      // a client can only produce content of one single type, so always override an present header and
       // only add a single type
       this.headers.remove(name);
       this.headers.put(name,
           HeaderTemplate.create(name, Collections.singletonList(values.iterator().next())));
       return this;
     }
+
     this.headers.compute(name, (headerName, headerTemplate) -> {
       if (headerTemplate == null) {
         return HeaderTemplate.create(headerName, values);

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -755,9 +755,14 @@ public final class RequestTemplate implements Serializable {
     return this;
   }
 
-	private boolean headerIsPresentOnHeaders(String name) {
-		return !name.equalsIgnoreCase("Content-Encoding") &&
-				this.headers.keySet().stream().anyMatch(name::equalsIgnoreCase);
+  /**
+   *
+   * @param headerName
+   * @return true when header has that key and is not Content-Encoding
+   */
+	private boolean headerIsPresentOnHeaders(String headerName) {
+		return !headerName.equalsIgnoreCase("Content-Encoding") &&
+				this.headers.keySet().stream().anyMatch(headerName::equalsIgnoreCase);
 	}
 
 	/**

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -737,8 +737,8 @@ public final class RequestTemplate implements Serializable {
     }
 
     if (headerIsPresentOnHeaders(name)) {
-      // a client can only produce content of one single type, so always override an present header and
-      // only add a single type
+      // a client can only produce content of one single type of Authorization and content-type
+      // so always override an present header and only add a single type
       this.headers.remove(name);
       this.headers.put(name,
           HeaderTemplate.create(name, Collections.singletonList(values.iterator().next())));

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -758,12 +758,12 @@ public final class RequestTemplate implements Serializable {
   /**
    *
    * @param headerName
-   * @return true when header is equal to Authorization or Content-Type and
-   * is already present on headers
+   * @return true when header is equal to Authorization or Content-Type and is already present on
+   *         headers
    */
   private boolean headerIsPresentOnHeaders(String headerName) {
-      return isAuthorizationOrContentType(headerName) &&
-              this.headers.keySet().stream().anyMatch(headerName::equalsIgnoreCase);
+    return isAuthorizationOrContentType(headerName) &&
+        this.headers.keySet().stream().anyMatch(headerName::equalsIgnoreCase);
   }
 
   /**
@@ -772,11 +772,11 @@ public final class RequestTemplate implements Serializable {
    * @return true when header is equal to Authorization or Content-Type
    */
   private boolean isAuthorizationOrContentType(String headerName) {
- 	return headerName.equalsIgnoreCase( "Authorization") ||
-			headerName.equalsIgnoreCase("Content-Type");
+    return headerName.equalsIgnoreCase("Authorization") ||
+        headerName.equalsIgnoreCase("Content-Type");
   }
 
-	/**
+  /**
    * Headers for this Request.
    *
    * @param headers to use.

--- a/core/src/test/java/feign/DefaultContractTest.java
+++ b/core/src/test/java/feign/DefaultContractTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -304,10 +304,10 @@ public class DefaultContractTest {
         parseAndValidateMetadata(HeaderParamsNotAtStart.class, "logout", String.class);
 
     assertThat(md.template())
-        .hasHeaders(entry("Authorization", asList("Bearer {authToken}", "Foo")));
+        .hasHeaders(entry("Authorization", Collections.singletonList("Bearer {authToken}")));
 
     assertThat(md.indexToName())
-        .containsExactly(entry(0, asList("authToken")));
+        .containsExactly(entry(0, Collections.singletonList("authToken")));
     assertThat(md.formParams()).isEmpty();
   }
 

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -352,22 +352,18 @@ public class RequestTemplateTest {
     final String value = "value1";
     template.header("TEST", value);
 
+    final String value2 = "value2";
+    template.header("tEST", value2);
+
     final Collection<String> test = template.headers().get("test");
+
     final String assertionMessage = "Header field names should be case insensitive";
 
     assertNotNull(assertionMessage, test);
     assertTrue(assertionMessage, test.contains(value));
+    assertTrue(assertionMessage, test.contains(value2));
     assertEquals(1, template.headers().size());
-    assertEquals(1, template.headers().get("tesT").size());
-
-    final String value2 = "value2";
-    template.header("tEST", value2);
-
-    final Collection<String> test2 = template.headers().get("test");
-
-    assertTrue(assertionMessage, test2.contains(value2));
-    assertEquals(1, template.headers().size());
-    assertEquals(1, template.headers().get("tesT").size());
+    assertEquals(2, template.headers().get("tesT").size());
   }
 
   @Test

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -352,18 +352,22 @@ public class RequestTemplateTest {
     final String value = "value1";
     template.header("TEST", value);
 
-    final String value2 = "value2";
-    template.header("tEST", value2);
-
     final Collection<String> test = template.headers().get("test");
-
     final String assertionMessage = "Header field names should be case insensitive";
 
     assertNotNull(assertionMessage, test);
     assertTrue(assertionMessage, test.contains(value));
-    assertTrue(assertionMessage, test.contains(value2));
     assertEquals(1, template.headers().size());
-    assertEquals(2, template.headers().get("tesT").size());
+    assertEquals(1, template.headers().get("tesT").size());
+
+    final String value2 = "value2";
+    template.header("tEST", value2);
+
+    final Collection<String> test2 = template.headers().get("test");
+
+    assertTrue(assertionMessage, test2.contains(value2));
+    assertEquals(1, template.headers().size());
+    assertEquals(1, template.headers().get("tesT").size());
   }
 
   @Test

--- a/jackson/src/main/java/feign/jackson/JacksonDecoder.java
+++ b/jackson/src/main/java/feign/jackson/JacksonDecoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
+++ b/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2012-2020 The Feign Authors
+    Copyright 2012-2021 The Feign Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/pom.xml
+++ b/pom.xml
@@ -802,13 +802,13 @@
                 <goals>
                   <goal>sign</goal>
                 </goals>
+                <phase>verify</phase>
                 <configuration>
                   <gpgArguments>
                     <arg>--pinentry-mode</arg>
                     <arg>loopback</arg>
                   </gpgArguments>
                 </configuration>
-                <phase>verify</phase>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
# What: 
Problem described on [Issue 1361](https://github.com/OpenFeign/feign/issues/1361)

# Why:
To fix integration and requests problems with the interceptor.

# Action:
Added validation to remove the previous header set. 

