### PR TITLE
Refactor async feign

### DIFF
--- a/README.md
+++ b/README.md
@@ -1077,7 +1077,7 @@ interface GitHub {
 
 public class MyApp {
   public static void main(String... args) {
-    GitHub github = AsyncFeign.asyncBuilder()
+    GitHub github = AsyncFeign.builder()
                          .decoder(new GsonDecoder())
                          .target(GitHub.class, "https://api.github.com");
 

--- a/core/src/main/java/feign/AsyncFeign.java
+++ b/core/src/main/java/feign/AsyncFeign.java
@@ -45,9 +45,16 @@ import java.util.function.Supplier;
  */
 @Experimental
 public abstract class AsyncFeign<C> {
-
-  public static <C> AsyncBuilder<C> asyncBuilder() {
+  public static <C> AsyncBuilder<C> builder() {
     return new AsyncBuilder<>();
+  }
+
+  /**
+   * @deprecated use {@link #builder()} instead.
+   */
+  @Deprecated()
+  public static <C> AsyncBuilder<C> asyncBuilder() {
+    return builder();
   }
 
   private static class LazyInitializedExecutorService {

--- a/core/src/main/java/feign/AsyncFeign.java
+++ b/core/src/main/java/feign/AsyncFeign.java
@@ -66,6 +66,7 @@ public abstract class AsyncFeign<C> extends Feign {
     private AsyncContextSupplier<C> defaultContextSupplier = () -> null;
     private AsyncClient<C> client = new AsyncClient.Default<>(
         new Client.Default(null, null), LazyInitializedExecutorService.instance);
+    private MethodInfoResolver methodInfoResolver = MethodInfo::new;
 
     @Deprecated
     public AsyncBuilder<C> defaultContextSupplier(Supplier<C> supplier) {
@@ -75,6 +76,11 @@ public abstract class AsyncFeign<C> extends Feign {
 
     public AsyncBuilder<C> client(AsyncClient<C> client) {
       this.client = client;
+      return this;
+    }
+
+    public AsyncBuilder<C> methodInfoResolver(MethodInfoResolver methodInfoResolver) {
+      this.methodInfoResolver = methodInfoResolver;
       return this;
     }
 
@@ -205,7 +211,7 @@ public abstract class AsyncFeign<C> extends Feign {
           .requestInterceptors(requestInterceptors)
           .responseInterceptor(responseInterceptor)
           .invocationHandlerFactory(invocationHandlerFactory)
-          .build(), defaultContextSupplier, activeContextHolder, MethodInfo::new);
+          .build(), defaultContextSupplier, activeContextHolder, methodInfoResolver);
     }
 
     private Client stageExecution(

--- a/core/src/main/java/feign/AsyncFeign.java
+++ b/core/src/main/java/feign/AsyncFeign.java
@@ -205,7 +205,7 @@ public abstract class AsyncFeign<C> extends Feign {
           .requestInterceptors(requestInterceptors)
           .responseInterceptor(responseInterceptor)
           .invocationHandlerFactory(invocationHandlerFactory)
-          .build(), defaultContextSupplier, activeContextHolder);
+          .build(), defaultContextSupplier, activeContextHolder, MethodInfo::new);
     }
 
     private Client stageExecution(

--- a/core/src/main/java/feign/AsyncFeign.java
+++ b/core/src/main/java/feign/AsyncFeign.java
@@ -44,7 +44,7 @@ import java.util.function.Supplier;
  * be done (for example, creating and submitting a task to an {@link ExecutorService}).
  */
 @Experimental
-public abstract class AsyncFeign<C> extends Feign {
+public abstract class AsyncFeign<C> {
 
   public static <C> AsyncBuilder<C> asyncBuilder() {
     return new AsyncBuilder<>();
@@ -299,7 +299,6 @@ public abstract class AsyncFeign<C> extends Feign {
     this.defaultContextSupplier = defaultContextSupplier;
   }
 
-  @Override
   public <T> T newInstance(Target<T> target) {
     return newInstance(target, defaultContextSupplier.newContext());
   }

--- a/core/src/main/java/feign/Capability.java
+++ b/core/src/main/java/feign/Capability.java
@@ -133,4 +133,8 @@ public interface Capability {
   default <C> AsyncContextSupplier<C> enrich(AsyncContextSupplier<C> asyncContextSupplier) {
     return asyncContextSupplier;
   }
+
+  default MethodInfoResolver enrich(MethodInfoResolver methodInfoResolver) {
+    return methodInfoResolver;
+  }
 }

--- a/core/src/main/java/feign/MethodInfoResolver.java
+++ b/core/src/main/java/feign/MethodInfoResolver.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012-2022 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+
+@Experimental
+public interface MethodInfoResolver {
+  public MethodInfo resolve(Class<?> targetType, Method method);
+}

--- a/core/src/main/java/feign/ReflectiveAsyncFeign.java
+++ b/core/src/main/java/feign/ReflectiveAsyncFeign.java
@@ -59,7 +59,7 @@ public class ReflectiveAsyncFeign<C> extends AsyncFeign<C> {
       }
 
       final MethodInfo methodInfo =
-          methodInfoLookup.computeIfAbsent(method, m -> new MethodInfo(type, m));
+          methodInfoLookup.computeIfAbsent(method, m -> methodInfoResolver.resolve(type, m));
 
       setInvocationContext(new AsyncInvocation<>(context, methodInfo));
       try {
@@ -97,11 +97,13 @@ public class ReflectiveAsyncFeign<C> extends AsyncFeign<C> {
   }
 
   private ThreadLocal<AsyncInvocation<C>> activeContextHolder;
+  private final MethodInfoResolver methodInfoResolver;
 
   public ReflectiveAsyncFeign(Feign feign, AsyncContextSupplier<C> defaultContextSupplier,
-      ThreadLocal<AsyncInvocation<C>> contextHolder) {
+      ThreadLocal<AsyncInvocation<C>> contextHolder, MethodInfoResolver methodInfoResolver) {
     super(feign, defaultContextSupplier);
     this.activeContextHolder = contextHolder;
+    this.methodInfoResolver = methodInfoResolver;
   }
 
   protected void setInvocationContext(AsyncInvocation<C> invocationContext) {

--- a/core/src/test/java/feign/AsyncFeignTest.java
+++ b/core/src/test/java/feign/AsyncFeignTest.java
@@ -503,7 +503,7 @@ public class AsyncFeignTest {
   public void throwsFeignExceptionIncludingBody() throws Throwable {
     server.enqueue(new MockResponse().setBody("success!"));
 
-    TestInterfaceAsync api = AsyncFeign.asyncBuilder().decoder((response, type) -> {
+    TestInterfaceAsync api = AsyncFeign.builder().decoder((response, type) -> {
       throw new IOException("timeout");
     }).target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
 
@@ -524,7 +524,7 @@ public class AsyncFeignTest {
   public void throwsFeignExceptionWithoutBody() {
     server.enqueue(new MockResponse().setBody("success!"));
 
-    TestInterfaceAsync api = AsyncFeign.asyncBuilder().decoder((response, type) -> {
+    TestInterfaceAsync api = AsyncFeign.builder().decoder((response, type) -> {
       throw new IOException("timeout");
     }).target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
 
@@ -549,7 +549,7 @@ public class AsyncFeignTest {
     ExecutorService execs = Executors.newSingleThreadExecutor();
 
     // fake client as Client.Default follows redirects.
-    TestInterfaceAsync api = AsyncFeign.<Void>asyncBuilder()
+    TestInterfaceAsync api = AsyncFeign.<Void>builder()
         .client(new AsyncClient.Default<>((request, options) -> response, execs))
         .target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
 
@@ -625,10 +625,10 @@ public class AsyncFeignTest {
     Target<OtherTestInterfaceAsync> t3 =
         new HardCodedTarget<>(OtherTestInterfaceAsync.class,
             "http://localhost:8080");
-    TestInterfaceAsync i1 = AsyncFeign.asyncBuilder().target(t1);
-    TestInterfaceAsync i2 = AsyncFeign.asyncBuilder().target(t1);
-    TestInterfaceAsync i3 = AsyncFeign.asyncBuilder().target(t2);
-    OtherTestInterfaceAsync i4 = AsyncFeign.asyncBuilder().target(t3);
+    TestInterfaceAsync i1 = AsyncFeign.builder().target(t1);
+    TestInterfaceAsync i2 = AsyncFeign.builder().target(t1);
+    TestInterfaceAsync i3 = AsyncFeign.builder().target(t2);
+    OtherTestInterfaceAsync i4 = AsyncFeign.builder().target(t3);
 
     assertThat(i1).isEqualTo(i2).isNotEqualTo(i3).isNotEqualTo(i4);
 
@@ -651,7 +651,7 @@ public class AsyncFeignTest {
     byte[] expectedResponse = {12, 34, 56};
     server.enqueue(new MockResponse().setBody(new Buffer().write(expectedResponse)));
 
-    OtherTestInterfaceAsync api = AsyncFeign.asyncBuilder().target(OtherTestInterfaceAsync.class,
+    OtherTestInterfaceAsync api = AsyncFeign.builder().target(OtherTestInterfaceAsync.class,
         "http://localhost:" + server.getPort());
 
     assertThat(unwrap(api.binaryResponseBody())).containsExactly(expectedResponse);
@@ -662,7 +662,7 @@ public class AsyncFeignTest {
     byte[] expectedRequest = {12, 34, 56};
     server.enqueue(new MockResponse());
 
-    OtherTestInterfaceAsync api = AsyncFeign.asyncBuilder().target(OtherTestInterfaceAsync.class,
+    OtherTestInterfaceAsync api = AsyncFeign.builder().target(OtherTestInterfaceAsync.class,
         "http://localhost:" + server.getPort());
 
     CompletableFuture<?> cf = api.binaryRequestBody(expectedRequest);
@@ -733,7 +733,7 @@ public class AsyncFeignTest {
     server.enqueue(new MockResponse().setBody("response!"));
 
     TestInterfaceAsync api =
-        AsyncFeign.asyncBuilder().mapAndDecode(upperCaseResponseMapper(), new StringDecoder())
+        AsyncFeign.builder().mapAndDecode(upperCaseResponseMapper(), new StringDecoder())
             .target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
 
     assertEquals("RESPONSE!", unwrap(api.post()));
@@ -962,7 +962,7 @@ public class AsyncFeignTest {
 
   static final class TestInterfaceAsyncBuilder {
 
-    private final AsyncFeign.AsyncBuilder<Void> delegate = AsyncFeign.<Void>asyncBuilder()
+    private final AsyncFeign.AsyncBuilder<Void> delegate = AsyncFeign.<Void>builder()
         .decoder(new Decoder.Default()).encoder(new Encoder() {
 
           @SuppressWarnings("deprecation")
@@ -1018,31 +1018,31 @@ public class AsyncFeignTest {
   @Test
   public void testNonInterface() {
     thrown.expect(IllegalArgumentException.class);
-    AsyncFeign.asyncBuilder().target(NonInterface.class, "http://localhost");
+    AsyncFeign.builder().target(NonInterface.class, "http://localhost");
   }
 
   @Test
   public void testExtendedCFReturnType() {
     thrown.expect(IllegalArgumentException.class);
-    AsyncFeign.asyncBuilder().target(ExtendedCFApi.class, "http://localhost");
+    AsyncFeign.builder().target(ExtendedCFApi.class, "http://localhost");
   }
 
   @Test
   public void testLowerWildReturnType() {
     thrown.expect(IllegalArgumentException.class);
-    AsyncFeign.asyncBuilder().target(LowerWildApi.class, "http://localhost");
+    AsyncFeign.builder().target(LowerWildApi.class, "http://localhost");
   }
 
   @Test
   public void testUpperWildReturnType() {
     thrown.expect(IllegalArgumentException.class);
-    AsyncFeign.asyncBuilder().target(UpperWildApi.class, "http://localhost");
+    AsyncFeign.builder().target(UpperWildApi.class, "http://localhost");
   }
 
   @Test
   public void testrWildReturnType() {
     thrown.expect(IllegalArgumentException.class);
-    AsyncFeign.asyncBuilder().target(WildApi.class, "http://localhost");
+    AsyncFeign.builder().target(WildApi.class, "http://localhost");
   }
 
 

--- a/core/src/test/java/feign/BaseBuilderTest.java
+++ b/core/src/test/java/feign/BaseBuilderTest.java
@@ -26,7 +26,7 @@ public class BaseBuilderTest {
   @Test
   public void checkEnrichTouchesAllAsyncBuilderFields()
       throws IllegalArgumentException, IllegalAccessException {
-    test(AsyncFeign.asyncBuilder().requestInterceptor(template -> {
+    test(AsyncFeign.builder().requestInterceptor(template -> {
     }), 14);
   }
 

--- a/core/src/test/java/feign/BaseBuilderTest.java
+++ b/core/src/test/java/feign/BaseBuilderTest.java
@@ -27,7 +27,7 @@ public class BaseBuilderTest {
   public void checkEnrichTouchesAllAsyncBuilderFields()
       throws IllegalArgumentException, IllegalAccessException {
     test(AsyncFeign.asyncBuilder().requestInterceptor(template -> {
-    }), 13);
+    }), 14);
   }
 
   private void test(BaseBuilder<?> builder, int expectedFieldsCount)

--- a/core/src/test/java/feign/FeignUnderAsyncTest.java
+++ b/core/src/test/java/feign/FeignUnderAsyncTest.java
@@ -487,7 +487,7 @@ public class FeignUnderAsyncTest {
   public void throwsFeignExceptionIncludingBody() {
     server.enqueue(new MockResponse().setBody("success!"));
 
-    TestInterface api = AsyncFeign.asyncBuilder()
+    TestInterface api = AsyncFeign.builder()
         .decoder((response, type) -> {
           throw new IOException("timeout");
         })
@@ -506,7 +506,7 @@ public class FeignUnderAsyncTest {
   public void throwsFeignExceptionWithoutBody() {
     server.enqueue(new MockResponse().setBody("success!"));
 
-    TestInterface api = AsyncFeign.asyncBuilder()
+    TestInterface api = AsyncFeign.builder()
         .decoder((response, type) -> {
           throw new IOException("timeout");
         })
@@ -536,7 +536,7 @@ public class FeignUnderAsyncTest {
     ExecutorService execs = Executors.newSingleThreadExecutor();
 
     // fake client as Client.Default follows redirects.
-    TestInterface api = AsyncFeign.<Void>asyncBuilder()
+    TestInterface api = AsyncFeign.<Void>builder()
         .client(new AsyncClient.Default<>((request, options) -> response, execs))
         .target(TestInterface.class, "http://localhost:" + server.getPort());
 
@@ -635,10 +635,10 @@ public class FeignUnderAsyncTest {
         new HardCodedTarget<TestInterface>(TestInterface.class, "http://localhost:8888");
     Target<OtherTestInterface> t3 =
         new HardCodedTarget<OtherTestInterface>(OtherTestInterface.class, "http://localhost:8080");
-    TestInterface i1 = AsyncFeign.asyncBuilder().target(t1);
-    TestInterface i2 = AsyncFeign.asyncBuilder().target(t1);
-    TestInterface i3 = AsyncFeign.asyncBuilder().target(t2);
-    OtherTestInterface i4 = AsyncFeign.asyncBuilder().target(t3);
+    TestInterface i1 = AsyncFeign.builder().target(t1);
+    TestInterface i2 = AsyncFeign.builder().target(t1);
+    TestInterface i3 = AsyncFeign.builder().target(t2);
+    OtherTestInterface i4 = AsyncFeign.builder().target(t3);
 
     assertThat(i1)
         .isEqualTo(i2)
@@ -671,7 +671,7 @@ public class FeignUnderAsyncTest {
     server.enqueue(new MockResponse().setBody(new Buffer().write(expectedResponse)));
 
     OtherTestInterface api =
-        AsyncFeign.asyncBuilder().target(OtherTestInterface.class,
+        AsyncFeign.builder().target(OtherTestInterface.class,
             "http://localhost:" + server.getPort());
 
     assertThat(api.binaryResponseBody())
@@ -684,7 +684,7 @@ public class FeignUnderAsyncTest {
     server.enqueue(new MockResponse());
 
     OtherTestInterface api =
-        AsyncFeign.asyncBuilder().target(OtherTestInterface.class,
+        AsyncFeign.builder().target(OtherTestInterface.class,
             "http://localhost:" + server.getPort());
 
     api.binaryRequestBody(expectedRequest);
@@ -743,7 +743,7 @@ public class FeignUnderAsyncTest {
   public void mapAndDecodeExecutesMapFunction() throws Exception {
     server.enqueue(new MockResponse().setBody("response!"));
 
-    TestInterface api = AsyncFeign.asyncBuilder()
+    TestInterface api = AsyncFeign.builder()
         .mapAndDecode(upperCaseResponseMapper(), new StringDecoder())
         .target(TestInterface.class, "http://localhost:" + server.getPort());
 
@@ -967,7 +967,7 @@ public class FeignUnderAsyncTest {
 
   static final class TestInterfaceBuilder {
 
-    private final AsyncFeign.AsyncBuilder<Void> delegate = AsyncFeign.<Void>asyncBuilder()
+    private final AsyncFeign.AsyncBuilder<Void> delegate = AsyncFeign.<Void>builder()
         .decoder(new Decoder.Default())
         .encoder(new Encoder() {
           @Override

--- a/example-github-with-coroutine/src/main/java/example/github/GitHubExample.kt
+++ b/example-github-with-coroutine/src/main/java/example/github/GitHubExample.kt
@@ -86,7 +86,7 @@ interface GitHub {
         fun connect(): GitHub {
             val decoder: Decoder = feign.gson.GsonDecoder()
             val encoder: Encoder = GsonEncoder()
-            return CoroutineFeign.coBuilder<Unit>()
+            return CoroutineFeign.builder<Unit>()
                 .encoder(encoder)
                 .decoder(decoder)
                 .errorDecoder(GitHubErrorDecoder(decoder))

--- a/hc5/src/test/java/feign/hc5/AsyncApacheHttp5ClientTest.java
+++ b/hc5/src/test/java/feign/hc5/AsyncApacheHttp5ClientTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.fail;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
-import org.apache.hc.core5.http.protocol.HttpContext;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -459,7 +458,7 @@ public class AsyncApacheHttp5ClientTest {
   public void throwsFeignExceptionIncludingBody() throws Throwable {
     server.enqueue(new MockResponse().setBody("success!"));
 
-    final TestInterfaceAsync api = AsyncFeign.asyncBuilder().decoder((response, type) -> {
+    final TestInterfaceAsync api = AsyncFeign.builder().decoder((response, type) -> {
       throw new IOException("timeout");
     }).target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
 
@@ -480,7 +479,7 @@ public class AsyncApacheHttp5ClientTest {
   public void throwsFeignExceptionWithoutBody() {
     server.enqueue(new MockResponse().setBody("success!"));
 
-    final TestInterfaceAsync api = AsyncFeign.asyncBuilder().decoder((response, type) -> {
+    final TestInterfaceAsync api = AsyncFeign.builder().decoder((response, type) -> {
       throw new IOException("timeout");
     }).target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
 
@@ -505,7 +504,7 @@ public class AsyncApacheHttp5ClientTest {
     final ExecutorService execs = Executors.newSingleThreadExecutor();
 
     // fake client as Client.Default follows redirects.
-    final TestInterfaceAsync api = AsyncFeign.<Void>asyncBuilder()
+    final TestInterfaceAsync api = AsyncFeign.<Void>builder()
         .client(new AsyncClient.Default<>((request, options) -> response, execs))
         .target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
 
@@ -581,10 +580,10 @@ public class AsyncApacheHttp5ClientTest {
     final Target<OtherTestInterfaceAsync> t3 =
         new HardCodedTarget<OtherTestInterfaceAsync>(OtherTestInterfaceAsync.class,
             "http://localhost:8080");
-    final TestInterfaceAsync i1 = AsyncFeign.asyncBuilder().target(t1);
-    final TestInterfaceAsync i2 = AsyncFeign.asyncBuilder().target(t1);
-    final TestInterfaceAsync i3 = AsyncFeign.asyncBuilder().target(t2);
-    final OtherTestInterfaceAsync i4 = AsyncFeign.asyncBuilder().target(t3);
+    final TestInterfaceAsync i1 = AsyncFeign.builder().target(t1);
+    final TestInterfaceAsync i2 = AsyncFeign.builder().target(t1);
+    final TestInterfaceAsync i3 = AsyncFeign.builder().target(t2);
+    final OtherTestInterfaceAsync i4 = AsyncFeign.builder().target(t3);
 
     assertThat(i1).isEqualTo(i2).isNotEqualTo(i3).isNotEqualTo(i4);
 
@@ -608,7 +607,7 @@ public class AsyncApacheHttp5ClientTest {
     server.enqueue(new MockResponse().setBody(new Buffer().write(expectedResponse)));
 
     final OtherTestInterfaceAsync api =
-        AsyncFeign.asyncBuilder().target(OtherTestInterfaceAsync.class,
+        AsyncFeign.builder().target(OtherTestInterfaceAsync.class,
             "http://localhost:" + server.getPort());
 
     assertThat(unwrap(api.binaryResponseBody())).containsExactly(expectedResponse);
@@ -620,7 +619,7 @@ public class AsyncApacheHttp5ClientTest {
     server.enqueue(new MockResponse());
 
     final OtherTestInterfaceAsync api =
-        AsyncFeign.asyncBuilder().target(OtherTestInterfaceAsync.class,
+        AsyncFeign.builder().target(OtherTestInterfaceAsync.class,
             "http://localhost:" + server.getPort());
 
     final CompletableFuture<?> cf = api.binaryRequestBody(expectedRequest);
@@ -691,7 +690,7 @@ public class AsyncApacheHttp5ClientTest {
     server.enqueue(new MockResponse().setBody("response!"));
 
     final TestInterfaceAsync api =
-        AsyncFeign.asyncBuilder().mapAndDecode(upperCaseResponseMapper(), new StringDecoder())
+        AsyncFeign.builder().mapAndDecode(upperCaseResponseMapper(), new StringDecoder())
             .target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
 
     assertEquals("RESPONSE!", unwrap(api.post()));
@@ -921,7 +920,7 @@ public class AsyncApacheHttp5ClientTest {
   static final class TestInterfaceAsyncBuilder {
 
     private final AsyncFeign.AsyncBuilder<HttpClientContext> delegate =
-        AsyncFeign.<HttpClientContext>asyncBuilder()
+        AsyncFeign.<HttpClientContext>builder()
             .client(new AsyncApacheHttp5Client())
             .decoder(new Decoder.Default()).encoder(new Encoder() {
 

--- a/java11/src/test/java/feign/http2client/test/Http2ClientAsyncTest.java
+++ b/java11/src/test/java/feign/http2client/test/Http2ClientAsyncTest.java
@@ -554,7 +554,7 @@ public class Http2ClientAsyncTest {
     final ExecutorService execs = Executors.newSingleThreadExecutor();
 
     // fake client as Client.Default follows redirects.
-    final TestInterfaceAsync api = AsyncFeign.<Void>asyncBuilder()
+    final TestInterfaceAsync api = AsyncFeign.<Void>builder()
         .client(new AsyncClient.Default<>((request, options) -> response, execs))
         .target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
 
@@ -745,7 +745,7 @@ public class Http2ClientAsyncTest {
     server.enqueue(new MockResponse().setBody("response!"));
 
     final TestInterfaceAsync api =
-        AsyncFeign.asyncBuilder().mapAndDecode(upperCaseResponseMapper(), new StringDecoder())
+        AsyncFeign.builder().mapAndDecode(upperCaseResponseMapper(), new StringDecoder())
             .target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
 
     assertEquals("RESPONSE!", unwrap(api.post()));
@@ -975,7 +975,7 @@ public class Http2ClientAsyncTest {
   static final class TestInterfaceAsyncBuilder {
 
     private final AsyncFeign.AsyncBuilder<Object> delegate =
-        AsyncFeign.asyncBuilder()
+        AsyncFeign.builder()
             .client(new Http2Client())
             .decoder(new Decoder.Default()).encoder(new Encoder() {
 

--- a/kotlin/src/main/java/feign/kotlin/CoroutineFeign.java
+++ b/kotlin/src/main/java/feign/kotlin/CoroutineFeign.java
@@ -33,8 +33,16 @@ import kotlinx.coroutines.future.FutureKt;
 
 @Experimental
 public class CoroutineFeign<C> {
-  public static <C> CoroutineBuilder<C> coBuilder() {
+  public static <C> CoroutineBuilder<C> builder() {
     return new CoroutineBuilder<>();
+  }
+
+  /**
+   * @deprecated use {@link #builder()} instead.
+   */
+  @Deprecated()
+  public static <C> CoroutineBuilder<C> coBuilder() {
+    return builder();
   }
 
   private static class LazyInitializedExecutorService {

--- a/kotlin/src/main/java/feign/kotlin/CoroutineFeign.java
+++ b/kotlin/src/main/java/feign/kotlin/CoroutineFeign.java
@@ -153,7 +153,7 @@ public class CoroutineFeign<C> {
     public CoroutineFeign<C> build() {
       super.enrich();
 
-      AsyncFeign<C> asyncFeign = (AsyncFeign<C>) AsyncFeign.asyncBuilder()
+      AsyncFeign<C> asyncFeign = (AsyncFeign<C>) AsyncFeign.builder()
           .logLevel(logLevel)
           .client((AsyncClient<Object>) client)
           .decoder(decoder)

--- a/kotlin/src/test/kotlin/feign/kotlin/CoroutineFeignTest.kt
+++ b/kotlin/src/test/kotlin/feign/kotlin/CoroutineFeignTest.kt
@@ -145,7 +145,7 @@ class CoroutineFeignTest {
     }
 
     internal class TestInterfaceAsyncBuilder {
-        private val delegate = CoroutineFeign.coBuilder<Void>()
+        private val delegate = CoroutineFeign.builder<Void>()
             .decoder(Decoder.Default()).encoder { `object`, bodyType, template ->
                 if (`object` is Map<*, *>) {
                     template.body(Gson().toJson(`object`))

--- a/micrometer/src/test/java/feign/micrometer/AbstractMetricsTestBase.java
+++ b/micrometer/src/test/java/feign/micrometer/AbstractMetricsTestBase.java
@@ -76,7 +76,7 @@ public abstract class AbstractMetricsTestBase<MR, METRIC_ID, METRIC> {
   @Test
   public final void addAsyncMetricsCapability() {
     final CompletableSource source =
-        AsyncFeign.asyncBuilder()
+        AsyncFeign.builder()
             .client(new MockClient().ok(HttpMethod.GET, "/get", "1234567890abcde"))
             .addCapability(createMetricCapability())
             .target(new MockTarget<>(CompletableSource.class));

--- a/okhttp/src/test/java/feign/okhttp/OkHttpClientAsyncTest.java
+++ b/okhttp/src/test/java/feign/okhttp/OkHttpClientAsyncTest.java
@@ -552,7 +552,7 @@ public class OkHttpClientAsyncTest {
     final ExecutorService execs = Executors.newSingleThreadExecutor();
 
     // fake client as Client.Default follows redirects.
-    final TestInterfaceAsync api = AsyncFeign.<Void>asyncBuilder()
+    final TestInterfaceAsync api = AsyncFeign.<Void>builder()
         .client(new AsyncClient.Default<>((request, options) -> response, execs))
         .target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
 
@@ -743,7 +743,7 @@ public class OkHttpClientAsyncTest {
     server.enqueue(new MockResponse().setBody("response!"));
 
     final TestInterfaceAsync api =
-        AsyncFeign.asyncBuilder().mapAndDecode(upperCaseResponseMapper(), new StringDecoder())
+        AsyncFeign.builder().mapAndDecode(upperCaseResponseMapper(), new StringDecoder())
             .target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
 
     assertEquals("RESPONSE!", unwrap(api.post()));
@@ -973,7 +973,7 @@ public class OkHttpClientAsyncTest {
   static final class TestInterfaceAsyncBuilder {
 
     private final AsyncFeign.AsyncBuilder<Object> delegate =
-        AsyncFeign.asyncBuilder()
+        AsyncFeign.builder()
             .client(new OkHttpClient())
             .decoder(new Decoder.Default()).encoder((object, bodyType, template) -> {
               if (object instanceof Map) {


### PR DESCRIPTION
Contains #1754 PR commits
If you want to see the final result, see PR #1757

## TODO

- [ ] Modify AsyncFeign.asyncBuilder to extend Feign.Builder or Modify Feign to support the features of AsyncFeign
    - It is intended to be used when [customizing](https://docs.spring.io/spring-cloud-openfeign/docs/current/reference/html/#spring-cloud-feign-circuitbreaker) Feign.Builder in Spring Cloud OpenFeign.
    - Please feedback on Feign supporting the features of AsyncFeign. Are there any concerns regarding the library experience?
    - I think it's okay to work after merged, because CoroutineFeign is an experimental feature right now.