### PR TITLE
Refactor coroutine feign

### DIFF
--- a/core/src/main/java/feign/AsyncFeign.java
+++ b/core/src/main/java/feign/AsyncFeign.java
@@ -66,6 +66,7 @@ public abstract class AsyncFeign<C> extends Feign {
     private AsyncContextSupplier<C> defaultContextSupplier = () -> null;
     private AsyncClient<C> client = new AsyncClient.Default<>(
         new Client.Default(null, null), LazyInitializedExecutorService.instance);
+    private MethodInfoResolver methodInfoResolver = MethodInfo::new;
 
     @Deprecated
     public AsyncBuilder<C> defaultContextSupplier(Supplier<C> supplier) {
@@ -75,6 +76,11 @@ public abstract class AsyncFeign<C> extends Feign {
 
     public AsyncBuilder<C> client(AsyncClient<C> client) {
       this.client = client;
+      return this;
+    }
+
+    public AsyncBuilder<C> methodInfoResolver(MethodInfoResolver methodInfoResolver) {
+      this.methodInfoResolver = methodInfoResolver;
       return this;
     }
 
@@ -205,7 +211,7 @@ public abstract class AsyncFeign<C> extends Feign {
           .requestInterceptors(requestInterceptors)
           .responseInterceptor(responseInterceptor)
           .invocationHandlerFactory(invocationHandlerFactory)
-          .build(), defaultContextSupplier, activeContextHolder, MethodInfo::new);
+          .build(), defaultContextSupplier, activeContextHolder, methodInfoResolver);
     }
 
     private Client stageExecution(

--- a/core/src/main/java/feign/AsyncFeign.java
+++ b/core/src/main/java/feign/AsyncFeign.java
@@ -205,7 +205,7 @@ public abstract class AsyncFeign<C> extends Feign {
           .requestInterceptors(requestInterceptors)
           .responseInterceptor(responseInterceptor)
           .invocationHandlerFactory(invocationHandlerFactory)
-          .build(), defaultContextSupplier, activeContextHolder);
+          .build(), defaultContextSupplier, activeContextHolder, MethodInfo::new);
     }
 
     private Client stageExecution(

--- a/core/src/main/java/feign/Capability.java
+++ b/core/src/main/java/feign/Capability.java
@@ -133,4 +133,8 @@ public interface Capability {
   default <C> AsyncContextSupplier<C> enrich(AsyncContextSupplier<C> asyncContextSupplier) {
     return asyncContextSupplier;
   }
+
+  default MethodInfoResolver enrich(MethodInfoResolver methodInfoResolver) {
+    return methodInfoResolver;
+  }
 }

--- a/core/src/main/java/feign/MethodInfoResolver.java
+++ b/core/src/main/java/feign/MethodInfoResolver.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012-2022 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+
+@Experimental
+public interface MethodInfoResolver {
+  public MethodInfo resolve(Class<?> targetType, Method method);
+}

--- a/core/src/main/java/feign/ReflectiveAsyncFeign.java
+++ b/core/src/main/java/feign/ReflectiveAsyncFeign.java
@@ -59,7 +59,7 @@ public class ReflectiveAsyncFeign<C> extends AsyncFeign<C> {
       }
 
       final MethodInfo methodInfo =
-          methodInfoLookup.computeIfAbsent(method, m -> new MethodInfo(type, m));
+          methodInfoLookup.computeIfAbsent(method, m -> methodInfoResolver.resolve(type, m));
 
       setInvocationContext(new AsyncInvocation<>(context, methodInfo));
       try {
@@ -97,11 +97,13 @@ public class ReflectiveAsyncFeign<C> extends AsyncFeign<C> {
   }
 
   private ThreadLocal<AsyncInvocation<C>> activeContextHolder;
+  private final MethodInfoResolver methodInfoResolver;
 
   public ReflectiveAsyncFeign(Feign feign, AsyncContextSupplier<C> defaultContextSupplier,
-      ThreadLocal<AsyncInvocation<C>> contextHolder) {
+      ThreadLocal<AsyncInvocation<C>> contextHolder, MethodInfoResolver methodInfoResolver) {
     super(feign, defaultContextSupplier);
     this.activeContextHolder = contextHolder;
+    this.methodInfoResolver = methodInfoResolver;
   }
 
   protected void setInvocationContext(AsyncInvocation<C> invocationContext) {

--- a/core/src/test/java/feign/BaseBuilderTest.java
+++ b/core/src/test/java/feign/BaseBuilderTest.java
@@ -27,7 +27,7 @@ public class BaseBuilderTest {
   public void checkEnrichTouchesAllAsyncBuilderFields()
       throws IllegalArgumentException, IllegalAccessException {
     test(AsyncFeign.asyncBuilder().requestInterceptor(template -> {
-    }), 13);
+    }), 14);
   }
 
   private void test(BaseBuilder<?> builder, int expectedFieldsCount)

--- a/example-github-with-coroutine/src/main/java/example/github/GitHubExample.kt
+++ b/example-github-with-coroutine/src/main/java/example/github/GitHubExample.kt
@@ -86,7 +86,7 @@ interface GitHub {
         fun connect(): GitHub {
             val decoder: Decoder = feign.gson.GsonDecoder()
             val encoder: Encoder = GsonEncoder()
-            return CoroutineFeign.coBuilder<Unit>()
+            return CoroutineFeign.builder<Unit>()
                 .encoder(encoder)
                 .decoder(decoder)
                 .errorDecoder(GitHubErrorDecoder(decoder))

--- a/kotlin/src/main/java/feign/kotlin/CoroutineFeign.java
+++ b/kotlin/src/main/java/feign/kotlin/CoroutineFeign.java
@@ -33,8 +33,16 @@ import kotlinx.coroutines.future.FutureKt;
 
 @Experimental
 public class CoroutineFeign<C> {
-  public static <C> CoroutineBuilder<C> coBuilder() {
+  public static <C> CoroutineBuilder<C> builder() {
     return new CoroutineBuilder<>();
+  }
+
+  /**
+   * @deprecated use {@link #builder()} instead.
+   */
+  @Deprecated()
+  public static <C> CoroutineBuilder<C> coBuilder() {
+    return builder();
   }
 
   private static class LazyInitializedExecutorService {

--- a/kotlin/src/test/kotlin/feign/kotlin/CoroutineFeignTest.kt
+++ b/kotlin/src/test/kotlin/feign/kotlin/CoroutineFeignTest.kt
@@ -145,7 +145,7 @@ class CoroutineFeignTest {
     }
 
     internal class TestInterfaceAsyncBuilder {
-        private val delegate = CoroutineFeign.coBuilder<Void>()
+        private val delegate = CoroutineFeign.builder<Void>()
             .decoder(Decoder.Default()).encoder { `object`, bodyType, template ->
                 if (`object` is Map<*, *>) {
                     template.body(Gson().toJson(`object`))


### PR DESCRIPTION
If you want to see the final result, see PR #1757

Eliminates the possibility of breaking changes following AsyncFeign's refactoring in advance

## TODO

- [ ] Modify CoroutineFeign.CoroutineBuilder to extend Feign.Builder
    - It is intended to be used when [customizing](https://docs.spring.io/spring-cloud-openfeign/docs/current/reference/html/#spring-cloud-feign-circuitbreaker) Feign.Builder in Spring Cloud OpenFeign.
    - I think it's okay to work after merged, because CoroutineFeign is an experimental feature right now.