### PR TITLE
Force Netty Version in Benchmark for CVE

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -71,6 +71,11 @@
       <version>1.61</version>
     </dependency>
     <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
+      <version>4.1.59.Final</version>
+    </dependency>
+    <dependency>
       <groupId>io.reactivex</groupId>
       <artifactId>rxnetty-http</artifactId>
       <version>${rx.netty.version}</version>


### PR DESCRIPTION
Synk is unable to resolve the high level BOM dependencies on Netty.  This change sets the version directly.