### PR TITLE
Fixed flaky tests due to `class.getMethods`

### DIFF
--- a/core/src/test/java/feign/TypesResolveReturnTypeTest.java
+++ b/core/src/test/java/feign/TypesResolveReturnTypeTest.java
@@ -19,8 +19,10 @@ import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,13 +43,8 @@ public class TypesResolveReturnTypeTest {
 
   public Method[] getMethods(Class<?> c) {
     Method[] methods = c.getMethods();
-    Arrays.sort(methods, new Comparator<Method>() {
-      @Override
-      public int compare(Method o1, Method o2) {
-        return (o1.getName() + o1.getGenericReturnType().getTypeName()).compareTo(
-            (o2.getName() + o2.getGenericReturnType().getTypeName()));
-      }
-    });
+    Arrays.sort(methods,
+        Comparator.comparing(o -> (o.getName() + o.getGenericReturnType().getTypeName())));
     return methods;
   }
 


### PR DESCRIPTION
I found some flaky tests in `feign.TypesResolveReturnTypeTest` that are caused by using the `class.getMethods` method. 

According to [Java docs](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getMethods--):
> The elements in the returned array are not sorted and are not in any particular order.

This means that future changes in Java may change the order of the returned list, and cause tests failures in this file. I created a `getMethods` method to sort the result from `class.getMethods` using alphabetical order with combos of the method name and return type name.

Then I just replaced the  `class.getMethods` with the new `getMethods` method, and updated some of the indexs in related tests to ensure deterministic order and behavior in the future.