### PR TITLE
Resolve Dependency CVE in benchmark

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -27,7 +27,9 @@
   <name>Feign Benchmark (JMH)</name>
 
   <properties>
-    <jmh.version>1.22</jmh.version>
+    <jmh.version>1.31</jmh.version>
+    <rx.netty.version>0.5.3</rx.netty.version>
+    <rx.java.version>1.3.8</rx.java.version>
     <main.basedir>${project.basedir}/..</main.basedir>
   </properties>
 
@@ -36,7 +38,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
-        <version>4.1.43.Final</version>
+        <version>4.1.59.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -71,22 +73,22 @@
     <dependency>
       <groupId>io.reactivex</groupId>
       <artifactId>rxnetty-http</artifactId>
-      <version>0.5.2</version>
+      <version>${rx.netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.reactivex</groupId>
       <artifactId>rxnetty-spectator-http</artifactId>
-      <version>0.5.2</version>
+      <version>${rx.netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.reactivex</groupId>
       <artifactId>rxnetty-common</artifactId>
-      <version>0.5.2</version>
+      <version>${rx.netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.reactivex</groupId>
       <artifactId>rxnetty-tcp</artifactId>
-      <version>0.5.2</version>
+      <version>${rx.netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
@@ -96,7 +98,7 @@
     <dependency>
       <groupId>io.reactivex</groupId>
       <artifactId>rxjava</artifactId>
-      <version>1.2.6</version>
+      <version>${rx.java.version}</version>
     </dependency>
     <dependency>
       <groupId>org.openjdk.jmh</groupId>


### PR DESCRIPTION
Update the legacy dependencies in benchmark to resolve any outstanding CVE issues reported by Snyk