### PR TITLE
Aggregate Micrometer "uri" label values under uri template

### DIFF
--- a/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredClient.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredClient.java
@@ -43,15 +43,18 @@ public class MeteredClient implements Client {
     final RequestTemplate template = request.requestTemplate();
     try (final Timer.Context classTimer =
         metricRegistry.timer(
-            metricName.metricName(template.methodMetadata(), template.feignTarget()),
+            MetricRegistry.name(
+                metricName.metricName(template.methodMetadata(), template.feignTarget()),
+                "uri", template.methodMetadata().template().path()),
             metricSuppliers.timers()).time()) {
       Response response = client.execute(request, options);
       metricRegistry.meter(
           MetricRegistry.name(
               metricName.metricName(template.methodMetadata(), template.feignTarget(),
                   "http_response_code"),
-              "status_group", response.status() / 100 + "xx", "http_status",
-              String.valueOf(response.status())),
+              "status_group", response.status() / 100 + "xx",
+              "http_status", String.valueOf(response.status()),
+              "uri", template.methodMetadata().template().path()),
           metricSuppliers.meters()).mark();
       return response;
     } catch (FeignException e) {
@@ -59,7 +62,9 @@ public class MeteredClient implements Client {
           MetricRegistry.name(
               metricName.metricName(template.methodMetadata(), template.feignTarget(),
                   "http_response_code"),
-              "status_group", e.status() / 100 + "xx", "http_status", String.valueOf(e.status())),
+              "status_group", e.status() / 100 + "xx",
+              "http_status", String.valueOf(e.status()),
+              "uri", template.methodMetadata().template().path()),
           metricSuppliers.meters()).mark();
       throw e;
     } catch (IOException | RuntimeException e) {

--- a/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredDecoder.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredDecoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -55,7 +55,10 @@ public class MeteredDecoder implements Decoder {
     final Object decoded;
     try (final Timer.Context classTimer =
         metricRegistry
-            .timer(metricName.metricName(template.methodMetadata(), template.feignTarget()),
+            .timer(
+                MetricRegistry.name(
+                    metricName.metricName(template.methodMetadata(), template.feignTarget()),
+                    "uri", template.methodMetadata().template().path()),
                 metricSuppliers.timers())
             .time()) {
       decoded = decoder.decode(response, type);

--- a/dropwizard-metrics4/src/test/java/feign/metrics4/Metrics4CapabilityTest.java
+++ b/dropwizard-metrics4/src/test/java/feign/metrics4/Metrics4CapabilityTest.java
@@ -13,14 +13,14 @@
  */
 package feign.metrics4;
 
-import java.util.Arrays;
-import java.util.Map;
-import java.util.Map.Entry;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
 import feign.Capability;
 import feign.Util;
 import feign.micrometer.AbstractMetricsTestBase;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Map.Entry;
 
 public class Metrics4CapabilityTest
     extends AbstractMetricsTestBase<MetricRegistry, String, Metric> {
@@ -84,5 +84,19 @@ public class Metrics4CapabilityTest
         .orElse(null);
   }
 
+  @Override
+  protected boolean isClientMetric(String metricId) {
+    return metricId.startsWith("feign.Client");
+  }
+
+  @Override
+  protected boolean isDecoderMetric(String metricId) {
+    return metricId.startsWith("feign.codec.Decoder");
+  }
+
+  @Override
+  protected boolean doesMetricIncludeUri(String metricId, String uri) {
+    return metricId.contains(uri);
+  }
 
 }

--- a/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredClient.java
+++ b/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredClient.java
@@ -43,14 +43,17 @@ public class MeteredClient implements Client {
     final RequestTemplate template = request.requestTemplate();
     try (final Context classTimer =
         metricRegistry.timer(
-            metricName.metricName(template.methodMetadata(), template.feignTarget()),
+            metricName.metricName(template.methodMetadata(),
+                template.feignTarget())
+                .tagged("uri", template.methodMetadata().template().path()),
             metricSuppliers.timers()).time()) {
       Response response = client.execute(request, options);
       metricRegistry.counter(
           metricName
               .metricName(template.methodMetadata(), template.feignTarget(), "http_response_code")
               .tagged("http_status", String.valueOf(response.status()))
-              .tagged("status_group", response.status() / 100 + "xx"))
+              .tagged("status_group", response.status() / 100 + "xx")
+              .tagged("uri", template.methodMetadata().template().path()))
           .inc();
       return response;
     } catch (FeignException e) {
@@ -58,7 +61,8 @@ public class MeteredClient implements Client {
           metricName
               .metricName(template.methodMetadata(), template.feignTarget(), "http_response_code")
               .tagged("http_status", String.valueOf(e.status()))
-              .tagged("status_group", e.status() / 100 + "xx"))
+              .tagged("status_group", e.status() / 100 + "xx")
+              .tagged("uri", template.methodMetadata().template().path()))
           .inc();
       throw e;
     } catch (IOException | RuntimeException e) {

--- a/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredDecoder.java
+++ b/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredDecoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -55,20 +55,23 @@ public class MeteredDecoder implements Decoder {
     final Object decoded;
     try (final Context classTimer =
         metricRegistry
-            .timer(metricName.metricName(template.methodMetadata(), template.feignTarget()),
+            .timer(metricName.metricName(template.methodMetadata(), template.feignTarget())
+                .tagged("uri", template.methodMetadata().template().path()),
                 metricSuppliers.timers())
             .time()) {
       decoded = decoder.decode(response, type);
     } catch (IOException | RuntimeException e) {
       metricRegistry.meter(
           metricName.metricName(template.methodMetadata(), template.feignTarget(), "error_count")
-              .tagged("exception_name", e.getClass().getSimpleName()),
+              .tagged("exception_name", e.getClass().getSimpleName())
+              .tagged("uri", template.methodMetadata().template().path()),
           metricSuppliers.meters()).mark();
       throw e;
     } catch (Exception e) {
       metricRegistry.meter(
           metricName.metricName(template.methodMetadata(), template.feignTarget(), "error_count")
-              .tagged("exception_name", e.getClass().getSimpleName()),
+              .tagged("exception_name", e.getClass().getSimpleName())
+              .tagged("uri", template.methodMetadata().template().path()),
           metricSuppliers.meters()).mark();
       throw new IOException(e);
     }
@@ -76,7 +79,8 @@ public class MeteredDecoder implements Decoder {
     if (body != null) {
       metricRegistry.histogram(
           metricName.metricName(template.methodMetadata(), template.feignTarget(),
-              "response_size"),
+              "response_size")
+              .tagged("uri", template.methodMetadata().template().path()),
           metricSuppliers.histograms()).update(body.count());
     }
 

--- a/dropwizard-metrics5/src/test/java/feign/metrics5/Metrics5CapabilityTest.java
+++ b/dropwizard-metrics5/src/test/java/feign/metrics5/Metrics5CapabilityTest.java
@@ -88,4 +88,19 @@ public class Metrics5CapabilityTest
         .orElse(null);
   }
 
+  @Override
+  protected boolean isClientMetric(MetricName metricId) {
+    return metricId.getKey().startsWith("feign.Client");
+  }
+
+  @Override
+  protected boolean isDecoderMetric(MetricName metricId) {
+    return metricId.getKey().startsWith("feign.codec.Decoder");
+  }
+
+  @Override
+  protected boolean doesMetricIncludeUri(MetricName metricId, String uri) {
+    return uri.equals(metricId.getTags().get("uri"));
+  }
+
 }

--- a/micrometer/src/main/java/feign/micrometer/MeteredClient.java
+++ b/micrometer/src/main/java/feign/micrometer/MeteredClient.java
@@ -83,9 +83,9 @@ public class MeteredClient implements Client {
     final RequestTemplate template = request.requestTemplate();
     final Tags allTags = metricTagResolver
         .tag(template.methodMetadata(), template.feignTarget(), e,
-            new Tag[] {Tag.of("http_status", String.valueOf(responseStatus)),
-                Tag.of("status_group", responseStatus / 100 + "xx"),
-                Tag.of("uri", template.path())})
+            Tag.of("http_status", String.valueOf(responseStatus)),
+            Tag.of("status_group", responseStatus / 100 + "xx"),
+            Tag.of("uri", template.methodMetadata().template().path()))
         .and(extraTags);
     meterRegistry.counter(
         metricName.name("http_response_code"),
@@ -99,7 +99,8 @@ public class MeteredClient implements Client {
                               Exception e) {
     final RequestTemplate template = request.requestTemplate();
     final Tags allTags = metricTagResolver
-        .tag(template.methodMetadata(), template.feignTarget(), e, Tag.of("uri", template.path()))
+        .tag(template.methodMetadata(), template.feignTarget(), e,
+            Tag.of("uri", template.methodMetadata().template().path()))
         .and(extraTags(request, response, options, e));
     return meterRegistry.timer(metricName.name(e), allTags);
   }

--- a/micrometer/src/main/java/feign/micrometer/MeteredDecoder.java
+++ b/micrometer/src/main/java/feign/micrometer/MeteredDecoder.java
@@ -95,7 +95,7 @@ public class MeteredDecoder implements Decoder {
     final Tag[] extraTags = extraTags(response, type, e);
     final RequestTemplate template = response.request().requestTemplate();
     final Tags allTags = metricTagResolver.tag(template.methodMetadata(), template.feignTarget(),
-        Tag.of("uri", template.path()),
+        Tag.of("uri", template.methodMetadata().template().path()),
         Tag.of("exception_name", e.getClass().getSimpleName()))
         .and(extraTags);
     return meterRegistry.counter(metricName.name("error_count"), allTags);

--- a/micrometer/src/main/java/feign/micrometer/MeteredDecoder.java
+++ b/micrometer/src/main/java/feign/micrometer/MeteredDecoder.java
@@ -110,6 +110,7 @@ public class MeteredDecoder implements Decoder {
   }
 
   protected Tag[] extraTags(Response response, Type type, Exception e) {
-    return EMPTY_TAGS_ARRAY;
+    RequestTemplate template = response.request().requestTemplate();
+    return new Tag[] {Tag.of("uri", template.methodMetadata().template().path())};
   }
 }

--- a/micrometer/src/test/java/feign/micrometer/MicrometerCapabilityTest.java
+++ b/micrometer/src/test/java/feign/micrometer/MicrometerCapabilityTest.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
 import feign.*;
 import feign.mock.HttpMethod;
 import feign.mock.MockClient;
@@ -54,12 +53,13 @@ public class MicrometerCapabilityTest
 
     source.get("0x3456789");
 
-    getFeignMetrics().entrySet()
-        .stream()
+    final Map<Meter.Id, Meter> clientMetrics = getFeignMetrics().entrySet().stream()
         .filter(this::isClientMetric)
-        .peek(e -> assertThat(
-            "Expect Client metric names to include uri:" + e,
-            doesMetricIncludeUri(e.getKey(), "/get")));
+        .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+    clientMetrics.keySet().forEach(metricId -> assertThat(
+        "Expect all Client metric names to include uri:" + metricId,
+        doesMetricIncludeUri(metricId, "/get")));
   }
 
   @Test
@@ -72,12 +72,13 @@ public class MicrometerCapabilityTest
 
     source.get("123", "0x3456789");
 
-    getFeignMetrics().entrySet()
-        .stream()
+    final Map<Meter.Id, Meter> clientMetrics = getFeignMetrics().entrySet().stream()
         .filter(this::isClientMetric)
-        .peek(e -> assertThat(
-            "Expect Client metric names to include uri with path expression:" + e,
-            doesMetricIncludeUri(e.getKey(), "/get/{id}")));
+        .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+    clientMetrics.keySet().forEach(metricId -> assertThat(
+        "Expect all Client metric names to include uri as aggregated path expression:" + metricId,
+        doesMetricIncludeUri(metricId, "/get/{id}")));
   }
 
   @Override


### PR DESCRIPTION
# Overview
Use path expression rather than explicit value for Micrometer `uri` labels

This new default means that the value of the `uri` metric label becomes `/get/{id}` rather than `/get/123`

* Changes the default value of the `uri` label
* Adds a bunch of new unit tests around that feature

# Motivation
This change provides better aggregation, protecting time series databases such as Prometheus from a large influx of time series (high-cardinality metrics).

Currently - as noted in #1481 - enabling feign client metrics from config on clients with a parametrized urls creates a scenario where a new time series is produced for each value of the provided parameter. This provides extremely high-cardinality metrics at a fast rate endangering the underlying time series database. (Resolves #1481, related to #873)

When traffic is significant, collecting client metrics with an uri expression such as `reservation/{reservationId}` can generate tens of thousands of time series (one for each value of the label, a potentially infinite set), putting Prometheus at risk. Enabling OOTB metrics without being aware of the high cardinality of some metrics is quite easy to do, so we thought we could protect some users by changing the default behavior 

# Testing
* Unit tests written
* Approach was also tested on one of my existing applications as described in this [comment](https://github.com/OpenFeign/feign/issues/1481#issuecomment-906349520)

<img width="1609" alt="Screen Shot 2021-08-26 at 12 38 08 PM" src="https://user-images.githubusercontent.com/17515408/131016963-6162efa9-5a51-42f4-b9f3-e6cd1596cccd.png">

# Questions
* Is there any integration or regression tests that are worth expanding to cover this feature?
* Which CHANGELOG can I add this feature to? 

Thank you for your time! 😊 

