### PR TITLE
Add missing encoder/decoder to overview-mindmap.iuml

### DIFF
--- a/src/docs/overview-mindmap.iuml
+++ b/src/docs/overview-mindmap.iuml
@@ -20,6 +20,7 @@
 *** Spring boot (3rd party)
 ** encoders/decoders
 *** GSON
+*** JAXB
 *** Jackson 1
 *** Jackson 2
 *** Jackson JAXB


### PR DESCRIPTION
The original feature map didn't mention the `JAXB` encoder/decoder