### PR TITLE
Advanced parametrized type resolution for AsyncFeign

### DIFF
--- a/core/src/main/java/feign/MethodInfo.java
+++ b/core/src/main/java/feign/MethodInfo.java
@@ -35,7 +35,8 @@ class MethodInfo {
 
     final Type type = Types.resolve(targetType, targetType, method.getGenericReturnType());
 
-    if (type instanceof ParameterizedType && Types.getRawType(type).isAssignableFrom(CompletableFuture.class)) {
+    if (type instanceof ParameterizedType
+        && Types.getRawType(type).isAssignableFrom(CompletableFuture.class)) {
       this.asyncReturnType = true;
       this.underlyingReturnType = ((ParameterizedType) type).getActualTypeArguments()[0];
     } else {

--- a/core/src/main/java/feign/MethodInfo.java
+++ b/core/src/main/java/feign/MethodInfo.java
@@ -33,14 +33,14 @@ class MethodInfo {
   MethodInfo(Class<?> targetType, Method method) {
     this.configKey = Feign.configKey(targetType, method);
 
-    final Type type = method.getGenericReturnType();
+    final Type type = Types.resolve(targetType, targetType, method.getGenericReturnType());
 
-    if (method.getReturnType() != CompletableFuture.class) {
-      this.asyncReturnType = false;
-      this.underlyingReturnType = type;
-    } else {
+    if (type instanceof ParameterizedType && Types.getRawType(type).isAssignableFrom(CompletableFuture.class)) {
       this.asyncReturnType = true;
       this.underlyingReturnType = ((ParameterizedType) type).getActualTypeArguments()[0];
+    } else {
+      this.asyncReturnType = false;
+      this.underlyingReturnType = type;
     }
   }
 

--- a/core/src/test/java/feign/MethodInfoTest.java
+++ b/core/src/test/java/feign/MethodInfoTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2012-2022 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import static org.junit.Assert.*;
+
+@RunWith(Enclosed.class)
+public class MethodInfoTest {
+
+  public static class AsyncClientTest {
+    public interface AsyncClient {
+      CompletableFuture<String> log();
+    }
+
+    @Test
+    public void testCompletableFutureOfString() throws Exception {
+      MethodInfo mi = new MethodInfo(AsyncClient.class, AsyncClient.class.getMethod("log"));
+      assertEquals("AsyncClient#log()", mi.configKey());
+      assertTrue(mi.isAsyncReturnType());
+      assertEquals(String.class, mi.underlyingReturnType());
+    }
+  }
+
+  public static class GenericAsyncClientTest {
+    public interface GenericAsyncClient<T> {
+      T log();
+    }
+
+    public interface AsyncClient extends GenericAsyncClient<CompletableFuture<String>> {
+    }
+
+    @Test
+    public void testGenericCompletableFutureOfString() throws Exception {
+      MethodInfo mi = new MethodInfo(AsyncClient.class, AsyncClient.class.getMethod("log"));
+      assertEquals("AsyncClient#log()", mi.configKey());
+      assertTrue(mi.isAsyncReturnType());
+      assertEquals(String.class, mi.underlyingReturnType());
+    }
+  }
+
+  public static class SyncClientTest {
+    public interface SyncClient {
+      String log();
+    }
+
+    @Test
+    public void testString() throws Exception {
+      MethodInfo mi = new MethodInfo(SyncClient.class, SyncClient.class.getMethod("log"));
+      assertEquals("SyncClient#log()", mi.configKey());
+      assertFalse(mi.isAsyncReturnType());
+      assertEquals(String.class, mi.underlyingReturnType());
+    }
+  }
+
+  public static class GenericSyncClientTest {
+    public interface GenericSyncClient<T> {
+      T log();
+    }
+
+    public interface SyncClient extends GenericSyncClient<List<String>> {
+    }
+
+    public static class ListOfStrings implements ParameterizedType {
+      @Override
+      public Type[] getActualTypeArguments() {
+        return new Type[] {String.class};
+      }
+
+      @Override
+      public Type getRawType() {
+        return List.class;
+      }
+
+      @Override
+      public Type getOwnerType() {
+        return null;
+      }
+    }
+
+    @Test
+    public void testListOfStrings() throws Exception {
+      MethodInfo mi = new MethodInfo(SyncClient.class, SyncClient.class.getMethod("log"));
+      assertEquals("SyncClient#log()", mi.configKey());
+      assertFalse(mi.isAsyncReturnType());
+      assertTrue(Types.equals(new ListOfStrings(), mi.underlyingReturnType()));
+    }
+  }
+}


### PR DESCRIPTION
I've faced an issue that `AsyncFeign` does not resolve generic parameters correctly when clients are also parametrized — for example, sync and async with a common parameterized interface for return types.

```
public interface TestClient<T> {
  @RequestLine("GET /log") T log();
}

public interface TestSyncClient extends TestClient<String> {}
public interface TestAsyncClient extends TestClient<CompletableFuture<String>> {}
```

`Feign` works just fine:
```
Feign.builder()
  .target(TestSyncClient.class, url)
  .log();
```

But `AsyncFeign` fails
```
AsyncFeign.asyncBuilder()
  .target(TestAsyncClient.class, url)
  .log()
  .get(); => T is not a type supported by this decoder.
```

I traced this down to `MethodInfo` where it does very basic detection unlike `Contract.parseAndValidateMetadata()` which is used by `Feign` to create an invocation handler.

The solution I propose is to use the same type-resolution that `Contract` does [here](https://github.com/OpenFeign/feign/blob/master/core/src/main/java/feign/Contract.java#L96-L97) inside `MethodInfo`.