### PR TITLE
docs: Change Java11 New HTTP/2 Client link to JEP 321

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ public class Example {
 ```
 
 ### Java 11 Http2
-[Http2Client](./java11) directs Feign's http requests to Java11 [New HTTP/2 Client](http://www.javamagazine.mozaicreader.com/JulyAug2017#&pageSet=39&page=0) that implements HTTP/2.
+[Http2Client](./java11) directs Feign's http requests to Java11 [New HTTP/2 Client](https://openjdk.java.net/jeps/321) that implements HTTP/2.
 
 To use New HTTP/2 Client with Feign, use Java SDK 11. Then, configure Feign to use the Http2Client:
 

--- a/java11/README.md
+++ b/java11/README.md
@@ -1,6 +1,6 @@
 # feign-java11
 
-This module directs Feign's http requests to Java11 [New HTTP/2 Client](http://www.javamagazine.mozaicreader.com/JulyAug2017#&pageSet=39&page=0) that implements HTTP/2.
+This module directs Feign's http requests to Java11 [New HTTP/2 Client](https://openjdk.java.net/jeps/321) that implements HTTP/2.
 
 To use New HTTP/2 Client with Feign, use Java SDK 11. Then, configure Feign to use the Http2Client:
 


### PR DESCRIPTION
It seems that the link to 'New HTTP/2 Client' is broken. I've changed the link to the official [JEP 321](https://openjdk.java.net/jeps/321).