### PR TITLE
Fix standard decoders trying to decode body on 404 with decode404 set

### DIFF
--- a/gson/src/main/java/feign/gson/GsonDecoder.java
+++ b/gson/src/main/java/feign/gson/GsonDecoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/gson/src/main/java/feign/gson/GsonDecoder.java
+++ b/gson/src/main/java/feign/gson/GsonDecoder.java
@@ -43,7 +43,7 @@ public class GsonDecoder implements Decoder {
 
   @Override
   public Object decode(Response response, Type type) throws IOException {
-    if (response.body() == null)
+    if (response.status() == 404 || response.body() == null)
       return null;
     Reader reader = response.body().asReader(UTF_8);
     try {

--- a/gson/src/test/java/feign/gson/GsonCodecTest.java
+++ b/gson/src/test/java/feign/gson/GsonCodecTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/gson/src/test/java/feign/gson/GsonCodecTest.java
+++ b/gson/src/test/java/feign/gson/GsonCodecTest.java
@@ -22,6 +22,7 @@ import feign.Request.HttpMethod;
 import feign.Util;
 import org.junit.Test;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -234,6 +235,19 @@ public class GsonCodecTest {
         .reason("NOT FOUND")
         .headers(Collections.emptyMap())
         .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .build();
+    assertThat((byte[]) new GsonDecoder().decode(response, byte[].class)).isNull();
+  }
+
+  /** Enabled via {@link feign.Feign.Builder#decode404()} */
+  @Test
+  public void notFoundWithBodyDecodesToNull() throws Exception {
+    Response response = Response.builder()
+        .status(404)
+        .reason("NOT FOUND")
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.emptyMap())
+        .body("description explaining the 404", StandardCharsets.UTF_8)
         .build();
     assertThat((byte[]) new GsonDecoder().decode(response, byte[].class)).isNull();
   }

--- a/jackson-jaxb/src/main/java/feign/jackson/jaxb/JacksonJaxbJsonDecoder.java
+++ b/jackson-jaxb/src/main/java/feign/jackson/jaxb/JacksonJaxbJsonDecoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jackson-jaxb/src/main/java/feign/jackson/jaxb/JacksonJaxbJsonDecoder.java
+++ b/jackson-jaxb/src/main/java/feign/jackson/jaxb/JacksonJaxbJsonDecoder.java
@@ -36,7 +36,7 @@ public final class JacksonJaxbJsonDecoder implements Decoder {
 
   @Override
   public Object decode(Response response, Type type) throws IOException, FeignException {
-    if (response.body() == null)
+    if (response.status() == 404 || response.body() == null)
       return null;
     return jacksonJaxbJsonProvider.readFrom(Object.class, type, null, APPLICATION_JSON_TYPE, null,
         response.body().asInputStream());

--- a/jackson-jaxb/src/test/java/feign/jackson/jaxb/JacksonJaxbCodecTest.java
+++ b/jackson-jaxb/src/test/java/feign/jackson/jaxb/JacksonJaxbCodecTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jackson-jaxb/src/test/java/feign/jackson/jaxb/JacksonJaxbCodecTest.java
+++ b/jackson-jaxb/src/test/java/feign/jackson/jaxb/JacksonJaxbCodecTest.java
@@ -20,7 +20,6 @@ import feign.Request.HttpMethod;
 import feign.RequestTemplate;
 import feign.Response;
 import feign.Util;
-
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import javax.xml.bind.annotation.XmlAccessType;

--- a/jackson-jaxb/src/test/java/feign/jackson/jaxb/JacksonJaxbCodecTest.java
+++ b/jackson-jaxb/src/test/java/feign/jackson/jaxb/JacksonJaxbCodecTest.java
@@ -20,6 +20,8 @@ import feign.Request.HttpMethod;
 import feign.RequestTemplate;
 import feign.Response;
 import feign.Util;
+
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -65,6 +67,21 @@ public class JacksonJaxbCodecTest {
         .reason("NOT FOUND")
         .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .headers(Collections.emptyMap())
+        .build();
+    assertThat((byte[]) new JacksonJaxbJsonDecoder().decode(response, byte[].class)).isNull();
+  }
+
+  /**
+   * Enabled via {@link feign.Feign.Builder#decode404()}
+   */
+  @Test
+  public void notFoundWithBodyDecodesToNull() throws Exception {
+    Response response = Response.builder()
+        .status(404)
+        .reason("NOT FOUND")
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.emptyMap())
+        .body("description explaining the 404", StandardCharsets.UTF_8)
         .build();
     assertThat((byte[]) new JacksonJaxbJsonDecoder().decode(response, byte[].class)).isNull();
   }

--- a/jackson/src/main/java/feign/jackson/JacksonDecoder.java
+++ b/jackson/src/main/java/feign/jackson/JacksonDecoder.java
@@ -47,7 +47,7 @@ public class JacksonDecoder implements Decoder {
 
   @Override
   public Object decode(Response response, Type type) throws IOException {
-    if (response.body() == null)
+    if (response.status() == 404 || response.body() == null)
       return null;
     Reader reader = response.body().asReader(response.charset());
     if (!reader.markSupported()) {

--- a/jackson/src/main/java/feign/jackson/JacksonIteratorDecoder.java
+++ b/jackson/src/main/java/feign/jackson/JacksonIteratorDecoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jackson/src/main/java/feign/jackson/JacksonIteratorDecoder.java
+++ b/jackson/src/main/java/feign/jackson/JacksonIteratorDecoder.java
@@ -64,7 +64,7 @@ public final class JacksonIteratorDecoder implements Decoder {
 
   @Override
   public Object decode(Response response, Type type) throws IOException {
-    if (response.body() == null)
+    if (response.status() == 404 || response.body() == null)
       return null;
     Reader reader = response.body().asReader(UTF_8);
     if (!reader.markSupported()) {

--- a/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
+++ b/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
@@ -318,12 +318,38 @@ public class JacksonCodecTest {
 
   /** Enabled via {@link feign.Feign.Builder#decode404()} */
   @Test
+  public void notFoundWithBodyDecodesToNull() throws Exception {
+    Response response = Response.builder()
+        .status(404)
+        .reason("NOT FOUND")
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.emptyMap())
+        .body("description explaining the 404", StandardCharsets.UTF_8)
+        .build();
+    assertThat((byte[]) new JacksonDecoder().decode(response, byte[].class)).isNull();
+  }
+
+  /** Enabled via {@link feign.Feign.Builder#decode404()} */
+  @Test
   public void notFoundDecodesToNullIterator() throws Exception {
     Response response = Response.builder()
         .status(404)
         .reason("NOT FOUND")
         .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .headers(Collections.emptyMap())
+        .build();
+    assertThat((byte[]) JacksonIteratorDecoder.create().decode(response, byte[].class)).isNull();
+  }
+
+  /** Enabled via {@link feign.Feign.Builder#decode404()} */
+  @Test
+  public void notFoundWithBodyDecodesToNullIterator() throws Exception {
+    Response response = Response.builder()
+        .status(404)
+        .reason("NOT FOUND")
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.emptyMap())
+        .body("description explaining the 404", StandardCharsets.UTF_8)
         .build();
     assertThat((byte[]) JacksonIteratorDecoder.create().decode(response, byte[].class)).isNull();
   }

--- a/jaxb/src/main/java/feign/jaxb/JAXBDecoder.java
+++ b/jaxb/src/main/java/feign/jaxb/JAXBDecoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jaxb/src/main/java/feign/jaxb/JAXBDecoder.java
+++ b/jaxb/src/main/java/feign/jaxb/JAXBDecoder.java
@@ -66,7 +66,7 @@ public class JAXBDecoder implements Decoder {
   public Object decode(Response response, Type type) throws IOException {
     if (response.status() == 204)
       return Util.emptyValueOf(type);
-    if (response.body() == null)
+    if (response.status() == 404 || response.body() == null)
       return null;
     while (type instanceof ParameterizedType) {
       ParameterizedType ptype = (ParameterizedType) type;

--- a/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
+++ b/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
+++ b/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
@@ -23,6 +23,7 @@ import feign.Response;
 import feign.Util;
 import feign.codec.Encoder;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -251,6 +252,22 @@ public class JAXBCodecTest {
         .reason("NOT FOUND")
         .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .headers(Collections.<String, Collection<String>>emptyMap())
+        .build();
+    assertThat((byte[]) new JAXBDecoder(new JAXBContextFactory.Builder().build())
+        .decode(response, byte[].class)).isNull();
+  }
+
+  /**
+   * Enabled via {@link feign.Feign.Builder#decode404()}
+   */
+  @Test
+  public void notFoundWithBodyDecodesToNull() throws Exception {
+    Response response = Response.builder()
+        .status(404)
+        .reason("NOT FOUND")
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.<String, Collection<String>>emptyMap())
+        .body("description explaining the 404", StandardCharsets.UTF_8)
         .build();
     assertThat((byte[]) new JAXBDecoder(new JAXBContextFactory.Builder().build())
         .decode(response, byte[].class)).isNull();

--- a/sax/src/main/java/feign/sax/SAXDecoder.java
+++ b/sax/src/main/java/feign/sax/SAXDecoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/sax/src/main/java/feign/sax/SAXDecoder.java
+++ b/sax/src/main/java/feign/sax/SAXDecoder.java
@@ -60,7 +60,7 @@ public class SAXDecoder implements Decoder {
 
   @Override
   public Object decode(Response response, Type type) throws IOException, DecodeException {
-    if (response.body() == null)
+    if (response.status() == 404 || response.body() == null)
       return null;
     ContentHandlerWithResult.Factory<?> handlerFactory = handlerFactories.get(type);
     checkState(handlerFactory != null, "type %s not in configured handlers %s", type,

--- a/sax/src/test/java/feign/sax/SAXDecoderTest.java
+++ b/sax/src/test/java/feign/sax/SAXDecoderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/sax/src/test/java/feign/sax/SAXDecoderTest.java
+++ b/sax/src/test/java/feign/sax/SAXDecoderTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.xml.sax.helpers.DefaultHandler;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.Collection;
 import java.util.Collections;
@@ -101,6 +102,19 @@ public class SAXDecoderTest {
         .reason("NOT FOUND")
         .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .headers(Collections.<String, Collection<String>>emptyMap())
+        .build();
+    assertThat((byte[]) decoder.decode(response, byte[].class)).isNull();
+  }
+
+  /** Enabled via {@link feign.Feign.Builder#decode404()} */
+  @Test
+  public void notFoundWithBodyDecodesToNull() throws Exception {
+    Response response = Response.builder()
+        .status(404)
+        .reason("NOT FOUND")
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.<String, Collection<String>>emptyMap())
+        .body("description explaining the 404", StandardCharsets.UTF_8)
         .build();
     assertThat((byte[]) decoder.decode(response, byte[].class)).isNull();
   }

--- a/soap/src/test/java/feign/soap/SOAPCodecTest.java
+++ b/soap/src/test/java/feign/soap/SOAPCodecTest.java
@@ -384,6 +384,22 @@ public class SOAPCodecTest {
         .decode(response, byte[].class)).isNull();
   }
 
+  /**
+   * Enabled via {@link feign.Feign.Builder#decode404()}
+   */
+  @Test
+  public void notFoundWithBodyDecodesToNull() throws Exception {
+    Response response = Response.builder()
+        .status(404)
+        .reason("NOT FOUND")
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .headers(Collections.emptyMap())
+        .body("description explaining the 404", StandardCharsets.UTF_8)
+        .build();
+    assertThat((byte[]) new JAXBDecoder(new JAXBContextFactory.Builder().build())
+        .decode(response, byte[].class)).isNull();
+  }
+
 
   @XmlRootElement(name = "GetPrice")
   @XmlAccessorType(XmlAccessType.FIELD)


### PR DESCRIPTION
If decode404 flag is set, according to documentation decoders are supposed to return null
on 404 (not found) return codes. Version 10.6 of OpenFeign changed behavior such that
non-empty bodies of 404 responses are decoded by the standard decoders (GsonDecoder,
JacksonJaxbJsonDecoder, JacksonDecoder, JacksonIteratorDecoder, JAXBDecoder, SAXDecoder),
eventually causing DecodeExceptions if the body does not honor the expected data format.
Only on empty bodies, 404 always was honored with a null return value.

Fixes #1528