### PR TITLE
Run java11 build, if JDK version is at least 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -843,7 +843,7 @@
     <profile>
       <id>active-on-jdk-11</id>
       <activation>
-        <jdk>11</jdk>
+        <jdk>[11,)</jdk>
       </activation>
       <modules>
         <module>java11</module>


### PR DESCRIPTION
before it was running version version was exactly 11, not building java11 module for java 14.