### PR TITLE
Proof that clients support gzip and deflate compression

### DIFF
--- a/core/src/test/java/feign/client/DefaultClientTest.java
+++ b/core/src/test/java/feign/client/DefaultClientTest.java
@@ -150,21 +150,4 @@ public class DefaultClientTest extends AbstractClientTest {
     assertThat(connection).isNotNull().isInstanceOf(HttpURLConnection.class);
   }
 
-  private byte[] compress(String data) throws Exception {
-    try (ByteArrayOutputStream bos = new ByteArrayOutputStream(data.length())) {
-      GZIPOutputStream gzipOutputStream = new GZIPOutputStream(bos);
-      gzipOutputStream.write(data.getBytes(StandardCharsets.UTF_8), 0, data.length());
-      gzipOutputStream.close();
-      return bos.toByteArray();
-    }
-  }
-
-  private byte[] deflate(String data) throws Exception {
-    try (ByteArrayOutputStream bos = new ByteArrayOutputStream(data.length())) {
-      DeflaterOutputStream deflaterOutputStream = new DeflaterOutputStream(bos);
-      deflaterOutputStream.write(data.getBytes(StandardCharsets.UTF_8), 0, data.length());
-      deflaterOutputStream.close();
-      return bos.toByteArray();
-    }
-  }
 }

--- a/core/src/test/java/feign/client/DefaultClientTest.java
+++ b/core/src/test/java/feign/client/DefaultClientTest.java
@@ -150,64 +150,6 @@ public class DefaultClientTest extends AbstractClientTest {
     assertThat(connection).isNotNull().isInstanceOf(HttpURLConnection.class);
   }
 
-
-  @Test
-  public void canSupportGzip() throws Exception {
-    /* enqueue a zipped response */
-    final String responseData = "Compressed Data";
-    server.enqueue(new MockResponse()
-        .addHeader("Content-Encoding", "gzip")
-        .setBody(new Buffer().write(compress(responseData))));
-
-    TestInterface api = newBuilder()
-        .target(TestInterface.class, "http://localhost:" + server.getPort());
-
-    String result = api.get();
-
-    /* verify that the response is unzipped */
-    assertThat(result).isNotNull()
-        .isEqualToIgnoringCase(responseData);
-
-  }
-
-  @Test
-  public void canExeptCaseInsensitiveHeader() throws Exception {
-    /* enqueue a zipped response */
-    final String responseData = "Compressed Data";
-    server.enqueue(new MockResponse()
-        .addHeader("content-encoding", "gzip")
-        .setBody(new Buffer().write(compress(responseData))));
-
-    TestInterface api = newBuilder()
-        .target(TestInterface.class, "http://localhost:" + server.getPort());
-
-    String result = api.get();
-
-    /* verify that the response is unzipped */
-    assertThat(result).isNotNull()
-        .isEqualToIgnoringCase(responseData);
-
-  }
-
-  @Test
-  public void canSupportDeflate() throws Exception {
-    /* enqueue a zipped response */
-    final String responseData = "Compressed Data";
-    server.enqueue(new MockResponse()
-        .addHeader("Content-Encoding", "deflate")
-        .setBody(new Buffer().write(deflate(responseData))));
-
-    TestInterface api = newBuilder()
-        .target(TestInterface.class, "http://localhost:" + server.getPort());
-
-    String result = api.get();
-
-    /* verify that the response is unzipped */
-    assertThat(result).isNotNull()
-        .isEqualToIgnoringCase(responseData);
-
-  }
-
   private byte[] compress(String data) throws Exception {
     try (ByteArrayOutputStream bos = new ByteArrayOutputStream(data.length())) {
       GZIPOutputStream gzipOutputStream = new GZIPOutputStream(bos);

--- a/googlehttpclient/README.md
+++ b/googlehttpclient/README.md
@@ -2,7 +2,7 @@
 
 This module is a feign [Client](https://github.com/OpenFeign/feign/blob/master/core/src/main/java/feign/Client.java) to use the java [Google Http Client](https://github.com/googleapis/google-http-java-client).
 
-To use this, add to your classpath (via maven, or otherwise). Then cofigure Feign to use the GoogleHttpClient:
+To use this, add to your classpath (via maven, or otherwise). Then configure Feign to use the GoogleHttpClient:
 
 ```java
 GitHub github = Feign.builder()

--- a/googlehttpclient/src/test/java/feign/googlehttpclient/GoogleHttpClientTest.java
+++ b/googlehttpclient/src/test/java/feign/googlehttpclient/GoogleHttpClientTest.java
@@ -16,6 +16,7 @@ package feign.googlehttpclient;
 import feign.Feign;
 import feign.Feign.Builder;
 import feign.client.AbstractClientTest;
+import static org.junit.Assume.assumeFalse;
 
 public class GoogleHttpClientTest extends AbstractClientTest {
   @Override
@@ -34,4 +35,24 @@ public class GoogleHttpClientTest extends AbstractClientTest {
 
   @Override
   public void parsesUnauthorizedResponseBody() {}
+
+  /*
+   * Google HTTP client with NetHttpTransport does not support gzip and deflate compression
+   * out-of-the-box. You can replace the transport with Apache HTTP Client.
+   */
+  @Override
+  public void canSupportGzip() throws Exception {
+    assumeFalse("Google HTTP client client do not support gzip compression", false);
+  }
+
+  @Override
+  public void canSupportDeflate() throws Exception {
+    assumeFalse("Google HTTP client client do not support deflate compression", false);
+  }
+
+  @Override
+  public void canExceptCaseInsensitiveHeader() throws Exception {
+    assumeFalse("Google HTTP client client do not support gzip compression", false);
+  }
+
 }

--- a/jaxrs2/src/test/java/feign/jaxrs2/JAXRSClientTest.java
+++ b/jaxrs2/src/test/java/feign/jaxrs2/JAXRSClientTest.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import static feign.Util.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeFalse;
 
 /**
  * Tests client-specific behavior, such as ensuring Content-Length is sent when specified.
@@ -141,6 +142,24 @@ public class JAXRSClientTest extends AbstractClientTest {
         .hasHeaders(MapEntry.entry("Content-Type",
             Collections.singletonList("application/json;charset=utf-8")))
         .hasMethod("POST");
+  }
+
+  /*
+   * JaxRS does not support gzip and deflate compression out-of-the-box.
+   */
+  @Override
+  public void canSupportGzip() throws Exception {
+    assumeFalse("JaxRS client do not support gzip compression", false);
+  }
+
+  @Override
+  public void canSupportDeflate() throws Exception {
+    assumeFalse("JaxRS client do not support deflate compression", false);
+  }
+
+  @Override
+  public void canExceptCaseInsensitiveHeader() throws Exception {
+    assumeFalse("JaxRS client do not support gzip compression", false);
   }
 
   public interface JaxRSClientTestInterface {

--- a/okhttp/src/test/java/feign/okhttp/OkHttpClientTest.java
+++ b/okhttp/src/test/java/feign/okhttp/OkHttpClientTest.java
@@ -29,6 +29,7 @@ import okhttp3.mockwebserver.MockResponse;
 import org.assertj.core.data.MapEntry;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeFalse;
 
 /** Tests client-specific behavior, such as ensuring Content-Length is sent when specified. */
 public class OkHttpClientTest extends AbstractClientTest {
@@ -103,6 +104,26 @@ public class OkHttpClientTest extends AbstractClientTest {
 
   }
 
+  /*
+   * OkHTTP does not support gzip and deflate compression out-of-the-box. But you can add an
+   * interceptor that implies it, see
+   * https://stackoverflow.com/questions/51901333/okhttp-3-how-to-decompress-gzip-deflate-response-
+   * manually-using-java-android
+   */
+  @Override
+  public void canSupportGzip() throws Exception {
+    assumeFalse("OkHTTP client do not support gzip compression", false);
+  }
+
+  @Override
+  public void canSupportDeflate() throws Exception {
+    assumeFalse("OkHTTP client do not support deflate compression", false);
+  }
+
+  @Override
+  public void canExceptCaseInsensitiveHeader() throws Exception {
+    assumeFalse("OkHTTP client do not support gzip compression", false);
+  }
 
   public interface OkHttpClientTestInterface {
 


### PR DESCRIPTION
Bunch of clients support gzip and deflate compression except of JAX-RS2, OkHTTP and Google HTTP client.

- OkHTTP client with an interceptor can proccess GZIP response, e.g. https://stackoverflow.com/questions/51901333/okhttp-3-how-to-decompress-gzip-deflate-response-manually-using-java-android
- Google HTTP client with NetHttpTransport does not support GZIP response at all but we can use Apache HTTP client as its transport
- JAX-RS2 client does not support GZIP responses out-of-the-box but we can register a class that implies it like Jersey implementation does it, see https://stackoverflow.com/questions/22519642/how-to-enable-gzip-compression-for-content-encoding-with-jersey-jax-rs-2-0-cli

Closes #1697