### PR TITLE
Only allow a single content-type header to be applied while using googlehttpclient

### DIFF
--- a/googlehttpclient/src/main/java/feign/googlehttpclient/GoogleHttpClient.java
+++ b/googlehttpclient/src/main/java/feign/googlehttpclient/GoogleHttpClient.java
@@ -22,12 +22,10 @@ import com.google.api.client.http.HttpRequestFactory;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.javanet.NetHttpTransport;
-
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.HashMap;
-
 import feign.Client;
 import feign.Request;
 import feign.Response;
@@ -90,7 +88,8 @@ public class GoogleHttpClient implements Client {
     final HttpHeaders headers = new HttpHeaders();
     for (final Map.Entry<String, Collection<String>> header : inputRequest.headers().entrySet()) {
       // We already set the Content-Type header via ByteArrayContent
-      // Content-Type is defined as a singleton field https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3-7
+      // Content-Type is defined as a singleton field
+      // https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3-7
       if (!header.getKey().equals("Content-Type")) {
         headers.set(header.getKey(), header.getValue());
       }

--- a/googlehttpclient/src/main/java/feign/googlehttpclient/GoogleHttpClient.java
+++ b/googlehttpclient/src/main/java/feign/googlehttpclient/GoogleHttpClient.java
@@ -22,10 +22,12 @@ import com.google.api.client.http.HttpRequestFactory;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.javanet.NetHttpTransport;
+
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.HashMap;
+
 import feign.Client;
 import feign.Request;
 import feign.Response;

--- a/googlehttpclient/src/main/java/feign/googlehttpclient/GoogleHttpClient.java
+++ b/googlehttpclient/src/main/java/feign/googlehttpclient/GoogleHttpClient.java
@@ -87,7 +87,11 @@ public class GoogleHttpClient implements Client {
     // Setup headers
     final HttpHeaders headers = new HttpHeaders();
     for (final Map.Entry<String, Collection<String>> header : inputRequest.headers().entrySet()) {
-      headers.set(header.getKey(), header.getValue());
+      // We already set the Content-Type header via ByteArrayContent
+      // Content-Type is defined as a singleton field https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3-7
+      if (!header.getKey().equals("Content-Type")) {
+        headers.set(header.getKey(), header.getValue());
+      }
     }
     // Some servers don't do well with no Accept header
     if (inputRequest.headers().get("Accept") == null) {

--- a/googlehttpclient/src/test/java/feign/googlehttpclient/GoogleHttpClientTest.java
+++ b/googlehttpclient/src/test/java/feign/googlehttpclient/GoogleHttpClientTest.java
@@ -39,13 +39,16 @@ public class GoogleHttpClientTest extends AbstractClientTest {
   // Google http client doesn't support PATCH. See:
   // https://github.com/googleapis/google-http-java-client/issues/167
   @Override
-  public void noResponseBodyForPatch() {}
+  public void noResponseBodyForPatch() {
+  }
 
   @Override
-  public void testPatch() {}
+  public void testPatch() {
+  }
 
   @Override
-  public void parsesUnauthorizedResponseBody() {}
+  public void parsesUnauthorizedResponseBody() {
+  }
 
   /*
    * Google HTTP client with NetHttpTransport does not support gzip and deflate compression
@@ -69,17 +72,17 @@ public class GoogleHttpClientTest extends AbstractClientTest {
   @Test
   public void testContentTypeHeaderGetsAddedOnce() throws Exception {
     server.enqueue(new MockResponse()
-            .setBody("AAAAAAAA"));
+        .setBody("AAAAAAAA"));
     TestInterface api = newBuilder()
-            .target(TestInterface.class, "http://localhost:" + server.getPort());
+        .target(TestInterface.class, "http://localhost:" + server.getPort());
 
     Response response = api.postWithContentType("foo", "text/plain");
     // Response length should not be null
     assertEquals("AAAAAAAA", Util.toString(response.body().asReader(UTF_8)));
 
     MockWebServerAssertions.assertThat(server.takeRequest())
-            .hasHeaders(entry("Content-Type", Collections.singletonList("text/plain")),
-                    entry("Content-Length", Collections.singletonList("3")))
-            .hasMethod("POST");
+        .hasHeaders(entry("Content-Type", Collections.singletonList("text/plain")),
+            entry("Content-Length", Collections.singletonList("3")))
+        .hasMethod("POST");
   }
 }

--- a/googlehttpclient/src/test/java/feign/googlehttpclient/GoogleHttpClientTest.java
+++ b/googlehttpclient/src/test/java/feign/googlehttpclient/GoogleHttpClientTest.java
@@ -21,9 +21,7 @@ import feign.assertj.MockWebServerAssertions;
 import feign.client.AbstractClientTest;
 import okhttp3.mockwebserver.MockResponse;
 import org.junit.Test;
-
 import java.util.Collections;
-
 import static feign.Util.UTF_8;
 import static org.assertj.core.api.Assertions.entry;
 import static org.junit.Assert.assertEquals;
@@ -39,16 +37,13 @@ public class GoogleHttpClientTest extends AbstractClientTest {
   // Google http client doesn't support PATCH. See:
   // https://github.com/googleapis/google-http-java-client/issues/167
   @Override
-  public void noResponseBodyForPatch() {
-  }
+  public void noResponseBodyForPatch() {}
 
   @Override
-  public void testPatch() {
-  }
+  public void testPatch() {}
 
   @Override
-  public void parsesUnauthorizedResponseBody() {
-  }
+  public void parsesUnauthorizedResponseBody() {}
 
   /*
    * Google HTTP client with NetHttpTransport does not support gzip and deflate compression

--- a/googlehttpclient/src/test/java/feign/googlehttpclient/GoogleHttpClientTest.java
+++ b/googlehttpclient/src/test/java/feign/googlehttpclient/GoogleHttpClientTest.java
@@ -15,7 +15,18 @@ package feign.googlehttpclient;
 
 import feign.Feign;
 import feign.Feign.Builder;
+import feign.Response;
+import feign.Util;
+import feign.assertj.MockWebServerAssertions;
 import feign.client.AbstractClientTest;
+import okhttp3.mockwebserver.MockResponse;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static feign.Util.UTF_8;
+import static org.assertj.core.api.Assertions.entry;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeFalse;
 
 public class GoogleHttpClientTest extends AbstractClientTest {
@@ -55,4 +66,20 @@ public class GoogleHttpClientTest extends AbstractClientTest {
     assumeFalse("Google HTTP client client do not support gzip compression", false);
   }
 
+  @Test
+  public void testContentTypeHeaderGetsAddedOnce() throws Exception {
+    server.enqueue(new MockResponse()
+            .setBody("AAAAAAAA"));
+    TestInterface api = newBuilder()
+            .target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    Response response = api.postWithContentType("foo", "text/plain");
+    // Response length should not be null
+    assertEquals("AAAAAAAA", Util.toString(response.body().asReader(UTF_8)));
+
+    MockWebServerAssertions.assertThat(server.takeRequest())
+            .hasHeaders(entry("Content-Type", Collections.singletonList("text/plain")),
+                    entry("Content-Length", Collections.singletonList("3")))
+            .hasMethod("POST");
+  }
 }


### PR DESCRIPTION
## Impact
Fixed issue where multiple content-type headers were being added to the request while using googlehttpclient.

## Research
Multiple `Content-Type` headers goes against the spec

> Content-Type is defined as a singleton field.... 
https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3-7

## Implementation Summary
Ignore `Content-Type` from being set on the request because it'll be added via ByteArrayContent 
