### PR TITLE
SLF4J Logging Capability

### DIFF
--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -128,16 +128,13 @@ final class SynchronousMethodHandler implements MethodHandler {
       }
       throw errorExecuting(request, e);
     }
-    long elapsedTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
-
 
     if (decoder != null)
       return decoder.decode(response, metadata.returnType());
 
     CompletableFuture<Object> resultFuture = new CompletableFuture<>();
     asyncResponseHandler.handleResponse(resultFuture, metadata.configKey(), response,
-        metadata.returnType(),
-        elapsedTime);
+        metadata.returnType(), elapsedTime(start));
 
     try {
       if (!resultFuture.isDone())

--- a/json/src/test/java/feign/json/JsonDecoderTest.java
+++ b/json/src/test/java/feign/json/JsonDecoderTest.java
@@ -15,7 +15,6 @@ package feign.json;
 
 import static feign.Util.UTF_8;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;

--- a/slf4j/README.md
+++ b/slf4j/README.md
@@ -3,11 +3,26 @@ SLF4J
 
 This module allows directing Feign's logging to [SLF4J](http://www.slf4j.org/), allowing you to easily use a logging backend of your choice (Logback, Log4J, etc.)
 
-To use SLF4J with Feign, add both the SLF4J module and an SLF4J binding of your choice to your classpath.  Then, configure Feign to use the Slf4jLogger:
+To use SLF4J with Feign, add both the SLF4J module and an SLF4J binding of your choice to your classpath.  Then, configure Feign to use the Slf4jLogger.
+
+## Logger implementation
 
 ```java
 GitHub github = Feign.builder()
                      .logger(new Slf4jLogger())
                      .logLevel(Level.FULL)
                      .target(GitHub.class, "https://api.github.com");
+```
+
+## Logger capability
+
+```java
+GitHub github = Feign.builder()
+                     .addCapability(
+                         Slf4jCapability.builder()
+                                        .withHeaders()
+                                        .withRequest()
+                                        .withResponse()
+                                        .build()
+                     ).target(GitHub.class, "https://api.github.com");
 ```

--- a/slf4j/pom.xml
+++ b/slf4j/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2012-2021 The Feign Authors
+    Copyright 2012-2022 The Feign Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -50,6 +50,17 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>

--- a/slf4j/src/main/java/feign/slf4j/Slf4jCapability.java
+++ b/slf4j/src/main/java/feign/slf4j/Slf4jCapability.java
@@ -1,0 +1,413 @@
+/*
+ * Copyright 2012-2022 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.slf4j;
+
+import feign.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import static feign.Util.*;
+import static java.util.Arrays.asList;
+import static java.util.Objects.nonNull;
+
+/**
+ * <a href="https://www.slf4j.org/">SLF4J</a> logging for debug messages.
+ * <p>
+ * Log the request method and URL and the response status code and execution time. See
+ * {@link Builder} for other options.
+ *
+ * @since 11.9
+ */
+public class Slf4jCapability implements Capability {
+
+  private final Logger logger;
+  private final List<String> allowedHeaders;
+  private final List<String> deniedHeaders;
+  private final boolean withHeaders;
+  private final boolean withRequest;
+  private final boolean withResponse;
+  private final boolean withRetryer;
+  private final boolean withStacktrace;
+
+  private Slf4jCapability(Builder builder) {
+    logger = builder.logger;
+    allowedHeaders = asList(builder.allowedHeaders);
+    deniedHeaders = asList(builder.deniedHeaders);
+    withHeaders = builder.withHeaders;
+    withRequest = builder.withRequest;
+    withResponse = builder.withResponse;
+    withRetryer = builder.withRetryer;
+    withStacktrace = builder.withStacktrace;
+
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  static String methodTag(String configKey) {
+    return '[' + configKey.substring(0, configKey.indexOf('(')) + "] ";
+  }
+
+  static String resolveProtocolVersion(Request.ProtocolVersion protocolVersion) {
+    if (nonNull(protocolVersion)) {
+      return protocolVersion.toString();
+    }
+    return "UNKNOWN";
+  }
+
+  @Override
+  public Client enrich(Client client) {
+    return new LoggedClient(client, logger, allowedHeaders, deniedHeaders, withHeaders, withRequest,
+        withResponse, withStacktrace);
+  }
+
+  @Override
+  public Retryer enrich(Retryer retryer) {
+    return (withRetryer) ? new LoggedRetryer(retryer, logger) : retryer;
+  }
+
+
+  /**
+   * Logger capability builder.
+   * <p>
+   * All options are isolated: you can use {@link #withResponse()}} to print a response body without
+   * headers unlike {@link feign.Logger.Level#FULL} does.
+   * <p>
+   * There is nothing like {@link feign.Logger.Level#NONE}: if you don't set any option it works
+   * like {@link feign.Logger.Level#BASIC}.
+   * <p>
+   * Both {@link #withAllowedHeaders(String...)} and {@link #withDeniedHeaders(String...)} set the
+   * flag <code>withHeaders</code>. They are case-insensitive.
+   * <ol>
+   * <li>if <code>allowed headers<</code> is not empty it writes out only allowed headers;</li>
+   * <li>if <code>allowed headers</code> is empty and <code>denied headers</code> isn't it writes
+   * out all headers other than denies ones;</li>
+   * <li>if both lists are empty it writes out all headers.</li>
+   * </ol>
+   */
+  public static class Builder {
+
+    public static final String FEIGN_LOGGER = "feign.logger";
+
+    private Logger logger;
+    private String[] allowedHeaders = {};
+    private String[] deniedHeaders = {};
+    private boolean withHeaders;
+    private boolean withRequest;
+    private boolean withResponse;
+    private boolean withRetryer;
+    private boolean withStacktrace;
+
+    private Builder() {
+      logger = LoggerFactory.getLogger(FEIGN_LOGGER);
+    }
+
+    /**
+     * Set a custom logger. The default one uses the name <em>feign.logger</em>.
+     *
+     * @param logger logger
+     * @return the builder
+     */
+    public Builder logger(Logger logger) {
+      this.logger = Objects.requireNonNull(logger, "Logger must not be null.");
+      return this;
+    }
+
+    /**
+     * Log allowed request and response headers.
+     *
+     * @param allowedHeaders allowed headers
+     * @return the builder
+     */
+    public Builder withAllowedHeaders(String... allowedHeaders) {
+      this.allowedHeaders = allowedHeaders;
+      return withHeaders();
+    }
+
+    /**
+     * Log request and response headers other than denied ones.
+     *
+     * @param deniedHeaders denied headers
+     * @return the builder
+     */
+    public Builder withDeniedHeaders(String... deniedHeaders) {
+      this.deniedHeaders = deniedHeaders;
+      return withHeaders();
+    }
+
+    /**
+     * Log request and response headers.
+     *
+     * @return the builder
+     */
+    public Builder withHeaders() {
+      this.withHeaders = true;
+      return this;
+    }
+
+    /**
+     * Log the request body and metadata.
+     *
+     * @return the builder
+     */
+    public Builder withRequest() {
+      this.withRequest = true;
+      return this;
+    }
+
+    /**
+     * Log the response body and metadata.
+     *
+     * @return the builder
+     */
+    public Builder withResponse() {
+      this.withResponse = true;
+      return this;
+    }
+
+    /**
+     * Log when Feign retries to call.
+     *
+     * @return the builder
+     */
+    public Builder withRetryer() {
+      this.withRetryer = true;
+      return this;
+    }
+
+    /**
+     * Log full stacktrace, usually for {@link java.io.IOException}.
+     *
+     * @return the builder
+     */
+    public Builder withStacktrace() {
+      this.withStacktrace = true;
+      return this;
+    }
+
+    public Slf4jCapability build() {
+      return new Slf4jCapability(this);
+    }
+
+  }
+
+
+  /**
+   * Logged {@link Client}.
+   */
+  static class LoggedClient implements Client {
+
+    private static final String EMPTY = "";
+
+    private final Client delegate;
+    private final Logger logger;
+    private final List<String> allowedHeaders;
+    private final List<String> deniedHeaders;
+    private final boolean withHeaders;
+    private final boolean withRequest;
+    private final boolean withResponse;
+    private final boolean withStacktrace;
+
+    LoggedClient(Client delegate,
+        Logger logger,
+        List<String> allowedHeaders,
+        List<String> deniedHeaders,
+        boolean withHeaders,
+        boolean withRequest,
+        boolean withResponse,
+        boolean withStacktrace) {
+      this.delegate = delegate;
+      this.logger = logger;
+      this.allowedHeaders = allowedHeaders;
+      this.deniedHeaders = deniedHeaders;
+      this.withHeaders = withHeaders;
+      this.withRequest = withRequest;
+      this.withResponse = withResponse;
+      this.withStacktrace = withStacktrace;
+    }
+
+    /**
+     * Write to log request method and URL, response status code, execution time, headers, request
+     * and response bodies, IOException's stacktrace.
+     *
+     * @param request safe to replay.
+     * @param options options to apply to this request.
+     * @return connected response, {@link Response.Body} is optionally rebuffered if a response is
+     *         logged.
+     * @throws IOException on a network error connecting to {@link Request#url()}.
+     * @see Builder
+     */
+    @Override
+    public Response execute(Request request, Request.Options options) throws IOException {
+      String methodTag = methodTag(request.requestTemplate().methodMetadata().configKey());
+      String protocolVersion = resolveProtocolVersion(request.protocolVersion());
+
+      logRequest(methodTag, protocolVersion, request);
+
+      long start = System.nanoTime();
+
+      try {
+        Response response = delegate.execute(request, options);
+
+        return logAndRebufferResponse(methodTag, protocolVersion, response, elapsedTime(start));
+      } catch (IOException exception) {
+        throw logIOException(methodTag, exception, elapsedTime(start));
+      }
+    }
+
+    // visible for testing
+    long elapsedTime(long start) {
+      return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+    }
+
+    private void logHeaders(String methodTag, Map<String, Collection<String>> headers) {
+      if (withHeaders) {
+        for (String header : headers.keySet()) {
+          if (shouldLogHeader(header)) {
+            for (String value : valuesOrEmpty(headers, header)) {
+              logger.debug(methodTag + "{}: {}", header, value);
+            }
+          }
+        }
+      }
+    }
+
+    private IOException logIOException(String methodTag, IOException exception, long elapsedTime) {
+      if (logger.isDebugEnabled()) {
+        logger.debug(methodTag + "<--- ERROR {}: {} ({}ms)", exception.getClass().getSimpleName(),
+            exception.getMessage(), elapsedTime);
+        if (withStacktrace) {
+          StringWriter writer = new StringWriter();
+          exception.printStackTrace(new PrintWriter(writer));
+          logger.debug(methodTag + "{}", writer);
+          logger.debug(methodTag + "<--- END ERROR");
+        }
+      }
+
+      return exception;
+    }
+
+    private Response logAndRebufferResponse(String methodTag,
+                                            String protocolVersion,
+                                            Response response,
+                                            long elapsedTime)
+        throws IOException {
+      if (logger.isDebugEnabled()) {
+        String reason = (nonNull(response.reason())) ? response.reason() : EMPTY;
+        int status = response.status();
+
+        logger.debug(methodTag + "<--- {} {} {} ({}ms)", protocolVersion, status, reason,
+            elapsedTime);
+        logHeaders(methodTag, response.headers());
+
+        int bodyLength = 0;
+
+        if (nonNull(response.body()) && !(status == 204 || status == 205)) {
+          byte[] bodyData = Util.toByteArray(response.body().asInputStream());
+
+          bodyLength = bodyData.length;
+          if (withResponse && bodyLength > 0) {
+            logger.debug(methodTag);
+            logger.debug(methodTag + "{}", decodeOrDefault(bodyData, UTF_8, "Binary data"));
+            logger.debug(methodTag + "<--- END HTTP ({}-byte body)", bodyLength);
+            return response.toBuilder().body(bodyData).build();
+          }
+        }
+        logger.debug(methodTag + "<--- END HTTP ({}-byte body)", bodyLength);
+      }
+
+      return response;
+    }
+
+    private void logRequest(String methodTag, String protocolVersion, Request request) {
+      if (logger.isDebugEnabled()) {
+        logger.debug(methodTag + "---> {} {} {}", request.httpMethod().name(), request.url(),
+            protocolVersion);
+        logHeaders(methodTag, request.headers());
+
+        int bodyLength = 0;
+
+        if (nonNull(request.body())) {
+          bodyLength = request.length();
+          if (withRequest) {
+            String bodyText =
+                (nonNull(request.charset())) ? new String(request.body(), request.charset()) : null;
+            logger.debug(methodTag); // empty line
+            logger.debug(methodTag + "{}", (nonNull(bodyText) ? bodyText : "Binary data"));
+          }
+        }
+        logger.debug(methodTag + "---> END HTTP ({}-byte body)", bodyLength);
+      }
+    }
+
+    private boolean shouldLogHeader(String header) {
+      if (!allowedHeaders.isEmpty()) {
+        return allowedHeaders.stream().anyMatch(header::equalsIgnoreCase);
+      }
+      if (!deniedHeaders.isEmpty()) {
+        return deniedHeaders.stream().noneMatch(header::equalsIgnoreCase);
+      }
+
+      return true;
+    }
+
+  }
+
+
+  /**
+   * Logged {@link Retryer}.
+   */
+  static class LoggedRetryer implements Retryer {
+
+    private final Retryer delegate;
+    private final Logger logger;
+
+    LoggedRetryer(Retryer delegate, Logger logger) {
+      this.delegate = delegate;
+      this.logger = logger;
+    }
+
+    /**
+     * If retry is permitted, write to log (on <strong>DEBUG</strong> level) then return. Otherwise,
+     * propagate the exception.
+     *
+     * @param retryableException retryable exception
+     * @see Builder
+     */
+    @Override
+    public void continueOrPropagate(RetryableException retryableException) {
+      delegate.continueOrPropagate(retryableException);
+      if (logger.isDebugEnabled()) {
+        logger.debug(
+            methodTag(retryableException.request().requestTemplate().methodMetadata().configKey())
+                + "---> RETRYING");
+      }
+    }
+
+    @Override
+    public Retryer clone() {
+      return new LoggedRetryer(delegate, logger);
+    }
+
+  }
+
+}

--- a/slf4j/src/test/java/feign/TestTools.java
+++ b/slf4j/src/test/java/feign/TestTools.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2012-2022 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign;
+
+public class TestTools {
+
+  public static MethodMetadata methodMetadata() {
+    return new MethodMetadata();
+  }
+
+}

--- a/slf4j/src/test/java/feign/slf4j/LoggedClientTest.java
+++ b/slf4j/src/test/java/feign/slf4j/LoggedClientTest.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2012-2022 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.slf4j;
+
+import feign.Client;
+import feign.MethodMetadata;
+import feign.Request;
+import feign.Response;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.impl.RecordingSimpleLogger;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import static feign.TestTools.methodMetadata;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.*;
+
+public class LoggedClientTest {
+
+  private Slf4jCapability.LoggedClient loggedClient;
+  private Client delegate;
+  private MethodMetadata metadata;
+  private Request request;
+  private Request.Options options;
+  private Response response;
+
+  @Rule
+  public final RecordingSimpleLogger slf4j = new RecordingSimpleLogger();
+
+  @Before
+  public void setUp() throws Exception {
+    delegate = mock(Client.class);
+    options = mock(Request.Options.class);
+
+    metadata = methodMetadata();
+    metadata.configKey("testInterface#testMethod(parameters)");
+    request = Request.create(Request.HttpMethod.GET, "/home",
+        Collections.singletonMap("accept", Collections.singleton("*/*")),
+        "request body".getBytes(UTF_8), UTF_8, metadata.template());
+    response = Response.builder().status(200).reason("OK").request(request).headers(
+        Collections.singletonMap("content-type", Collections.singleton("application/json")))
+        .body("response body", UTF_8).build();
+
+    when(delegate.execute(isA(Request.class), isA(Request.Options.class))).thenReturn(response);
+  }
+
+  @Test
+  public void noLoggingOnInfoLevel() throws Exception {
+    // given
+    slf4j.logLevel("info");
+    loggedClient =
+        (Slf4jCapability.LoggedClient) Slf4jCapability.builder().withHeaders().withRequest()
+            .withResponse().withStacktrace().build().enrich(delegate);
+    // when
+    Response notLoggedResponse = loggedClient.execute(request, options);
+    // then
+    assertSame(response, notLoggedResponse);
+  }
+
+  @Test
+  public void fullLogging() throws Exception {
+    // given
+    slf4j.logLevel("debug");
+    slf4j.expectMessages("DEBUG feign.logger - [testInterface#testMethod] ---> GET /home HTTP/1.1",
+        "DEBUG feign.logger - [testInterface#testMethod] accept: */*",
+        "DEBUG feign.logger - [testInterface#testMethod] ",
+        "DEBUG feign.logger - [testInterface#testMethod] request body",
+        "DEBUG feign.logger - [testInterface#testMethod] ---> END HTTP (12-byte body)",
+        "DEBUG feign.logger - [testInterface#testMethod] <--- HTTP/1.1 200 OK (123ms)",
+        "DEBUG feign.logger - [testInterface#testMethod] content-type: application/json",
+        "DEBUG feign.logger - [testInterface#testMethod] ",
+        "DEBUG feign.logger - [testInterface#testMethod] response body",
+        "DEBUG feign.logger - [testInterface#testMethod] <--- END HTTP (13-byte body)");
+    loggedClient =
+        spy((Slf4jCapability.LoggedClient) Slf4jCapability.builder().withHeaders().withRequest()
+            .withResponse().withStacktrace().build().enrich(delegate));
+    when(loggedClient.elapsedTime(anyLong())).thenReturn(123L);
+    // when
+    Response loggedResponse = loggedClient.execute(request, options);
+    // then
+    assertNotSame(response, loggedResponse);
+  }
+
+  @Test
+  public void basicLogging() throws Exception {
+    // given
+    slf4j.logLevel("debug");
+    slf4j.expectMessages("DEBUG feign.logger - [testInterface#testMethod] ---> GET /home HTTP/1.1",
+        "DEBUG feign.logger - [testInterface#testMethod] ---> END HTTP (12-byte body)",
+        "DEBUG feign.logger - [testInterface#testMethod] <--- HTTP/1.1 200 OK (123ms)",
+        "DEBUG feign.logger - [testInterface#testMethod] <--- END HTTP (13-byte body)");
+    loggedClient =
+        spy((Slf4jCapability.LoggedClient) Slf4jCapability.builder().build().enrich(delegate));
+    when(loggedClient.elapsedTime(anyLong())).thenReturn(123L);
+    // when
+    Response loggedResponse = loggedClient.execute(request, options);
+    // then
+    assertSame(response, loggedResponse);
+  }
+
+  @Test
+  public void basicExceptionLogging() throws Exception {
+    // given
+    slf4j.logLevel("debug");
+    slf4j.expectMessages("DEBUG feign.logger - [testInterface#testMethod] ---> GET /home HTTP/1.1",
+        "DEBUG feign.logger - [testInterface#testMethod] ---> END HTTP (12-byte body)",
+        "DEBUG feign.logger - [testInterface#testMethod] <--- ERROR IOException: test exception (123ms)");
+    loggedClient =
+        spy((Slf4jCapability.LoggedClient) Slf4jCapability.builder().build().enrich(delegate));
+    when(delegate.execute(isA(Request.class), isA(Request.Options.class))).thenThrow(
+        new IOException("test exception"));
+    when(loggedClient.elapsedTime(anyLong())).thenReturn(123L);
+    // when
+    assertThrows(IOException.class, () -> loggedClient.execute(request, options));
+  }
+
+  @Test
+  public void headerLogging() throws Exception {
+    // given
+    slf4j.logLevel("debug");
+    slf4j.expectMessages("DEBUG feign.logger - [testInterface#testMethod] ---> GET /home HTTP/1.1",
+        "DEBUG feign.logger - [testInterface#testMethod] accept: */*",
+        "DEBUG feign.logger - [testInterface#testMethod] ---> END HTTP (12-byte body)",
+        "DEBUG feign.logger - [testInterface#testMethod] <--- HTTP/1.1 200 OK (123ms)",
+        "DEBUG feign.logger - [testInterface#testMethod] content-type: application/json",
+        "DEBUG feign.logger - [testInterface#testMethod] <--- END HTTP (13-byte body)");
+    loggedClient =
+        spy((Slf4jCapability.LoggedClient) Slf4jCapability.builder().withHeaders().build()
+            .enrich(delegate));
+    when(loggedClient.elapsedTime(anyLong())).thenReturn(123L);
+    // when
+    Response loggedResponse = loggedClient.execute(request, options);
+    // then
+    assertSame(response, loggedResponse);
+  }
+
+  @Test
+  public void allowedHeaderLogging() throws Exception {
+    // given
+    slf4j.logLevel("debug");
+    slf4j.expectMessages("DEBUG feign.logger - [testInterface#testMethod] ---> GET /home HTTP/1.1",
+        "DEBUG feign.logger - [testInterface#testMethod] AccEpT: text/html",
+        "DEBUG feign.logger - [testInterface#testMethod] AccEpT: application/json",
+        "DEBUG feign.logger - [testInterface#testMethod] AccEpT: text/plain",
+        "DEBUG feign.logger - [testInterface#testMethod] ---> END HTTP (12-byte body)",
+        "DEBUG feign.logger - [testInterface#testMethod] <--- HTTP/1.1 200 OK (123ms)",
+        "DEBUG feign.logger - [testInterface#testMethod] content-type: application/json",
+        "DEBUG feign.logger - [testInterface#testMethod] <--- END HTTP (13-byte body)");
+    Map<String, Collection<String>> requestHeaders = new HashMap<>();
+    requestHeaders.put("AccEpT", asList("text/html", "application/json", "text/plain"));
+    requestHeaders.put("HOST", Collections.singleton("localhost"));
+    requestHeaders.put("User-Agent", Collections.singleton("unit test"));
+    Map<String, Collection<String>> responseHeaders = new HashMap<>();
+    responseHeaders.put("Content-Type", Collections.singleton("application/json"));
+    responseHeaders.put("Server", Collections.singleton("test server"));
+    request = Request.create(Request.HttpMethod.GET, "/home", requestHeaders,
+        "request body".getBytes(UTF_8), UTF_8, metadata.template());
+    response = Response.builder().status(200).reason("OK").request(request).headers(responseHeaders)
+        .body("response body", UTF_8).build();
+    loggedClient = spy((Slf4jCapability.LoggedClient) Slf4jCapability.builder()
+        .withAllowedHeaders("accept", "content-type").build().enrich(delegate));
+    when(delegate.execute(isA(Request.class), isA(Request.Options.class))).thenReturn(response);
+    when(loggedClient.elapsedTime(anyLong())).thenReturn(123L);
+    // when
+    Response loggedResponse = loggedClient.execute(request, options);
+    // then
+    assertSame(response, loggedResponse);
+  }
+
+  @Test
+  public void deniedHeaderLogging() throws Exception {
+    // given
+    slf4j.logLevel("debug");
+    slf4j.expectMessages("DEBUG feign.logger - [testInterface#testMethod] ---> GET /home HTTP/1.1",
+        "DEBUG feign.logger - [testInterface#testMethod] User-Agent: unit test",
+        "DEBUG feign.logger - [testInterface#testMethod] HOST: localhost",
+        "DEBUG feign.logger - [testInterface#testMethod] ---> END HTTP (12-byte body)",
+        "DEBUG feign.logger - [testInterface#testMethod] <--- HTTP/1.1 200 OK (123ms)",
+        "DEBUG feign.logger - [testInterface#testMethod] server: test server",
+        "DEBUG feign.logger - [testInterface#testMethod] <--- END HTTP (13-byte body)");
+    Map<String, Collection<String>> requestHeaders = new HashMap<>();
+    requestHeaders.put("AccEpT", asList("text/html", "application/json", "text/plain"));
+    requestHeaders.put("HOST", Collections.singleton("localhost"));
+    requestHeaders.put("User-Agent", Collections.singleton("unit test"));
+    Map<String, Collection<String>> responseHeaders = new HashMap<>();
+    responseHeaders.put("Content-Type", Collections.singleton("application/json"));
+    responseHeaders.put("Server", Collections.singleton("test server"));
+    request = Request.create(Request.HttpMethod.GET, "/home", requestHeaders,
+        "request body".getBytes(UTF_8), UTF_8, metadata.template());
+    response = Response.builder().status(200).reason("OK").request(request).headers(responseHeaders)
+        .body("response body", UTF_8).build();
+    loggedClient = spy((Slf4jCapability.LoggedClient) Slf4jCapability.builder()
+        .withDeniedHeaders("accept", "content-type").build().enrich(delegate));
+    when(delegate.execute(isA(Request.class), isA(Request.Options.class))).thenReturn(response);
+    when(loggedClient.elapsedTime(anyLong())).thenReturn(123L);
+    // when
+    Response loggedResponse = loggedClient.execute(request, options);
+    // then
+    assertSame(response, loggedResponse);
+  }
+
+  @Test
+  public void combinedHeaderLogging() throws Exception {
+    // given
+    slf4j.logLevel("debug");
+    slf4j.expectMessages("DEBUG feign.logger - [testInterface#testMethod] ---> GET /home HTTP/1.1",
+        "DEBUG feign.logger - [testInterface#testMethod] HOST: localhost",
+        "DEBUG feign.logger - [testInterface#testMethod] ---> END HTTP (12-byte body)",
+        "DEBUG feign.logger - [testInterface#testMethod] <--- HTTP/1.1 200 OK (123ms)",
+        "DEBUG feign.logger - [testInterface#testMethod] server: test server",
+        "DEBUG feign.logger - [testInterface#testMethod] <--- END HTTP (13-byte body)");
+    Map<String, Collection<String>> requestHeaders = new HashMap<>();
+    requestHeaders.put("AccEpT", asList("text/html", "application/json", "text/plain"));
+    requestHeaders.put("HOST", Collections.singleton("localhost"));
+    requestHeaders.put("User-Agent", Collections.singleton("unit test"));
+    Map<String, Collection<String>> responseHeaders = new HashMap<>();
+    responseHeaders.put("Content-Type", Collections.singleton("application/json"));
+    responseHeaders.put("Server", Collections.singleton("test server"));
+    request = Request.create(Request.HttpMethod.GET, "/home", requestHeaders,
+        "request body".getBytes(UTF_8), UTF_8, metadata.template());
+    response = Response.builder().status(200).reason("OK").request(request).headers(responseHeaders)
+        .body("response body", UTF_8).build();
+    loggedClient = spy((Slf4jCapability.LoggedClient) Slf4jCapability.builder()
+        .withAllowedHeaders("SeRvEr", "host").withDeniedHeaders("accept", "content-type").build()
+        .enrich(delegate));
+    when(delegate.execute(isA(Request.class), isA(Request.Options.class))).thenReturn(response);
+    when(loggedClient.elapsedTime(anyLong())).thenReturn(123L);
+    // when
+    Response loggedResponse = loggedClient.execute(request, options);
+    // then
+    assertSame(response, loggedResponse);
+  }
+
+  @Test
+  public void requestLogging() throws Exception {
+    // given
+    slf4j.logLevel("debug");
+    slf4j.expectMessages("DEBUG feign.logger - [testInterface#testMethod] ---> GET /home HTTP/1.1",
+        "DEBUG feign.logger - [testInterface#testMethod] ",
+        "DEBUG feign.logger - [testInterface#testMethod] request body",
+        "DEBUG feign.logger - [testInterface#testMethod] ---> END HTTP (12-byte body)",
+        "DEBUG feign.logger - [testInterface#testMethod] <--- HTTP/1.1 200 OK (123ms)",
+        "DEBUG feign.logger - [testInterface#testMethod] <--- END HTTP (13-byte body)");
+    loggedClient =
+        spy((Slf4jCapability.LoggedClient) Slf4jCapability.builder().withRequest().build()
+            .enrich(delegate));
+    when(loggedClient.elapsedTime(anyLong())).thenReturn(123L);
+    // when
+    Response loggedResponse = loggedClient.execute(request, options);
+    // then
+    assertSame(response, loggedResponse);
+  }
+
+  @Test
+  public void responseLogging() throws Exception {
+    // given
+    slf4j.logLevel("debug");
+    slf4j.expectMessages("DEBUG feign.logger - [testInterface#testMethod] ---> GET /home HTTP/1.1",
+        "DEBUG feign.logger - [testInterface#testMethod] ---> END HTTP (12-byte body)",
+        "DEBUG feign.logger - [testInterface#testMethod] <--- HTTP/1.1 200 OK (123ms)",
+        "DEBUG feign.logger - [testInterface#testMethod] ",
+        "DEBUG feign.logger - [testInterface#testMethod] response body",
+        "DEBUG feign.logger - [testInterface#testMethod] <--- END HTTP (13-byte body)");
+    loggedClient =
+        spy((Slf4jCapability.LoggedClient) Slf4jCapability.builder().withResponse().build()
+            .enrich(delegate));
+    when(loggedClient.elapsedTime(anyLong())).thenReturn(123L);
+    // when
+    Response loggedResponse = loggedClient.execute(request, options);
+    // then
+    assertNotSame(response, loggedResponse);
+  }
+
+  @Test
+  public void stacktraceLogging() throws Exception {
+    // given
+    slf4j.logLevel("debug");
+    slf4j.expectMessages("DEBUG feign.logger - [testInterface#testMethod] ---> GET /home HTTP/1.1",
+        "DEBUG feign.logger - [testInterface#testMethod] ---> END HTTP (12-byte body)",
+        "DEBUG feign.logger - [testInterface#testMethod] <--- ERROR IOException: test exception (123ms)",
+        "DEBUG feign.logger - [testInterface#testMethod] java.io.IOException: test exception",
+        "\tat feign.slf4j.Slf4jCapability$LoggedClient.execute(Slf4jCapability.java:269)",
+        "\tat feign.slf4j.LoggedClientTest.lambda$stacktraceLogging$1(LoggedClientTest.java:309)");
+    loggedClient =
+        spy((Slf4jCapability.LoggedClient) Slf4jCapability.builder().withStacktrace().build()
+            .enrich(delegate));
+    when(delegate.execute(isA(Request.class), isA(Request.Options.class))).thenThrow(
+        new IOException("test exception"));
+    when(loggedClient.elapsedTime(anyLong())).thenReturn(123L);
+    // when
+    assertThrows(IOException.class, () -> loggedClient.execute(request, options));
+  }
+
+}

--- a/slf4j/src/test/java/feign/slf4j/LoggedRetryerTest.java
+++ b/slf4j/src/test/java/feign/slf4j/LoggedRetryerTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2012-2022 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.slf4j;
+
+import feign.MethodMetadata;
+import feign.Request;
+import feign.RetryableException;
+import feign.Retryer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+import org.slf4j.impl.RecordingSimpleLogger;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import static feign.Request.HttpMethod.HEAD;
+import static feign.TestTools.methodMetadata;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.*;
+
+public class LoggedRetryerTest {
+
+  private Retryer delegate;
+  private Retryer loggedRetryer;
+
+  @Rule
+  public final RecordingSimpleLogger slf4j = new RecordingSimpleLogger();
+
+  @Before
+  public void setUp() {
+    delegate = mock(Retryer.class);
+  }
+
+  @Test
+  public void noLogging() throws Exception {
+    // given
+    slf4j.logLevel("debug");
+    loggedRetryer = Slf4jCapability.builder().build().enrich(delegate);
+    MethodMetadata metadata = methodMetadata();
+    metadata.configKey("testMethod(parameters)");
+    Request request = Request.create(Request.HttpMethod.GET, "/home", Collections.emptyMap(),
+        "data".getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8, metadata.template());
+    RetryableException exception = new RetryableException(-1, "test message", HEAD, null, request);
+    // when
+    loggedRetryer.continueOrPropagate(exception);
+  }
+
+  @Test
+  public void noLoggingOnInfoLevel() throws Exception {
+    // given
+    slf4j.logLevel("info");
+    loggedRetryer = Slf4jCapability.builder().withRetryer().build().enrich(delegate);
+    MethodMetadata metadata = methodMetadata();
+    metadata.configKey("testMethod(parameters)");
+    Request request = Request.create(Request.HttpMethod.GET, "/home", Collections.emptyMap(),
+        "data".getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8, metadata.template());
+    RetryableException exception = new RetryableException(-1, "test message", HEAD, null, request);
+    // when
+    loggedRetryer.continueOrPropagate(exception);
+  }
+
+  @Test
+  public void testContinue() throws Exception {
+    // given
+    slf4j.logLevel("debug");
+    slf4j.expectMessages("DEBUG feign.logger - [testMethod] ---> RETRYING");
+    loggedRetryer = Slf4jCapability.builder().withRetryer().build().enrich(delegate);
+    MethodMetadata metadata = methodMetadata();
+    metadata.configKey("testMethod(parameters)");
+    Request request = Request.create(Request.HttpMethod.GET, "/home", Collections.emptyMap(),
+        "data".getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8, metadata.template());
+    RetryableException exception = new RetryableException(-1, "test message", HEAD, null, request);
+    // when
+    loggedRetryer.continueOrPropagate(exception);
+  }
+
+  @Test
+  public void testPropagate() throws Exception {
+    // given
+    slf4j.logLevel("debug");
+    loggedRetryer = Slf4jCapability.builder().withRetryer().build().enrich(delegate);
+    MethodMetadata metadata = methodMetadata();
+    metadata.configKey("testInterface#testMethod(parameters)");
+    Request request = Request.create(Request.HttpMethod.GET, "/home", Collections.emptyMap(),
+        "data".getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8, null);
+    RetryableException exception = new RetryableException(-1, "test message", HEAD, null, request);
+    doThrow(exception).when(delegate).continueOrPropagate(isA(RetryableException.class));
+    // when
+    assertThrows(RetryableException.class, () -> loggedRetryer.continueOrPropagate(exception));
+  }
+
+  @Test
+  public void customLogger() throws Exception {
+    // given
+    slf4j.logLevel("debug");
+    slf4j.expectMessages("DEBUG test - [testMethod] ---> RETRYING");
+    loggedRetryer =
+        Slf4jCapability.builder().withRetryer().logger(LoggerFactory.getLogger("test")).build()
+            .enrich(delegate);
+    MethodMetadata metadata = methodMetadata();
+    metadata.configKey("testMethod(parameters)");
+    Request request = Request.create(Request.HttpMethod.GET, "/home", Collections.emptyMap(),
+        "data".getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8, metadata.template());
+    RetryableException exception = new RetryableException(-1, "test message", HEAD, null, request);
+    // when
+    loggedRetryer.continueOrPropagate(exception);
+  }
+
+  @Test
+  public void testClone() {
+    loggedRetryer = Slf4jCapability.builder().withRetryer().build().enrich(delegate);
+    assertNotSame("cloned retryer", loggedRetryer, loggedRetryer.clone());
+  }
+
+}

--- a/slf4j/src/test/java/feign/slf4j/Slf4jLoggerTest.java
+++ b/slf4j/src/test/java/feign/slf4j/Slf4jLoggerTest.java
@@ -49,8 +49,7 @@ public class Slf4jLoggerTest {
   @Test
   public void useFeignLoggerByDefault() throws Exception {
     slf4j.logLevel("debug");
-    slf4j.expectMessages(
-        "DEBUG feign.Logger - [someMethod] This is my message" + System.lineSeparator());
+    slf4j.expectMessages("DEBUG feign.Logger - [someMethod] This is my message");
 
     logger = new Slf4jLogger();
     logger.log(CONFIG_KEY, "This is my message");
@@ -59,8 +58,7 @@ public class Slf4jLoggerTest {
   @Test
   public void useLoggerByNameIfRequested() throws Exception {
     slf4j.logLevel("debug");
-    slf4j.expectMessages(
-        "DEBUG named.logger - [someMethod] This is my message" + System.lineSeparator());
+    slf4j.expectMessages("DEBUG named.logger - [someMethod] This is my message");
 
     logger = new Slf4jLogger("named.logger");
     logger.log(CONFIG_KEY, "This is my message");
@@ -69,8 +67,7 @@ public class Slf4jLoggerTest {
   @Test
   public void useLoggerByClassIfRequested() throws Exception {
     slf4j.logLevel("debug");
-    slf4j.expectMessages(
-        "DEBUG feign.Feign - [someMethod] This is my message" + System.lineSeparator());
+    slf4j.expectMessages("DEBUG feign.Feign - [someMethod] This is my message");
 
     logger = new Slf4jLogger(Feign.class);
     logger.log(CONFIG_KEY, "This is my message");
@@ -79,8 +76,7 @@ public class Slf4jLoggerTest {
   @Test
   public void useSpecifiedLoggerIfRequested() throws Exception {
     slf4j.logLevel("debug");
-    slf4j.expectMessages(
-        "DEBUG specified.logger - [someMethod] This is my message" + System.lineSeparator());
+    slf4j.expectMessages("DEBUG specified.logger - [someMethod] This is my message");
 
     logger = new Slf4jLogger(LoggerFactory.getLogger("specified.logger"));
     logger.log(CONFIG_KEY, "This is my message");
@@ -99,12 +95,9 @@ public class Slf4jLoggerTest {
   @Test
   public void logRequestsAndResponses() throws Exception {
     slf4j.logLevel("debug");
-    slf4j.expectMessages("DEBUG feign.Logger - [someMethod] A message with 2 formatting tokens."
-        + System.lineSeparator() +
-        "DEBUG feign.Logger - [someMethod] ---> GET http://api.example.com HTTP/1.1"
-        + System.lineSeparator() +
-        "DEBUG feign.Logger - [someMethod] <--- HTTP/1.1 200 OK (273ms)"
-        + System.lineSeparator());
+    slf4j.expectMessages("DEBUG feign.Logger - [someMethod] A message with 2 formatting tokens.",
+        "DEBUG feign.Logger - [someMethod] ---> GET http://api.example.com HTTP/1.1",
+        "DEBUG feign.Logger - [someMethod] <--- HTTP/1.1 200 OK (273ms)");
 
     logger = new Slf4jLogger();
     logger.log(CONFIG_KEY, "A message with %d formatting %s.", 2, "tokens");

--- a/slf4j/src/test/java/org/slf4j/impl/RecordingSimpleLogger.java
+++ b/slf4j/src/test/java/org/slf4j/impl/RecordingSimpleLogger.java
@@ -19,7 +19,10 @@ import org.junit.runners.model.Statement;
 import org.slf4j.LoggerFactory;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import static org.junit.Assert.assertEquals;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.slf4j.impl.SimpleLogger.DEFAULT_LOG_LEVEL_KEY;
 import static org.slf4j.impl.SimpleLogger.SHOW_THREAD_NAME_KEY;
 
@@ -46,8 +49,10 @@ public final class RecordingSimpleLogger implements TestRule {
   /**
    * Newline delimited output that would be sent to stderr.
    */
-  public RecordingSimpleLogger expectMessages(String expectedMessages) {
-    this.expectedMessages = expectedMessages;
+  public RecordingSimpleLogger expectMessages(String... expectedMessages) {
+    this.expectedMessages =
+        Stream.of(expectedMessages).map(message -> message + System.lineSeparator())
+            .collect(Collectors.joining());
     return this;
   }
 
@@ -64,7 +69,7 @@ public final class RecordingSimpleLogger implements TestRule {
         try {
           System.setErr(new PrintStream(buff));
           base.evaluate();
-          assertEquals(expectedMessages, buff.toString());
+          assertThat(buff.toString(), startsWith(expectedMessages));
         } finally {
           System.setErr(stderr);
         }


### PR DESCRIPTION
Proposal for #1143.

Add logging as capability, see [feign.Capability](https://github.com/OpenFeign/feign/blob/55b35f711d82658c84366e56e5f589050ab856a9/core/src/main/java/feign/Capability.java).

It overrides enrich(Client) and enrich(Retryer). The implementations covers logging of basic information, headers with filtering, IO exception stacktrace, retrying, request and response. In opposite to [feign.Logger](https://github.com/OpenFeign/feign/blob/55b35f711d82658c84366e56e5f589050ab856a9/core/src/main/java/feign/Logger.java) headers, request and response can be logged in any combination, e.g. only response without headers and request.