### PR TITLE
Add @Shared methods to configure shared parameters

### DIFF
--- a/core/src/main/java/feign/ConfigurationParameters.java
+++ b/core/src/main/java/feign/ConfigurationParameters.java
@@ -1,0 +1,38 @@
+package feign;
+
+import feign.InvocationHandlerFactory.MethodHandler;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+public class ConfigurationParameters {
+
+    private final Map<String, Object> configuredParams = new HashMap<>();
+
+    public ConfigurationMethodHandler newHandler(final MethodMetadata methodMetadata) {
+        return new ConfigurationMethodHandler(methodMetadata);
+    }
+
+    public Map<String, Object> getParameterMap() {
+        return configuredParams;
+    }
+
+    public class ConfigurationMethodHandler implements MethodHandler {
+
+        private final MethodMetadata methodMetadata;
+
+        public ConfigurationMethodHandler(final MethodMetadata methodMetadata) {
+            this.methodMetadata = methodMetadata;
+        }
+
+        @Override
+        public Object invoke(Object[] argv) throws Throwable {
+            IntStream.range(0, argv.length)
+                .forEach(index -> methodMetadata.indexToName()
+                    .get(index)
+                    .forEach(name -> configuredParams.put(name, argv[index])));
+            return null;
+        }
+    }
+}

--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -97,7 +97,8 @@ public interface Contract {
       if (data.isIgnored()) {
         return data;
       }
-      checkState(data.template().method() != null,
+      checkState(data.isConfigurationMethod() ||
+              data.template().method() != null,
           "Method %s not annotated with HTTP method type (ex. GET, POST)%s",
           data.configKey(), data.warnings());
       final Class<?>[] parameterTypes = method.getParameterTypes();
@@ -286,7 +287,8 @@ public interface Contract {
         if (expander != Param.ToStringExpander.class) {
           data.indexToExpanderClass().put(paramIndex, expander);
         }
-        if (!data.template().hasRequestVariable(name)) {
+        if (!data.isConfigurationMethod() &&
+            !data.template().hasRequestVariable(name)) {
           data.formParams().add(name);
         }
       });
@@ -300,6 +302,9 @@ public interface Contract {
         checkState(data.headerMapIndex() == null,
             "HeaderMap annotation was present on multiple parameters.");
         data.headerMapIndex(paramIndex);
+      });
+      super.registerMethodAnnotation(Configuration.class, (ann, data) -> {
+        data.setAsConfigurationMethod();
       });
     }
 

--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -303,7 +303,11 @@ public interface Contract {
             "HeaderMap annotation was present on multiple parameters.");
         data.headerMapIndex(paramIndex);
       });
-      super.registerMethodAnnotation(Configuration.class, (ann, data) -> {
+      super.registerMethodAnnotation(Shared.class, (ann, data) -> {
+        boolean allParametersAreAnnotated = Arrays.stream(data.method().getParameters())
+            .allMatch(param -> param.isAnnotationPresent(Param.class));
+        checkState(allParametersAreAnnotated,
+            "Param annotation was not present on some parameters");
         data.setAsConfigurationMethod();
       });
     }

--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -307,7 +307,9 @@ public interface Contract {
         boolean allParametersAreAnnotated = Arrays.stream(data.method().getParameters())
             .allMatch(param -> param.isAnnotationPresent(Param.class));
         checkState(allParametersAreAnnotated,
-            "Param annotation was not present on some parameters");
+            "Param annotation was not present on some parameters of method %s", data.configKey());
+        checkState(data.returnType().equals(data.targetType()),
+            "Shared method %s return type must be its own interface", data.configKey());
         data.setAsConfigurationMethod();
       });
     }

--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -98,7 +98,7 @@ public interface Contract {
         return data;
       }
       checkState(data.isConfigurationMethod() ||
-              data.template().method() != null,
+          data.template().method() != null,
           "Method %s not annotated with HTTP method type (ex. GET, POST)%s",
           data.configKey(), data.warnings());
       final Class<?>[] parameterTypes = method.getParameterTypes();

--- a/core/src/main/java/feign/InvocationHandlerFactory.java
+++ b/core/src/main/java/feign/InvocationHandlerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -24,6 +24,10 @@ public interface InvocationHandlerFactory {
 
   InvocationHandler create(Target target, Map<Method, MethodHandler> dispatch);
 
+  default InvocationHandlerFactory withFeignFactory(SharedParameters.FeignFactory feignFactory) {
+    return this;
+  }
+
   /**
    * Like {@link InvocationHandler#invoke(Object, java.lang.reflect.Method, Object[])}, except for a
    * single method.
@@ -33,11 +37,26 @@ public interface InvocationHandlerFactory {
     Object invoke(Object[] argv) throws Throwable;
   }
 
-  static final class Default implements InvocationHandlerFactory {
+  final class Default implements InvocationHandlerFactory {
+
+    private final SharedParameters.FeignFactory feignFactory;
+
+    public Default() {
+      this(null);
+    }
+
+    private Default(SharedParameters.FeignFactory feignFactory) {
+      this.feignFactory = feignFactory;
+    }
+
+    @Override
+    public InvocationHandlerFactory withFeignFactory(SharedParameters.FeignFactory feignFactory) {
+      return new Default(feignFactory);
+    }
 
     @Override
     public InvocationHandler create(Target target, Map<Method, MethodHandler> dispatch) {
-      return new ReflectiveFeign.FeignInvocationHandler(target, dispatch);
+      return new ReflectiveFeign.FeignInvocationHandler(target, dispatch, feignFactory);
     }
   }
 }

--- a/core/src/main/java/feign/MethodMetadata.java
+++ b/core/src/main/java/feign/MethodMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/MethodMetadata.java
+++ b/core/src/main/java/feign/MethodMetadata.java
@@ -41,6 +41,7 @@ public final class MethodMetadata implements Serializable {
   private transient Map<Integer, Expander> indexToExpander;
   private BitSet parameterToIgnore = new BitSet();
   private boolean ignored;
+  private boolean configurationMethod;
   private transient Class<?> targetType;
   private transient Method method;
   private transient final List<String> warnings = new ArrayList<>();
@@ -218,6 +219,14 @@ public final class MethodMetadata implements Serializable {
 
   public boolean isIgnored() {
     return ignored;
+  }
+
+  public void setAsConfigurationMethod() {
+    this.configurationMethod = true;
+  }
+
+  public boolean isConfigurationMethod() {
+    return configurationMethod;
   }
 
   @Experimental

--- a/core/src/main/java/feign/ReflectiveFeign.java
+++ b/core/src/main/java/feign/ReflectiveFeign.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/ReflectiveFeign.java
+++ b/core/src/main/java/feign/ReflectiveFeign.java
@@ -160,12 +160,14 @@ public class ReflectiveFeign extends Feign {
           continue;
         }
         if (!md.formParams().isEmpty() && md.template().bodyTemplate() == null) {
-          buildTemplate =
-              new BuildFormEncodedTemplateFromArgs(md, encoder, queryMapEncoder, sharedParameters, target);
+          buildTemplate = new BuildFormEncodedTemplateFromArgs(md, encoder, queryMapEncoder,
+              sharedParameters, target);
         } else if (md.bodyIndex() != null) {
-          buildTemplate = new BuildEncodedTemplateFromArgs(md, encoder, queryMapEncoder, sharedParameters, target);
+          buildTemplate = new BuildEncodedTemplateFromArgs(md, encoder, queryMapEncoder,
+              sharedParameters, target);
         } else {
-          buildTemplate = new BuildTemplateByResolvingArgs(md, queryMapEncoder, sharedParameters, target);
+          buildTemplate = new BuildTemplateByResolvingArgs(md, queryMapEncoder,
+              sharedParameters, target);
         }
         if (md.isIgnored()) {
           result.put(md.configKey(), args -> {
@@ -190,7 +192,7 @@ public class ReflectiveFeign extends Feign {
     private final SharedParameters sharedParameters;
 
     private BuildTemplateByResolvingArgs(MethodMetadata metadata, QueryMapEncoder queryMapEncoder,
-                                         SharedParameters sharedParameters, Target target) {
+        SharedParameters sharedParameters, Target target) {
       this.metadata = metadata;
       this.target = target;
       this.queryMapEncoder = queryMapEncoder;
@@ -224,7 +226,7 @@ public class ReflectiveFeign extends Feign {
         checkArgument(argv[urlIndex] != null, "URI parameter %s was null", urlIndex);
         mutable.target(String.valueOf(argv[urlIndex]));
       }
-      Map<String, Object> varBuilder = new LinkedHashMap<String, Object>(sharedParameters.getParameterMap());
+      Map<String, Object> varBuilder = new LinkedHashMap<String, Object>(sharedParameters.asMap());
       for (Entry<Integer, Collection<String>> entry : metadata.indexToName().entrySet()) {
         int i = entry.getKey();
         Object value = argv[entry.getKey()];
@@ -348,8 +350,8 @@ public class ReflectiveFeign extends Feign {
     private final Encoder encoder;
 
     private BuildFormEncodedTemplateFromArgs(MethodMetadata metadata, Encoder encoder,
-                                             QueryMapEncoder queryMapEncoder, SharedParameters sharedParameters,
-                                             Target target) {
+        QueryMapEncoder queryMapEncoder, SharedParameters sharedParameters,
+        Target target) {
       super(metadata, queryMapEncoder, sharedParameters, target);
       this.encoder = encoder;
     }
@@ -380,8 +382,8 @@ public class ReflectiveFeign extends Feign {
     private final Encoder encoder;
 
     private BuildEncodedTemplateFromArgs(MethodMetadata metadata, Encoder encoder,
-                                         QueryMapEncoder queryMapEncoder, SharedParameters sharedParameters,
-                                         Target target) {
+        QueryMapEncoder queryMapEncoder, SharedParameters sharedParameters,
+        Target target) {
       super(metadata, queryMapEncoder, sharedParameters, target);
       this.encoder = encoder;
     }

--- a/core/src/main/java/feign/Shared.java
+++ b/core/src/main/java/feign/Shared.java
@@ -1,0 +1,12 @@
+package feign;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target(METHOD)
+@Retention(RUNTIME)
+public @interface Configuration {
+}

--- a/core/src/main/java/feign/Shared.java
+++ b/core/src/main/java/feign/Shared.java
@@ -1,8 +1,20 @@
+/**
+ * Copyright 2012-2021 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package feign;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 

--- a/core/src/main/java/feign/Shared.java
+++ b/core/src/main/java/feign/Shared.java
@@ -8,5 +8,5 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @Target(METHOD)
 @Retention(RUNTIME)
-public @interface Configuration {
+public @interface Shared {
 }

--- a/core/src/main/java/feign/SharedParameters.java
+++ b/core/src/main/java/feign/SharedParameters.java
@@ -1,7 +1,19 @@
+/**
+ * Copyright 2012-2021 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package feign;
 
 import feign.InvocationHandlerFactory.MethodHandler;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.IntStream;

--- a/core/src/main/java/feign/SharedParameters.java
+++ b/core/src/main/java/feign/SharedParameters.java
@@ -22,19 +22,19 @@ public class SharedParameters {
 
   private final Map<String, Object> paramNameToValue = new HashMap<>();
 
-  public ConfigurationMethodHandler newHandler(final MethodMetadata methodMetadata) {
-    return new ConfigurationMethodHandler(methodMetadata);
+  public SharedMethodHandler newHandler(final MethodMetadata methodMetadata) {
+    return new SharedMethodHandler(methodMetadata);
   }
 
   public Map<String, Object> asMap() {
     return paramNameToValue;
   }
 
-  public class ConfigurationMethodHandler implements MethodHandler {
+  public class SharedMethodHandler implements MethodHandler {
 
     private final MethodMetadata methodMetadata;
 
-    public ConfigurationMethodHandler(final MethodMetadata methodMetadata) {
+    public SharedMethodHandler(final MethodMetadata methodMetadata) {
       this.methodMetadata = methodMetadata;
     }
 

--- a/core/src/main/java/feign/SharedParameters.java
+++ b/core/src/main/java/feign/SharedParameters.java
@@ -6,16 +6,16 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.IntStream;
 
-public class ConfigurationParameters {
+public class SharedParameters {
 
-    private final Map<String, Object> configuredParams = new HashMap<>();
+    private final Map<String, Object> paramNameToValue = new HashMap<>();
 
     public ConfigurationMethodHandler newHandler(final MethodMetadata methodMetadata) {
         return new ConfigurationMethodHandler(methodMetadata);
     }
 
     public Map<String, Object> getParameterMap() {
-        return configuredParams;
+        return paramNameToValue;
     }
 
     public class ConfigurationMethodHandler implements MethodHandler {
@@ -31,7 +31,7 @@ public class ConfigurationParameters {
             IntStream.range(0, argv.length)
                 .forEach(index -> methodMetadata.indexToName()
                     .get(index)
-                    .forEach(name -> configuredParams.put(name, argv[index])));
+                    .forEach(name -> paramNameToValue.put(name, argv[index])));
             return null;
         }
     }

--- a/core/src/main/java/feign/SharedParameters.java
+++ b/core/src/main/java/feign/SharedParameters.java
@@ -8,31 +8,31 @@ import java.util.stream.IntStream;
 
 public class SharedParameters {
 
-    private final Map<String, Object> paramNameToValue = new HashMap<>();
+  private final Map<String, Object> paramNameToValue = new HashMap<>();
 
-    public ConfigurationMethodHandler newHandler(final MethodMetadata methodMetadata) {
-        return new ConfigurationMethodHandler(methodMetadata);
+  public ConfigurationMethodHandler newHandler(final MethodMetadata methodMetadata) {
+    return new ConfigurationMethodHandler(methodMetadata);
+  }
+
+  public Map<String, Object> asMap() {
+    return paramNameToValue;
+  }
+
+  public class ConfigurationMethodHandler implements MethodHandler {
+
+    private final MethodMetadata methodMetadata;
+
+    public ConfigurationMethodHandler(final MethodMetadata methodMetadata) {
+      this.methodMetadata = methodMetadata;
     }
 
-    public Map<String, Object> getParameterMap() {
-        return paramNameToValue;
+    @Override
+    public Object invoke(Object[] argv) throws Throwable {
+      IntStream.range(0, argv.length)
+          .forEach(index -> methodMetadata.indexToName()
+              .get(index)
+              .forEach(name -> paramNameToValue.put(name, argv[index])));
+      return null;
     }
-
-    public class ConfigurationMethodHandler implements MethodHandler {
-
-        private final MethodMetadata methodMetadata;
-
-        public ConfigurationMethodHandler(final MethodMetadata methodMetadata) {
-            this.methodMetadata = methodMetadata;
-        }
-
-        @Override
-        public Object invoke(Object[] argv) throws Throwable {
-            IntStream.range(0, argv.length)
-                .forEach(index -> methodMetadata.indexToName()
-                    .get(index)
-                    .forEach(name -> paramNameToValue.put(name, argv[index])));
-            return null;
-        }
-    }
+  }
 }

--- a/core/src/main/java/feign/SharedParameters.java
+++ b/core/src/main/java/feign/SharedParameters.java
@@ -39,7 +39,7 @@ public class SharedParameters {
     return paramNameToValue;
   }
 
-  interface FeignFactory {
+  public interface FeignFactory {
     Feign create(SharedParameters sharedParameters);
   }
 

--- a/core/src/test/java/feign/DefaultContractTest.java
+++ b/core/src/test/java/feign/DefaultContractTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,8 +17,12 @@ import static feign.assertj.FeignAssertions.assertThat;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.MapEntry.entry;
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.CoreMatchers.startsWith;
 import com.google.gson.reflect.TypeToken;
 import org.assertj.core.api.Fail;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matcher;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -955,5 +959,33 @@ public class DefaultContractTest {
     Response findAllClientsByUid2(@Category(value = String.class) String uid,
                                   Integer limit,
                                   @SuppressWarnings({"a"}) Integer offset);
+  }
+
+  @Test
+  public void errorOnSharedMethodWithUnannotatedParameters() {
+    thrown.expect(IllegalStateException.class);
+    thrown
+        .expectMessage(startsWith("Param annotation was not present on some parameters of method"));
+
+    contract.parseAndValidateMetadata(SharedMethodWithUnannotatedParameters.class);
+  }
+
+  @Test
+  public void errorOnSharedMethodWithUnexpectedReturnType() {
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage(startsWith("Shared method"));
+    thrown.expectMessage(endsWith("return type must be its own interface"));
+
+    contract.parseAndValidateMetadata(SharedMethodWithVoidReturnType.class);
+  }
+
+  interface SharedMethodWithUnannotatedParameters {
+    @Shared
+    SharedMethodWithUnannotatedParameters configure(String param);
+  }
+
+  interface SharedMethodWithVoidReturnType {
+    @Shared
+    void configure(@Param("param") String param);
   }
 }

--- a/core/src/test/java/feign/FeignBuilderTest.java
+++ b/core/src/test/java/feign/FeignBuilderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -268,7 +268,8 @@ public class FeignBuilderTest {
     final AtomicInteger callCount = new AtomicInteger();
     // noinspection rawtypes
     InvocationHandlerFactory factory = new InvocationHandlerFactory() {
-      private final InvocationHandlerFactory delegate = new Default();
+      private final InvocationHandlerFactory delegate = new Default()
+          .withFeignFactory(sharedParameters -> null);
 
       @Override
       public InvocationHandler create(Target target, Map<Method, MethodHandler> dispatch) {

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -906,42 +906,42 @@ public class FeignTest {
   }
 
   @Test
-  public void configuredPathParameterIsIncluded() throws Exception {
+  public void sharedPathParameterIsIncluded() throws Exception {
     TestInterface api = new TestInterfaceBuilder().queryMapEndcoder(new BeanQueryMapEncoder())
         .target("http://localhost:" + server.getPort());
-    api.configure("configuredValue");
+    api.configure("sharedValue");
 
     server.enqueue(new MockResponse());
-    api.configuredPathParam("requestValue");
+    api.sharedPathParam("exclusiveValue");
     assertThat(server.takeRequest())
-        .hasQueryParams("/configuredValue/requestValue");
+        .hasQueryParams("/sharedValue/exclusiveValue");
   }
 
   @Test
-  public void configuredHeaderParameterIsIncluded() throws Exception {
+  public void sharedHeaderParameterIsIncluded() throws Exception {
     TestInterface api = new TestInterfaceBuilder().queryMapEndcoder(new BeanQueryMapEncoder())
         .target("http://localhost:" + server.getPort());
-    api.configure("configuredValue");
+    api.configure("sharedValue");
 
     server.enqueue(new MockResponse());
-    api.configuredHeaderParam("requestValue");
+    api.sharedHeaderParam("exclusiveValue");
     assertThat(server.takeRequest())
         .hasHeaders(
-            entry("configuredheader", Collections.singletonList("configuredValue")),
-            entry("requestheader", Collections.singletonList("requestValue"))
+            entry("sharedheader", Collections.singletonList("sharedValue")),
+            entry("exclusiveheader", Collections.singletonList("exclusiveValue"))
         );
   }
 
   @Test
-  public void configuredBodyParameterIsIncluded() throws Exception {
+  public void sharedBodyParameterIsIncluded() throws Exception {
     TestInterface api = new TestInterfaceBuilder().queryMapEndcoder(new BeanQueryMapEncoder())
         .target("http://localhost:" + server.getPort());
-    api.configure("configuredValue");
+    api.configure("sharedValue");
 
     server.enqueue(new MockResponse());
-    api.configuredBodyParam("requestValue");
+    api.sharedBodyParam("exclusiveValue");
     assertThat(server.takeRequest())
-        .hasBody("{\"configuredProperty\": \"configuredValue\", \"requestProperty\": \"requestValue\"}");
+        .hasBody("{\"sharedProperty\": \"sharedValue\", \"requestProperty\": \"exclusiveValue\"}");
   }
 
   interface TestInterface {
@@ -1029,22 +1029,22 @@ public class FeignTest {
     @RequestLine("GET /")
     void queryMapPropertyInheritence(@QueryMap ChildPojo object);
 
-    @Configuration
-    void configure(@Param("configuredParam") String configuredParam);
+    @Shared
+    void configure(@Param("sharedParam") String sharedParam);
 
-    @RequestLine("GET /{configuredParam}/{requestParam}")
-    void configuredPathParam(@Param("requestParam") String requestParam);
+    @RequestLine("GET /{sharedParam}/{exclusiveParam}")
+    void sharedPathParam(@Param("exclusiveParam") String exclusiveParam);
 
     @RequestLine("POST /")
     @Headers({
-        "ConfiguredHeader: {configuredParam}",
-        "RequestHeader: {requestParam}"
+        "SharedHeader: {sharedParam}",
+        "ExclusiveHeader: {exclusiveParam}"
     })
-    void configuredHeaderParam(@Param("requestParam") String requestParam);
+    void sharedHeaderParam(@Param("exclusiveParam") String exclusiveParam);
 
     @RequestLine("POST /")
-    @Body("%7B\"configuredProperty\": \"{configuredParam}\", \"requestProperty\": \"{requestParam}\"%7D")
-    void configuredBodyParam(@Param("requestParam") String requestParam);
+    @Body("%7B\"sharedProperty\": \"{sharedParam}\", \"requestProperty\": \"{exclusiveParam}\"%7D")
+    void sharedBodyParam(@Param("exclusiveParam") String exclusiveParam);
 
     class DateToMillis implements Param.Expander {
 

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -928,8 +928,7 @@ public class FeignTest {
     assertThat(server.takeRequest())
         .hasHeaders(
             entry("sharedheader", Collections.singletonList("sharedValue")),
-            entry("exclusiveheader", Collections.singletonList("exclusiveValue"))
-        );
+            entry("exclusiveheader", Collections.singletonList("exclusiveValue")));
   }
 
   @Test

--- a/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredInvocationHandleFactory.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredInvocationHandleFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -92,5 +92,9 @@ public class MeteredInvocationHandleFactory implements InvocationHandlerFactory 
     };
   }
 
-
+  @Override
+  public InvocationHandlerFactory withFeignFactory(SharedParameters.FeignFactory feignFactory) {
+    return new MeteredInvocationHandleFactory(invocationHandler.withFeignFactory(feignFactory),
+        metricRegistry, metricSuppliers);
+  }
 }

--- a/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredInvocationHandleFactory.java
+++ b/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredInvocationHandleFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -95,5 +95,9 @@ public class MeteredInvocationHandleFactory implements InvocationHandlerFactory 
     };
   }
 
-
+  @Override
+  public InvocationHandlerFactory withFeignFactory(SharedParameters.FeignFactory feignFactory) {
+    return new MeteredInvocationHandleFactory(invocationHandler.withFeignFactory(feignFactory),
+        metricRegistry, metricSuppliers);
+  }
 }

--- a/micrometer/src/main/java/feign/micrometer/MeteredInvocationHandleFactory.java
+++ b/micrometer/src/main/java/feign/micrometer/MeteredInvocationHandleFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -22,6 +22,7 @@ import java.util.Map;
 import feign.Feign;
 import feign.FeignException;
 import feign.InvocationHandlerFactory;
+import feign.SharedParameters;
 import feign.Target;
 import feign.Util;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -103,5 +104,9 @@ public class MeteredInvocationHandleFactory implements InvocationHandlerFactory 
     };
   }
 
-
+  @Override
+  public InvocationHandlerFactory withFeignFactory(SharedParameters.FeignFactory feignFactory) {
+    return new MeteredInvocationHandleFactory(invocationHandler.withFeignFactory(feignFactory),
+        meterRegistry, metricName);
+  }
 }


### PR DESCRIPTION
Add the `@Shared` annotation to the default contract. Annotating a method with `@Shared` turns it into a setter/configurator for the built client. 

```java
interface ClientApi {

  @Shared
  ClientApi setEnv(@Param("env") String env);

  @RequestLine("GET /{resource}/{env}")
  void getResource(@Param("resource") String resource);
}
```

This allows users to perform one-time configuration on their client.

```java
ClientApi clientApi = Feign.builder()
  .target(ClientApi.class, "https://example-host.com")
  .setEnv("qa");

// ...

clientApi.getResource("resource-identifier");
```