### PR TITLE
Fixed flaky tests in `feign.json.JsonEncoderTest`

### DIFF
--- a/json/pom.xml
+++ b/json/pom.xml
@@ -52,6 +52,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <version>1.5.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>feign-mock</artifactId>
       <scope>test</scope>

--- a/json/src/test/java/feign/json/JsonEncoderTest.java
+++ b/json/src/test/java/feign/json/JsonEncoderTest.java
@@ -19,6 +19,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 import java.util.Date;
 import static feign.Util.UTF_8;
 import static org.junit.Assert.*;
@@ -43,13 +44,15 @@ public class JsonEncoderTest {
   @Test
   public void encodesArray() {
     new JsonEncoder().encode(jsonArray, JSONArray.class, requestTemplate);
-    assertEquals("[{\"a\":\"b\",\"c\":1},123]", new String(requestTemplate.body(), UTF_8));
+    JSONAssert.assertEquals("[{\"a\":\"b\",\"c\":1},123]",
+        new String(requestTemplate.body(), UTF_8), false);
   }
 
   @Test
   public void encodesObject() {
     new JsonEncoder().encode(jsonObject, JSONObject.class, requestTemplate);
-    assertEquals("{\"a\":\"b\",\"c\":1}", new String(requestTemplate.body(), UTF_8));
+    JSONAssert.assertEquals("{\"a\":\"b\",\"c\":1}", new String(requestTemplate.body(), UTF_8),
+        false);
   }
 
   @Test


### PR DESCRIPTION
I found some flaky tests in `feign.json.JsonEncoderTest` that are caused by java `JSONObject`'s usage of `HashMap`. 

Thus, the toString method for the `JSONObject` does not guarantee a deterministic output.

This means that future changes in Java may change the order of the returned string, and cause tests failures in this file. I used a library `JSONAssert` from `org.skyscreamer` to compare JSON strings. It compares the logical structure and data in the JSON object from the JSON string.