### PR TITLE
Remove deprecated method.

### DIFF
--- a/core/src/test/java/feign/CapabilityTest.java
+++ b/core/src/test/java/feign/CapabilityTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,7 +14,7 @@
 package feign;
 
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 import java.io.IOException;

--- a/core/src/test/java/feign/EmptyTargetTest.java
+++ b/core/src/test/java/feign/EmptyTargetTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/EmptyTargetTest.java
+++ b/core/src/test/java/feign/EmptyTargetTest.java
@@ -18,7 +18,7 @@ import feign.Target.EmptyTarget;
 import org.junit.Test;
 import java.net.URI;
 import static feign.assertj.FeignAssertions.assertThat;
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 public class EmptyTargetTest {

--- a/core/src/test/java/feign/EmptyTargetTest.java
+++ b/core/src/test/java/feign/EmptyTargetTest.java
@@ -14,17 +14,16 @@
 package feign;
 
 import feign.Request.HttpMethod;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import java.net.URI;
 import feign.Target.EmptyTarget;
+import org.junit.Test;
+
+import java.net.URI;
+
 import static feign.assertj.FeignAssertions.assertThat;
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class EmptyTargetTest {
-
-  @Rule
-  public final ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void whenNameNotSupplied() {
@@ -46,11 +45,10 @@ public class EmptyTargetTest {
 
   @Test
   public void mustApplyToAbsoluteUrl() {
-    thrown.expect(UnsupportedOperationException.class);
-    thrown.expectMessage("Request with non-absolute URL not supported with empty target");
-
-    EmptyTarget.create(UriInterface.class)
-        .apply(new RequestTemplate().method(HttpMethod.GET).uri("/relative"));
+    UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
+            () -> EmptyTarget.create(UriInterface.class)
+                    .apply(new RequestTemplate().method(HttpMethod.GET).uri("/relative")));
+    assertEquals("Request with non-absolute URL not supported with empty target", exception.getMessage());
   }
 
   interface UriInterface {

--- a/core/src/test/java/feign/EmptyTargetTest.java
+++ b/core/src/test/java/feign/EmptyTargetTest.java
@@ -16,9 +16,7 @@ package feign;
 import feign.Request.HttpMethod;
 import feign.Target.EmptyTarget;
 import org.junit.Test;
-
 import java.net.URI;
-
 import static feign.assertj.FeignAssertions.assertThat;
 import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertThrows;
@@ -46,9 +44,10 @@ public class EmptyTargetTest {
   @Test
   public void mustApplyToAbsoluteUrl() {
     UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
-            () -> EmptyTarget.create(UriInterface.class)
-                    .apply(new RequestTemplate().method(HttpMethod.GET).uri("/relative")));
-    assertEquals("Request with non-absolute URL not supported with empty target", exception.getMessage());
+        () -> EmptyTarget.create(UriInterface.class)
+            .apply(new RequestTemplate().method(HttpMethod.GET).uri("/relative")));
+    assertEquals("Request with non-absolute URL not supported with empty target",
+        exception.getMessage());
   }
 
   interface UriInterface {

--- a/core/src/test/java/feign/template/HeaderTemplateTest.java
+++ b/core/src/test/java/feign/template/HeaderTemplateTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/template/HeaderTemplateTest.java
+++ b/core/src/test/java/feign/template/HeaderTemplateTest.java
@@ -13,38 +13,36 @@
  */
 package feign.template;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import org.junit.Test;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Map;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class HeaderTemplateTest {
 
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
-
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void it_should_throw_exception_when_name_is_null() {
-    HeaderTemplate.create(null, Collections.singletonList("test"));
-    exception.expectMessage("name is required.");
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+            () -> HeaderTemplate.create(null, Collections.singletonList("test")));
+    assertEquals("name is required.", exception.getMessage());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void it_should_throw_exception_when_name_is_empty() {
-    HeaderTemplate.create("", Collections.singletonList("test"));
-    exception.expectMessage("name is required.");
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+            () -> HeaderTemplate.create("", Collections.singletonList("test")));
+    assertEquals("name is required.", exception.getMessage());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void it_should_throw_exception_when_value_is_null() {
-    HeaderTemplate.create("test", null);
-    exception.expectMessage("values are required");
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+            () -> HeaderTemplate.create("test", null));
+    assertEquals("values are required", exception.getMessage());
   }
 
   @Test
@@ -79,13 +77,13 @@ public class HeaderTemplateTest {
      */
     HeaderTemplate headerTemplateWithFirstOrdering =
         HeaderTemplate.create("hello", Arrays.asList("test 1", "test 2"));
-    assertThat(new ArrayList<>(headerTemplateWithFirstOrdering.getValues()),
-        equalTo(Arrays.asList("test 1", "test 2")));
+    assertEquals(Arrays.asList("test 1", "test 2"),
+            new ArrayList<>(headerTemplateWithFirstOrdering.getValues()));
 
     HeaderTemplate headerTemplateWithSecondOrdering =
         HeaderTemplate.create("hello", Arrays.asList("test 2", "test 1"));
-    assertThat(new ArrayList<>(headerTemplateWithSecondOrdering.getValues()),
-        equalTo(Arrays.asList("test 2", "test 1")));
+    assertEquals(Arrays.asList("test 2", "test 1"),
+            new ArrayList<>(headerTemplateWithSecondOrdering.getValues()));
   }
 
   @Test
@@ -97,23 +95,22 @@ public class HeaderTemplateTest {
     HeaderTemplate headerTemplateWithFirstOrdering =
         HeaderTemplate.append(HeaderTemplate.create("hello", Collections.emptyList()),
             Arrays.asList("test 1", "test 2"));
-    assertThat(new ArrayList<>(headerTemplateWithFirstOrdering.getValues()),
-        equalTo(Arrays.asList("test 1", "test 2")));
+    assertEquals(Arrays.asList("test 1", "test 2"),
+            new ArrayList<>(headerTemplateWithFirstOrdering.getValues()));
 
     HeaderTemplate headerTemplateWithSecondOrdering =
         HeaderTemplate.append(HeaderTemplate.create("hello", Collections.emptyList()),
             Arrays.asList("test 2", "test 1"));
-    assertThat(new ArrayList<>(headerTemplateWithSecondOrdering.getValues()),
-        equalTo(Arrays.asList("test 2", "test 1")));
+    assertEquals(Arrays.asList("test 2", "test 1"),
+            new ArrayList<>(headerTemplateWithSecondOrdering.getValues()));
   }
 
   @Test
   public void it_should_support_http_date() {
     HeaderTemplate headerTemplate =
         HeaderTemplate.create("Expires", Collections.singletonList("{expires}"));
-    assertEquals(
+    assertEquals("Wed, 4 Jul 2001 12:08:56 -0700",
         headerTemplate.expand(
-            Collections.singletonMap("expires", "Wed, 4 Jul 2001 12:08:56 -0700")),
-        "Wed, 4 Jul 2001 12:08:56 -0700");
+            Collections.singletonMap("expires", "Wed, 4 Jul 2001 12:08:56 -0700")));
   }
 }

--- a/core/src/test/java/feign/template/HeaderTemplateTest.java
+++ b/core/src/test/java/feign/template/HeaderTemplateTest.java
@@ -14,11 +14,9 @@
 package feign.template;
 
 import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-
 import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -27,21 +25,21 @@ public class HeaderTemplateTest {
   @Test
   public void it_should_throw_exception_when_name_is_null() {
     IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-            () -> HeaderTemplate.create(null, Collections.singletonList("test")));
+        () -> HeaderTemplate.create(null, Collections.singletonList("test")));
     assertEquals("name is required.", exception.getMessage());
   }
 
   @Test
   public void it_should_throw_exception_when_name_is_empty() {
     IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-            () -> HeaderTemplate.create("", Collections.singletonList("test")));
+        () -> HeaderTemplate.create("", Collections.singletonList("test")));
     assertEquals("name is required.", exception.getMessage());
   }
 
   @Test
   public void it_should_throw_exception_when_value_is_null() {
     IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-            () -> HeaderTemplate.create("test", null));
+        () -> HeaderTemplate.create("test", null));
     assertEquals("values are required", exception.getMessage());
   }
 
@@ -78,12 +76,12 @@ public class HeaderTemplateTest {
     HeaderTemplate headerTemplateWithFirstOrdering =
         HeaderTemplate.create("hello", Arrays.asList("test 1", "test 2"));
     assertEquals(Arrays.asList("test 1", "test 2"),
-            new ArrayList<>(headerTemplateWithFirstOrdering.getValues()));
+        new ArrayList<>(headerTemplateWithFirstOrdering.getValues()));
 
     HeaderTemplate headerTemplateWithSecondOrdering =
         HeaderTemplate.create("hello", Arrays.asList("test 2", "test 1"));
     assertEquals(Arrays.asList("test 2", "test 1"),
-            new ArrayList<>(headerTemplateWithSecondOrdering.getValues()));
+        new ArrayList<>(headerTemplateWithSecondOrdering.getValues()));
   }
 
   @Test
@@ -96,13 +94,13 @@ public class HeaderTemplateTest {
         HeaderTemplate.append(HeaderTemplate.create("hello", Collections.emptyList()),
             Arrays.asList("test 1", "test 2"));
     assertEquals(Arrays.asList("test 1", "test 2"),
-            new ArrayList<>(headerTemplateWithFirstOrdering.getValues()));
+        new ArrayList<>(headerTemplateWithFirstOrdering.getValues()));
 
     HeaderTemplate headerTemplateWithSecondOrdering =
         HeaderTemplate.append(HeaderTemplate.create("hello", Collections.emptyList()),
             Arrays.asList("test 2", "test 1"));
     assertEquals(Arrays.asList("test 2", "test 1"),
-            new ArrayList<>(headerTemplateWithSecondOrdering.getValues()));
+        new ArrayList<>(headerTemplateWithSecondOrdering.getValues()));
   }
 
   @Test

--- a/core/src/test/java/feign/template/HeaderTemplateTest.java
+++ b/core/src/test/java/feign/template/HeaderTemplateTest.java
@@ -18,6 +18,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import static junit.framework.TestCase.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThrows;
 
 public class HeaderTemplateTest {
@@ -75,13 +77,13 @@ public class HeaderTemplateTest {
      */
     HeaderTemplate headerTemplateWithFirstOrdering =
         HeaderTemplate.create("hello", Arrays.asList("test 1", "test 2"));
-    assertEquals(Arrays.asList("test 1", "test 2"),
-        new ArrayList<>(headerTemplateWithFirstOrdering.getValues()));
+    assertThat(new ArrayList<>(headerTemplateWithFirstOrdering.getValues()),
+        equalTo(Arrays.asList("test 1", "test 2")));
 
     HeaderTemplate headerTemplateWithSecondOrdering =
         HeaderTemplate.create("hello", Arrays.asList("test 2", "test 1"));
-    assertEquals(Arrays.asList("test 2", "test 1"),
-        new ArrayList<>(headerTemplateWithSecondOrdering.getValues()));
+    assertThat(new ArrayList<>(headerTemplateWithSecondOrdering.getValues()),
+        equalTo(Arrays.asList("test 2", "test 1")));
   }
 
   @Test
@@ -93,14 +95,14 @@ public class HeaderTemplateTest {
     HeaderTemplate headerTemplateWithFirstOrdering =
         HeaderTemplate.append(HeaderTemplate.create("hello", Collections.emptyList()),
             Arrays.asList("test 1", "test 2"));
-    assertEquals(Arrays.asList("test 1", "test 2"),
-        new ArrayList<>(headerTemplateWithFirstOrdering.getValues()));
+    assertThat(new ArrayList<>(headerTemplateWithFirstOrdering.getValues()),
+        equalTo(Arrays.asList("test 1", "test 2")));
 
     HeaderTemplate headerTemplateWithSecondOrdering =
         HeaderTemplate.append(HeaderTemplate.create("hello", Collections.emptyList()),
             Arrays.asList("test 2", "test 1"));
-    assertEquals(Arrays.asList("test 2", "test 1"),
-        new ArrayList<>(headerTemplateWithSecondOrdering.getValues()));
+    assertThat(new ArrayList<>(headerTemplateWithSecondOrdering.getValues()),
+        equalTo(Arrays.asList("test 2", "test 1")));
   }
 
   @Test

--- a/core/src/test/java/feign/template/HeaderTemplateTest.java
+++ b/core/src/test/java/feign/template/HeaderTemplateTest.java
@@ -17,9 +17,9 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 public class HeaderTemplateTest {

--- a/example-github/src/test/java/feign/example/github/GitHubExampleIT.java
+++ b/example-github/src/test/java/feign/example/github/GitHubExampleIT.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,7 +13,7 @@
  */
 package feign.example.github;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecutor;
 import org.hamcrest.CoreMatchers;

--- a/example-wikipedia/src/test/java/feign/example/wikipedia/WikipediaExampleIT.java
+++ b/example-wikipedia/src/test/java/feign/example/wikipedia/WikipediaExampleIT.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,7 +13,7 @@
  */
 package feign.example.wikipedia;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecutor;
 import org.hamcrest.CoreMatchers;

--- a/mock/src/test/java/feign/mock/MockTargetTest.java
+++ b/mock/src/test/java/feign/mock/MockTargetTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,7 +14,7 @@
 package feign.mock;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/mock/src/test/java/feign/mock/RequestKeyTest.java
+++ b/mock/src/test/java/feign/mock/RequestKeyTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,7 +19,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;

--- a/ribbon/src/test/java/feign/ribbon/RibbonClientTest.java
+++ b/ribbon/src/test/java/feign/ribbon/RibbonClientTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,7 +19,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import java.io.IOException;


### PR DESCRIPTION
[Replace JUnit ExpectedException with assertThrows.](https://junit.org/junit4/javadoc/latest/org/junit/rules/ExpectedException.html#none())
[Replace `org.junit.Assert.assertThat()` with `org.hamcrest.MatcherAssert.assertThat()`.](https://junit.org/junit4/javadoc/4.13/org/junit/Assert.html#assertThat(T,%20org.hamcrest.Matcher))
Fix assertEquals parameter position.