### PR TITLE
FeignException uses request and response but doesn't use a response body

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -29,7 +29,6 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-    <hamcrest.version>1.3</hamcrest.version>
   </properties>
 
   <dependencies>
@@ -67,8 +66,7 @@
 
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <version>${hamcrest.version}</version>
+      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/core/src/main/java/feign/AsyncResponseHandler.java
+++ b/core/src/main/java/feign/AsyncResponseHandler.java
@@ -13,8 +13,8 @@
  */
 package feign;
 
+import static feign.FeignException.errorReading;
 import static feign.Util.ensureClosed;
-import static java.lang.String.format;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.concurrent.CompletableFuture;
@@ -118,14 +118,5 @@ class AsyncResponseHandler {
     } catch (final RuntimeException e) {
       throw new DecodeException(response.status(), e.getMessage(), response, e);
     }
-  }
-
-  static FeignException errorReading(Response response, IOException cause) {
-    Request request = response.request();
-    return new FeignException(
-        response.status(),
-        format("%s reading %s %s", cause.getMessage(), request.httpMethod(), request.url()),
-        response,
-        cause);
   }
 }

--- a/core/src/main/java/feign/FeignException.java
+++ b/core/src/main/java/feign/FeignException.java
@@ -44,38 +44,30 @@ public class FeignException extends RuntimeException {
   private Request request;
   private Response response;
 
-  // EncodeException
   protected FeignException(int status, String message) {
     super(message);
     this.status = status;
     this.request = null;
   }
 
-  // EncodeException
   protected FeignException(int status, String message, Throwable cause) {
     super(message, cause);
     this.status = status;
     this.request = null;
   }
 
-  // RetryableException, DecodeException - optional headers is needed
-  // DecodeException should be replaced by (status, message, response)
   protected FeignException(int status, String message, Request request) {
     super(message);
     this.status = status;
     this.request = checkRequestNotNull(request);
   }
 
-  // AsyncJoinException, RetryableException, DecodeException - optional headers is needed
-  // AsyncJoinException and DecodeException should be replaced by (status, message, response, cause)
   protected FeignException(int status, String message, Request request, Throwable cause) {
     super(message, cause);
     this.status = status;
     this.request = checkRequestNotNull(request);
   }
 
-  // errorStatus() -> ErrorDecoder, FeignClientException, FeignServerException
-  // status, message, response
   protected FeignException(int status, String message, Response response) {
     super(message);
     this.status = status;
@@ -83,8 +75,6 @@ public class FeignException extends RuntimeException {
     this.request = checkRequestNotNull(response.request());
   }
 
-  // errorReading() -> AsyncResponseHandler - add response objects
-  // status, message, response, cause
   protected FeignException(int status, String message, Response response, Throwable cause) {
     super(message, cause);
     this.status = status;
@@ -203,7 +193,6 @@ public class FeignException extends RuntimeException {
     }
   }
 
-  // move to SynchronousMethodHandler
   static FeignException errorExecuting(Request request, IOException cause) {
     return new RetryableException(
         -1,

--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -24,8 +24,8 @@ import feign.Request.Options;
 import feign.codec.Decoder;
 import feign.codec.ErrorDecoder;
 import static feign.ExceptionPropagationPolicy.UNWRAP;
+import static feign.FeignException.errorExecuting;
 import static feign.Util.checkNotNull;
-import static java.lang.String.format;
 
 final class SynchronousMethodHandler implements MethodHandler {
 
@@ -172,15 +172,6 @@ final class SynchronousMethodHandler implements MethodHandler {
         .map(Options.class::cast)
         .findFirst()
         .orElse(this.options);
-  }
-
-  static FeignException errorExecuting(Request request, IOException cause) {
-    return new RetryableException(
-        -1,
-        format("%s executing %s %s", cause.getMessage(), request.httpMethod(), request.url()),
-        request.httpMethod(),
-        cause,
-        null, request);
   }
 
   static class Factory {

--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -24,8 +24,8 @@ import feign.Request.Options;
 import feign.codec.Decoder;
 import feign.codec.ErrorDecoder;
 import static feign.ExceptionPropagationPolicy.UNWRAP;
-import static feign.FeignException.errorExecuting;
 import static feign.Util.checkNotNull;
+import static java.lang.String.format;
 
 final class SynchronousMethodHandler implements MethodHandler {
 
@@ -172,6 +172,15 @@ final class SynchronousMethodHandler implements MethodHandler {
         .map(Options.class::cast)
         .findFirst()
         .orElse(this.options);
+  }
+
+  static FeignException errorExecuting(Request request, IOException cause) {
+    return new RetryableException(
+        -1,
+        format("%s executing %s %s", cause.getMessage(), request.httpMethod(), request.url()),
+        request.httpMethod(),
+        cause,
+        null, request);
   }
 
   static class Factory {

--- a/core/src/main/java/feign/codec/DecodeException.java
+++ b/core/src/main/java/feign/codec/DecodeException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,6 +15,7 @@ package feign.codec;
 
 import feign.FeignException;
 import feign.Request;
+import feign.Response;
 import static feign.Util.checkNotNull;
 
 /**
@@ -29,15 +30,15 @@ public class DecodeException extends FeignException {
   /**
    * @param message the reason for the failure.
    */
-  public DecodeException(int status, String message, Request request) {
-    super(status, checkNotNull(message, "message"), request);
+  public DecodeException(int status, String message, Response response) {
+    super(status, checkNotNull(message, "message"), response);
   }
 
   /**
    * @param message possibly null reason for the failure.
    * @param cause the cause of the error.
    */
-  public DecodeException(int status, String message, Request request, Throwable cause) {
-    super(status, message, request, checkNotNull(cause, "cause"));
+  public DecodeException(int status, String message, Response response, Throwable cause) {
+    super(status, message, response, checkNotNull(cause, "cause"));
   }
 }

--- a/core/src/main/java/feign/codec/StringDecoder.java
+++ b/core/src/main/java/feign/codec/StringDecoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -31,6 +31,6 @@ public class StringDecoder implements Decoder {
       return Util.toString(body.asReader(Util.UTF_8));
     }
     throw new DecodeException(response.status(),
-        format("%s is not a type supported by this decoder.", type), response.request());
+        format("%s is not a type supported by this decoder.", type), response);
   }
 }

--- a/core/src/test/java/feign/AsyncFeignTest.java
+++ b/core/src/test/java/feign/AsyncFeignTest.java
@@ -506,44 +506,6 @@ public class AsyncFeignTest {
     unwrap(cf);
   }
 
-  @Test
-  public void throwsFeignExceptionIncludingBody() throws Throwable {
-    server.enqueue(new MockResponse().setBody("success!"));
-
-    TestInterfaceAsync api = AsyncFeign.asyncBuilder().decoder((response, type) -> {
-      throw new IOException("timeout");
-    }).target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
-
-    CompletableFuture<?> cf = api.body("Request body");
-    server.takeRequest();
-    try {
-      unwrap(cf);
-    } catch (FeignException e) {
-      assertThat(e.getMessage())
-          .isEqualTo("timeout reading POST http://localhost:" + server.getPort() + "/");
-      assertThat(e.contentUTF8()).isEqualTo("Request body");
-      return;
-    }
-    fail();
-  }
-
-  @Test
-  public void throwsFeignExceptionWithoutBody() {
-    server.enqueue(new MockResponse().setBody("success!"));
-
-    TestInterfaceAsync api = AsyncFeign.asyncBuilder().decoder((response, type) -> {
-      throw new IOException("timeout");
-    }).target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
-
-    try {
-      api.noContent();
-    } catch (FeignException e) {
-      assertThat(e.getMessage())
-          .isEqualTo("timeout reading POST http://localhost:" + server.getPort() + "/");
-      assertThat(e.contentUTF8()).isEqualTo("");
-    }
-  }
-
   @SuppressWarnings("deprecation")
   @Test
   public void whenReturnTypeIsResponseNoErrorHandling() throws Throwable {
@@ -756,7 +718,7 @@ public class AsyncFeignTest {
   @Test
   public void beanQueryMapEncoderWithPrivateGetterIgnored() throws Exception {
     TestInterfaceAsync api =
-        new TestInterfaceAsyncBuilder().queryMapEndcoder(new BeanQueryMapEncoder())
+        new TestInterfaceAsyncBuilder().queryMapEncoder(new BeanQueryMapEncoder())
             .target("http://localhost:" + server.getPort());
 
     PropertyPojo.ChildPojoClass propertyPojo = new PropertyPojo.ChildPojoClass();
@@ -773,7 +735,7 @@ public class AsyncFeignTest {
   @Test
   public void queryMap_with_child_pojo() throws Exception {
     TestInterfaceAsync api =
-        new TestInterfaceAsyncBuilder().queryMapEndcoder(new FieldQueryMapEncoder())
+        new TestInterfaceAsyncBuilder().queryMapEncoder(new FieldQueryMapEncoder())
             .target("http://localhost:" + server.getPort());
 
     ChildPojo childPojo = new ChildPojo();
@@ -792,7 +754,7 @@ public class AsyncFeignTest {
   @Test
   public void beanQueryMapEncoderWithNullValueIgnored() throws Exception {
     TestInterfaceAsync api =
-        new TestInterfaceAsyncBuilder().queryMapEndcoder(new BeanQueryMapEncoder())
+        new TestInterfaceAsyncBuilder().queryMapEncoder(new BeanQueryMapEncoder())
             .target("http://localhost:" + server.getPort());
 
     PropertyPojo.ChildPojoClass propertyPojo = new PropertyPojo.ChildPojoClass();
@@ -810,7 +772,7 @@ public class AsyncFeignTest {
   @Test
   public void beanQueryMapEncoderWithEmptyParams() throws Exception {
     TestInterfaceAsync api =
-        new TestInterfaceAsyncBuilder().queryMapEndcoder(new BeanQueryMapEncoder())
+        new TestInterfaceAsyncBuilder().queryMapEncoder(new BeanQueryMapEncoder())
             .target("http://localhost:" + server.getPort());
 
     PropertyPojo.ChildPojoClass propertyPojo = new PropertyPojo.ChildPojoClass();
@@ -1015,7 +977,7 @@ public class AsyncFeignTest {
       return this;
     }
 
-    TestInterfaceAsyncBuilder queryMapEndcoder(QueryMapEncoder queryMapEncoder) {
+    TestInterfaceAsyncBuilder queryMapEncoder(QueryMapEncoder queryMapEncoder) {
       delegate.queryMapEncoder(queryMapEncoder);
       return this;
     }

--- a/core/src/test/java/feign/FeignExceptionTest.java
+++ b/core/src/test/java/feign/FeignExceptionTest.java
@@ -36,9 +36,10 @@ public class FeignExceptionTest {
         .build();
 
     FeignException exception =
-        FeignException.errorReading(request, response, new IOException("socket closed"));
-    assertThat(exception.responseBody()).isNotEmpty();
+        FeignException.errorReading(response, new IOException("socket closed"));
+    assertThat(exception.hasResponse()).isTrue();
     assertThat(exception.hasRequest()).isTrue();
+    assertThat(exception.response()).isNotNull();
     assertThat(exception.request()).isNotNull();
   }
 
@@ -52,9 +53,9 @@ public class FeignExceptionTest {
 
     FeignException exception =
         FeignException.errorExecuting(request, new IOException("connection timeout"));
-    assertThat(exception.responseBody()).isEmpty();
-    assertThat(exception.content()).isNullOrEmpty();
+    assertThat(exception.hasResponse()).isFalse();
     assertThat(exception.hasRequest()).isTrue();
+    assertThat(exception.response()).isNull();
     assertThat(exception.request()).isNotNull();
   }
 
@@ -110,74 +111,48 @@ public class FeignExceptionTest {
         .isNotEqualTo("[400] during [GET] to [/home] [methodKey]: [response]");
   }
 
-  @Test
-  public void canGetResponseHeadersFromException() {
-    Request request = Request.create(
-        Request.HttpMethod.GET,
-        "/home",
-        Collections.emptyMap(),
-        "data".getBytes(StandardCharsets.UTF_8),
-        StandardCharsets.UTF_8,
-        null);
-
-    Map<String, Collection<String>> responseHeaders = new HashMap<>();
-    responseHeaders.put("Content-Type", Collections.singletonList("text/plain"));
-    responseHeaders.put("Cookie", Arrays.asList("cookie1", "cookie2"));
-
-    Response response = Response.builder()
-        .request(request)
-        .body("some text", StandardCharsets.UTF_8)
-        .headers(responseHeaders)
-        .build();
-
-    FeignException exception = FeignException.errorStatus("methodKey", response);
-    assertThat(exception.responseHeaders())
-        .hasEntrySatisfying("Content-Type", value -> {
-          assertThat(value).contains("text/plain");
-        }).hasEntrySatisfying("Cookie", value -> {
-          assertThat(value).contains("cookie1", "cookie2");
-        });
+  @Test(expected = NullPointerException.class)
+  public void nullRequestShouldThrowNPE() {
+    Request request = null;
+    new Derived(404, "message", request);
   }
 
   @Test(expected = NullPointerException.class)
   public void nullRequestShouldThrowNPEwThrowable() {
-    new Derived(404, "message", null, new Throwable());
+    Request request = null;
+    new Derived(404, "message", request, new Throwable());
   }
 
   @Test(expected = NullPointerException.class)
-  public void nullRequestShouldThrowNPEwThrowableAndBytes() {
-    new Derived(404, "message", null, new Throwable(), new byte[1], Collections.emptyMap());
+  public void nullResponseShouldThrowNPE() {
+    Response response = null;
+    new Derived(404, "message", response);
   }
 
   @Test(expected = NullPointerException.class)
-  public void nullRequestShouldThrowNPE() {
-    new Derived(404, "message", null);
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void nullRequestShouldThrowNPEwBytes() {
-    new Derived(404, "message", null, new byte[1], Collections.emptyMap());
+  public void nullResponseShouldThrowNPEwThrowable() {
+    Response response = null;
+    new Derived(404, "message", response, new Throwable());
   }
 
   static class Derived extends FeignException {
-
-    public Derived(int status, String message, Request request, Throwable cause) {
-      super(status, message, request, cause);
-    }
-
-    public Derived(int status, String message, Request request, Throwable cause, byte[] content,
-        Map<String, Collection<String>> headers) {
-      super(status, message, request, cause, content, headers);
-    }
 
     public Derived(int status, String message, Request request) {
       super(status, message, request);
     }
 
-    public Derived(int status, String message, Request request, byte[] content,
-        Map<String, Collection<String>> headers) {
-      super(status, message, request, content, headers);
+    public Derived(int status, String message, Request request, Throwable cause) {
+      super(status, message, request, cause);
     }
+
+    public Derived(int status, String message, Response response) {
+      super(status, message, response);
+    }
+
+    public Derived(int status, String message, Response response, Throwable cause) {
+      super(status, message, response, cause);
+    }
+
   }
 
 }

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -512,44 +512,6 @@ public class FeignTest {
   }
 
   @Test
-  public void throwsFeignExceptionIncludingBody() {
-    server.enqueue(new MockResponse().setBody("success!"));
-
-    TestInterface api = Feign.builder()
-        .decoder((response, type) -> {
-          throw new IOException("timeout");
-        })
-        .target(TestInterface.class, "http://localhost:" + server.getPort());
-
-    try {
-      api.body("Request body");
-    } catch (FeignException e) {
-      assertThat(e.getMessage())
-          .isEqualTo("timeout reading POST http://localhost:" + server.getPort() + "/");
-      assertThat(e.contentUTF8()).isEqualTo("Request body");
-    }
-  }
-
-  @Test
-  public void throwsFeignExceptionWithoutBody() {
-    server.enqueue(new MockResponse().setBody("success!"));
-
-    TestInterface api = Feign.builder()
-        .decoder((response, type) -> {
-          throw new IOException("timeout");
-        })
-        .target(TestInterface.class, "http://localhost:" + server.getPort());
-
-    try {
-      api.noContent();
-    } catch (FeignException e) {
-      assertThat(e.getMessage())
-          .isEqualTo("timeout reading POST http://localhost:" + server.getPort() + "/");
-      assertThat(e.contentUTF8()).isEqualTo("");
-    }
-  }
-
-  @Test
   public void ensureRetryerClonesItself() throws Exception {
     server.enqueue(new MockResponse().setResponseCode(503).setBody("foo 1"));
     server.enqueue(new MockResponse().setResponseCode(200).setBody("foo 2"));

--- a/core/src/test/java/feign/FeignUnderAsyncTest.java
+++ b/core/src/test/java/feign/FeignUnderAsyncTest.java
@@ -484,44 +484,6 @@ public class FeignUnderAsyncTest {
   }
 
   @Test
-  public void throwsFeignExceptionIncludingBody() {
-    server.enqueue(new MockResponse().setBody("success!"));
-
-    TestInterface api = AsyncFeign.asyncBuilder()
-        .decoder((response, type) -> {
-          throw new IOException("timeout");
-        })
-        .target(TestInterface.class, "http://localhost:" + server.getPort());
-
-    try {
-      api.body("Request body");
-    } catch (FeignException e) {
-      assertThat(e.getMessage())
-          .isEqualTo("timeout reading POST http://localhost:" + server.getPort() + "/");
-      assertThat(e.contentUTF8()).isEqualTo("Request body");
-    }
-  }
-
-  @Test
-  public void throwsFeignExceptionWithoutBody() {
-    server.enqueue(new MockResponse().setBody("success!"));
-
-    TestInterface api = AsyncFeign.asyncBuilder()
-        .decoder((response, type) -> {
-          throw new IOException("timeout");
-        })
-        .target(TestInterface.class, "http://localhost:" + server.getPort());
-
-    try {
-      api.noContent();
-    } catch (FeignException e) {
-      assertThat(e.getMessage())
-          .isEqualTo("timeout reading POST http://localhost:" + server.getPort() + "/");
-      assertThat(e.contentUTF8()).isEqualTo("");
-    }
-  }
-
-  @Test
   public void whenReturnTypeIsResponseNoErrorHandling() {
     Map<String, Collection<String>> headers = new LinkedHashMap<>();
     headers.put("Location", Collections.singletonList("http://bar.com"));

--- a/core/src/test/java/feign/client/AbstractClientTest.java
+++ b/core/src/test/java/feign/client/AbstractClientTest.java
@@ -134,38 +134,6 @@ public abstract class AbstractClientTest {
   }
 
   @Test
-  public void parsesErrorResponseBody() {
-    String expectedResponseBody = "ARGHH";
-
-    server.enqueue(new MockResponse().setResponseCode(500).setBody("ARGHH"));
-
-    TestInterface api = newBuilder()
-        .target(TestInterface.class, "http://localhost:" + server.getPort());
-
-    try {
-      api.get();
-    } catch (FeignException e) {
-      assertThat(e.contentUTF8()).isEqualTo(expectedResponseBody);
-    }
-  }
-
-  @Test
-  public void parsesUnauthorizedResponseBody() {
-    String expectedResponseBody = "ARGHH";
-
-    server.enqueue(new MockResponse().setResponseCode(401).setBody("ARGHH"));
-
-    TestInterface api = newBuilder()
-        .target(TestInterface.class, "http://localhost:" + server.getPort());
-
-    try {
-      api.postForString("HELLO");
-    } catch (FeignException e) {
-      assertThat(e.contentUTF8()).isEqualTo(expectedResponseBody);
-    }
-  }
-
-  @Test
   public void safeRebuffering() {
     server.enqueue(new MockResponse().setBody("foo"));
 

--- a/core/src/test/java/feign/codec/DefaultErrorDecoderTest.java
+++ b/core/src/test/java/feign/codec/DefaultErrorDecoderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -52,49 +52,6 @@ public class DefaultErrorDecoderTest {
         .build();
 
     throw errorDecoder.decode("Service#foo()", response);
-  }
-
-  @Test
-  public void throwsFeignExceptionIncludingBody() throws Throwable {
-    Response response = Response.builder()
-        .status(500)
-        .reason("Internal server error")
-        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
-        .headers(headers)
-        .body("hello world", UTF_8)
-        .build();
-
-    try {
-      throw errorDecoder.decode("Service#foo()", response);
-    } catch (FeignException e) {
-      assertThat(e.getMessage())
-          .isEqualTo(
-              "[500 Internal server error] during [GET] to [/api] [Service#foo()]: [hello world]");
-      assertThat(e.contentUTF8()).isEqualTo("hello world");
-    }
-  }
-
-  @Test
-  public void throwsFeignExceptionIncludingLongBody() throws Throwable {
-    String actualBody = repeatString("hello world ", 200);
-    Response response = Response.builder()
-        .status(500)
-        .reason("Internal server error")
-        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
-        .headers(headers)
-        .body(actualBody, UTF_8)
-        .build();
-    String expectedBody = repeatString("hello world ", 16) + "hello wo... (2400 bytes)";
-
-    try {
-      throw errorDecoder.decode("Service#foo()", response);
-    } catch (FeignException e) {
-      assertThat(e.getMessage())
-          .isEqualTo(
-              "[500 Internal server error] during [GET] to [/api] [Service#foo()]: [" + expectedBody
-                  + "]");
-      assertThat(e.contentUTF8()).isEqualTo(actualBody);
-    }
   }
 
   private String repeatString(String string, int times) {

--- a/dropwizard-metrics4/pom.xml
+++ b/dropwizard-metrics4/pom.xml
@@ -46,8 +46,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>java-hamcrest</artifactId>
-      <version>2.0.0.0</version>
+      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/dropwizard-metrics5/pom.xml
+++ b/dropwizard-metrics5/pom.xml
@@ -46,8 +46,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>java-hamcrest</artifactId>
-      <version>2.0.0.0</version>
+      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/googlehttpclient/src/test/java/feign/googlehttpclient/GoogleHttpClientTest.java
+++ b/googlehttpclient/src/test/java/feign/googlehttpclient/GoogleHttpClientTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -31,7 +31,4 @@ public class GoogleHttpClientTest extends AbstractClientTest {
 
   @Override
   public void testPatch() {}
-
-  @Override
-  public void parsesUnauthorizedResponseBody() {}
 }

--- a/hc5/src/test/java/feign/hc5/AsyncApacheHttp5ClientTest.java
+++ b/hc5/src/test/java/feign/hc5/AsyncApacheHttp5ClientTest.java
@@ -455,44 +455,6 @@ public class AsyncApacheHttp5ClientTest {
     unwrap(cf);
   }
 
-  @Test
-  public void throwsFeignExceptionIncludingBody() throws Throwable {
-    server.enqueue(new MockResponse().setBody("success!"));
-
-    final TestInterfaceAsync api = AsyncFeign.asyncBuilder().decoder((response, type) -> {
-      throw new IOException("timeout");
-    }).target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
-
-    final CompletableFuture<?> cf = api.body("Request body");
-    server.takeRequest();
-    try {
-      unwrap(cf);
-    } catch (final FeignException e) {
-      assertThat(e.getMessage())
-          .isEqualTo("timeout reading POST http://localhost:" + server.getPort() + "/");
-      assertThat(e.contentUTF8()).isEqualTo("Request body");
-      return;
-    }
-    fail();
-  }
-
-  @Test
-  public void throwsFeignExceptionWithoutBody() {
-    server.enqueue(new MockResponse().setBody("success!"));
-
-    final TestInterfaceAsync api = AsyncFeign.asyncBuilder().decoder((response, type) -> {
-      throw new IOException("timeout");
-    }).target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
-
-    try {
-      api.noContent();
-    } catch (final FeignException e) {
-      assertThat(e.getMessage())
-          .isEqualTo("timeout reading POST http://localhost:" + server.getPort() + "/");
-      assertThat(e.contentUTF8()).isEqualTo("");
-    }
-  }
-
   @SuppressWarnings("deprecation")
   @Test
   public void whenReturnTypeIsResponseNoErrorHandling() throws Throwable {

--- a/jackson-jr/src/main/java/feign/jackson/jr/JacksonJrDecoder.java
+++ b/jackson-jr/src/main/java/feign/jackson/jr/JacksonJrDecoder.java
@@ -43,7 +43,7 @@ public class JacksonJrDecoder extends JacksonJrMapper implements Decoder {
 
   /**
    * Construct with a custom {@link JSON} to use for decoding
-   * 
+   *
    * @param mapper the mapper to use
    */
   public JacksonJrDecoder(JSON mapper) {
@@ -53,7 +53,7 @@ public class JacksonJrDecoder extends JacksonJrMapper implements Decoder {
   /**
    * Construct with a series of {@link JacksonJrExtension} objects that are registered into the
    * {@link JSON}
-   * 
+   *
    * @param iterable the source of the extensions
    */
   public JacksonJrDecoder(Iterable<JacksonJrExtension> iterable) {
@@ -102,6 +102,6 @@ public class JacksonJrDecoder extends JacksonJrMapper implements Decoder {
         return (mapper, reader) -> mapper.mapOfFrom((Class<?>) parameterType[1], reader);
       }
     }
-    throw new DecodeException(500, "Cannot decode type: " + type.getTypeName(), response.request());
+    throw new DecodeException(500, "Cannot decode type: " + type.getTypeName(), response);
   }
 }

--- a/jackson/src/main/java/feign/jackson/JacksonIteratorDecoder.java
+++ b/jackson/src/main/java/feign/jackson/JacksonIteratorDecoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -154,7 +154,7 @@ public final class JacksonIteratorDecoder implements Decoder {
         return objectReader.readValue(parser);
       } catch (IOException e) {
         // Input Stream closed automatically by parser
-        throw new DecodeException(response.status(), e.getMessage(), response.request(), e);
+        throw new DecodeException(response.status(), e.getMessage(), response, e);
       }
     }
 

--- a/jaxb/src/main/java/feign/jaxb/JAXBDecoder.java
+++ b/jaxb/src/main/java/feign/jaxb/JAXBDecoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -92,7 +92,7 @@ public class JAXBDecoder implements Decoder {
           saxParserFactory.newSAXParser().getXMLReader(),
           new InputSource(response.body().asInputStream())));
     } catch (JAXBException | ParserConfigurationException | SAXException e) {
-      throw new DecodeException(response.status(), e.toString(), response.request(), e);
+      throw new DecodeException(response.status(), e.toString(), response, e);
     } finally {
       if (response.body() != null) {
         response.body().close();

--- a/jaxrs2/pom.xml
+++ b/jaxrs2/pom.xml
@@ -98,8 +98,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>java-hamcrest</artifactId>
-      <version>2.0.0.0</version>
+      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -29,7 +29,6 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-    <hamcrest.version>1.3</hamcrest.version>
     <mockito.version>1.10.19</mockito.version>
   </properties>
 
@@ -44,14 +43,12 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <version>${hamcrest.version}</version>
+      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
-      <version>${hamcrest.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/json/src/main/java/feign/json/JsonDecoder.java
+++ b/json/src/main/java/feign/json/JsonDecoder.java
@@ -67,7 +67,7 @@ public class JsonDecoder implements Decoder {
       if (jsonException.getCause() != null && jsonException.getCause() instanceof IOException) {
         throw (IOException) jsonException.getCause();
       }
-      throw new DecodeException(response.status(), jsonException.getMessage(), response.request(),
+      throw new DecodeException(response.status(), jsonException.getMessage(), response,
           jsonException);
     }
   }
@@ -80,7 +80,7 @@ public class JsonDecoder implements Decoder {
       return new JSONArray(tokenizer);
     else
       throw new DecodeException(response.status(),
-          format("%s is not a type supported by this decoder.", type), response.request());
+          format("%s is not a type supported by this decoder.", type), response);
   }
 
 }

--- a/micrometer/pom.xml
+++ b/micrometer/pom.xml
@@ -46,8 +46,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>java-hamcrest</artifactId>
-      <version>2.0.0.0</version>
+      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/micrometer/src/test/java/feign/micrometer/AbstractMetricsTestBase.java
+++ b/micrometer/src/test/java/feign/micrometer/AbstractMetricsTestBase.java
@@ -90,7 +90,7 @@ public abstract class AbstractMetricsTestBase<MR, METRIC_ID, METRIC> {
 
     final SimpleSource source = Feign.builder()
         .client((request, options) -> {
-          notFound.set(new FeignException.NotFound("test", request, null, null));
+          notFound.set(new FeignException.NotFound("test", request));
           throw notFound.get();
         })
         .addCapability(createMetricCapability())
@@ -118,7 +118,7 @@ public abstract class AbstractMetricsTestBase<MR, METRIC_ID, METRIC> {
         .client(new MockClient()
             .ok(HttpMethod.GET, "/get", "1234567890abcde"))
         .decoder((response, type) -> {
-          notFound.set(new FeignException.NotFound("test", response.request(), null, null));
+          notFound.set(new FeignException.NotFound("test", response.request()));
           throw notFound.get();
         })
         .addCapability(createMetricCapability())

--- a/mock/pom.xml
+++ b/mock/pom.xml
@@ -30,7 +30,6 @@
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
 
-    <hamcrest.version>1.3</hamcrest.version>
   </properties>
 
   <dependencies>
@@ -46,14 +45,12 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <version>${hamcrest.version}</version>
+      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
-      <version>${hamcrest.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
     <junit.version>4.13.1</junit.version>
     <jackson.version>2.12.3</jackson.version>
     <assertj.version>3.10.0</assertj.version>
+    <hamcrest.version>2.2</hamcrest.version>
 
     <animal-sniffer-maven-plugin.version>1.17</animal-sniffer-maven-plugin.version>
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
@@ -283,6 +284,17 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest</artifactId>
+        <version>${hamcrest.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-library</artifactId>
+        <version>${hamcrest.version}</version>
       </dependency>
 
       <dependency>

--- a/sax/src/main/java/feign/sax/SAXDecoder.java
+++ b/sax/src/main/java/feign/sax/SAXDecoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -84,7 +84,7 @@ public class SAXDecoder implements Decoder {
       }
       return handler.result();
     } catch (SAXException e) {
-      throw new DecodeException(response.status(), e.getMessage(), response.request(), e);
+      throw new DecodeException(response.status(), e.getMessage(), response, e);
     }
   }
 

--- a/soap/src/main/java/feign/soap/SOAPDecoder.java
+++ b/soap/src/main/java/feign/soap/SOAPDecoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -133,7 +133,7 @@ public class SOAPDecoder implements Decoder {
         }
       }
     } catch (SOAPException | JAXBException e) {
-      throw new DecodeException(response.status(), e.toString(), response.request(), e);
+      throw new DecodeException(response.status(), e.toString(), response, e);
     } finally {
       if (response.body() != null) {
         response.body().close();

--- a/spring4/pom.xml
+++ b/spring4/pom.xml
@@ -31,7 +31,6 @@
     <main.basedir>${project.basedir}/..</main.basedir>
 
     <spring.version>4.3.6.RELEASE</spring.version>
-    <hamcrest.version>1.3</hamcrest.version>
   </properties>
 
   <dependencies>
@@ -58,14 +57,12 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <version>${hamcrest.version}</version>
+      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
-      <version>${hamcrest.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Simplifying of FeignException: it uses request and response objects but does not use a response body as byte array.

It is breaking changes if any extension use the methods _content_. _contentUTF8_, _responseBody_ or _responseHeaders_.
FeignException and DecodeException have new constructors.

These changers start from the discussion #1452

P.S.
I like [the idea to make FeignException more simplier](https://github.com/OpenFeign/feign/pull/1452#issuecomment-875538393). But I have not found how to do it without breaking changes.