### PR TITLE
Fix no response logging on async Feign

### DIFF
--- a/core/src/main/java/feign/AsyncFeign.java
+++ b/core/src/main/java/feign/AsyncFeign.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -63,7 +63,7 @@ public abstract class AsyncFeign<C> extends Feign {
     private Supplier<C> defaultContextSupplier = () -> null;
     private AsyncClient<C> client;
 
-    private final Logger.Level logLevel = Logger.Level.NONE;
+    private Logger.Level logLevel = Logger.Level.NONE;
     private final Logger logger = new NoOpLogger();
 
     private Decoder decoder = new Decoder.Default();

--- a/core/src/main/java/feign/AsyncFeign.java
+++ b/core/src/main/java/feign/AsyncFeign.java
@@ -159,6 +159,7 @@ public abstract class AsyncFeign<C> extends Feign {
      */
     public AsyncBuilder<C> logLevel(Logger.Level logLevel) {
       builder.logLevel(logLevel);
+      this.logLevel = logLevel
       return this;
     }
 

--- a/core/src/main/java/feign/AsyncFeign.java
+++ b/core/src/main/java/feign/AsyncFeign.java
@@ -159,7 +159,7 @@ public abstract class AsyncFeign<C> extends Feign {
      */
     public AsyncBuilder<C> logLevel(Logger.Level logLevel) {
       builder.logLevel(logLevel);
-      this.logLevel = logLevel
+      this.logLevel = logLevel;
       return this;
     }
 


### PR DESCRIPTION
Copy log level onto asyncBuilder as well as setting it on the builder, so responses get logged in the asynchronous case.

I apologize if this is in the wrong format. You can see a test reproducing the issue below.

I have yet to build the project locally-- I likely won't have time to do that until the morning. The build failure appears to be asking me to add a license header to this file, which I can do but seems unrelated to this issue 🤷 

 
## Test Example
```java

import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
import static com.github.tomakehurst.wiremock.client.WireMock.get;
import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
import static org.junit.jupiter.api.Assertions.assertEquals;

import com.github.tomakehurst.wiremock.client.WireMock;
import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
import com.github.tomakehurst.wiremock.junit.WireMockRule;
import feign.AsyncFeign;
import feign.Logger.ErrorLogger;
import feign.Logger.Level;
import feign.RequestLine;
import java.util.concurrent.CompletableFuture;
import org.junit.Rule;
import org.junit.Test;


public class FeignPermissionResourceTest {

  public interface ExampleApi {

    @RequestLine("GET /")
    CompletableFuture<String> hello();
  }

  @Rule
  public WireMockRule wireMockRule = new WireMockRule(
      options()
          .dynamicPort()
          .notifier(new Slf4jNotifier(true))
  );

  @Test
  public void testLoggerFailure() {

    final ExampleApi target = AsyncFeign.asyncBuilder()
        .logger(new ErrorLogger())
        .logLevel(Level.FULL)
        .target(ExampleApi.class, wireMockRule.baseUrl());

    var response = WireMock.aResponse()
        .withStatus(200)
        .withHeader("Content-Type", "text/plain")
        .withBody("hello!");

    stubFor(get(anyUrl()).willReturn(response));

    final CompletableFuture<String> hello = target.hello();

    final String responseText = hello.join();
    assertEquals("hello!", responseText);
  }
}
```

## Output on STDERR
```
[ExampleApi#hello] ---> GET http://localhost:62764/ HTTP/1.1
[ExampleApi#hello] ---> END HTTP (0-byte body)

Process finished with exit code 0
```
