### PR TITLE
Add response headers to FeignException

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -29,6 +29,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
+    <hamcrest.version>1.3</hamcrest.version>
   </properties>
 
   <dependencies>
@@ -61,6 +62,13 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>${hamcrest.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/core/src/main/java/feign/Response.java
+++ b/core/src/main/java/feign/Response.java
@@ -13,11 +13,11 @@
  */
 package feign;
 
-import static feign.Util.*;
 import java.io.*;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import static feign.Util.*;
 
 /**
  * An immutable response to an http invocation which only returns string content.
@@ -35,9 +35,7 @@ public final class Response implements Closeable {
     this.status = builder.status;
     this.request = builder.request;
     this.reason = builder.reason; // nullable
-    this.headers = (builder.headers != null)
-        ? Collections.unmodifiableMap(caseInsensitiveCopyOf(builder.headers))
-        : new LinkedHashMap<>();
+    this.headers = caseInsensitiveCopyOf(builder.headers);
     this.body = builder.body; // nullable
 
   }
@@ -360,17 +358,4 @@ public final class Response implements Closeable {
 
   }
 
-  private static Map<String, Collection<String>> caseInsensitiveCopyOf(Map<String, Collection<String>> headers) {
-    Map<String, Collection<String>> result =
-        new TreeMap<String, Collection<String>>(String.CASE_INSENSITIVE_ORDER);
-
-    for (Map.Entry<String, Collection<String>> entry : headers.entrySet()) {
-      String headerName = entry.getKey();
-      if (!result.containsKey(headerName)) {
-        result.put(headerName.toLowerCase(Locale.ROOT), new LinkedList<String>());
-      }
-      result.get(headerName).addAll(entry.getValue());
-    }
-    return result;
-  }
 }

--- a/core/src/main/java/feign/Util.java
+++ b/core/src/main/java/feign/Util.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -30,15 +30,7 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -360,4 +352,33 @@ public class Util {
   public static boolean isBlank(String value) {
     return value == null || value.isEmpty();
   }
+
+  /**
+   * Copy entire map of string collection.
+   *
+   * The copy is unmodified map of unmodified collections.
+   *
+   * @param map string collection map
+   * @return copy of the map or an empty map if the map is null.
+   */
+  public static Map<String, Collection<String>> caseInsensitiveCopyOf(Map<String, Collection<String>> map) {
+    if (map == null) {
+      return Collections.emptyMap();
+    }
+
+    Map<String, Collection<String>> result =
+        new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
+    for (Map.Entry<String, Collection<String>> entry : map.entrySet()) {
+      String key = entry.getKey();
+      if (!result.containsKey(key)) {
+        result.put(key.toLowerCase(Locale.ROOT), new LinkedList<>());
+      }
+      result.get(key).addAll(entry.getValue());
+    }
+    result.replaceAll((key, value) -> Collections.unmodifiableCollection(value));
+
+    return Collections.unmodifiableMap(result);
+  }
+
 }

--- a/core/src/main/java/feign/Util.java
+++ b/core/src/main/java/feign/Util.java
@@ -356,7 +356,7 @@ public class Util {
   /**
    * Copy entire map of string collection.
    *
-   * The copy is unmodified map of unmodified collections.
+   * The copy is unmodifiable map of unmodifiable collections.
    *
    * @param map string collection map
    * @return copy of the map or an empty map if the map is null.

--- a/core/src/test/java/feign/AsyncFeignTest.java
+++ b/core/src/test/java/feign/AsyncFeignTest.java
@@ -560,8 +560,9 @@ public class AsyncFeignTest {
         .client(new AsyncClient.Default<>((request, options) -> response, execs))
         .target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
 
-    assertEquals(Collections.singletonList("http://bar.com"),
-        unwrap(api.response()).headers().get("Location"));
+    assertThat(unwrap(api.response()).headers()).hasEntrySatisfying("Location", value -> {
+      assertThat(value).contains("http://bar.com");
+    });
 
     execs.shutdown();
   }

--- a/core/src/test/java/feign/FeignBuilderTest.java
+++ b/core/src/test/java/feign/FeignBuilderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -121,9 +121,9 @@ public class FeignBuilderTest {
 
     Response response = noFollowApi.defaultMethodPassthrough();
     assertThat(response.status()).isEqualTo(302);
-    assertThat(response.headers().getOrDefault("Location", null))
-        .isNotNull()
-        .isEqualTo(Collections.singletonList("/"));
+    assertThat(response.headers()).hasEntrySatisfying("Location", value -> {
+      assertThat(value).contains("/");
+    });
 
     server.enqueue(new MockResponse().setResponseCode(302).addHeader("Location", "/"));
     server.enqueue(new MockResponse().setResponseCode(200));

--- a/core/src/test/java/feign/FeignExceptionTest.java
+++ b/core/src/test/java/feign/FeignExceptionTest.java
@@ -117,7 +117,7 @@ public class FeignExceptionTest {
 
   @Test(expected = NullPointerException.class)
   public void nullRequestShouldThrowNPEwThrowableAndBytes() {
-    new Derived(404, "message", null, new Throwable(), new byte[1]);
+    new Derived(404, "message", null, new Throwable(), new byte[1], Collections.emptyMap());
   }
 
   @Test(expected = NullPointerException.class)
@@ -127,7 +127,7 @@ public class FeignExceptionTest {
 
   @Test(expected = NullPointerException.class)
   public void nullRequestShouldThrowNPEwBytes() {
-    new Derived(404, "message", null, new byte[1]);
+    new Derived(404, "message", null, new byte[1], Collections.emptyMap());
   }
 
   static class Derived extends FeignException {
@@ -136,16 +136,18 @@ public class FeignExceptionTest {
       super(status, message, request, cause);
     }
 
-    public Derived(int status, String message, Request request, Throwable cause, byte[] content) {
-      super(status, message, request, cause, content);
+    public Derived(int status, String message, Request request, Throwable cause, byte[] content,
+        Map<String, Collection<String>> headers) {
+      super(status, message, request, cause, content, headers);
     }
 
     public Derived(int status, String message, Request request) {
       super(status, message, request);
     }
 
-    public Derived(int status, String message, Request request, byte[] content) {
-      super(status, message, request, content);
+    public Derived(int status, String message, Request request, byte[] content,
+        Map<String, Collection<String>> headers) {
+      super(status, message, request, content, headers);
     }
   }
 

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -43,9 +43,8 @@ import static feign.ExceptionPropagationPolicy.UNWRAP;
 import static feign.Util.UTF_8;
 import static feign.assertj.MockWebServerAssertions.assertThat;
 import static org.assertj.core.data.MapEntry.entry;
-import static org.hamcrest.CoreMatchers.isA;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("deprecation")
 public class FeignTest {
@@ -637,8 +636,9 @@ public class FeignTest {
         .client((request, options) -> response)
         .target(TestInterface.class, "http://localhost:" + server.getPort());
 
-    assertEquals(api.response().headers().get("Location"),
-        Collections.singletonList("http://bar.com"));
+    assertThat(api.response().headers()).hasEntrySatisfying("Location", value -> {
+      assertThat(value).contains("http://bar.com");
+    });
   }
 
   private static class MockRetryer implements Retryer {

--- a/core/src/test/java/feign/FeignUnderAsyncTest.java
+++ b/core/src/test/java/feign/FeignUnderAsyncTest.java
@@ -49,7 +49,6 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
-import static feign.ExceptionPropagationPolicy.*;
 import static feign.Util.*;
 import static feign.assertj.MockWebServerAssertions.assertThat;
 import static org.assertj.core.data.MapEntry.entry;
@@ -541,8 +540,9 @@ public class FeignUnderAsyncTest {
         .client(new AsyncClient.Default<>((request, options) -> response, execs))
         .target(TestInterface.class, "http://localhost:" + server.getPort());
 
-    assertEquals(api.response().headers().get("Location"),
-        Collections.singletonList("http://bar.com"));
+    assertThat(api.response().headers()).hasEntrySatisfying("Location", value -> {
+      assertThat(value).contains("http://bar.com");
+    });
 
     execs.shutdown();
   }

--- a/core/src/test/java/feign/ResponseTest.java
+++ b/core/src/test/java/feign/ResponseTest.java
@@ -14,17 +14,10 @@
 package feign;
 
 import feign.Request.HttpMethod;
-import java.nio.charset.StandardCharsets;
 import org.assertj.core.util.Lists;
 import org.junit.Test;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import static feign.assertj.FeignAssertions.assertThat;
-import static org.assertj.core.api.Assertions.entry;
 
 @SuppressWarnings("deprecation")
 public class ResponseTest {
@@ -53,8 +46,12 @@ public class ResponseTest {
         .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .body(new byte[0])
         .build();
-    assertThat(response.headers().get("content-type")).isEqualTo(valueList);
-    assertThat(response.headers().get("Content-Type")).isEqualTo(valueList);
+    assertThat(response.headers())
+        .hasEntrySatisfying("content-type", value -> {
+          assertThat(value).contains("application/json");
+        }).hasEntrySatisfying("Content-Type", value -> {
+          assertThat(value).contains("application/json");
+        });
   }
 
   @Test
@@ -70,9 +67,9 @@ public class ResponseTest {
         .body(new byte[0])
         .build();
 
-    List<String> expectedHeaderValue =
-        Arrays.asList("Cookie-A=Value", "Cookie-B=Value", "Cookie-C=Value");
-    assertThat(response.headers()).containsOnly(entry(("set-cookie"), expectedHeaderValue));
+    assertThat(response.headers()).hasEntrySatisfying("set-cookie", value -> {
+      assertThat(value).contains("Cookie-A=Value", "Cookie-B=Value", "Cookie-C=Value");
+    });
   }
 
   @Test

--- a/core/src/test/java/feign/UtilTest.java
+++ b/core/src/test/java/feign/UtilTest.java
@@ -254,18 +254,18 @@ public class UtilTest {
   }
 
   @Test
-  public void copyIsUnmodified() {
+  public void copyIsUnmodifiable() {
     // Arrange
     Map<String, Collection<String>> sourceMap = new HashMap<>();
 
     sourceMap.put("First", Arrays.asList("abc", "qwerty", "xyz"));
     sourceMap.put("camelCase", Collections.singleton("123"));
     // Act
-    Map<String, Collection<String>> unmodifiedMap = caseInsensitiveCopyOf(sourceMap);
+    Map<String, Collection<String>> unmodifiableMap = caseInsensitiveCopyOf(sourceMap);
     // Assert result
-    assertThatThrownBy(() -> unmodifiedMap.put("new", Collections.singleton("223322")))
+    assertThatThrownBy(() -> unmodifiableMap.put("new", Collections.singleton("223322")))
         .isInstanceOf(UnsupportedOperationException.class);
-    assertThatThrownBy(() -> unmodifiedMap.get("camelCase").clear())
+    assertThatThrownBy(() -> unmodifiableMap.get("camelCase").clear())
         .isInstanceOf(UnsupportedOperationException.class);
   }
 

--- a/core/src/test/java/feign/UtilTest.java
+++ b/core/src/test/java/feign/UtilTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,25 +13,18 @@
  */
 package feign;
 
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.junit.Test;
 import java.io.Reader;
 import java.lang.reflect.Type;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import feign.codec.Decoder;
-import static feign.Util.emptyToNull;
-import static feign.Util.removeValues;
-import static feign.Util.resolveLastTypeParameter;
+import static feign.Util.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class UtilTest {
 
@@ -163,7 +156,7 @@ public class UtilTest {
     // Act
     final Object retval = Util.checkNotNull(reference, errorMessageTemplate, errorMessageArgs);
     // Assert result
-    Assert.assertEquals(new Integer(0), retval);
+    assertEquals(new Integer(0), retval);
   }
 
   @Test
@@ -185,7 +178,7 @@ public class UtilTest {
     // Act
     final String retval = Util.emptyToNull(string);
     // Assert result
-    Assert.assertEquals("AAAAAAAA", retval);
+    assertEquals("AAAAAAAA", retval);
   }
 
   @Test
@@ -195,7 +188,7 @@ public class UtilTest {
     // Act
     final String retval = Util.emptyToNull(string);
     // Assert result
-    Assert.assertNull(retval);
+    assertNull(retval);
   }
 
   @Test
@@ -205,7 +198,7 @@ public class UtilTest {
     // Act
     final boolean retval = Util.isBlank(value);
     // Assert result
-    Assert.assertEquals(false, retval);
+    assertEquals(false, retval);
   }
 
   @Test
@@ -215,7 +208,7 @@ public class UtilTest {
     // Act
     final boolean retval = Util.isBlank(value);
     // Assert result
-    Assert.assertEquals(true, retval);
+    assertEquals(true, retval);
   }
 
   @Test
@@ -225,7 +218,7 @@ public class UtilTest {
     // Act
     final boolean retval = Util.isNotBlank(value);
     // Assert result
-    Assert.assertEquals(false, retval);
+    assertEquals(false, retval);
   }
 
   @Test
@@ -235,15 +228,63 @@ public class UtilTest {
     // Act
     final boolean retval = Util.isNotBlank(value);
     // Assert result
-    Assert.assertEquals(true, retval);
+    assertEquals(true, retval);
+  }
+
+  @Test
+  public void caseInsensitiveCopyOfMap() {
+    // Arrange
+    Map<String, Collection<String>> sourceMap = new HashMap<>();
+
+    sourceMap.put("First", Arrays.asList("abc", "qwerty", "xyz"));
+    sourceMap.put("camelCase", Collections.singleton("123"));
+    // Act
+    Map<String, Collection<String>> actualMap = caseInsensitiveCopyOf(sourceMap);
+    // Assert result
+    assertThat(actualMap)
+        .hasEntrySatisfying("First", value -> {
+          assertThat(value).contains("xyz", "abc", "qwerty");
+        }).hasEntrySatisfying("first", value -> {
+          assertThat(value).contains("xyz", "abc", "qwerty");
+        }).hasEntrySatisfying("CAMELCASE", value -> {
+          assertThat(value).contains("123");
+        }).hasEntrySatisfying("camelcase", value -> {
+          assertThat(value).contains("123");
+        });
+  }
+
+  @Test
+  public void copyIsUnmodified() {
+    // Arrange
+    Map<String, Collection<String>> sourceMap = new HashMap<>();
+
+    sourceMap.put("First", Arrays.asList("abc", "qwerty", "xyz"));
+    sourceMap.put("camelCase", Collections.singleton("123"));
+    // Act
+    Map<String, Collection<String>> unmodifiedMap = caseInsensitiveCopyOf(sourceMap);
+    // Assert result
+    assertThatThrownBy(() -> unmodifiedMap.put("new", Collections.singleton("223322")))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> unmodifiedMap.get("camelCase").clear())
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  public void nullMap() {
+    // Act
+    Map<String, Collection<String>> actualMap = caseInsensitiveCopyOf(null);
+    // Assert result
+    assertThat(actualMap)
+        .isNotNull()
+        .isEmpty();
   }
 
   interface LastTypeParameter {
-    final List<String> LIST_STRING = null;
-    final Parameterized<List<String>> PARAMETERIZED_LIST_STRING = null;
-    final Parameterized<? extends List<String>> PARAMETERIZED_WILDCARD_LIST_STRING = null;
-    final ParameterizedDecoder<List<String>> PARAMETERIZED_DECODER_LIST_STRING = null;
-    final ParameterizedDecoder<?> PARAMETERIZED_DECODER_UNBOUND = null;
+    List<String> LIST_STRING = null;
+    Parameterized<List<String>> PARAMETERIZED_LIST_STRING = null;
+    Parameterized<? extends List<String>> PARAMETERIZED_WILDCARD_LIST_STRING = null;
+    ParameterizedDecoder<List<String>> PARAMETERIZED_DECODER_LIST_STRING = null;
+    ParameterizedDecoder<?> PARAMETERIZED_DECODER_UNBOUND = null;
   }
 
   interface ParameterizedDecoder<T extends List<String>> extends Decoder {

--- a/core/src/test/java/feign/client/AbstractClientTest.java
+++ b/core/src/test/java/feign/client/AbstractClientTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,8 +14,7 @@
 package feign.client;
 
 import static feign.Util.UTF_8;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.assertEquals;
 import feign.Client;
 import feign.CollectionFormat;
@@ -89,8 +88,12 @@ public abstract class AbstractClientTest {
     assertThat(response.status()).isEqualTo(200);
     assertThat(response.reason()).isEqualTo("OK");
     assertThat(response.headers())
-        .containsEntry("Content-Length", Collections.singletonList("3"))
-        .containsEntry("Foo", Collections.singletonList("Bar"));
+        .hasEntrySatisfying("Content-Length", value -> {
+          assertThat(value).contains("3");
+        })
+        .hasEntrySatisfying("Foo", value -> {
+          assertThat(value).contains("Bar");
+        });
     assertThat(response.body().asInputStream())
         .hasSameContentAs(new ByteArrayInputStream("foo".getBytes(UTF_8)));
 

--- a/hc5/src/test/java/feign/hc5/AsyncApacheHttp5ClientTest.java
+++ b/hc5/src/test/java/feign/hc5/AsyncApacheHttp5ClientTest.java
@@ -509,8 +509,9 @@ public class AsyncApacheHttp5ClientTest {
         .client(new AsyncClient.Default<>((request, options) -> response, execs))
         .target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
 
-    assertEquals(Collections.singletonList("http://bar.com"),
-        unwrap(api.response()).headers().get("Location"));
+    assertThat(unwrap(api.response()).headers()).hasEntrySatisfying("Location", value -> {
+      assertThat(value).contains("http://bar.com");
+    });
 
     execs.shutdown();
   }

--- a/jaxrs2/src/test/java/feign/jaxrs2/JAXRSClientTest.java
+++ b/jaxrs2/src/test/java/feign/jaxrs2/JAXRSClientTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,31 +13,22 @@
  */
 package feign.jaxrs2;
 
-import static feign.Util.UTF_8;
-import static java.util.Arrays.asList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import feign.Feign;
+import feign.*;
 import feign.Feign.Builder;
-import feign.Headers;
-import feign.RequestLine;
-import feign.Response;
-import feign.Util;
 import feign.assertj.MockWebServerAssertions;
 import feign.client.AbstractClientTest;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.util.Collections;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.ProcessingException;
 import feign.jaxrs.JAXRSContract;
 import okhttp3.mockwebserver.MockResponse;
 import org.assertj.core.data.MapEntry;
 import org.junit.Assume;
 import org.junit.Test;
+import javax.ws.rs.*;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Collections;
+import static feign.Util.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests client-specific behavior, such as ensuring Content-Length is sent when specified.
@@ -101,9 +92,11 @@ public class JAXRSClientTest extends AbstractClientTest {
 
     assertThat(response.status()).isEqualTo(200);
     assertThat(response.reason()).isEqualTo("OK");
-    assertThat(response.headers())
-        .containsEntry("Content-Length", asList("3"))
-        .containsEntry("Foo", asList("Bar"));
+    assertThat(response.headers()).hasEntrySatisfying("Content-Length", value -> {
+      assertThat(value).contains("3");
+    }).hasEntrySatisfying("Foo", value -> {
+      assertThat(value).contains("Bar");
+    });
     assertThat(response.body().asInputStream())
         .hasSameContentAs(new ByteArrayInputStream("foo".getBytes(UTF_8)));
 

--- a/jaxrs2/src/test/java/feign/jaxrs2/JAXRSClientTest.java
+++ b/jaxrs2/src/test/java/feign/jaxrs2/JAXRSClientTest.java
@@ -92,11 +92,12 @@ public class JAXRSClientTest extends AbstractClientTest {
 
     assertThat(response.status()).isEqualTo(200);
     assertThat(response.reason()).isEqualTo("OK");
-    assertThat(response.headers()).hasEntrySatisfying("Content-Length", value -> {
-      assertThat(value).contains("3");
-    }).hasEntrySatisfying("Foo", value -> {
-      assertThat(value).contains("Bar");
-    });
+    assertThat(response.headers())
+        .hasEntrySatisfying("Content-Length", value -> {
+          assertThat(value).contains("3");
+        }).hasEntrySatisfying("Foo", value -> {
+          assertThat(value).contains("Bar");
+        });
     assertThat(response.body().asInputStream())
         .hasSameContentAs(new ByteArrayInputStream("foo".getBytes(UTF_8)));
 

--- a/micrometer/src/test/java/feign/micrometer/AbstractMetricsTestBase.java
+++ b/micrometer/src/test/java/feign/micrometer/AbstractMetricsTestBase.java
@@ -89,7 +89,7 @@ public abstract class AbstractMetricsTestBase<MR, METRIC_ID, METRIC> {
 
     final SimpleSource source = Feign.builder()
         .client((request, options) -> {
-          notFound.set(new FeignException.NotFound("test", request, null));
+          notFound.set(new FeignException.NotFound("test", request, null, null));
           throw notFound.get();
         })
         .addCapability(createMetricCapability())
@@ -117,7 +117,7 @@ public abstract class AbstractMetricsTestBase<MR, METRIC_ID, METRIC> {
         .client(new MockClient()
             .ok(HttpMethod.GET, "/get", "1234567890abcde"))
         .decoder((response, type) -> {
-          notFound.set(new FeignException.NotFound("test", response.request(), null));
+          notFound.set(new FeignException.NotFound("test", response.request(), null, null));
           throw notFound.get();
         })
         .addCapability(createMetricCapability())


### PR DESCRIPTION
Implementation of #1268

This PR adds the ability to retrieve the response headers from a `FeignException`.

This is replacement for #1277 as the source branch is gone.