### PR TITLE
Collect `http_response_code` for successfull and failed requests

### DIFF
--- a/dropwizard-metrics4/pom.xml
+++ b/dropwizard-metrics4/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2012-2020 The Feign Authors
+    Copyright 2012-2021 The Feign Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -48,6 +48,12 @@
       <groupId>org.hamcrest</groupId>
       <artifactId>java-hamcrest</artifactId>
       <version>2.0.0.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>feign-micrometer</artifactId>
+      <type>test-jar</type>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredClient.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -45,7 +45,27 @@ public class MeteredClient implements Client {
         metricRegistry.timer(
             metricName.metricName(template.methodMetadata(), template.feignTarget()),
             metricSuppliers.timers()).time()) {
-      return client.execute(request, options);
+      Response response = client.execute(request, options);
+      metricRegistry.meter(
+          MetricRegistry.name(
+              metricName.metricName(template.methodMetadata(), template.feignTarget(),
+                  "http_response_code"),
+              "status_group", response.status() / 100 + "xx", "http_status",
+              String.valueOf(response.status())),
+          metricSuppliers.meters()).mark();
+      return response;
+    } catch (FeignException e) {
+      metricRegistry.meter(
+          MetricRegistry.name(
+              metricName.metricName(template.methodMetadata(), template.feignTarget(),
+                  "http_response_code"),
+              "status_group", e.status() / 100 + "xx", "http_status", String.valueOf(e.status())),
+          metricSuppliers.meters()).mark();
+      throw e;
+    } catch (IOException | RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IOException(e);
     }
   }
 

--- a/dropwizard-metrics5/pom.xml
+++ b/dropwizard-metrics5/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2012-2020 The Feign Authors
+    Copyright 2012-2021 The Feign Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -48,6 +48,12 @@
       <groupId>org.hamcrest</groupId>
       <artifactId>java-hamcrest</artifactId>
       <version>2.0.0.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>feign-micrometer</artifactId>
+      <type>test-jar</type>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredClient.java
+++ b/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -45,7 +45,26 @@ public class MeteredClient implements Client {
         metricRegistry.timer(
             metricName.metricName(template.methodMetadata(), template.feignTarget()),
             metricSuppliers.timers()).time()) {
-      return client.execute(request, options);
+      Response response = client.execute(request, options);
+      metricRegistry.counter(
+          metricName
+              .metricName(template.methodMetadata(), template.feignTarget(), "http_response_code")
+              .tagged("http_status", String.valueOf(response.status()))
+              .tagged("status_group", response.status() / 100 + "xx"))
+          .inc();
+      return response;
+    } catch (FeignException e) {
+      metricRegistry.counter(
+          metricName
+              .metricName(template.methodMetadata(), template.feignTarget(), "http_response_code")
+              .tagged("http_status", String.valueOf(e.status()))
+              .tagged("status_group", e.status() / 100 + "xx"))
+          .inc();
+      throw e;
+    } catch (IOException | RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IOException(e);
     }
   }
 

--- a/micrometer/pom.xml
+++ b/micrometer/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2012-2020 The Feign Authors
+    Copyright 2012-2021 The Feign Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -51,4 +51,20 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/micrometer/src/main/java/feign/micrometer/MeteredClient.java
+++ b/micrometer/src/main/java/feign/micrometer/MeteredClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,11 +15,13 @@ package feign.micrometer;
 
 import java.io.IOException;
 import feign.Client;
+import feign.FeignException;
 import feign.Request;
 import feign.Request.Options;
 import feign.RequestTemplate;
 import feign.Response;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 
 /**
  * Warp feign {@link Client} with metrics.
@@ -48,7 +50,28 @@ public class MeteredClient implements Client {
       return meterRegistry.timer(
           metricName.name(),
           metricName.tag(template.methodMetadata(), template.feignTarget()))
-          .recordCallable(() -> client.execute(request, options));
+          .recordCallable(() -> {
+            Response response = client.execute(request, options);
+            meterRegistry.counter(
+                metricName.name("http_response_code"),
+                metricName.tag(
+                    template.methodMetadata(),
+                    template.feignTarget(),
+                    Tag.of("http_status", String.valueOf(response.status())),
+                    Tag.of("status_group", response.status() / 100 + "xx")))
+                .increment();
+            return response;
+          });
+    } catch (FeignException e) {
+      meterRegistry.counter(
+          metricName.name("http_response_code"),
+          metricName.tag(
+              template.methodMetadata(),
+              template.feignTarget(),
+              Tag.of("http_status", String.valueOf(e.status())),
+              Tag.of("status_group", e.status() / 100 + "xx")))
+          .increment();
+      throw e;
     } catch (IOException | RuntimeException e) {
       throw e;
     } catch (Exception e) {

--- a/micrometer/src/test/java/feign/micrometer/AbstractMetricsTestBase.java
+++ b/micrometer/src/test/java/feign/micrometer/AbstractMetricsTestBase.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright 2012-2021 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.micrometer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import feign.Capability;
+import feign.Feign;
+import feign.FeignException;
+import feign.RequestLine;
+import feign.mock.HttpMethod;
+import feign.mock.MockClient;
+import feign.mock.MockTarget;
+
+public abstract class AbstractMetricsTestBase<MR, METRIC_ID, METRIC> {
+
+  public interface SimpleSource {
+
+    @RequestLine("GET /get")
+    String get(String body);
+
+  }
+
+  protected MR metricsRegistry;
+
+  @Before
+  public final void initializeMetricRegistry() {
+    this.metricsRegistry = createMetricsRegistry();
+  }
+
+  protected abstract MR createMetricsRegistry();
+
+  @Test
+  public final void addMetricsCapability() {
+    final SimpleSource source = Feign.builder()
+        .client(new MockClient()
+            .ok(HttpMethod.GET, "/get", "1234567890abcde"))
+        .addCapability(createMetricCapability())
+        .target(new MockTarget<>(SimpleSource.class));
+
+    source.get("0x3456789");
+
+    Map<METRIC_ID, METRIC> metrics = getFeignMetrics();
+    assertThat(metrics, aMapWithSize(7));
+    metrics.keySet().forEach(metricId -> assertThat(
+        "Expect all metric names to include client name:" + metricId,
+        doesMetricIdIncludeClient(metricId)));
+    metrics.keySet().forEach(metricId -> assertThat(
+        "Expect all metric names to include method name:" + metricId,
+        doesMetricIncludeVerb(metricId, "get")));
+    metrics.keySet().forEach(metricId -> assertThat(
+        "Expect all metric names to include host name:" + metricId,
+        doesMetricIncludeHost(metricId)));
+  }
+
+  protected abstract boolean doesMetricIncludeHost(METRIC_ID metricId);
+
+  protected abstract boolean doesMetricIncludeVerb(METRIC_ID metricId, String verb);
+
+  protected abstract boolean doesMetricIdIncludeClient(METRIC_ID metricId);
+
+  protected abstract Capability createMetricCapability();
+
+  protected abstract Map<METRIC_ID, METRIC> getFeignMetrics();
+
+
+  @Test
+  public void clientPropagatesUncheckedException() {
+    final AtomicReference<FeignException.NotFound> notFound = new AtomicReference<>();
+
+    final SimpleSource source = Feign.builder()
+        .client((request, options) -> {
+          notFound.set(new FeignException.NotFound("test", request, null));
+          throw notFound.get();
+        })
+        .addCapability(createMetricCapability())
+        .target(new MockTarget<>(MicrometerCapabilityTest.SimpleSource.class));
+
+    try {
+      source.get("0x3456789");
+      fail("Should throw NotFound exception");
+    } catch (FeignException.NotFound e) {
+      assertSame(notFound.get(), e);
+    }
+
+    assertThat(getMetric("http_response_code", "http_status", "404", "status_group", "4xx"),
+        notNullValue());
+  }
+
+
+  protected abstract METRIC getMetric(String suffix, String... tags);
+
+  @Test
+  public void decoderPropagatesUncheckedException() {
+    final AtomicReference<FeignException.NotFound> notFound = new AtomicReference<>();
+
+    final SimpleSource source = Feign.builder()
+        .client(new MockClient()
+            .ok(HttpMethod.GET, "/get", "1234567890abcde"))
+        .decoder((response, type) -> {
+          notFound.set(new FeignException.NotFound("test", response.request(), null));
+          throw notFound.get();
+        })
+        .addCapability(createMetricCapability())
+        .target(new MockTarget<>(MicrometerCapabilityTest.SimpleSource.class));
+
+    try {
+      source.get("0x3456789");
+      fail("Should throw NotFound exception");
+    } catch (FeignException.NotFound e) {
+      assertSame(notFound.get(), e);
+    }
+  }
+
+}

--- a/micrometer/src/test/java/feign/micrometer/MicrometerCapabilityTest.java
+++ b/micrometer/src/test/java/feign/micrometer/MicrometerCapabilityTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,108 +13,89 @@
  */
 package feign.micrometer;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
-import feign.FeignException;
-import org.junit.Test;
-import feign.Feign;
-import feign.RequestLine;
-import feign.mock.HttpMethod;
-import feign.mock.MockClient;
-import feign.mock.MockTarget;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import feign.Capability;
+import feign.Util;
 import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Meter.Id;
 import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
-public class MicrometerCapabilityTest {
+public class MicrometerCapabilityTest
+    extends AbstractMetricsTestBase<SimpleMeterRegistry, Id, Meter> {
 
-  public interface SimpleSource {
-
-    @RequestLine("GET /get")
-    String get(String body);
-
+  @Override
+  protected SimpleMeterRegistry createMetricsRegistry() {
+    return new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
   }
 
-  @Test
-  public void addMetricsCapability() {
-    SimpleMeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
+  protected Capability createMetricCapability() {
+    return new MicrometerCapability(metricsRegistry);
+  }
 
-    final SimpleSource source = Feign.builder()
-        .client(new MockClient()
-            .ok(HttpMethod.GET, "/get", "1234567890abcde"))
-        .addCapability(new MicrometerCapability(registry))
-        .target(new MockTarget<>(MicrometerCapabilityTest.SimpleSource.class));
-
-    source.get("0x3456789");
-
+  @Override
+  protected Map<Id, Meter> getFeignMetrics() {
     List<Meter> metrics = new ArrayList<>();
-    registry.forEachMeter(metrics::add);
+    metricsRegistry.forEachMeter(metrics::add);
     metrics.removeIf(meter -> !meter.getId().getName().startsWith("feign."));
-
-    metrics.forEach(meter -> assertThat(
-        "Expect all metric names to include client name:" + meter.getId(),
-        meter.getId().getTag("client"),
-        equalTo("feign.micrometer.MicrometerCapabilityTest$SimpleSource")));
-    metrics.forEach(meter -> assertThat(
-        "Expect all metric names to include method name:" + meter.getId(),
-        meter.getId().getTag("method"),
-        equalTo("get")));
-    metrics.forEach(meter -> assertThat(
-        "Expect all metric names to include host name:" + meter.getId(),
-        meter.getId().getTag("host"),
-        // hostname is blank due to feign-mock shortfalls
-        equalTo("")));
+    return metrics.stream()
+        .collect(Collectors.toMap(
+            Meter::getId,
+            Function.identity()));
   }
 
-  @Test
-  public void clientPropagatesUncheckedException() {
-    SimpleMeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
+  @Override
+  protected boolean doesMetricIdIncludeClient(Id metricId) {
+    return metricId.getTag("client")
+        .contains("feign.micrometer.AbstractMetricsTestBase$SimpleSource");
+  }
 
-    final AtomicReference<FeignException.NotFound> notFound = new AtomicReference<>();
+  @Override
+  protected boolean doesMetricIncludeVerb(Id metricId, String verb) {
+    return metricId.getTag("method").equals(verb);
+  }
 
-    final SimpleSource source = Feign.builder()
-        .client((request, options) -> {
-          notFound.set(new FeignException.NotFound("test", request, null));
-          throw notFound.get();
+  @Override
+  protected boolean doesMetricIncludeHost(Id metricId) {
+    return metricId.getTag("host").equals("");
+  }
+
+
+  @Override
+  protected Meter getMetric(String suffix, String... tags) {
+    Util.checkArgument(tags.length % 2 == 0, "tags must contain key-value pairs %s",
+        Arrays.toString(tags));
+
+
+    return getFeignMetrics().entrySet()
+        .stream()
+        .filter(entry -> {
+          Id name = entry.getKey();
+          if (!name.getName().endsWith(suffix)) {
+            return false;
+          }
+
+          for (int i = 0; i < tags.length; i += 2) {
+            if (name.getTag(tags[i]) != null) {
+              if (!name.getTag(tags[i]).equals(tags[i + 1])) {
+                return false;
+              }
+            }
+          }
+
+          return true;
         })
-        .addCapability(new MicrometerCapability(registry))
-        .target(new MockTarget<>(MicrometerCapabilityTest.SimpleSource.class));
-
-    try {
-      source.get("0x3456789");
-      fail("Should throw NotFound exception");
-    } catch (FeignException.NotFound e) {
-      assertSame(notFound.get(), e);
-    }
+        .findAny()
+        .map(Entry::getValue)
+        .orElse(null);
   }
 
-  @Test
-  public void decoderPropagatesUncheckedException() {
-    SimpleMeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
 
-    final AtomicReference<FeignException.NotFound> notFound = new AtomicReference<>();
-
-    final SimpleSource source = Feign.builder()
-        .client(new MockClient()
-            .ok(HttpMethod.GET, "/get", "1234567890abcde"))
-        .decoder((response, type) -> {
-          notFound.set(new FeignException.NotFound("test", response.request(), null));
-          throw notFound.get();
-        })
-        .addCapability(new MicrometerCapability(registry))
-        .target(new MockTarget<>(MicrometerCapabilityTest.SimpleSource.class));
-
-    try {
-      source.get("0x3456789");
-      fail("Should throw NotFound exception");
-    } catch (FeignException.NotFound e) {
-      assertSame(notFound.get(), e);
-    }
-  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,7 @@
         <artifactId>feign-core</artifactId>
         <version>${project.version}</version>
         <type>test-jar</type>
+        <scope>test</scope>
       </dependency>
 
       <dependency>
@@ -226,6 +227,7 @@
         <artifactId>feign-jaxrs</artifactId>
         <version>${project.version}</version>
         <type>test-jar</type>
+        <scope>test</scope>
       </dependency>
 
       <dependency>
@@ -238,6 +240,7 @@
         <groupId>${project.groupId}</groupId>
         <artifactId>feign-mock</artifactId>
         <version>${project.version}</version>
+        <scope>test</scope>
       </dependency>
 
       <dependency>
@@ -262,6 +265,14 @@
         <groupId>${project.groupId}</groupId>
         <artifactId>feign-slf4j</artifactId>
         <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>feign-micrometer</artifactId>
+        <version>${project.version}</version>
+        <type>test-jar</type>
+        <scope>test</scope>
       </dependency>
 
       <dependency>
@@ -803,13 +814,13 @@
                 <goals>
                   <goal>sign</goal>
                 </goals>
+                <phase>verify</phase>
                 <configuration>
                   <gpgArguments>
                     <arg>--pinentry-mode</arg>
                     <arg>loopback</arg>
                   </gpgArguments>
                 </configuration>
-                <phase>verify</phase>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
On previous implementation response code would only be collected for errors.

To avoid mixing new and old metrics, gave the one that includes successfull codes a different name