### PR TITLE
Deprecate QueryMap.encode, remove processing of the "encode" parameter

### DIFF
--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -308,7 +308,6 @@ public interface Contract {
         checkState(data.queryMapIndex() == null,
             "QueryMap annotation was present on multiple parameters.");
         data.queryMapIndex(paramIndex);
-        data.queryMapEncoded(queryMap.encoded());
       });
       super.registerParameterAnnotation(HeaderMap.class, (queryMap, data, paramIndex) -> {
         checkState(data.headerMapIndex() == null,

--- a/core/src/main/java/feign/MethodMetadata.java
+++ b/core/src/main/java/feign/MethodMetadata.java
@@ -29,7 +29,6 @@ public final class MethodMetadata implements Serializable {
   private Integer bodyIndex;
   private Integer headerMapIndex;
   private Integer queryMapIndex;
-  private boolean queryMapEncoded;
   private boolean alwaysEncodeBody;
   private transient Type bodyType;
   private final RequestTemplate template = new RequestTemplate();
@@ -107,15 +106,6 @@ public final class MethodMetadata implements Serializable {
 
   public MethodMetadata queryMapIndex(Integer queryMapIndex) {
     this.queryMapIndex = queryMapIndex;
-    return this;
-  }
-
-  public boolean queryMapEncoded() {
-    return queryMapEncoded;
-  }
-
-  public MethodMetadata queryMapEncoded(boolean queryMapEncoded) {
-    this.queryMapEncoded = queryMapEncoded;
     return this;
   }
 

--- a/core/src/main/java/feign/QueryMap.java
+++ b/core/src/main/java/feign/QueryMap.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012-2020 The Feign Authors
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -53,15 +53,21 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * Once this conversion is applied, the query keys and resulting String values follow the same
  * contract as if they were set using {@link RequestTemplate#query(String, String...)}.
  */
-@SuppressWarnings("deprecation")
 @Retention(RUNTIME)
 @java.lang.annotation.Target(PARAMETER)
 public @interface QueryMap {
 
   /**
    * Specifies whether parameter names and values are already encoded.
+   * <p>
+   * Deprecation: there are two options
+   * <ul>
+   * <li>if name or value are already encoded we do nothing;</li>
+   * <li>if name or value are not encoded we encode them.</li>
+   * </ul>
    *
    * @see Param#encoded
+   * @deprecated
    */
   boolean encoded() default false;
 }

--- a/core/src/main/java/feign/ReflectiveFeign.java
+++ b/core/src/main/java/feign/ReflectiveFeign.java
@@ -302,27 +302,22 @@ public class ReflectiveFeign extends Feign {
       for (Entry<String, Object> currEntry : queryMap.entrySet()) {
         Collection<String> values = new ArrayList<String>();
 
-        boolean encoded = metadata.queryMapEncoded();
         Object currValue = currEntry.getValue();
         if (currValue instanceof Iterable<?>) {
           Iterator<?> iter = ((Iterable<?>) currValue).iterator();
           while (iter.hasNext()) {
             Object nextObject = iter.next();
-            values.add(nextObject == null ? null
-                : encoded ? nextObject.toString()
-                    : UriUtils.encode(nextObject.toString()));
+            values.add(nextObject == null ? null : UriUtils.encode(nextObject.toString()));
           }
         } else if (currValue instanceof Object[]) {
           for (Object value : (Object[]) currValue) {
-            values.add(value == null ? null
-                : encoded ? value.toString() : UriUtils.encode(value.toString()));
+            values.add(value == null ? null : UriUtils.encode(value.toString()));
           }
         } else {
-          values.add(currValue == null ? null
-              : encoded ? currValue.toString() : UriUtils.encode(currValue.toString()));
+          values.add(currValue == null ? null : UriUtils.encode(currValue.toString()));
         }
 
-        mutable.query(encoded ? currEntry.getKey() : UriUtils.encode(currEntry.getKey()), values);
+        mutable.query(UriUtils.encode(currEntry.getKey()), values);
       }
       return mutable;
     }

--- a/core/src/test/java/feign/DefaultContractTest.java
+++ b/core/src/test/java/feign/DefaultContractTest.java
@@ -327,30 +327,6 @@ public class DefaultContractTest {
   }
 
   @Test
-  public void queryMapEncodedDefault() throws Exception {
-    final MethodMetadata md =
-        parseAndValidateMetadata(QueryMapTestInterface.class, "queryMap", Map.class);
-
-    assertThat(md.queryMapEncoded()).isFalse();
-  }
-
-  @Test
-  public void queryMapEncodedTrue() throws Exception {
-    final MethodMetadata md =
-        parseAndValidateMetadata(QueryMapTestInterface.class, "queryMapEncoded", Map.class);
-
-    assertThat(md.queryMapEncoded()).isTrue();
-  }
-
-  @Test
-  public void queryMapEncodedFalse() throws Exception {
-    final MethodMetadata md =
-        parseAndValidateMetadata(QueryMapTestInterface.class, "queryMapNotEncoded", Map.class);
-
-    assertThat(md.queryMapEncoded()).isFalse();
-  }
-
-  @Test
   public void queryMapMapSubclass() throws Exception {
     final MethodMetadata md =
         parseAndValidateMetadata(QueryMapTestInterface.class, "queryMapMapSubclass",
@@ -386,24 +362,6 @@ public class DefaultContractTest {
         parseAndValidateMetadata(QueryMapTestInterface.class, "pojoObject", Object.class);
 
     assertThat(md.queryMapIndex()).isEqualTo(0);
-  }
-
-  @Test
-  public void queryMapPojoObjectEncoded() throws Exception {
-    final MethodMetadata md =
-        parseAndValidateMetadata(QueryMapTestInterface.class, "pojoObjectEncoded", Object.class);
-
-    assertThat(md.queryMapIndex()).isEqualTo(0);
-    assertThat(md.queryMapEncoded()).isTrue();
-  }
-
-  @Test
-  public void queryMapPojoObjectNotEncoded() throws Exception {
-    final MethodMetadata md =
-        parseAndValidateMetadata(QueryMapTestInterface.class, "pojoObjectNotEncoded", Object.class);
-
-    assertThat(md.queryMapIndex()).isEqualTo(0);
-    assertThat(md.queryMapEncoded()).isFalse();
   }
 
   @Test
@@ -610,19 +568,7 @@ public class DefaultContractTest {
     void queryMapMapSubclass(@QueryMap SortedMap<String, String> queryMap);
 
     @RequestLine("POST /")
-    void queryMapEncoded(@QueryMap(encoded = true) Map<String, String> queryMap);
-
-    @RequestLine("POST /")
-    void queryMapNotEncoded(@QueryMap(encoded = false) Map<String, String> queryMap);
-
-    @RequestLine("POST /")
     void pojoObject(@QueryMap Object object);
-
-    @RequestLine("POST /")
-    void pojoObjectEncoded(@QueryMap(encoded = true) Object object);
-
-    @RequestLine("POST /")
-    void pojoObjectNotEncoded(@QueryMap(encoded = false) Object object);
 
     // invalid
     @RequestLine("POST /")

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -365,14 +365,14 @@ public class FeignTest {
     server.enqueue(new MockResponse());
     queryMap = new LinkedHashMap<String, Object>();
     queryMap.put("name", "%7Balice");
-    api.queryMapEncoded(queryMap);
+    api.queryMap(queryMap);
     assertThat(server.takeRequest())
         .hasPath("/?name=%7Balice");
 
     server.enqueue(new MockResponse());
     queryMap = new LinkedHashMap<String, Object>();
     queryMap.put("%7Bname", "%7Balice");
-    api.queryMapEncoded(queryMap);
+    api.queryMap(queryMap);
     assertThat(server.takeRequest())
         .hasPath("/?%7Bname=%7Balice");
   }
@@ -970,9 +970,6 @@ public class FeignTest {
 
     @RequestLine("GET /")
     void queryMap(@QueryMap Map<String, Object> queryMap);
-
-    @RequestLine("GET /")
-    void queryMapEncoded(@QueryMap(encoded = true) Map<String, Object> queryMap);
 
     @RequestLine("GET /?name={name}")
     void queryMapWithQueryParams(@Param("name") String name,


### PR DESCRIPTION
Was mentioned in #1475:

- as Param.encode is deprecated,
- as we have two encode steps:
  - first [processes `encode` parameter in ReflectiveFeign](https://github.com/OpenFeign/feign/blob/1f7ca4c74cefdeeea96d4b90be2a945d77e6905a/core/src/main/java/feign/ReflectiveFeign.java#L305)
  - but second ignores[[1](https://github.com/OpenFeign/feign/blob/1f7ca4c74cefdeeea96d4b90be2a945d77e6905a/core/src/main/java/feign/CollectionFormat.java#L77)][[2](https://github.com/OpenFeign/feign/blob/1f7ca4c74cefdeeea96d4b90be2a945d77e6905a/core/src/main/java/feign/CollectionFormat.java#L85)] it when build a query string in CollectionFormat.join, especially for names (fields),
- as UriUtils.encode does not encode string if it is already encoded.
  
I propose:

- encode both names and values in ReflectiveFeign, leave another names' encoding in CollectionFormat as it is not conflict with first. see UriUtils.isEncoded
- mark QueryMap.encode as deprecated too.