### PR TITLE
updated com.spotify:docker-maven-plugin version to be 1.2.2

### DIFF
--- a/apt-test-generator/pom.xml
+++ b/apt-test-generator/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2012-2020 The Feign Authors
+    Copyright 2012-2021 The Feign Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/apt-test-generator/pom.xml
+++ b/apt-test-generator/pom.xml
@@ -140,6 +140,7 @@
         <!-- used to create docker images -->
         <groupId>com.spotify</groupId>
         <artifactId>docker-maven-plugin</artifactId>
+        <version>${docker-maven-plugin.version}</version>
         <configuration>
           <!-- docker file copied here after maven replaces properties -->
           <dockerDirectory>${project.build.directory}/classes/docker/</dockerDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
     <maven-versions-plugin.version>2.7</maven-versions-plugin.version>
     <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
     <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
+    <docker-maven-plugin.version>1.2.2</docker-maven-plugin.version>
   </properties>
   <url>https://github.com/openfeign/feign</url>
   <inceptionYear>2012</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2012-2020 The Feign Authors
+    Copyright 2012-2021 The Feign Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
 this appears to have fixed plugin not found error showing up in Intellij 2020.03