### PR TITLE
 All decoders follow rule: if a status is 404 it returns empty or null value

### DIFF
--- a/core/src/main/java/feign/AsyncFeign.java
+++ b/core/src/main/java/feign/AsyncFeign.java
@@ -68,7 +68,7 @@ public abstract class AsyncFeign<C> extends Feign {
 
     private Decoder decoder = new Decoder.Default();
     private ErrorDecoder errorDecoder = new ErrorDecoder.Default();
-    private boolean decode404;
+    private boolean dismiss404;
     private boolean closeAfterDecode = true;
 
     public AsyncBuilder() {
@@ -104,9 +104,18 @@ public abstract class AsyncFeign<C> extends Feign {
 
     /**
      * @see Builder#decode404()
+     * @deprecated
      */
     public AsyncBuilder<C> decode404() {
-      this.decode404 = true;
+      this.dismiss404 = true;
+      return this;
+    }
+
+    /**
+     * @see Builder#dismiss404()
+     */
+    public AsyncBuilder<C> dismiss404() {
+      this.dismiss404 = true;
       return this;
     }
 
@@ -256,7 +265,7 @@ public abstract class AsyncFeign<C> extends Feign {
         asyncBuilder.logger,
         asyncBuilder.decoder,
         asyncBuilder.errorDecoder,
-        asyncBuilder.decode404,
+        asyncBuilder.dismiss404,
         asyncBuilder.closeAfterDecode);
 
     asyncBuilder.builder.client(this::stageExecution);

--- a/core/src/main/java/feign/AsyncResponseHandler.java
+++ b/core/src/main/java/feign/AsyncResponseHandler.java
@@ -37,17 +37,17 @@ class AsyncResponseHandler {
 
   private final Decoder decoder;
   private final ErrorDecoder errorDecoder;
-  private final boolean decode404;
+  private final boolean dismiss404;
   private final boolean closeAfterDecode;
 
   AsyncResponseHandler(Level logLevel, Logger logger, Decoder decoder, ErrorDecoder errorDecoder,
-      boolean decode404, boolean closeAfterDecode) {
+      boolean dismiss404, boolean closeAfterDecode) {
     super();
     this.logLevel = logLevel;
     this.logger = logger;
     this.decoder = decoder;
     this.errorDecoder = errorDecoder;
-    this.decode404 = decode404;
+    this.dismiss404 = dismiss404;
     this.closeAfterDecode = closeAfterDecode;
   }
 
@@ -88,7 +88,7 @@ class AsyncResponseHandler {
           shouldClose = closeAfterDecode;
           resultFuture.complete(result);
         }
-      } else if (decode404 && response.status() == 404 && !isVoidType(returnType)) {
+      } else if (dismiss404 && response.status() == 404 && !isVoidType(returnType)) {
         final Object result = decode(response, returnType);
         shouldClose = closeAfterDecode;
         resultFuture.complete(result);

--- a/core/src/main/java/feign/Feign.java
+++ b/core/src/main/java/feign/Feign.java
@@ -110,7 +110,7 @@ public abstract class Feign {
     private Options options = new Options();
     private InvocationHandlerFactory invocationHandlerFactory =
         new InvocationHandlerFactory.Default();
-    private boolean decode404;
+    private boolean dismiss404;
     private boolean closeAfterDecode = true;
     private ExceptionPropagationPolicy propagationPolicy = NONE;
     private boolean forceDecoding = false;
@@ -180,9 +180,32 @@ public abstract class Feign {
      * custom {@link #client(Client) client}.
      *
      * @since 8.12
+     * @deprecated
      */
     public Builder decode404() {
-      this.decode404 = true;
+      this.dismiss404 = true;
+      return this;
+    }
+
+    /**
+     * This flag indicates that the {@link #decoder(Decoder) decoder} should process responses with
+     * 404 status, specifically returning null or empty instead of throwing {@link FeignException}.
+     *
+     * <p/>
+     * All first-party (ex gson) decoders return well-known empty values defined by
+     * {@link Util#emptyValueOf}. To customize further, wrap an existing {@link #decoder(Decoder)
+     * decoder} or make your own.
+     *
+     * <p/>
+     * This flag only works with 404, as opposed to all or arbitrary status codes. This was an
+     * explicit decision: 404 -> empty is safe, common and doesn't complicate redirection, retry or
+     * fallback policy. If your server returns a different status for not-found, correct via a
+     * custom {@link #client(Client) client}.
+     *
+     * @since 11.9
+     */
+    public Builder dismiss404() {
+      this.dismiss404 = true;
       return this;
     }
 
@@ -285,7 +308,7 @@ public abstract class Feign {
 
       SynchronousMethodHandler.Factory synchronousMethodHandlerFactory =
           new SynchronousMethodHandler.Factory(client, retryer, requestInterceptors, logger,
-              logLevel, decode404, closeAfterDecode, propagationPolicy, forceDecoding);
+              logLevel, dismiss404, closeAfterDecode, propagationPolicy, forceDecoding);
       ParseHandlersByName handlersByName =
           new ParseHandlersByName(contract, options, encoder, decoder, queryMapEncoder,
               errorDecoder, synchronousMethodHandlerFactory);

--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -51,7 +51,7 @@ final class SynchronousMethodHandler implements MethodHandler {
       List<RequestInterceptor> requestInterceptors, Logger logger,
       Logger.Level logLevel, MethodMetadata metadata,
       RequestTemplate.Factory buildTemplateFromArgs, Options options,
-      Decoder decoder, ErrorDecoder errorDecoder, boolean decode404,
+      Decoder decoder, ErrorDecoder errorDecoder, boolean dismiss404,
       boolean closeAfterDecode, ExceptionPropagationPolicy propagationPolicy,
       boolean forceDecoding) {
 
@@ -75,7 +75,7 @@ final class SynchronousMethodHandler implements MethodHandler {
     } else {
       this.decoder = null;
       this.asyncResponseHandler = new AsyncResponseHandler(logLevel, logger, decoder, errorDecoder,
-          decode404, closeAfterDecode);
+          dismiss404, closeAfterDecode);
     }
   }
 
@@ -181,20 +181,20 @@ final class SynchronousMethodHandler implements MethodHandler {
     private final List<RequestInterceptor> requestInterceptors;
     private final Logger logger;
     private final Logger.Level logLevel;
-    private final boolean decode404;
+    private final boolean dismiss404;
     private final boolean closeAfterDecode;
     private final ExceptionPropagationPolicy propagationPolicy;
     private final boolean forceDecoding;
 
     Factory(Client client, Retryer retryer, List<RequestInterceptor> requestInterceptors,
-        Logger logger, Logger.Level logLevel, boolean decode404, boolean closeAfterDecode,
+        Logger logger, Logger.Level logLevel, boolean dismiss404, boolean closeAfterDecode,
         ExceptionPropagationPolicy propagationPolicy, boolean forceDecoding) {
       this.client = checkNotNull(client, "client");
       this.retryer = checkNotNull(retryer, "retryer");
       this.requestInterceptors = checkNotNull(requestInterceptors, "requestInterceptors");
       this.logger = checkNotNull(logger, "logger");
       this.logLevel = checkNotNull(logLevel, "logLevel");
-      this.decode404 = decode404;
+      this.dismiss404 = dismiss404;
       this.closeAfterDecode = closeAfterDecode;
       this.propagationPolicy = propagationPolicy;
       this.forceDecoding = forceDecoding;
@@ -208,7 +208,7 @@ final class SynchronousMethodHandler implements MethodHandler {
                                 ErrorDecoder errorDecoder) {
       return new SynchronousMethodHandler(target, client, retryer, requestInterceptors, logger,
           logLevel, md, buildTemplateFromArgs, options, decoder,
-          errorDecoder, decode404, closeAfterDecode, propagationPolicy, forceDecoding);
+          errorDecoder, dismiss404, closeAfterDecode, propagationPolicy, forceDecoding);
     }
   }
 }

--- a/core/src/main/java/feign/Util.java
+++ b/core/src/main/java/feign/Util.java
@@ -241,7 +241,7 @@ public class Util {
    * </ul>
    *
    * <p/>
-   * When {@link Feign.Builder#decode404() decoding HTTP 404 status}, you'll need to teach decoders
+   * When {@link Feign.Builder#dismiss404() decoding HTTP 404 status}, you'll need to teach decoders
    * a default empty value for a type. This method cheaply supports typical types by only looking at
    * the raw type (vs type hierarchy). Decorate for sophistication.
    */

--- a/core/src/main/java/feign/codec/Decoder.java
+++ b/core/src/main/java/feign/codec/Decoder.java
@@ -58,7 +58,7 @@ import feign.Util;
  * List<Foo>}. <br/>
  * <h3>Note on exception propagation</h3> Exceptions thrown by {@link Decoder}s get wrapped in a
  * {@link DecodeException} unless they are a subclass of {@link FeignException} already, and unless
- * the client was configured with {@link Feign.Builder#decode404()}.
+ * the client was configured with {@link Feign.Builder#dismiss404()}.
  */
 public interface Decoder {
 

--- a/core/src/main/java/feign/codec/ErrorDecoder.java
+++ b/core/src/main/java/feign/codec/ErrorDecoder.java
@@ -64,7 +64,7 @@ import java.util.Map;
  * <p/>
  * It is commonly the case that 404 (Not Found) status has semantic value in HTTP apis. While the
  * default behavior is to raise exeception, users can alternatively enable 404 processing via
- * {@link feign.Feign.Builder#decode404()}.
+ * {@link feign.Feign.Builder#dismiss404()}.
  */
 public interface ErrorDecoder {
 

--- a/core/src/main/java/feign/codec/StringDecoder.java
+++ b/core/src/main/java/feign/codec/StringDecoder.java
@@ -24,7 +24,7 @@ public class StringDecoder implements Decoder {
   @Override
   public Object decode(Response response, Type type) throws IOException {
     Response.Body body = response.body();
-    if (body == null) {
+    if (response.status() == 404 || response.status() == 204 || body == null) {
       return null;
     }
     if (String.class.equals(type)) {

--- a/core/src/test/java/feign/AsyncFeignTest.java
+++ b/core/src/test/java/feign/AsyncFeignTest.java
@@ -583,12 +583,12 @@ public class AsyncFeignTest {
   }
 
   @Test
-  public void decodingExceptionGetWrappedInDecode404Mode() throws Throwable {
+  public void decodingExceptionGetWrappedInDismiss404Mode() throws Throwable {
     server.enqueue(new MockResponse().setResponseCode(404));
     thrown.expect(DecodeException.class);
     thrown.expectCause(isA(NoSuchElementException.class));;
 
-    TestInterfaceAsync api = new TestInterfaceAsyncBuilder().decode404().decoder(new Decoder() {
+    TestInterfaceAsync api = new TestInterfaceAsyncBuilder().dismiss404().decoder(new Decoder() {
       @Override
       public Object decode(Response response, Type type) throws IOException {
         assertEquals(404, response.status());
@@ -600,11 +600,11 @@ public class AsyncFeignTest {
   }
 
   @Test
-  public void decodingDoesNotSwallow404ErrorsInDecode404Mode() throws Throwable {
+  public void decodingDoesNotSwallow404ErrorsInDismiss404Mode() throws Throwable {
     server.enqueue(new MockResponse().setResponseCode(404));
     thrown.expect(IllegalArgumentException.class);
 
-    TestInterfaceAsync api = new TestInterfaceAsyncBuilder().decode404()
+    TestInterfaceAsync api = new TestInterfaceAsyncBuilder().dismiss404()
         .errorDecoder(new IllegalArgumentExceptionOn404())
         .target("http://localhost:" + server.getPort());
 
@@ -1010,8 +1010,8 @@ public class AsyncFeignTest {
       return this;
     }
 
-    TestInterfaceAsyncBuilder decode404() {
-      delegate.decode404();
+    TestInterfaceAsyncBuilder dismiss404() {
+      delegate.dismiss404();
       return this;
     }
 

--- a/core/src/test/java/feign/FeignBuilderTest.java
+++ b/core/src/test/java/feign/FeignBuilderTest.java
@@ -66,7 +66,7 @@ public class FeignBuilderTest {
 
   /** Shows exception handling isn't required to coerce 404 to null or empty */
   @Test
-  public void testDecode404() {
+  public void testDismiss404() {
     server.enqueue(new MockResponse().setResponseCode(404));
     server.enqueue(new MockResponse().setResponseCode(404));
     server.enqueue(new MockResponse().setResponseCode(404));
@@ -75,7 +75,7 @@ public class FeignBuilderTest {
     server.enqueue(new MockResponse().setResponseCode(400));
 
     String url = "http://localhost:" + server.getPort();
-    TestInterface api = Feign.builder().decode404().target(TestInterface.class, url);
+    TestInterface api = Feign.builder().dismiss404().target(TestInterface.class, url);
 
     assertThat(api.getQueues("/")).isEmpty(); // empty, not null!
     assertThat(api.decodedLazyPost().hasNext()).isFalse(); // empty, not null!

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -723,13 +723,13 @@ public class FeignTest {
   }
 
   @Test
-  public void decodingExceptionGetWrappedInDecode404Mode() throws Exception {
+  public void decodingExceptionGetWrappedInDismiss404Mode() throws Exception {
     server.enqueue(new MockResponse().setResponseCode(404));
     thrown.expect(DecodeException.class);
     thrown.expectCause(isA(NoSuchElementException.class));;
 
     TestInterface api = new TestInterfaceBuilder()
-        .decode404()
+        .dismiss404()
         .decoder(new Decoder() {
           @Override
           public Object decode(Response response, Type type) throws IOException {
@@ -741,12 +741,12 @@ public class FeignTest {
   }
 
   @Test
-  public void decodingDoesNotSwallow404ErrorsInDecode404Mode() throws Exception {
+  public void decodingDoesNotSwallow404ErrorsInDismiss404Mode() throws Exception {
     server.enqueue(new MockResponse().setResponseCode(404));
     thrown.expect(IllegalArgumentException.class);
 
     TestInterface api = new TestInterfaceBuilder()
-        .decode404()
+        .dismiss404()
         .errorDecoder(new IllegalArgumentExceptionOn404())
         .target("http://localhost:" + server.getPort());
     api.queryMap(Collections.<String, Object>emptyMap());
@@ -1168,8 +1168,8 @@ public class FeignTest {
       return this;
     }
 
-    TestInterfaceBuilder decode404() {
-      delegate.decode404();
+    TestInterfaceBuilder dismiss404() {
+      delegate.dismiss404();
       return this;
     }
 

--- a/core/src/test/java/feign/FeignUnderAsyncTest.java
+++ b/core/src/test/java/feign/FeignUnderAsyncTest.java
@@ -582,13 +582,13 @@ public class FeignUnderAsyncTest {
   }
 
   @Test
-  public void decodingExceptionGetWrappedInDecode404Mode() throws Exception {
+  public void decodingExceptionGetWrappedInDismiss404Mode() throws Exception {
     server.enqueue(new MockResponse().setResponseCode(404));
     thrown.expect(DecodeException.class);
     thrown.expectCause(isA(NoSuchElementException.class));;
 
     TestInterface api = new TestInterfaceBuilder()
-        .decode404()
+        .dismiss404()
         .decoder(new Decoder() {
           @Override
           public Object decode(Response response, Type type) throws IOException {
@@ -600,12 +600,12 @@ public class FeignUnderAsyncTest {
   }
 
   @Test
-  public void decodingDoesNotSwallow404ErrorsInDecode404Mode() throws Exception {
+  public void decodingDoesNotSwallow404ErrorsInDismiss404Mode() throws Exception {
     server.enqueue(new MockResponse().setResponseCode(404));
     thrown.expect(IllegalArgumentException.class);
 
     TestInterface api = new TestInterfaceBuilder()
-        .decode404()
+        .dismiss404()
         .errorDecoder(new IllegalArgumentExceptionOn404())
         .target("http://localhost:" + server.getPort());
     api.queryMap(Collections.<String, Object>emptyMap());
@@ -1000,8 +1000,8 @@ public class FeignUnderAsyncTest {
       return this;
     }
 
-    TestInterfaceBuilder decode404() {
-      delegate.decode404();
+    TestInterfaceBuilder dismiss404() {
+      delegate.dismiss404();
       return this;
     }
 

--- a/core/src/test/java/feign/optionals/OptionalDecoderTests.java
+++ b/core/src/test/java/feign/optionals/OptionalDecoderTests.java
@@ -40,7 +40,7 @@ public class OptionalDecoderTests {
     server.enqueue(new MockResponse().setBody("foo"));
 
     final OptionalInterface api = Feign.builder()
-        .decode404()
+        .dismiss404()
         .decoder(new OptionalDecoder(new Decoder.Default()))
         .target(OptionalInterface.class, server.url("/").toString());
 

--- a/gson/src/main/java/feign/gson/GsonDecoder.java
+++ b/gson/src/main/java/feign/gson/GsonDecoder.java
@@ -21,6 +21,7 @@ import java.io.Reader;
 import java.lang.reflect.Type;
 import java.util.Collections;
 import feign.Response;
+import feign.Util;
 import feign.codec.Decoder;
 import static feign.Util.UTF_8;
 import static feign.Util.ensureClosed;
@@ -43,6 +44,8 @@ public class GsonDecoder implements Decoder {
 
   @Override
   public Object decode(Response response, Type type) throws IOException {
+    if (response.status() == 404 || response.status() == 204)
+      return Util.emptyValueOf(type);
     if (response.body() == null)
       return null;
     Reader reader = response.body().asReader(UTF_8);

--- a/gson/src/test/java/feign/gson/GsonCodecTest.java
+++ b/gson/src/test/java/feign/gson/GsonCodecTest.java
@@ -226,7 +226,7 @@ public class GsonCodecTest {
         + "]");
   }
 
-  /** Enabled via {@link feign.Feign.Builder#decode404()} */
+  /** Enabled via {@link feign.Feign.Builder#dismiss404()} */
   @Test
   public void notFoundDecodesToEmpty() throws Exception {
     Response response = Response.builder()

--- a/gson/src/test/java/feign/gson/GsonCodecTest.java
+++ b/gson/src/test/java/feign/gson/GsonCodecTest.java
@@ -228,13 +228,13 @@ public class GsonCodecTest {
 
   /** Enabled via {@link feign.Feign.Builder#decode404()} */
   @Test
-  public void notFoundDecodesToNull() throws Exception {
+  public void notFoundDecodesToEmpty() throws Exception {
     Response response = Response.builder()
         .status(404)
         .reason("NOT FOUND")
         .headers(Collections.emptyMap())
         .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .build();
-    assertThat((byte[]) new GsonDecoder().decode(response, byte[].class)).isNull();
+    assertThat((byte[]) new GsonDecoder().decode(response, byte[].class)).isEmpty();
   }
 }

--- a/hc5/src/test/java/feign/hc5/AsyncApacheHttp5ClientTest.java
+++ b/hc5/src/test/java/feign/hc5/AsyncApacheHttp5ClientTest.java
@@ -529,13 +529,13 @@ public class AsyncApacheHttp5ClientTest {
   }
 
   @Test
-  public void decodingExceptionGetWrappedInDecode404Mode() throws Throwable {
+  public void decodingExceptionGetWrappedInDismiss404Mode() throws Throwable {
     server.enqueue(new MockResponse().setResponseCode(404));
     thrown.expect(DecodeException.class);
     thrown.expectCause(isA(NoSuchElementException.class));
 
     final TestInterfaceAsync api =
-        new TestInterfaceAsyncBuilder().decode404().decoder((response, type) -> {
+        new TestInterfaceAsyncBuilder().dismiss404().decoder((response, type) -> {
           assertEquals(404, response.status());
           throw new NoSuchElementException();
         }).target("http://localhost:" + server.getPort());
@@ -544,11 +544,11 @@ public class AsyncApacheHttp5ClientTest {
   }
 
   @Test
-  public void decodingDoesNotSwallow404ErrorsInDecode404Mode() throws Throwable {
+  public void decodingDoesNotSwallow404ErrorsInDismiss404Mode() throws Throwable {
     server.enqueue(new MockResponse().setResponseCode(404));
     thrown.expect(IllegalArgumentException.class);
 
-    final TestInterfaceAsync api = new TestInterfaceAsyncBuilder().decode404()
+    final TestInterfaceAsync api = new TestInterfaceAsyncBuilder().dismiss404()
         .errorDecoder(new IllegalArgumentExceptionOn404())
         .target("http://localhost:" + server.getPort());
 
@@ -956,8 +956,8 @@ public class AsyncApacheHttp5ClientTest {
       return this;
     }
 
-    TestInterfaceAsyncBuilder decode404() {
-      delegate.decode404();
+    TestInterfaceAsyncBuilder dismiss404() {
+      delegate.dismiss404();
       return this;
     }
 

--- a/hystrix/src/main/java/feign/hystrix/HystrixFeign.java
+++ b/hystrix/src/main/java/feign/hystrix/HystrixFeign.java
@@ -193,6 +193,11 @@ public final class HystrixFeign {
     }
 
     @Override
+    public Builder dismiss404() {
+      return (Builder) super.dismiss404();
+    }
+
+    @Override
     public Builder errorDecoder(ErrorDecoder errorDecoder) {
       return (Builder) super.errorDecoder(errorDecoder);
     }

--- a/jackson-jaxb/src/main/java/feign/jackson/jaxb/JacksonJaxbJsonDecoder.java
+++ b/jackson-jaxb/src/main/java/feign/jackson/jaxb/JacksonJaxbJsonDecoder.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import feign.FeignException;
 import feign.Response;
+import feign.Util;
 import feign.codec.Decoder;
 import static com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider.DEFAULT_ANNOTATIONS;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
@@ -36,6 +37,8 @@ public final class JacksonJaxbJsonDecoder implements Decoder {
 
   @Override
   public Object decode(Response response, Type type) throws IOException, FeignException {
+    if (response.status() == 404 || response.status() == 204)
+      return Util.emptyValueOf(type);
     if (response.body() == null)
       return null;
     return jacksonJaxbJsonProvider.readFrom(Object.class, type, null, APPLICATION_JSON_TYPE, null,

--- a/jackson-jaxb/src/test/java/feign/jackson/jaxb/JacksonJaxbCodecTest.java
+++ b/jackson-jaxb/src/test/java/feign/jackson/jaxb/JacksonJaxbCodecTest.java
@@ -56,7 +56,7 @@ public class JacksonJaxbCodecTest {
   }
 
   /**
-   * Enabled via {@link feign.Feign.Builder#decode404()}
+   * Enabled via {@link feign.Feign.Builder#dismiss404()}
    */
   @Test
   public void notFoundDecodesToEmpty() throws Exception {

--- a/jackson-jaxb/src/test/java/feign/jackson/jaxb/JacksonJaxbCodecTest.java
+++ b/jackson-jaxb/src/test/java/feign/jackson/jaxb/JacksonJaxbCodecTest.java
@@ -59,14 +59,14 @@ public class JacksonJaxbCodecTest {
    * Enabled via {@link feign.Feign.Builder#decode404()}
    */
   @Test
-  public void notFoundDecodesToNull() throws Exception {
+  public void notFoundDecodesToEmpty() throws Exception {
     Response response = Response.builder()
         .status(404)
         .reason("NOT FOUND")
         .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .headers(Collections.emptyMap())
         .build();
-    assertThat((byte[]) new JacksonJaxbJsonDecoder().decode(response, byte[].class)).isNull();
+    assertThat((byte[]) new JacksonJaxbJsonDecoder().decode(response, byte[].class)).isEmpty();
   }
 
   @XmlRootElement

--- a/jackson-jr/src/main/java/feign/jackson/jr/JacksonJrDecoder.java
+++ b/jackson-jr/src/main/java/feign/jackson/jr/JacksonJrDecoder.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.JSONObjectException;
 import com.fasterxml.jackson.jr.ob.JacksonJrExtension;
 import feign.Response;
+import feign.Util;
 import feign.codec.DecodeException;
 import feign.codec.Decoder;
 import java.io.BufferedReader;
@@ -65,6 +66,9 @@ public class JacksonJrDecoder extends JacksonJrMapper implements Decoder {
 
     Transformer transformer = findTransformer(response, type);
 
+    if (response.status() == 404 || response.status() == 204) {
+      return Util.emptyValueOf(type);
+    }
     if (response.body() == null) {
       return null;
     }

--- a/jackson-jr/src/test/java/feign/jackson/jr/JacksonCodecTest.java
+++ b/jackson-jr/src/test/java/feign/jackson/jr/JacksonCodecTest.java
@@ -271,7 +271,7 @@ public class JacksonCodecTest {
     }
   }
 
-  /** Enabled via {@link feign.Feign.Builder#decode404()} */
+  /** Enabled via {@link feign.Feign.Builder#dismiss404()} */
   @Test
   public void notFoundDecodesToEmpty() throws Exception {
     Response response = Response.builder()

--- a/jackson-jr/src/test/java/feign/jackson/jr/JacksonCodecTest.java
+++ b/jackson-jr/src/test/java/feign/jackson/jr/JacksonCodecTest.java
@@ -90,18 +90,18 @@ public class JacksonCodecTest {
   }
 
   @Test
-  public void nullBodyDecodesToNull() throws Exception {
+  public void nullBodyDecodesToEmpty() throws Exception {
     Response response = Response.builder()
         .status(204)
         .reason("OK")
         .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .headers(Collections.emptyMap())
         .build();
-    assertNull(new JacksonJrDecoder().decode(response, String.class));
+    assertThat((byte[]) new JacksonJrDecoder().decode(response, byte[].class)).isEmpty();
   }
 
   @Test
-  public void emptyBodyDecodesToNull() throws Exception {
+  public void emptyBodyDecodesToEmpty() throws Exception {
     Response response = Response.builder()
         .status(204)
         .reason("OK")
@@ -109,7 +109,7 @@ public class JacksonCodecTest {
         .headers(Collections.emptyMap())
         .body(new byte[0])
         .build();
-    assertNull(new JacksonJrDecoder().decode(response, String.class));
+    assertThat((byte[]) new JacksonJrDecoder().decode(response, byte[].class)).isEmpty();
   }
 
   @Test
@@ -273,13 +273,13 @@ public class JacksonCodecTest {
 
   /** Enabled via {@link feign.Feign.Builder#decode404()} */
   @Test
-  public void notFoundDecodesToNull() throws Exception {
+  public void notFoundDecodesToEmpty() throws Exception {
     Response response = Response.builder()
         .status(404)
         .reason("NOT FOUND")
         .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .headers(Collections.emptyMap())
         .build();
-    assertThat((byte[]) new JacksonJrDecoder().decode(response, byte[].class)).isNull();
+    assertThat((byte[]) new JacksonJrDecoder().decode(response, byte[].class)).isEmpty();
   }
 }

--- a/jackson/src/main/java/feign/jackson/JacksonDecoder.java
+++ b/jackson/src/main/java/feign/jackson/JacksonDecoder.java
@@ -47,6 +47,8 @@ public class JacksonDecoder implements Decoder {
 
   @Override
   public Object decode(Response response, Type type) throws IOException {
+    if (response.status() == 404 || response.status() == 204)
+      return Util.emptyValueOf(type);
     if (response.body() == null)
       return null;
     Reader reader = response.body().asReader(response.charset());

--- a/jackson/src/main/java/feign/jackson/JacksonIteratorDecoder.java
+++ b/jackson/src/main/java/feign/jackson/JacksonIteratorDecoder.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.*;
 import feign.Response;
+import feign.Util;
 import feign.codec.DecodeException;
 import feign.codec.Decoder;
 import java.io.BufferedReader;
@@ -64,6 +65,8 @@ public final class JacksonIteratorDecoder implements Decoder {
 
   @Override
   public Object decode(Response response, Type type) throws IOException {
+    if (response.status() == 404 || response.status() == 204)
+      return Util.emptyValueOf(type);
     if (response.body() == null)
       return null;
     Reader reader = response.body().asReader(UTF_8);

--- a/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
+++ b/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
@@ -304,7 +304,7 @@ public class JacksonCodecTest {
     }
   }
 
-  /** Enabled via {@link feign.Feign.Builder#decode404()} */
+  /** Enabled via {@link feign.Feign.Builder#dismiss404()} */
   @Test
   public void notFoundDecodesToEmpty() throws Exception {
     Response response = Response.builder()
@@ -316,7 +316,7 @@ public class JacksonCodecTest {
     assertThat((byte[]) new JacksonDecoder().decode(response, byte[].class)).isEmpty();
   }
 
-  /** Enabled via {@link feign.Feign.Builder#decode404()} */
+  /** Enabled via {@link feign.Feign.Builder#dismiss404()} */
   @Test
   public void notFoundDecodesToEmptyIterator() throws Exception {
     Response response = Response.builder()

--- a/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
+++ b/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
@@ -223,18 +223,18 @@ public class JacksonCodecTest {
   }
 
   @Test
-  public void nullBodyDecodesToNullIterator() throws Exception {
+  public void nullBodyDecodesToEmptyIterator() throws Exception {
     Response response = Response.builder()
         .status(204)
         .reason("OK")
         .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .headers(Collections.emptyMap())
         .build();
-    assertNull(JacksonIteratorDecoder.create().decode(response, Iterator.class));
+    assertThat((byte[]) JacksonIteratorDecoder.create().decode(response, byte[].class)).isEmpty();
   }
 
   @Test
-  public void emptyBodyDecodesToNullIterator() throws Exception {
+  public void emptyBodyDecodesToEmptyIterator() throws Exception {
     Response response = Response.builder()
         .status(204)
         .reason("OK")
@@ -242,7 +242,7 @@ public class JacksonCodecTest {
         .headers(Collections.emptyMap())
         .body(new byte[0])
         .build();
-    assertNull(JacksonIteratorDecoder.create().decode(response, Iterator.class));
+    assertThat((byte[]) JacksonIteratorDecoder.create().decode(response, byte[].class)).isEmpty();
   }
 
   static class Zone extends LinkedHashMap<String, Object> {
@@ -306,25 +306,25 @@ public class JacksonCodecTest {
 
   /** Enabled via {@link feign.Feign.Builder#decode404()} */
   @Test
-  public void notFoundDecodesToNull() throws Exception {
+  public void notFoundDecodesToEmpty() throws Exception {
     Response response = Response.builder()
         .status(404)
         .reason("NOT FOUND")
         .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .headers(Collections.emptyMap())
         .build();
-    assertThat((byte[]) new JacksonDecoder().decode(response, byte[].class)).isNull();
+    assertThat((byte[]) new JacksonDecoder().decode(response, byte[].class)).isEmpty();
   }
 
   /** Enabled via {@link feign.Feign.Builder#decode404()} */
   @Test
-  public void notFoundDecodesToNullIterator() throws Exception {
+  public void notFoundDecodesToEmptyIterator() throws Exception {
     Response response = Response.builder()
         .status(404)
         .reason("NOT FOUND")
         .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .headers(Collections.emptyMap())
         .build();
-    assertThat((byte[]) JacksonIteratorDecoder.create().decode(response, byte[].class)).isNull();
+    assertThat((byte[]) JacksonIteratorDecoder.create().decode(response, byte[].class)).isEmpty();
   }
 }

--- a/java11/src/test/java/feign/http2client/test/Http2ClientAsyncTest.java
+++ b/java11/src/test/java/feign/http2client/test/Http2ClientAsyncTest.java
@@ -577,13 +577,13 @@ public class Http2ClientAsyncTest {
   }
 
   @Test
-  public void decodingExceptionGetWrappedInDecode404Mode() throws Throwable {
+  public void decodingExceptionGetWrappedInDismiss404Mode() throws Throwable {
     server.enqueue(new MockResponse().setResponseCode(404));
     thrown.expect(DecodeException.class);
     thrown.expectCause(isA(NoSuchElementException.class));
 
     final TestInterfaceAsync api =
-        newAsyncBuilder().decode404().decoder((response, type) -> {
+        newAsyncBuilder().dismiss404().decoder((response, type) -> {
           assertEquals(404, response.status());
           throw new NoSuchElementException();
         }).target("http://localhost:" + server.getPort());
@@ -592,11 +592,11 @@ public class Http2ClientAsyncTest {
   }
 
   @Test
-  public void decodingDoesNotSwallow404ErrorsInDecode404Mode() throws Throwable {
+  public void decodingDoesNotSwallow404ErrorsInDismiss404Mode() throws Throwable {
     server.enqueue(new MockResponse().setResponseCode(404));
     thrown.expect(IllegalArgumentException.class);
 
-    final TestInterfaceAsync api = newAsyncBuilder().decode404()
+    final TestInterfaceAsync api = newAsyncBuilder().dismiss404()
         .errorDecoder(new IllegalArgumentExceptionOn404())
         .target("http://localhost:" + server.getPort());
 
@@ -1010,8 +1010,8 @@ public class Http2ClientAsyncTest {
       return this;
     }
 
-    TestInterfaceAsyncBuilder decode404() {
-      delegate.decode404();
+    TestInterfaceAsyncBuilder dismiss404() {
+      delegate.dismiss404();
       return this;
     }
 

--- a/jaxb/src/main/java/feign/jaxb/JAXBDecoder.java
+++ b/jaxb/src/main/java/feign/jaxb/JAXBDecoder.java
@@ -64,7 +64,7 @@ public class JAXBDecoder implements Decoder {
 
   @Override
   public Object decode(Response response, Type type) throws IOException {
-    if (response.status() == 204)
+    if (response.status() == 404 || response.status() == 204)
       return Util.emptyValueOf(type);
     if (response.body() == null)
       return null;

--- a/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
+++ b/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
@@ -242,7 +242,7 @@ public class JAXBCodecTest {
   }
 
   /**
-   * Enabled via {@link feign.Feign.Builder#decode404()}
+   * Enabled via {@link feign.Feign.Builder#dismiss404()}
    */
   @Test
   public void notFoundDecodesToEmpty() throws Exception {

--- a/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
+++ b/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
@@ -245,7 +245,7 @@ public class JAXBCodecTest {
    * Enabled via {@link feign.Feign.Builder#decode404()}
    */
   @Test
-  public void notFoundDecodesToNull() throws Exception {
+  public void notFoundDecodesToEmpty() throws Exception {
     Response response = Response.builder()
         .status(404)
         .reason("NOT FOUND")
@@ -253,7 +253,7 @@ public class JAXBCodecTest {
         .headers(Collections.<String, Collection<String>>emptyMap())
         .build();
     assertThat((byte[]) new JAXBDecoder(new JAXBContextFactory.Builder().build())
-        .decode(response, byte[].class)).isNull();
+        .decode(response, byte[].class)).isEmpty();
   }
 
   @XmlRootElement

--- a/json/src/main/java/feign/json/JsonDecoder.java
+++ b/json/src/main/java/feign/json/JsonDecoder.java
@@ -24,7 +24,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.lang.reflect.Type;
-import static feign.Util.UTF_8;
 import static java.lang.String.format;
 
 /**
@@ -53,6 +52,14 @@ public class JsonDecoder implements Decoder {
 
   @Override
   public Object decode(Response response, Type type) throws IOException, DecodeException {
+    if (response.status() == 404 || response.status() == 204)
+      if (JSONObject.class.isAssignableFrom((Class<?>) type))
+        return new JSONObject();
+      else if (JSONArray.class.isAssignableFrom((Class<?>) type))
+        return new JSONArray();
+      else
+        throw new DecodeException(response.status(),
+            format("%s is not a type supported by this decoder.", type), response.request());
     if (response.body() == null)
       return null;
     try (Reader reader = response.body().asReader(response.charset())) {

--- a/json/src/test/java/feign/json/JsonDecoderTest.java
+++ b/json/src/test/java/feign/json/JsonDecoderTest.java
@@ -56,7 +56,7 @@ public class JsonDecoderTest {
   public void decodesArray() throws IOException {
     String json = "[{\"a\":\"b\",\"c\":1},123]";
     Response response = Response.builder()
-        .status(204)
+        .status(200)
         .reason("OK")
         .headers(Collections.emptyMap())
         .body(json, UTF_8)
@@ -69,7 +69,7 @@ public class JsonDecoderTest {
   public void decodesObject() throws IOException {
     String json = "{\"a\":\"b\",\"c\":1}";
     Response response = Response.builder()
-        .status(204)
+        .status(200)
         .reason("OK")
         .headers(Collections.emptyMap())
         .body(json, UTF_8)
@@ -79,18 +79,29 @@ public class JsonDecoderTest {
   }
 
   @Test
-  public void nullBodyDecodesToNull() throws IOException {
+  public void notFoundDecodesToEmpty() throws IOException {
+    Response response = Response.builder()
+        .status(404)
+        .reason("Not found")
+        .headers(Collections.emptyMap())
+        .request(request)
+        .build();
+    assertTrue(((JSONObject) new JsonDecoder().decode(response, JSONObject.class)).isEmpty());
+  }
+
+  @Test
+  public void nullBodyDecodesToEmpty() throws IOException {
     Response response = Response.builder()
         .status(204)
         .reason("OK")
         .headers(Collections.emptyMap())
         .request(request)
         .build();
-    assertNull(new JsonDecoder().decode(response, JSONObject.class));
+    assertTrue(((JSONObject) new JsonDecoder().decode(response, JSONObject.class)).isEmpty());
   }
 
   @Test
-  public void emptyBodyDecodesToNull() throws IOException {
+  public void emptyBodyDecodesToEmpty() throws IOException {
     Response response = Response.builder()
         .status(204)
         .reason("OK")
@@ -98,14 +109,14 @@ public class JsonDecoderTest {
         .body("", UTF_8)
         .request(request)
         .build();
-    assertNull(new JsonDecoder().decode(response, JSONObject.class));
+    assertTrue(((JSONObject) new JsonDecoder().decode(response, JSONObject.class)).isEmpty());
   }
 
   @Test
   public void unknownTypeThrowsDecodeException() throws IOException {
     String json = "[{\"a\":\"b\",\"c\":1},123]";
     Response response = Response.builder()
-        .status(204)
+        .status(200)
         .reason("OK")
         .headers(Collections.emptyMap())
         .body(json, UTF_8)
@@ -121,7 +132,7 @@ public class JsonDecoderTest {
   public void badJsonThrowsWrappedJSONException() throws IOException {
     String json = "{\"a\":\"b\",\"c\":1}";
     Response response = Response.builder()
-        .status(204)
+        .status(200)
         .reason("OK")
         .headers(Collections.emptyMap())
         .body(json, UTF_8)
@@ -140,7 +151,7 @@ public class JsonDecoderTest {
     when(body.asReader(any())).thenThrow(new JSONException("test exception",
         new Exception("test cause exception")));
     Response response = Response.builder()
-        .status(204)
+        .status(200)
         .reason("OK")
         .headers(Collections.emptyMap())
         .body(body)
@@ -157,7 +168,7 @@ public class JsonDecoderTest {
     when(body.asReader(any())).thenThrow(new JSONException("test exception",
         new IOException("test cause exception")));
     Response response = Response.builder()
-        .status(204)
+        .status(200)
         .reason("OK")
         .headers(Collections.emptyMap())
         .body(body)
@@ -173,7 +184,7 @@ public class JsonDecoderTest {
     Response.Body body = mock(Response.Body.class);
     when(body.asReader(any())).thenThrow(new IOException("test exception"));
     Response response = Response.builder()
-        .status(204)
+        .status(200)
         .reason("OK")
         .headers(Collections.emptyMap())
         .body(body)
@@ -188,7 +199,7 @@ public class JsonDecoderTest {
   public void decodesExtendedArray() throws IOException {
     String json = "[{\"a\":\"b\",\"c\":1},123]";
     Response response = Response.builder()
-        .status(204)
+        .status(200)
         .reason("OK")
         .headers(Collections.emptyMap())
         .body(json, UTF_8)
@@ -201,7 +212,7 @@ public class JsonDecoderTest {
   public void decodeExtendedObject() throws IOException {
     String json = "{\"a\":\"b\",\"c\":1}";
     Response response = Response.builder()
-        .status(204)
+        .status(200)
         .reason("OK")
         .headers(Collections.emptyMap())
         .body(json, UTF_8)

--- a/reactive/src/test/java/feign/reactive/ReactiveFeignIntegrationTest.java
+++ b/reactive/src/test/java/feign/reactive/ReactiveFeignIntegrationTest.java
@@ -90,7 +90,7 @@ public class ReactiveFeignIntegrationTest {
         .encoder(new JacksonEncoder())
         .decoder(new JacksonDecoder())
         .logger(new ConsoleLogger())
-        .decode404()
+        .dismiss404()
         .options(new Options())
         .logLevel(Level.FULL)
         .target(TestReactorService.class, this.getServerUrl());

--- a/sax/src/main/java/feign/sax/SAXDecoder.java
+++ b/sax/src/main/java/feign/sax/SAXDecoder.java
@@ -13,6 +13,7 @@
  */
 package feign.sax;
 
+import feign.Util;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -60,6 +61,8 @@ public class SAXDecoder implements Decoder {
 
   @Override
   public Object decode(Response response, Type type) throws IOException, DecodeException {
+    if (response.status() == 404 || response.status() == 204)
+      return Util.emptyValueOf(type);
     if (response.body() == null)
       return null;
     ContentHandlerWithResult.Factory<?> handlerFactory = handlerFactories.get(type);

--- a/sax/src/test/java/feign/sax/SAXDecoderTest.java
+++ b/sax/src/test/java/feign/sax/SAXDecoderTest.java
@@ -83,26 +83,26 @@ public class SAXDecoderTest {
   }
 
   @Test
-  public void nullBodyDecodesToNull() throws Exception {
+  public void nullBodyDecodesToEmpty() throws Exception {
     Response response = Response.builder()
         .status(204)
         .reason("OK")
         .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .headers(Collections.<String, Collection<String>>emptyMap())
         .build();
-    assertNull(decoder.decode(response, String.class));
+    assertThat((byte[]) decoder.decode(response, byte[].class)).isEmpty();
   }
 
   /** Enabled via {@link feign.Feign.Builder#decode404()} */
   @Test
-  public void notFoundDecodesToNull() throws Exception {
+  public void notFoundDecodesToEmpty() throws Exception {
     Response response = Response.builder()
         .status(404)
         .reason("NOT FOUND")
         .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .headers(Collections.<String, Collection<String>>emptyMap())
         .build();
-    assertThat((byte[]) decoder.decode(response, byte[].class)).isNull();
+    assertThat((byte[]) decoder.decode(response, byte[].class)).isEmpty();
   }
 
   static enum NetworkStatus {

--- a/sax/src/test/java/feign/sax/SAXDecoderTest.java
+++ b/sax/src/test/java/feign/sax/SAXDecoderTest.java
@@ -93,7 +93,7 @@ public class SAXDecoderTest {
     assertThat((byte[]) decoder.decode(response, byte[].class)).isEmpty();
   }
 
-  /** Enabled via {@link feign.Feign.Builder#decode404()} */
+  /** Enabled via {@link feign.Feign.Builder#dismiss404()} */
   @Test
   public void notFoundDecodesToEmpty() throws Exception {
     Response response = Response.builder()

--- a/soap/src/test/java/feign/soap/SOAPCodecTest.java
+++ b/soap/src/test/java/feign/soap/SOAPCodecTest.java
@@ -37,7 +37,6 @@ import feign.Response;
 import feign.Util;
 import feign.codec.Encoder;
 import feign.jaxb.JAXBContextFactory;
-import feign.jaxb.JAXBDecoder;
 
 @SuppressWarnings("deprecation")
 public class SOAPCodecTest {
@@ -380,8 +379,8 @@ public class SOAPCodecTest {
         .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
         .headers(Collections.emptyMap())
         .build();
-    assertThat((byte[]) new JAXBDecoder(new JAXBContextFactory.Builder().build())
-        .decode(response, byte[].class)).isNull();
+    assertThat((byte[]) new SOAPDecoder(new JAXBContextFactory.Builder().build())
+        .decode(response, byte[].class)).isEmpty();
   }
 
 

--- a/soap/src/test/java/feign/soap/SOAPCodecTest.java
+++ b/soap/src/test/java/feign/soap/SOAPCodecTest.java
@@ -369,7 +369,7 @@ public class SOAPCodecTest {
   }
 
   /**
-   * Enabled via {@link feign.Feign.Builder#decode404()}
+   * Enabled via {@link feign.Feign.Builder#dismiss404()}
    */
   @Test
   public void notFoundDecodesToNull() throws Exception {


### PR DESCRIPTION
Now some decoders follow this rule but other don't.

After 11.6 the flag `decode404` doesn't work as it is described in the documentation. In new implementation a response body will be ignored, not decoded. I propose to replace `decode404` with `dismiss404` following the comment https://github.com/OpenFeign/feign/pull/1529#issuecomment-952232211

Fixes #1595


