### PR TITLE
MeteredDecoder records timer once in happy path

### DIFF
--- a/micrometer/src/main/java/feign/micrometer/MeteredDecoder.java
+++ b/micrometer/src/main/java/feign/micrometer/MeteredDecoder.java
@@ -62,7 +62,6 @@ public class MeteredDecoder implements Decoder {
     try {
       decoded = decoder.decode(meteredResponse, type);
       timer = createTimer(response, type, null);
-      sample.stop(timer);
     } catch (IOException | RuntimeException e) {
       timer = createTimer(response, type, e);
       createExceptionCounter(response, type, e).count();

--- a/micrometer/src/test/java/feign/micrometer/AbstractMetricsTestBase.java
+++ b/micrometer/src/test/java/feign/micrometer/AbstractMetricsTestBase.java
@@ -74,6 +74,13 @@ public abstract class AbstractMetricsTestBase<MR, METRIC_ID, METRIC> {
         .filter(this::doesMetricHasCounter)
         .forEach(metric -> assertEquals(1, getMetricCounter(metric)));
 
+    final Map<METRIC_ID, METRIC> decoderMetrics = getFeignMetrics().entrySet().stream()
+        .filter(entry -> isDecoderMetric(entry.getKey()))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+    decoderMetrics.values().stream()
+        .filter(this::doesMetricHasCounter)
+        .forEach(metric -> assertEquals(1, getMetricCounter(metric)));
   }
 
   protected abstract boolean doesMetricIncludeHost(METRIC_ID metricId);


### PR DESCRIPTION
Fixes #1553 

The decoder has had same issue that the client: on happy path it calls times twice - first in main block and second in finally one.