### PR TITLE
SOAPEncoder: Add support to modify soap message manually

### DIFF
--- a/soap/src/main/java/feign/soap/SOAPDecoder.java
+++ b/soap/src/main/java/feign/soap/SOAPDecoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/soap/src/main/java/feign/soap/SOAPEncoder.java
+++ b/soap/src/main/java/feign/soap/SOAPEncoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/soap/src/main/java/feign/soap/SOAPEncoder.java
+++ b/soap/src/main/java/feign/soap/SOAPEncoder.java
@@ -125,7 +125,7 @@ public class SOAPEncoder implements Encoder {
       soapMessage.setProperty(SOAPMessage.CHARACTER_SET_ENCODING, charsetEncoding.displayName());
       soapMessage.getSOAPBody().addDocument(document);
 
-      modifySOAPMessage(soapMessage);
+      soapMessage = modifySOAPMessage(soapMessage);
 
       ByteArrayOutputStream bos = new ByteArrayOutputStream();
       if (formattedOutput) {
@@ -148,7 +148,7 @@ public class SOAPEncoder implements Encoder {
    * This might be useful to add SOAP Headers, which are not supported by this SOAPEncoder directly.
    * <br>
    * This is an example of how to add a security header: <code>
-   *   protected void modifySOAPMessage(SOAPMessage soapMessage) throws SOAPException {
+   *   protected SOAPMessage modifySOAPMessage(SOAPMessage soapMessage) throws SOAPException {
    *     SOAPFactory soapFactory = SOAPFactory.newInstance();
    *     String uri = "http://schemas.xmlsoap.org/ws/2002/12/secext";
    *     String prefix = "wss";
@@ -158,11 +158,13 @@ public class SOAPEncoder implements Encoder {
    *     usernameToken.addChildElement("Password", prefix, uri).setValue("test");
    *     security.addChildElement(usernameToken);
    *     soapMessage.getSOAPHeader().addChildElement(security);
+   *     return soapMessage;
    *   }
    * </code>
    */
-  protected void modifySOAPMessage(SOAPMessage soapMessage) throws SOAPException {
+  protected SOAPMessage modifySOAPMessage(SOAPMessage soapMessage) throws SOAPException {
     // Intentionally blank
+    return soapMessage;
   }
 
   /**

--- a/soap/src/main/java/feign/soap/SOAPEncoder.java
+++ b/soap/src/main/java/feign/soap/SOAPEncoder.java
@@ -124,6 +124,9 @@ public class SOAPEncoder implements Encoder {
           Boolean.toString(writeXmlDeclaration));
       soapMessage.setProperty(SOAPMessage.CHARACTER_SET_ENCODING, charsetEncoding.displayName());
       soapMessage.getSOAPBody().addDocument(document);
+      
+      modifySOAPMessage(soapMessage);
+      
       ByteArrayOutputStream bos = new ByteArrayOutputStream();
       if (formattedOutput) {
         Transformer t = TransformerFactory.newInstance().newTransformer();
@@ -138,6 +141,30 @@ public class SOAPEncoder implements Encoder {
         | TransformerFactoryConfigurationError | TransformerException e) {
       throw new EncodeException(e.toString(), e);
     }
+  }
+  
+  /**
+   * Override this in order to modify the SOAP message object before it's finally encoded.
+   * <br>
+   * This might be useful to add SOAP Headers, which are not supported by this SOAPEncoder directly.
+   * <br>
+   * This is an example of how to add a security header:
+   * <code>
+   *   protected void modifySOAPMessage(SOAPMessage soapMessage) throws SOAPException {
+   *     SOAPFactory soapFactory = SOAPFactory.newInstance();
+   *     String uri = "http://schemas.xmlsoap.org/ws/2002/12/secext";
+   *     String prefix = "wss";
+   *     SOAPElement security = soapFactory.createElement("Security", prefix, uri);
+   *     SOAPElement usernameToken = soapFactory.createElement("UsernameToken", prefix, uri);
+   *     usernameToken.addChildElement("Username", prefix, uri).setValue("test");
+   *     usernameToken.addChildElement("Password", prefix, uri).setValue("test");
+   *     security.addChildElement(usernameToken);
+   *     soapMessage.getSOAPHeader().addChildElement(security);
+   *   }
+   * </code>
+   */
+  protected void modifySOAPMessage(SOAPMessage soapMessage) throws SOAPException {
+    // Intentionally blank
   }
 
   /**

--- a/soap/src/main/java/feign/soap/SOAPEncoder.java
+++ b/soap/src/main/java/feign/soap/SOAPEncoder.java
@@ -1,11 +1,11 @@
 /**
  * Copyright 2012-2021 The Feign Authors
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under

--- a/soap/src/main/java/feign/soap/SOAPEncoder.java
+++ b/soap/src/main/java/feign/soap/SOAPEncoder.java
@@ -1,11 +1,11 @@
 /**
  * Copyright 2012-2021 The Feign Authors
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -33,6 +33,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.TransformerFactoryConfigurationError;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+
 import org.w3c.dom.Document;
 import feign.RequestTemplate;
 import feign.codec.EncodeException;
@@ -45,22 +46,22 @@ import feign.jaxb.JAXBContextFactory;
  * <p>
  * Basic example with with Feign.Builder:
  * </p>
- * 
+ *
  * <pre>
- * 
+ *
  * public interface MyApi {
- * 
+ *
  *    &#64;RequestLine("POST /getObject")
  *    &#64;Headers({
  *      "SOAPAction: getObject",
  *      "Content-Type: text/xml"
  *    })
  *    MyJaxbObjectResponse getObject(MyJaxbObjectRequest request);
- *    
+ *
  * }
- * 
+ *
  * ...
- * 
+ *
  * JAXBContextFactory jaxbFactory = new JAXBContextFactory.Builder()
  *     .withMarshallerJAXBEncoding("UTF-8")
  *     .withMarshallerSchemaLocation("http://apihost http://apihost/schema.xsd")
@@ -69,7 +70,7 @@ import feign.jaxb.JAXBContextFactory;
  * api = Feign.builder()
  *     .encoder(new SOAPEncoder(jaxbFactory))
  *     .target(MyApi.class, "http://api");
- *     
+ *
  * ...
  *
  * try {
@@ -78,7 +79,7 @@ import feign.jaxb.JAXBContextFactory;
  *    log.info(faultException.getFault().getFaultString());
  * }
  * </pre>
- * 
+ *
  * <p>
  * The JAXBContextFactory should be reused across requests as it caches the created JAXB contexts.
  * </p>
@@ -124,9 +125,9 @@ public class SOAPEncoder implements Encoder {
           Boolean.toString(writeXmlDeclaration));
       soapMessage.setProperty(SOAPMessage.CHARACTER_SET_ENCODING, charsetEncoding.displayName());
       soapMessage.getSOAPBody().addDocument(document);
-      
+
       modifySOAPMessage(soapMessage);
-      
+
       ByteArrayOutputStream bos = new ByteArrayOutputStream();
       if (formattedOutput) {
         Transformer t = TransformerFactory.newInstance().newTransformer();
@@ -142,7 +143,7 @@ public class SOAPEncoder implements Encoder {
       throw new EncodeException(e.toString(), e);
     }
   }
-  
+
   /**
    * Override this in order to modify the SOAP message object before it's finally encoded.
    * <br>
@@ -204,9 +205,9 @@ public class SOAPEncoder implements Encoder {
 
     /**
      * The protocol used to create message factory. Default is "SOAP 1.1 Protocol".
-     * 
+     *
      * @param soapProtocol a string constant representing the MessageFactory protocol.
-     * 
+     *
      * @see SOAPConstants#SOAP_1_1_PROTOCOL
      * @see SOAPConstants#SOAP_1_2_PROTOCOL
      * @see SOAPConstants#DYNAMIC_SOAP_PROTOCOL

--- a/soap/src/main/java/feign/soap/SOAPEncoder.java
+++ b/soap/src/main/java/feign/soap/SOAPEncoder.java
@@ -33,7 +33,6 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.TransformerFactoryConfigurationError;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-
 import org.w3c.dom.Document;
 import feign.RequestTemplate;
 import feign.codec.EncodeException;
@@ -145,12 +144,10 @@ public class SOAPEncoder implements Encoder {
   }
 
   /**
-   * Override this in order to modify the SOAP message object before it's finally encoded.
-   * <br>
+   * Override this in order to modify the SOAP message object before it's finally encoded. <br>
    * This might be useful to add SOAP Headers, which are not supported by this SOAPEncoder directly.
    * <br>
-   * This is an example of how to add a security header:
-   * <code>
+   * This is an example of how to add a security header: <code>
    *   protected void modifySOAPMessage(SOAPMessage soapMessage) throws SOAPException {
    *     SOAPFactory soapFactory = SOAPFactory.newInstance();
    *     String uri = "http://schemas.xmlsoap.org/ws/2002/12/secext";

--- a/soap/src/main/java/feign/soap/SOAPErrorDecoder.java
+++ b/soap/src/main/java/feign/soap/SOAPErrorDecoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/soap/src/test/java/feign/soap/SOAPCodecTest.java
+++ b/soap/src/test/java/feign/soap/SOAPCodecTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/soap/src/test/java/feign/soap/SOAPFaultDecoderTest.java
+++ b/soap/src/test/java/feign/soap/SOAPFaultDecoderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/soap/src/test/java/feign/soap/package-info.java
+++ b/soap/src/test/java/feign/soap/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
This small extension adds the possibility to manually set soap headers.
An example is given in the javadoc.