### PR TITLE
Allow QueryMapEncoder accept null value

### DIFF
--- a/core/src/main/java/feign/querymap/BeanQueryMapEncoder.java
+++ b/core/src/main/java/feign/querymap/BeanQueryMapEncoder.java
@@ -38,6 +38,9 @@ public class BeanQueryMapEncoder implements QueryMapEncoder {
 
   @Override
   public Map<String, Object> encode(Object object) throws EncodeException {
+    if (object == null) {
+      return Collections.emptyMap();
+    }
     try {
       ObjectParamMetadata metadata = getMetadata(object.getClass());
       Map<String, Object> propertyNameToValue = new HashMap<String, Object>();

--- a/core/src/main/java/feign/querymap/FieldQueryMapEncoder.java
+++ b/core/src/main/java/feign/querymap/FieldQueryMapEncoder.java
@@ -40,6 +40,9 @@ public class FieldQueryMapEncoder implements QueryMapEncoder {
 
   @Override
   public Map<String, Object> encode(Object object) throws EncodeException {
+    if (object == null) {
+      return Collections.emptyMap();
+    }
     ObjectParamMetadata metadata =
         classToMetadata.computeIfAbsent(object.getClass(), ObjectParamMetadata::parseObjectType);
 

--- a/core/src/test/java/feign/querymap/BeanQueryMapEncoderTest.java
+++ b/core/src/test/java/feign/querymap/BeanQueryMapEncoderTest.java
@@ -18,6 +18,8 @@ import feign.QueryMapEncoder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -33,6 +35,11 @@ public class BeanQueryMapEncoderTest {
   public final ExpectedException thrown = ExpectedException.none();
 
   private final QueryMapEncoder encoder = new BeanQueryMapEncoder();
+
+  @Test
+  public void testDefaultEncoder_acceptNullValue() {
+    assertEquals("Empty map should be returned", Collections.EMPTY_MAP, encoder.encode(null));
+  }
 
   @Test
   public void testDefaultEncoder_normalClassWithValues() {

--- a/core/src/test/java/feign/querymap/FieldQueryMapEncoderTest.java
+++ b/core/src/test/java/feign/querymap/FieldQueryMapEncoderTest.java
@@ -17,6 +17,8 @@ import feign.Param;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -32,6 +34,11 @@ public class FieldQueryMapEncoderTest {
   public final ExpectedException thrown = ExpectedException.none();
 
   private final QueryMapEncoder encoder = new FieldQueryMapEncoder();
+
+  @Test
+  public void testDefaultEncoder_acceptNullValue() {
+    assertEquals("Empty map should be returned", Collections.EMPTY_MAP, encoder.encode(null));
+  }
 
   @Test
   public void testDefaultEncoder_normalClassWithValues() {


### PR DESCRIPTION
```java
	@GetMapping
	public Paged<User> list(int page, int size, @QueryMap User user);
```
Currently feign doesn't accept null `user`
```java
Paged<User> paged = userClient.list(1, 10, new User()); // query map will include primitive type default values which is unexpected
Paged<User> paged = userClient.list(1, 10, null); // will leave query map empty
```