### PR TITLE
Fixed dangling javadoc comment warning for license header

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2020 The Feign Authors
+# Copyright 2012-2021 The Feign Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ All files are released with the Apache 2.0 license.
 If you are adding a new file it should have a header like this:
 
 ```
-/**
+/*
  * Copyright 2012 The Feign Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/annotation-error-decoder/src/main/java/feign/error/AnnotationErrorDecoder.java
+++ b/annotation-error-decoder/src/main/java/feign/error/AnnotationErrorDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/annotation-error-decoder/src/main/java/feign/error/ErrorCodes.java
+++ b/annotation-error-decoder/src/main/java/feign/error/ErrorCodes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/annotation-error-decoder/src/main/java/feign/error/ErrorHandling.java
+++ b/annotation-error-decoder/src/main/java/feign/error/ErrorHandling.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/annotation-error-decoder/src/main/java/feign/error/ExceptionGenerator.java
+++ b/annotation-error-decoder/src/main/java/feign/error/ExceptionGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/annotation-error-decoder/src/main/java/feign/error/FeignExceptionConstructor.java
+++ b/annotation-error-decoder/src/main/java/feign/error/FeignExceptionConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/annotation-error-decoder/src/main/java/feign/error/MethodErrorHandler.java
+++ b/annotation-error-decoder/src/main/java/feign/error/MethodErrorHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/annotation-error-decoder/src/main/java/feign/error/ResponseBody.java
+++ b/annotation-error-decoder/src/main/java/feign/error/ResponseBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/annotation-error-decoder/src/main/java/feign/error/ResponseHeaders.java
+++ b/annotation-error-decoder/src/main/java/feign/error/ResponseHeaders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/annotation-error-decoder/src/test/java/feign/error/AbstractAnnotationErrorDecoderTest.java
+++ b/annotation-error-decoder/src/test/java/feign/error/AbstractAnnotationErrorDecoderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/annotation-error-decoder/src/test/java/feign/error/AnnotationErrorDecoderAnnotationInheritanceTest.java
+++ b/annotation-error-decoder/src/test/java/feign/error/AnnotationErrorDecoderAnnotationInheritanceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/annotation-error-decoder/src/test/java/feign/error/AnnotationErrorDecoderClassInheritanceTest.java
+++ b/annotation-error-decoder/src/test/java/feign/error/AnnotationErrorDecoderClassInheritanceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/annotation-error-decoder/src/test/java/feign/error/AnnotationErrorDecoderExceptionConstructorsTest.java
+++ b/annotation-error-decoder/src/test/java/feign/error/AnnotationErrorDecoderExceptionConstructorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/annotation-error-decoder/src/test/java/feign/error/AnnotationErrorDecoderIllegalInterfacesTest.java
+++ b/annotation-error-decoder/src/test/java/feign/error/AnnotationErrorDecoderIllegalInterfacesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/annotation-error-decoder/src/test/java/feign/error/AnnotationErrorDecoderInheritanceClassLevelAnnotationTest.java
+++ b/annotation-error-decoder/src/test/java/feign/error/AnnotationErrorDecoderInheritanceClassLevelAnnotationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/annotation-error-decoder/src/test/java/feign/error/AnnotationErrorDecoderInheritanceMethodLevelAnnotationTest.java
+++ b/annotation-error-decoder/src/test/java/feign/error/AnnotationErrorDecoderInheritanceMethodLevelAnnotationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/annotation-error-decoder/src/test/java/feign/error/AnnotationErrorDecoderInheritanceTest.java
+++ b/annotation-error-decoder/src/test/java/feign/error/AnnotationErrorDecoderInheritanceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/annotation-error-decoder/src/test/java/feign/error/AnnotationErrorDecoderNoAnnotationTest.java
+++ b/annotation-error-decoder/src/test/java/feign/error/AnnotationErrorDecoderNoAnnotationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/annotation-error-decoder/src/test/java/feign/error/AnnotationErrorDecoderPriorityTest.java
+++ b/annotation-error-decoder/src/test/java/feign/error/AnnotationErrorDecoderPriorityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/annotation-error-decoder/src/test/java/feign/error/TestPojo.java
+++ b/annotation-error-decoder/src/test/java/feign/error/TestPojo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/apt-test-generator/src/main/java/feign/apttestgenerator/ArgumentDefinition.java
+++ b/apt-test-generator/src/main/java/feign/apttestgenerator/ArgumentDefinition.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/apt-test-generator/src/main/java/feign/apttestgenerator/ClientDefinition.java
+++ b/apt-test-generator/src/main/java/feign/apttestgenerator/ClientDefinition.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/apt-test-generator/src/main/java/feign/apttestgenerator/GenerateTestStubAPT.java
+++ b/apt-test-generator/src/main/java/feign/apttestgenerator/GenerateTestStubAPT.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/apt-test-generator/src/main/java/feign/apttestgenerator/MethodDefinition.java
+++ b/apt-test-generator/src/main/java/feign/apttestgenerator/MethodDefinition.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/apt-test-generator/src/test/java/example/github/GitHubStub.java
+++ b/apt-test-generator/src/test/java/example/github/GitHubStub.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/apt-test-generator/src/test/java/feign/apttestgenerator/GenerateTestStubAPTTest.java
+++ b/apt-test-generator/src/test/java/feign/apttestgenerator/GenerateTestStubAPTTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/benchmark/src/main/java/feign/benchmark/DecoderIteratorsBenchmark.java
+++ b/benchmark/src/main/java/feign/benchmark/DecoderIteratorsBenchmark.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/benchmark/src/main/java/feign/benchmark/FeignTestInterface.java
+++ b/benchmark/src/main/java/feign/benchmark/FeignTestInterface.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/benchmark/src/main/java/feign/benchmark/RealRequestBenchmarks.java
+++ b/benchmark/src/main/java/feign/benchmark/RealRequestBenchmarks.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/benchmark/src/main/java/feign/benchmark/WhatShouldWeCacheBenchmarks.java
+++ b/benchmark/src/main/java/feign/benchmark/WhatShouldWeCacheBenchmarks.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/AlwaysEncodeBodyContract.java
+++ b/core/src/main/java/feign/AlwaysEncodeBodyContract.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/main/java/feign/AsyncClient.java
+++ b/core/src/main/java/feign/AsyncClient.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/AsyncFeign.java
+++ b/core/src/main/java/feign/AsyncFeign.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/main/java/feign/AsyncInvocation.java
+++ b/core/src/main/java/feign/AsyncInvocation.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/AsyncJoinException.java
+++ b/core/src/main/java/feign/AsyncJoinException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/AsyncResponseHandler.java
+++ b/core/src/main/java/feign/AsyncResponseHandler.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/Body.java
+++ b/core/src/main/java/feign/Body.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/Capability.java
+++ b/core/src/main/java/feign/Capability.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/Client.java
+++ b/core/src/main/java/feign/Client.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/main/java/feign/CollectionFormat.java
+++ b/core/src/main/java/feign/CollectionFormat.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/main/java/feign/DeclarativeContract.java
+++ b/core/src/main/java/feign/DeclarativeContract.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/main/java/feign/DefaultMethodHandler.java
+++ b/core/src/main/java/feign/DefaultMethodHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/main/java/feign/ExceptionPropagationPolicy.java
+++ b/core/src/main/java/feign/ExceptionPropagationPolicy.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/Experimental.java
+++ b/core/src/main/java/feign/Experimental.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/Feign.java
+++ b/core/src/main/java/feign/Feign.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/main/java/feign/FeignException.java
+++ b/core/src/main/java/feign/FeignException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/main/java/feign/HeaderMap.java
+++ b/core/src/main/java/feign/HeaderMap.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/Headers.java
+++ b/core/src/main/java/feign/Headers.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/InvocationHandlerFactory.java
+++ b/core/src/main/java/feign/InvocationHandlerFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/Logger.java
+++ b/core/src/main/java/feign/Logger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/main/java/feign/MethodInfo.java
+++ b/core/src/main/java/feign/MethodInfo.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/MethodMetadata.java
+++ b/core/src/main/java/feign/MethodMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/main/java/feign/Param.java
+++ b/core/src/main/java/feign/Param.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/QueryMap.java
+++ b/core/src/main/java/feign/QueryMap.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/QueryMapEncoder.java
+++ b/core/src/main/java/feign/QueryMapEncoder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/ReflectiveAsyncFeign.java
+++ b/core/src/main/java/feign/ReflectiveAsyncFeign.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/ReflectiveFeign.java
+++ b/core/src/main/java/feign/ReflectiveFeign.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/main/java/feign/Request.java
+++ b/core/src/main/java/feign/Request.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/main/java/feign/RequestInterceptor.java
+++ b/core/src/main/java/feign/RequestInterceptor.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/RequestLine.java
+++ b/core/src/main/java/feign/RequestLine.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/Response.java
+++ b/core/src/main/java/feign/Response.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/main/java/feign/ResponseMapper.java
+++ b/core/src/main/java/feign/ResponseMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/RetryableException.java
+++ b/core/src/main/java/feign/RetryableException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/Retryer.java
+++ b/core/src/main/java/feign/Retryer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/Target.java
+++ b/core/src/main/java/feign/Target.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/Types.java
+++ b/core/src/main/java/feign/Types.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/main/java/feign/Util.java
+++ b/core/src/main/java/feign/Util.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/main/java/feign/auth/Base64.java
+++ b/core/src/main/java/feign/auth/Base64.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/auth/BasicAuthRequestInterceptor.java
+++ b/core/src/main/java/feign/auth/BasicAuthRequestInterceptor.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/codec/DecodeException.java
+++ b/core/src/main/java/feign/codec/DecodeException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/codec/Decoder.java
+++ b/core/src/main/java/feign/codec/Decoder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/codec/EncodeException.java
+++ b/core/src/main/java/feign/codec/EncodeException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/codec/Encoder.java
+++ b/core/src/main/java/feign/codec/Encoder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/codec/ErrorDecoder.java
+++ b/core/src/main/java/feign/codec/ErrorDecoder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/codec/StringDecoder.java
+++ b/core/src/main/java/feign/codec/StringDecoder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/optionals/OptionalDecoder.java
+++ b/core/src/main/java/feign/optionals/OptionalDecoder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/querymap/BeanQueryMapEncoder.java
+++ b/core/src/main/java/feign/querymap/BeanQueryMapEncoder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/querymap/FieldQueryMapEncoder.java
+++ b/core/src/main/java/feign/querymap/FieldQueryMapEncoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/main/java/feign/stream/StreamDecoder.java
+++ b/core/src/main/java/feign/stream/StreamDecoder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/template/BodyTemplate.java
+++ b/core/src/main/java/feign/template/BodyTemplate.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/template/Expression.java
+++ b/core/src/main/java/feign/template/Expression.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/template/Expressions.java
+++ b/core/src/main/java/feign/template/Expressions.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/template/HeaderTemplate.java
+++ b/core/src/main/java/feign/template/HeaderTemplate.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/template/Literal.java
+++ b/core/src/main/java/feign/template/Literal.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/template/QueryTemplate.java
+++ b/core/src/main/java/feign/template/QueryTemplate.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/template/Template.java
+++ b/core/src/main/java/feign/template/Template.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/template/TemplateChunk.java
+++ b/core/src/main/java/feign/template/TemplateChunk.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/template/UriTemplate.java
+++ b/core/src/main/java/feign/template/UriTemplate.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/template/UriUtils.java
+++ b/core/src/main/java/feign/template/UriUtils.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/AlwaysEncodeBodyContractTest.java
+++ b/core/src/test/java/feign/AlwaysEncodeBodyContractTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/test/java/feign/AsyncFeignTest.java
+++ b/core/src/test/java/feign/AsyncFeignTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/test/java/feign/BaseApiTest.java
+++ b/core/src/test/java/feign/BaseApiTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/CapabilityTest.java
+++ b/core/src/test/java/feign/CapabilityTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/ChildPojo.java
+++ b/core/src/test/java/feign/ChildPojo.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/ContractWithRuntimeInjectionTest.java
+++ b/core/src/test/java/feign/ContractWithRuntimeInjectionTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/CustomPojo.java
+++ b/core/src/test/java/feign/CustomPojo.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/DefaultContractInheritanceTest.java
+++ b/core/src/test/java/feign/DefaultContractInheritanceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/test/java/feign/DefaultContractTest.java
+++ b/core/src/test/java/feign/DefaultContractTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/test/java/feign/DefaultQueryMapEncoderTest.java
+++ b/core/src/test/java/feign/DefaultQueryMapEncoderTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/EmptyTargetTest.java
+++ b/core/src/test/java/feign/EmptyTargetTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/EnumForNameTest.java
+++ b/core/src/test/java/feign/EnumForNameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/test/java/feign/FeignBuilderTest.java
+++ b/core/src/test/java/feign/FeignBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/test/java/feign/FeignExceptionTest.java
+++ b/core/src/test/java/feign/FeignExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/test/java/feign/FeignUnderAsyncTest.java
+++ b/core/src/test/java/feign/FeignUnderAsyncTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/test/java/feign/LoggerTest.java
+++ b/core/src/test/java/feign/LoggerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/test/java/feign/MethodMetadataPresenceTest.java
+++ b/core/src/test/java/feign/MethodMetadataPresenceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/MultipleLoggerTest.java
+++ b/core/src/test/java/feign/MultipleLoggerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/test/java/feign/OptionsTest.java
+++ b/core/src/test/java/feign/OptionsTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/PropertyPojo.java
+++ b/core/src/test/java/feign/PropertyPojo.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/QueryMapEncoderObject.java
+++ b/core/src/test/java/feign/QueryMapEncoderObject.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/ResponseTest.java
+++ b/core/src/test/java/feign/ResponseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/test/java/feign/RetryerTest.java
+++ b/core/src/test/java/feign/RetryerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/TargetTest.java
+++ b/core/src/test/java/feign/TargetTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/TypesResolveReturnTypeTest.java
+++ b/core/src/test/java/feign/TypesResolveReturnTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/test/java/feign/UtilTest.java
+++ b/core/src/test/java/feign/UtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/test/java/feign/assertj/FeignAssertions.java
+++ b/core/src/test/java/feign/assertj/FeignAssertions.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/assertj/MockWebServerAssertions.java
+++ b/core/src/test/java/feign/assertj/MockWebServerAssertions.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/assertj/RecordedRequestAssert.java
+++ b/core/src/test/java/feign/assertj/RecordedRequestAssert.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/assertj/RequestTemplateAssert.java
+++ b/core/src/test/java/feign/assertj/RequestTemplateAssert.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/auth/BasicAuthRequestInterceptorTest.java
+++ b/core/src/test/java/feign/auth/BasicAuthRequestInterceptorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/client/AbstractClientTest.java
+++ b/core/src/test/java/feign/client/AbstractClientTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/test/java/feign/client/DefaultClientTest.java
+++ b/core/src/test/java/feign/client/DefaultClientTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/core/src/test/java/feign/client/TrustingSSLSocketFactory.java
+++ b/core/src/test/java/feign/client/TrustingSSLSocketFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/codec/DefaultDecoderTest.java
+++ b/core/src/test/java/feign/codec/DefaultDecoderTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/codec/DefaultEncoderTest.java
+++ b/core/src/test/java/feign/codec/DefaultEncoderTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/codec/DefaultErrorDecoderHttpErrorTest.java
+++ b/core/src/test/java/feign/codec/DefaultErrorDecoderHttpErrorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/codec/DefaultErrorDecoderTest.java
+++ b/core/src/test/java/feign/codec/DefaultErrorDecoderTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/codec/RetryAfterDecoderTest.java
+++ b/core/src/test/java/feign/codec/RetryAfterDecoderTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/examples/GitHubExample.java
+++ b/core/src/test/java/feign/examples/GitHubExample.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/optionals/OptionalDecoderTests.java
+++ b/core/src/test/java/feign/optionals/OptionalDecoderTests.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/querymap/BeanQueryMapEncoderTest.java
+++ b/core/src/test/java/feign/querymap/BeanQueryMapEncoderTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/querymap/FieldQueryMapEncoderTest.java
+++ b/core/src/test/java/feign/querymap/FieldQueryMapEncoderTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/stream/StreamDecoderTest.java
+++ b/core/src/test/java/feign/stream/StreamDecoderTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/template/BodyTemplateTest.java
+++ b/core/src/test/java/feign/template/BodyTemplateTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/template/HeaderTemplateTest.java
+++ b/core/src/test/java/feign/template/HeaderTemplateTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/template/QueryTemplateTest.java
+++ b/core/src/test/java/feign/template/QueryTemplateTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/template/UriTemplateTest.java
+++ b/core/src/test/java/feign/template/UriTemplateTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/test/java/feign/template/UriUtilsTest.java
+++ b/core/src/test/java/feign/template/UriUtilsTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/dropwizard-metrics4/src/main/java/feign/metrics4/CountingInputStream.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/CountingInputStream.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/dropwizard-metrics4/src/main/java/feign/metrics4/FeignMetricName.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/FeignMetricName.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredBody.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredBody.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredClient.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredDecoder.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredEncoder.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredEncoder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredInvocationHandleFactory.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/MeteredInvocationHandleFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/dropwizard-metrics4/src/main/java/feign/metrics4/MetricSuppliers.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/MetricSuppliers.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/dropwizard-metrics4/src/main/java/feign/metrics4/Metrics4Capability.java
+++ b/dropwizard-metrics4/src/main/java/feign/metrics4/Metrics4Capability.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/dropwizard-metrics4/src/test/java/feign/metrics4/Metrics4CapabilityTest.java
+++ b/dropwizard-metrics4/src/test/java/feign/metrics4/Metrics4CapabilityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/dropwizard-metrics5/src/main/java/feign/metrics5/CountingInputStream.java
+++ b/dropwizard-metrics5/src/main/java/feign/metrics5/CountingInputStream.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/dropwizard-metrics5/src/main/java/feign/metrics5/FeignMetricName.java
+++ b/dropwizard-metrics5/src/main/java/feign/metrics5/FeignMetricName.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredBody.java
+++ b/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredBody.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredClient.java
+++ b/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredDecoder.java
+++ b/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredEncoder.java
+++ b/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredEncoder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredInvocationHandleFactory.java
+++ b/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredInvocationHandleFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/dropwizard-metrics5/src/main/java/feign/metrics5/MetricSuppliers.java
+++ b/dropwizard-metrics5/src/main/java/feign/metrics5/MetricSuppliers.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/dropwizard-metrics5/src/main/java/feign/metrics5/Metrics5Capability.java
+++ b/dropwizard-metrics5/src/main/java/feign/metrics5/Metrics5Capability.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/dropwizard-metrics5/src/test/java/feign/metrics5/Metrics5CapabilityTest.java
+++ b/dropwizard-metrics5/src/test/java/feign/metrics5/Metrics5CapabilityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/example-github/src/main/java/example/github/GitHubExample.java
+++ b/example-github/src/main/java/example/github/GitHubExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/example-github/src/test/java/feign/example/github/GitHubExampleIT.java
+++ b/example-github/src/test/java/feign/example/github/GitHubExampleIT.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/example-wikipedia/src/main/java/example/wikipedia/ResponseAdapter.java
+++ b/example-wikipedia/src/main/java/example/wikipedia/ResponseAdapter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/example-wikipedia/src/main/java/example/wikipedia/WikipediaExample.java
+++ b/example-wikipedia/src/main/java/example/wikipedia/WikipediaExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/example-wikipedia/src/test/java/feign/example/wikipedia/WikipediaExampleIT.java
+++ b/example-wikipedia/src/test/java/feign/example/wikipedia/WikipediaExampleIT.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/googlehttpclient/src/main/java/feign/googlehttpclient/GoogleHttpClient.java
+++ b/googlehttpclient/src/main/java/feign/googlehttpclient/GoogleHttpClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/googlehttpclient/src/test/java/feign/googlehttpclient/GoogleHttpClientTest.java
+++ b/googlehttpclient/src/test/java/feign/googlehttpclient/GoogleHttpClientTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/gson/src/main/java/feign/gson/DoubleToIntMapTypeAdapter.java
+++ b/gson/src/main/java/feign/gson/DoubleToIntMapTypeAdapter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/gson/src/main/java/feign/gson/GsonDecoder.java
+++ b/gson/src/main/java/feign/gson/GsonDecoder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/gson/src/main/java/feign/gson/GsonEncoder.java
+++ b/gson/src/main/java/feign/gson/GsonEncoder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/gson/src/main/java/feign/gson/GsonFactory.java
+++ b/gson/src/main/java/feign/gson/GsonFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/gson/src/test/java/feign/gson/GsonCodecTest.java
+++ b/gson/src/test/java/feign/gson/GsonCodecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/gson/src/test/java/feign/gson/examples/GitHubExample.java
+++ b/gson/src/test/java/feign/gson/examples/GitHubExample.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/hc5/src/main/java/feign/hc5/ApacheHttp5Client.java
+++ b/hc5/src/main/java/feign/hc5/ApacheHttp5Client.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/hc5/src/main/java/feign/hc5/AsyncApacheHttp5Client.java
+++ b/hc5/src/main/java/feign/hc5/AsyncApacheHttp5Client.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/hc5/src/test/java/feign/hc5/ApacheHttp5ClientTest.java
+++ b/hc5/src/test/java/feign/hc5/ApacheHttp5ClientTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/hc5/src/test/java/feign/hc5/AsyncApacheHttp5ClientTest.java
+++ b/hc5/src/test/java/feign/hc5/AsyncApacheHttp5ClientTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/hc5/src/test/java/feign/hc5/CustomPojo.java
+++ b/hc5/src/test/java/feign/hc5/CustomPojo.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
+++ b/httpclient/src/main/java/feign/httpclient/ApacheHttpClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/httpclient/src/test/java/feign/httpclient/ApacheHttpClientTest.java
+++ b/httpclient/src/test/java/feign/httpclient/ApacheHttpClientTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/hystrix/src/main/java/feign/hystrix/FallbackFactory.java
+++ b/hystrix/src/main/java/feign/hystrix/FallbackFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/hystrix/src/main/java/feign/hystrix/HystrixCapability.java
+++ b/hystrix/src/main/java/feign/hystrix/HystrixCapability.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/hystrix/src/main/java/feign/hystrix/HystrixDelegatingContract.java
+++ b/hystrix/src/main/java/feign/hystrix/HystrixDelegatingContract.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/hystrix/src/main/java/feign/hystrix/HystrixFeign.java
+++ b/hystrix/src/main/java/feign/hystrix/HystrixFeign.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/hystrix/src/main/java/feign/hystrix/HystrixInvocationHandler.java
+++ b/hystrix/src/main/java/feign/hystrix/HystrixInvocationHandler.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/hystrix/src/main/java/feign/hystrix/ObservableCompletableFuture.java
+++ b/hystrix/src/main/java/feign/hystrix/ObservableCompletableFuture.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/hystrix/src/main/java/feign/hystrix/SetterFactory.java
+++ b/hystrix/src/main/java/feign/hystrix/SetterFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/hystrix/src/test/java/feign/hystrix/FallbackFactoryTest.java
+++ b/hystrix/src/test/java/feign/hystrix/FallbackFactoryTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/hystrix/src/test/java/feign/hystrix/HystrixBuilderTest.java
+++ b/hystrix/src/test/java/feign/hystrix/HystrixBuilderTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/hystrix/src/test/java/feign/hystrix/HystrixCapabilityTest.java
+++ b/hystrix/src/test/java/feign/hystrix/HystrixCapabilityTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/hystrix/src/test/java/feign/hystrix/SetterFactoryTest.java
+++ b/hystrix/src/test/java/feign/hystrix/SetterFactoryTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jackson-jaxb/src/main/java/feign/jackson/jaxb/JacksonJaxbJsonDecoder.java
+++ b/jackson-jaxb/src/main/java/feign/jackson/jaxb/JacksonJaxbJsonDecoder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jackson-jaxb/src/main/java/feign/jackson/jaxb/JacksonJaxbJsonEncoder.java
+++ b/jackson-jaxb/src/main/java/feign/jackson/jaxb/JacksonJaxbJsonEncoder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jackson-jaxb/src/test/java/feign/jackson/jaxb/JacksonJaxbCodecTest.java
+++ b/jackson-jaxb/src/test/java/feign/jackson/jaxb/JacksonJaxbCodecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jackson-jr/src/main/java/feign/jackson/jr/JacksonJrDecoder.java
+++ b/jackson-jr/src/main/java/feign/jackson/jr/JacksonJrDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/jackson-jr/src/main/java/feign/jackson/jr/JacksonJrEncoder.java
+++ b/jackson-jr/src/main/java/feign/jackson/jr/JacksonJrEncoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/jackson-jr/src/main/java/feign/jackson/jr/JacksonJrMapper.java
+++ b/jackson-jr/src/main/java/feign/jackson/jr/JacksonJrMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/jackson-jr/src/test/java/feign/jackson/jr/JacksonCodecTest.java
+++ b/jackson-jr/src/test/java/feign/jackson/jr/JacksonCodecTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/jackson-jr/src/test/java/feign/jackson/jr/JavaLocalDateExtension.java
+++ b/jackson-jr/src/test/java/feign/jackson/jr/JavaLocalDateExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/jackson-jr/src/test/java/feign/jackson/jr/examples/GitHubExample.java
+++ b/jackson-jr/src/test/java/feign/jackson/jr/examples/GitHubExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/jackson/src/main/java/feign/jackson/JacksonDecoder.java
+++ b/jackson/src/main/java/feign/jackson/JacksonDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/jackson/src/main/java/feign/jackson/JacksonEncoder.java
+++ b/jackson/src/main/java/feign/jackson/JacksonEncoder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jackson/src/main/java/feign/jackson/JacksonIteratorDecoder.java
+++ b/jackson/src/main/java/feign/jackson/JacksonIteratorDecoder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
+++ b/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/jackson/src/test/java/feign/jackson/JacksonIteratorTest.java
+++ b/jackson/src/test/java/feign/jackson/JacksonIteratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/jackson/src/test/java/feign/jackson/examples/GitHubExample.java
+++ b/jackson/src/test/java/feign/jackson/examples/GitHubExample.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jackson/src/test/java/feign/jackson/examples/GitHubIteratorExample.java
+++ b/jackson/src/test/java/feign/jackson/examples/GitHubIteratorExample.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/java11/src/main/java/feign/http2client/Http2Client.java
+++ b/java11/src/main/java/feign/http2client/Http2Client.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/java11/src/test/java/feign/http2client/test/CustomPojo.java
+++ b/java11/src/test/java/feign/http2client/test/CustomPojo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/java11/src/test/java/feign/http2client/test/Http2ClientAsyncTest.java
+++ b/java11/src/test/java/feign/http2client/test/Http2ClientAsyncTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/java11/src/test/java/feign/http2client/test/Http2ClientTest.java
+++ b/java11/src/test/java/feign/http2client/test/Http2ClientTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/jaxb/src/main/java/feign/jaxb/JAXBContextFactory.java
+++ b/jaxb/src/main/java/feign/jaxb/JAXBContextFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jaxb/src/main/java/feign/jaxb/JAXBDecoder.java
+++ b/jaxb/src/main/java/feign/jaxb/JAXBDecoder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jaxb/src/main/java/feign/jaxb/JAXBEncoder.java
+++ b/jaxb/src/main/java/feign/jaxb/JAXBEncoder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
+++ b/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jaxb/src/test/java/feign/jaxb/JAXBContextFactoryTest.java
+++ b/jaxb/src/test/java/feign/jaxb/JAXBContextFactoryTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jaxb/src/test/java/feign/jaxb/examples/AWSSignatureVersion4.java
+++ b/jaxb/src/test/java/feign/jaxb/examples/AWSSignatureVersion4.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jaxb/src/test/java/feign/jaxb/examples/IAMExample.java
+++ b/jaxb/src/test/java/feign/jaxb/examples/IAMExample.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jaxb/src/test/java/feign/jaxb/examples/package-info.java
+++ b/jaxb/src/test/java/feign/jaxb/examples/package-info.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jaxrs/src/main/java/feign/jaxrs/JAXRSContract.java
+++ b/jaxrs/src/main/java/feign/jaxrs/JAXRSContract.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jaxrs/src/test/java/feign/jaxrs/JAXRSContractTest.java
+++ b/jaxrs/src/test/java/feign/jaxrs/JAXRSContractTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jaxrs/src/test/java/feign/jaxrs/examples/GitHubExample.java
+++ b/jaxrs/src/test/java/feign/jaxrs/examples/GitHubExample.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jaxrs2/src/main/java/feign/jaxrs2/JAXRS2Contract.java
+++ b/jaxrs2/src/main/java/feign/jaxrs2/JAXRS2Contract.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jaxrs2/src/main/java/feign/jaxrs2/JAXRSClient.java
+++ b/jaxrs2/src/main/java/feign/jaxrs2/JAXRSClient.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jaxrs2/src/test/java/feign/jaxrs2/JAXRS2ContractTest.java
+++ b/jaxrs2/src/test/java/feign/jaxrs2/JAXRS2ContractTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jaxrs2/src/test/java/feign/jaxrs2/JAXRSClientTest.java
+++ b/jaxrs2/src/test/java/feign/jaxrs2/JAXRSClientTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/json/src/main/java/feign/json/JsonDecoder.java
+++ b/json/src/main/java/feign/json/JsonDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/json/src/main/java/feign/json/JsonEncoder.java
+++ b/json/src/main/java/feign/json/JsonEncoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/json/src/test/java/feign/json/JsonCodecTest.java
+++ b/json/src/test/java/feign/json/JsonCodecTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/json/src/test/java/feign/json/JsonDecoderTest.java
+++ b/json/src/test/java/feign/json/JsonDecoderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/json/src/test/java/feign/json/JsonEncoderTest.java
+++ b/json/src/test/java/feign/json/JsonEncoderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/json/src/test/java/feign/json/examples/GitHubExample.java
+++ b/json/src/test/java/feign/json/examples/GitHubExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/micrometer/src/main/java/feign/micrometer/CountingInputStream.java
+++ b/micrometer/src/main/java/feign/micrometer/CountingInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/micrometer/src/main/java/feign/micrometer/FeignMetricName.java
+++ b/micrometer/src/main/java/feign/micrometer/FeignMetricName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/micrometer/src/main/java/feign/micrometer/FeignMetricTagResolver.java
+++ b/micrometer/src/main/java/feign/micrometer/FeignMetricTagResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/micrometer/src/main/java/feign/micrometer/MeteredBody.java
+++ b/micrometer/src/main/java/feign/micrometer/MeteredBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/micrometer/src/main/java/feign/micrometer/MeteredClient.java
+++ b/micrometer/src/main/java/feign/micrometer/MeteredClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/micrometer/src/main/java/feign/micrometer/MeteredDecoder.java
+++ b/micrometer/src/main/java/feign/micrometer/MeteredDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/micrometer/src/main/java/feign/micrometer/MeteredEncoder.java
+++ b/micrometer/src/main/java/feign/micrometer/MeteredEncoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/micrometer/src/main/java/feign/micrometer/MeteredInvocationHandleFactory.java
+++ b/micrometer/src/main/java/feign/micrometer/MeteredInvocationHandleFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/micrometer/src/main/java/feign/micrometer/MetricName.java
+++ b/micrometer/src/main/java/feign/micrometer/MetricName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/micrometer/src/main/java/feign/micrometer/MetricTagResolver.java
+++ b/micrometer/src/main/java/feign/micrometer/MetricTagResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/micrometer/src/main/java/feign/micrometer/MicrometerCapability.java
+++ b/micrometer/src/main/java/feign/micrometer/MicrometerCapability.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/micrometer/src/test/java/feign/micrometer/AbstractMetricsTestBase.java
+++ b/micrometer/src/test/java/feign/micrometer/AbstractMetricsTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/micrometer/src/test/java/feign/micrometer/MicrometerCapabilityTest.java
+++ b/micrometer/src/test/java/feign/micrometer/MicrometerCapabilityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/mock/src/main/java/feign/mock/HttpMethod.java
+++ b/mock/src/main/java/feign/mock/HttpMethod.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/mock/src/main/java/feign/mock/MockClient.java
+++ b/mock/src/main/java/feign/mock/MockClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/mock/src/main/java/feign/mock/MockTarget.java
+++ b/mock/src/main/java/feign/mock/MockTarget.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/mock/src/main/java/feign/mock/RequestHeaders.java
+++ b/mock/src/main/java/feign/mock/RequestHeaders.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/mock/src/main/java/feign/mock/RequestKey.java
+++ b/mock/src/main/java/feign/mock/RequestKey.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/mock/src/main/java/feign/mock/VerificationAssertionError.java
+++ b/mock/src/main/java/feign/mock/VerificationAssertionError.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/mock/src/test/java/feign/mock/HttpProtocolVersionTest.java
+++ b/mock/src/test/java/feign/mock/HttpProtocolVersionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/mock/src/test/java/feign/mock/MockClientSequentialTest.java
+++ b/mock/src/test/java/feign/mock/MockClientSequentialTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/mock/src/test/java/feign/mock/MockClientTest.java
+++ b/mock/src/test/java/feign/mock/MockClientTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/mock/src/test/java/feign/mock/MockTargetTest.java
+++ b/mock/src/test/java/feign/mock/MockTargetTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/mock/src/test/java/feign/mock/RequestHeadersTest.java
+++ b/mock/src/test/java/feign/mock/RequestHeadersTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/mock/src/test/java/feign/mock/RequestKeyTest.java
+++ b/mock/src/test/java/feign/mock/RequestKeyTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/okhttp/src/main/java/feign/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/feign/okhttp/OkHttpClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/okhttp/src/test/java/feign/okhttp/OkHttpClientTest.java
+++ b/okhttp/src/test/java/feign/okhttp/OkHttpClientTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/pom.xml
+++ b/pom.xml
@@ -582,7 +582,7 @@
           </excludes>
           <strictCheck>true</strictCheck>
           <mapping>
-            <java>JAVADOC_STYLE</java>
+            <java>SLASHSTAR_STYLE</java>
           </mapping>
         </configuration>
         <executions>

--- a/reactive/src/main/java/feign/reactive/ReactiveDelegatingContract.java
+++ b/reactive/src/main/java/feign/reactive/ReactiveDelegatingContract.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/reactive/src/main/java/feign/reactive/ReactiveFeign.java
+++ b/reactive/src/main/java/feign/reactive/ReactiveFeign.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/reactive/src/main/java/feign/reactive/ReactiveInvocationHandler.java
+++ b/reactive/src/main/java/feign/reactive/ReactiveInvocationHandler.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/reactive/src/main/java/feign/reactive/ReactorFeign.java
+++ b/reactive/src/main/java/feign/reactive/ReactorFeign.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/reactive/src/main/java/feign/reactive/ReactorInvocationHandler.java
+++ b/reactive/src/main/java/feign/reactive/ReactorInvocationHandler.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/reactive/src/main/java/feign/reactive/RxJavaFeign.java
+++ b/reactive/src/main/java/feign/reactive/RxJavaFeign.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/reactive/src/main/java/feign/reactive/RxJavaInvocationHandler.java
+++ b/reactive/src/main/java/feign/reactive/RxJavaInvocationHandler.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/reactive/src/test/java/feign/reactive/ReactiveDelegatingContractTest.java
+++ b/reactive/src/test/java/feign/reactive/ReactiveDelegatingContractTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/reactive/src/test/java/feign/reactive/ReactiveFeignIntegrationTest.java
+++ b/reactive/src/test/java/feign/reactive/ReactiveFeignIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/reactive/src/test/java/feign/reactive/ReactiveInvocationHandlerTest.java
+++ b/reactive/src/test/java/feign/reactive/ReactiveInvocationHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/ribbon/src/main/java/feign/ribbon/LBClient.java
+++ b/ribbon/src/main/java/feign/ribbon/LBClient.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/ribbon/src/main/java/feign/ribbon/LBClientFactory.java
+++ b/ribbon/src/main/java/feign/ribbon/LBClientFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/ribbon/src/main/java/feign/ribbon/LoadBalancingTarget.java
+++ b/ribbon/src/main/java/feign/ribbon/LoadBalancingTarget.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/ribbon/src/main/java/feign/ribbon/RibbonClient.java
+++ b/ribbon/src/main/java/feign/ribbon/RibbonClient.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/ribbon/src/test/java/feign/ribbon/LBClientFactoryTest.java
+++ b/ribbon/src/test/java/feign/ribbon/LBClientFactoryTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/ribbon/src/test/java/feign/ribbon/LBClientTest.java
+++ b/ribbon/src/test/java/feign/ribbon/LBClientTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/ribbon/src/test/java/feign/ribbon/LoadBalancingTargetTest.java
+++ b/ribbon/src/test/java/feign/ribbon/LoadBalancingTargetTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/ribbon/src/test/java/feign/ribbon/PropagateFirstIOExceptionTest.java
+++ b/ribbon/src/test/java/feign/ribbon/PropagateFirstIOExceptionTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/ribbon/src/test/java/feign/ribbon/RibbonClientTest.java
+++ b/ribbon/src/test/java/feign/ribbon/RibbonClientTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/sax/src/main/java/feign/sax/SAXDecoder.java
+++ b/sax/src/main/java/feign/sax/SAXDecoder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/sax/src/test/java/feign/sax/SAXDecoderTest.java
+++ b/sax/src/test/java/feign/sax/SAXDecoderTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/sax/src/test/java/feign/sax/examples/AWSSignatureVersion4.java
+++ b/sax/src/test/java/feign/sax/examples/AWSSignatureVersion4.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/sax/src/test/java/feign/sax/examples/IAMExample.java
+++ b/sax/src/test/java/feign/sax/examples/IAMExample.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/slf4j/src/main/java/feign/slf4j/Slf4jLogger.java
+++ b/slf4j/src/main/java/feign/slf4j/Slf4jLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/slf4j/src/test/java/feign/slf4j/Slf4jLoggerTest.java
+++ b/slf4j/src/test/java/feign/slf4j/Slf4jLoggerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/slf4j/src/test/java/org/slf4j/impl/RecordingSimpleLogger.java
+++ b/slf4j/src/test/java/org/slf4j/impl/RecordingSimpleLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/soap/src/main/java/feign/soap/SOAPDecoder.java
+++ b/soap/src/main/java/feign/soap/SOAPDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/soap/src/main/java/feign/soap/SOAPEncoder.java
+++ b/soap/src/main/java/feign/soap/SOAPEncoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/soap/src/main/java/feign/soap/SOAPErrorDecoder.java
+++ b/soap/src/main/java/feign/soap/SOAPErrorDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/soap/src/test/java/feign/soap/SOAPCodecTest.java
+++ b/soap/src/test/java/feign/soap/SOAPCodecTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/soap/src/test/java/feign/soap/SOAPFaultDecoderTest.java
+++ b/soap/src/test/java/feign/soap/SOAPFaultDecoderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/soap/src/test/java/feign/soap/package-info.java
+++ b/soap/src/test/java/feign/soap/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/spring4/src/main/java/feign/spring/SpringContract.java
+++ b/spring4/src/main/java/feign/spring/SpringContract.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/spring4/src/test/java/feign/spring/Data.java
+++ b/spring4/src/test/java/feign/spring/Data.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/spring4/src/test/java/feign/spring/SpringContractTest.java
+++ b/spring4/src/test/java/feign/spring/SpringContractTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2012-2020 The Feign Authors
+/*
+ * Copyright 2012-2021 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
I was scrolling through the source code and I noticed a warning that the license header is marked as `dangling javadoc comment` I did some research and found out that the better way is to have a license header in the following format:

```
/*
 *
 */
```

Instead of:
```
/**
 *
 */
```

I don't think the existing header is incorrect formatted but my idea gave warnings and this was a way to resolve it. Not quite sure if you guys want this change. Because I change the format the copyright date needed to be updated to 2021 because of the maven license plugin scan. Looking to hear from you soon.