### PR TITLE
Upgrade Netty Dependencies in Benchmark

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -38,7 +38,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
-        <version>4.1.59.Final</version>
+        <version>4.1.63.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -73,7 +73,12 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
-      <version>4.1.59.Final</version>
+      <version>4.1.63.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-http</artifactId>
+      <version>4.1.63.Final</version>
     </dependency>
     <dependency>
       <groupId>io.reactivex</groupId>


### PR DESCRIPTION
Upgrade to latest Netty 4.x version