### PR TITLE
Reason is optional in HTTP2

### DIFF
--- a/java11/src/main/java/feign/http2client/Http2Client.java
+++ b/java11/src/main/java/feign/http2client/Http2Client.java
@@ -129,7 +129,7 @@ public class Http2Client implements Client, AsyncClient<Object> {
         .protocolVersion(enumForName(ProtocolVersion.class, httpResponse.version()))
         .body(new ByteArrayInputStream(httpResponse.body()),
             length.isPresent() ? (int) length.getAsLong() : null)
-        .reason(httpResponse.headers().firstValue("Reason-Phrase").orElse("OK"))
+        .reason(httpResponse.headers().firstValue("Reason-Phrase").orElse(null))
         .request(request)
         .status(httpResponse.statusCode())
         .headers(castMapCollectType(httpResponse.headers().map()))

--- a/java11/src/test/java/feign/http2client/test/Http2ClientTest.java
+++ b/java11/src/test/java/feign/http2client/test/Http2ClientTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -68,6 +68,20 @@ public class Http2ClientTest extends AbstractClientTest {
   @Test
   public void reasonPhraseIsOptional() throws IOException, InterruptedException {
     server.enqueue(new MockResponse()
+        .setStatus("HTTP/1.1 " + 200));
+
+    final AbstractClientTest.TestInterface api = newBuilder()
+        .target(AbstractClientTest.TestInterface.class, "http://localhost:" + server.getPort());
+
+    final Response response = api.post("foo");
+
+    assertThat(response.status()).isEqualTo(200);
+    assertThat(response.reason()).isNull();
+  }
+
+  @Test
+  public void reasonPhraseInHeader() throws IOException, InterruptedException {
+    server.enqueue(new MockResponse()
         .addHeader("Reason-Phrase", "There is A reason")
         .setStatus("HTTP/1.1 " + 200));
 
@@ -79,7 +93,6 @@ public class Http2ClientTest extends AbstractClientTest {
     assertThat(response.status()).isEqualTo(200);
     assertThat(response.reason()).isEqualTo("There is A reason");
   }
-
 
   @Override
   @Test


### PR DESCRIPTION
Fixes #1382 

See [comment](https://github.com/OpenFeign/feign/blob/24635e6e85f4d50445e94aed779712e18fd2a1bc/core/src/main/java/feign/Response.java#L159) on Response#reason(): Nullable and not set when using http/2

The current implementation returns **OK** is the reason is not present and the reason header is not present too. 