### PR TITLE
Fix Truncated JSON literals in Headers Values

### DIFF
--- a/core/src/main/java/feign/template/Template.java
+++ b/core/src/main/java/feign/template/Template.java
@@ -22,7 +22,6 @@ import java.util.Objects;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
 import feign.template.util.JSONException;
 import feign.template.util.JSONObject;
 

--- a/core/src/main/java/feign/template/Template.java
+++ b/core/src/main/java/feign/template/Template.java
@@ -23,6 +23,9 @@ import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import feign.template.util.JSONException;
+import feign.template.util.JSONObject;
+
 /**
  * A Generic representation of a Template Expression as defined by
  * <a href="https://tools.ietf.org/html/rfc6570">RFC 6570</a>, with some relaxed rules, allowing the
@@ -228,7 +231,12 @@ public class Template {
   }
 
   boolean isValidJsonLiteral(String jsonLiteral) {
-    
+    try {
+      JSONObject jsonObject = new JSONObject(jsonLiteral);
+    } catch (JSONException ex) {
+      return false;
+    }
+    return true;
   }
 
   @Override

--- a/core/src/main/java/feign/template/Template.java
+++ b/core/src/main/java/feign/template/Template.java
@@ -214,7 +214,7 @@ public class Template {
       /* check to see if we have an expression or a literal */
       String chunk = tokenizer.next();
 
-      if (chunk.startsWith("{")) {
+      if (chunk.startsWith("{") && !isValidJsonLiteral(fragment)) {
         Expression expression = Expressions.create(chunk);
         if (expression == null) {
           this.templateChunks.add(Literal.create(this.encodeLiteral(chunk)));
@@ -225,6 +225,10 @@ public class Template {
         this.templateChunks.add(Literal.create(this.encodeLiteral(chunk)));
       }
     }
+  }
+
+  boolean isValidJsonLiteral(String jsonLiteral) {
+    
   }
 
   @Override

--- a/core/src/main/java/feign/template/util/JSONArray.java
+++ b/core/src/main/java/feign/template/util/JSONArray.java
@@ -1,14 +1,14 @@
 package feign.template.util;
 
-/*
-Public Domain.
- */
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Map;
 
+/*
+ * Modified and Utilized with the Feign project via Public Domain
+ */
 
 /**
  * A JSONArray is an ordered sequence of values. Its external text form is a
@@ -52,7 +52,8 @@ import java.util.Map;
  * </ul>
  *
  * @author JSON.org
- * @version 2016-08/15
+ * @author Justin Ziegler
+ * @version 2022-09-21
  */
 public class JSONArray implements Iterable<Object> {
 

--- a/core/src/main/java/feign/template/util/JSONArray.java
+++ b/core/src/main/java/feign/template/util/JSONArray.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2012-2022 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+ /*
+ * Code Originally Sourced From the JSON.ORG project and utilized under Public Domain
+ */
 package feign.template.util;
 
 import java.math.BigDecimal;
@@ -5,10 +22,6 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Map;
-
-/*
- * Modified and Utilized with the Feign project via Public Domain
- */
 
 /**
  * A JSONArray is an ordered sequence of values. Its external text form is a

--- a/core/src/main/java/feign/template/util/JSONArray.java
+++ b/core/src/main/java/feign/template/util/JSONArray.java
@@ -12,7 +12,7 @@
  * the License.
  */
 
- /*
+/*
  * Code Originally Sourced From the JSON.ORG project and utilized under Public Domain
  */
 package feign.template.util;
@@ -24,44 +24,36 @@ import java.util.Iterator;
 import java.util.Map;
 
 /**
- * A JSONArray is an ordered sequence of values. Its external text form is a
- * string wrapped in square brackets with commas separating the values. The
- * internal form is an object having <code>get</code> and <code>opt</code>
- * methods for accessing the values by index, and <code>put</code> methods for
- * adding or replacing values. The values can be any of these types:
- * <code>Boolean</code>, <code>JSONArray</code>, <code>JSONObject</code>,
- * <code>Number</code>, <code>String</code>, or the
- * <code>JSONObject.NULL object</code>.
+ * A JSONArray is an ordered sequence of values. Its external text form is a string wrapped in
+ * square brackets with commas separating the values. The internal form is an object having
+ * <code>get</code> and <code>opt</code> methods for accessing the values by index, and
+ * <code>put</code> methods for adding or replacing values. The values can be any of these types:
+ * <code>Boolean</code>, <code>JSONArray</code>, <code>JSONObject</code>, <code>Number</code>,
+ * <code>String</code>, or the <code>JSONObject.NULL object</code>.
  * <p>
- * The constructor can convert a JSON text into a Java object. The
- * <code>toString</code> method converts to JSON text.
+ * The constructor can convert a JSON text into a Java object. The <code>toString</code> method
+ * converts to JSON text.
  * <p>
- * A <code>get</code> method returns a value if one can be found, and throws an
- * exception if one cannot be found. An <code>opt</code> method returns a
- * default value instead of throwing an exception, and so is useful for
- * obtaining optional values.
+ * A <code>get</code> method returns a value if one can be found, and throws an exception if one
+ * cannot be found. An <code>opt</code> method returns a default value instead of throwing an
+ * exception, and so is useful for obtaining optional values.
  * <p>
- * The generic <code>get()</code> and <code>opt()</code> methods return an
- * object which you can cast or query for type. There are also typed
- * <code>get</code> and <code>opt</code> methods that do type checking and type
- * coercion for you.
+ * The generic <code>get()</code> and <code>opt()</code> methods return an object which you can cast
+ * or query for type. There are also typed <code>get</code> and <code>opt</code> methods that do
+ * type checking and type coercion for you.
  * <p>
- * The texts produced by the <code>toString</code> methods strictly conform to
- * JSON syntax rules. The constructors are more forgiving in the texts they will
- * accept:
+ * The texts produced by the <code>toString</code> methods strictly conform to JSON syntax rules.
+ * The constructors are more forgiving in the texts they will accept:
  * <ul>
- * <li>An extra <code>,</code>&nbsp;<small>(comma)</small> may appear just
- * before the closing bracket.</li>
+ * <li>An extra <code>,</code>&nbsp;<small>(comma)</small> may appear just before the closing
+ * bracket.</li>
  * <li>The <code>null</code> value will be inserted when there is <code>,</code>
  * &nbsp;<small>(comma)</small> elision.</li>
- * <li>Strings may be quoted with <code>'</code>&nbsp;<small>(single
- * quote)</small>.</li>
- * <li>Strings do not need to be quoted at all if they do not begin with a quote
- * or single quote, and if they do not contain leading or trailing spaces, and
- * if they do not contain any of these characters:
- * <code>{ } [ ] / \ : , #</code> and if they do not look like numbers and
- * if they are not the reserved words <code>true</code>, <code>false</code>, or
- * <code>null</code>.</li>
+ * <li>Strings may be quoted with <code>'</code>&nbsp;<small>(single quote)</small>.</li>
+ * <li>Strings do not need to be quoted at all if they do not begin with a quote or single quote,
+ * and if they do not contain leading or trailing spaces, and if they do not contain any of these
+ * characters: <code>{ } [ ] / \ : , #</code> and if they do not look like numbers and if they are
+ * not the reserved words <code>true</code>, <code>false</code>, or <code>null</code>.</li>
  * </ul>
  *
  * @author JSON.org
@@ -70,1108 +62,968 @@ import java.util.Map;
  */
 public class JSONArray implements Iterable<Object> {
 
-    /**
-     * The arrayList where the JSONArray's properties are kept.
-     */
-    private final ArrayList<Object> myArrayList;
+  /**
+   * The arrayList where the JSONArray's properties are kept.
+   */
+  private final ArrayList<Object> myArrayList;
 
-    /**
-     * Construct an empty JSONArray.
-     */
-    public JSONArray() {
-        this.myArrayList = new ArrayList<Object>();
+  /**
+   * Construct an empty JSONArray.
+   */
+  public JSONArray() {
+    this.myArrayList = new ArrayList<Object>();
+  }
+
+  /**
+   * Construct a JSONArray from a JSONTokener.
+   *
+   * @param x A JSONTokener
+   * @throws JSONException If there is a syntax error.
+   */
+  public JSONArray(JSONTokener x) throws JSONException {
+    this();
+    if (x.nextClean() != '[') {
+      throw x.syntaxError("A JSONArray text must start with '['");
     }
 
-    /**
-     * Construct a JSONArray from a JSONTokener.
-     *
-     * @param x
-     *            A JSONTokener
-     * @throws JSONException
-     *             If there is a syntax error.
-     */
-    public JSONArray(JSONTokener x) throws JSONException {
-        this();
-        if (x.nextClean() != '[') {
-            throw x.syntaxError("A JSONArray text must start with '['");
+    char nextChar = x.nextClean();
+    if (nextChar == 0) {
+      // array is unclosed. No ']' found, instead EOF
+      throw x.syntaxError("Expected a ',' or ']'");
+    }
+    if (nextChar != ']') {
+      x.back();
+      for (;;) {
+        if (x.nextClean() == ',') {
+          x.back();
+          this.myArrayList.add(JSONObject.NULL);
+        } else {
+          x.back();
+          this.myArrayList.add(x.nextValue());
         }
-        
-        char nextChar = x.nextClean();
-        if (nextChar == 0) {
+        switch (x.nextClean()) {
+          case 0:
             // array is unclosed. No ']' found, instead EOF
             throw x.syntaxError("Expected a ',' or ']'");
-        }
-        if (nextChar != ']') {
+          case ',':
+            nextChar = x.nextClean();
+            if (nextChar == 0) {
+              // array is unclosed. No ']' found, instead EOF
+              throw x.syntaxError("Expected a ',' or ']'");
+            }
+            if (nextChar == ']') {
+              return;
+            }
             x.back();
-            for (;;) {
-                if (x.nextClean() == ',') {
-                    x.back();
-                    this.myArrayList.add(JSONObject.NULL);
-                } else {
-                    x.back();
-                    this.myArrayList.add(x.nextValue());
-                }
-                switch (x.nextClean()) {
-                case 0:
-                    // array is unclosed. No ']' found, instead EOF
-                    throw x.syntaxError("Expected a ',' or ']'");
-                case ',':
-                    nextChar = x.nextClean();
-                    if (nextChar == 0) {
-                        // array is unclosed. No ']' found, instead EOF
-                        throw x.syntaxError("Expected a ',' or ']'");
-                    }
-                    if (nextChar == ']') {
-                        return;
-                    }
-                    x.back();
-                    break;
-                case ']':
-                    return;
-                default:
-                    throw x.syntaxError("Expected a ',' or ']'");
-                }
-            }
+            break;
+          case ']':
+            return;
+          default:
+            throw x.syntaxError("Expected a ',' or ']'");
         }
+      }
     }
+  }
 
-    /**
-     * Construct a JSONArray from a source JSON text.
-     *
-     * @param source
-     *            A string that begins with <code>[</code>&nbsp;<small>(left
-     *            bracket)</small> and ends with <code>]</code>
-     *            &nbsp;<small>(right bracket)</small>.
-     * @throws JSONException
-     *             If there is a syntax error.
-     */
-    public JSONArray(String source) throws JSONException {
-        this(new JSONTokener(source));
+  /**
+   * Construct a JSONArray from a source JSON text.
+   *
+   * @param source A string that begins with <code>[</code>&nbsp;<small>(left bracket)</small> and
+   *        ends with <code>]</code> &nbsp;<small>(right bracket)</small>.
+   * @throws JSONException If there is a syntax error.
+   */
+  public JSONArray(String source) throws JSONException {
+    this(new JSONTokener(source));
+  }
+
+  /**
+   * Construct a JSONArray from another JSONArray. This is a shallow copy.
+   *
+   * @param array A array.
+   */
+  public JSONArray(JSONArray array) {
+    if (array == null) {
+      this.myArrayList = new ArrayList<Object>();
+    } else {
+      // shallow copy directly the internal array lists as any wrapping
+      // should have been done already in the original JSONArray
+      this.myArrayList = new ArrayList<Object>(array.myArrayList);
     }
+  }
 
-    /**
-     * Construct a JSONArray from another JSONArray. This is a shallow copy.
-     *
-     * @param array
-     *            A array.
-     */
-    public JSONArray(JSONArray array) {
-        if (array == null) {
-            this.myArrayList = new ArrayList<Object>();
-        } else {
-            // shallow copy directly the internal array lists as any wrapping
-            // should have been done already in the original JSONArray
-            this.myArrayList = new ArrayList<Object>(array.myArrayList);
-        }
+  /**
+   * Construct a JSONArray with the specified initial capacity.
+   *
+   * @param initialCapacity the initial capacity of the JSONArray.
+   * @throws JSONException If the initial capacity is negative.
+   */
+  public JSONArray(int initialCapacity) throws JSONException {
+    if (initialCapacity < 0) {
+      throw new JSONException(
+          "JSONArray initial capacity cannot be negative.");
     }
+    this.myArrayList = new ArrayList<Object>(initialCapacity);
+  }
 
-    /**
-     * Construct a JSONArray with the specified initial capacity.
-     *
-     * @param initialCapacity
-     *            the initial capacity of the JSONArray.
-     * @throws JSONException
-     *             If the initial capacity is negative.
-     */
-    public JSONArray(int initialCapacity) throws JSONException {
-    	if (initialCapacity < 0) {
-            throw new JSONException(
-                    "JSONArray initial capacity cannot be negative.");
-    	}
-    	this.myArrayList = new ArrayList<Object>(initialCapacity);
+  @Override
+  public Iterator<Object> iterator() {
+    return this.myArrayList.iterator();
+  }
+
+  /**
+   * Get the object value associated with an index.
+   *
+   * @param index The index must be between 0 and length() - 1.
+   * @return An object value.
+   * @throws JSONException If there is no value for the index.
+   */
+  public Object get(int index) throws JSONException {
+    Object object = this.opt(index);
+    if (object == null) {
+      throw new JSONException("JSONArray[" + index + "] not found.");
     }
+    return object;
+  }
 
-    @Override
-    public Iterator<Object> iterator() {
-        return this.myArrayList.iterator();
+  /**
+   * Get the boolean value associated with an index. The string values "true" and "false" are
+   * converted to boolean.
+   *
+   * @param index The index must be between 0 and length() - 1.
+   * @return The truth.
+   * @throws JSONException If there is no value for the index or if the value is not convertible to
+   *         boolean.
+   */
+  public boolean getBoolean(int index) throws JSONException {
+    Object object = this.get(index);
+    if (object.equals(Boolean.FALSE)
+        || (object instanceof String && ((String) object)
+            .equalsIgnoreCase("false"))) {
+      return false;
+    } else if (object.equals(Boolean.TRUE)
+        || (object instanceof String && ((String) object)
+            .equalsIgnoreCase("true"))) {
+      return true;
     }
+    throw wrongValueFormatException(index, "boolean", object, null);
+  }
 
-    /**
-     * Get the object value associated with an index.
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @return An object value.
-     * @throws JSONException
-     *             If there is no value for the index.
-     */
-    public Object get(int index) throws JSONException {
-        Object object = this.opt(index);
-        if (object == null) {
-            throw new JSONException("JSONArray[" + index + "] not found.");
-        }
-        return object;
+  /**
+   * Get the double value associated with an index.
+   *
+   * @param index The index must be between 0 and length() - 1.
+   * @return The value.
+   * @throws JSONException If the key is not found or if the value cannot be converted to a number.
+   */
+  public double getDouble(int index) throws JSONException {
+    final Object object = this.get(index);
+    if (object instanceof Number) {
+      return ((Number) object).doubleValue();
     }
-
-    /**
-     * Get the boolean value associated with an index. The string values "true"
-     * and "false" are converted to boolean.
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @return The truth.
-     * @throws JSONException
-     *             If there is no value for the index or if the value is not
-     *             convertible to boolean.
-     */
-    public boolean getBoolean(int index) throws JSONException {
-        Object object = this.get(index);
-        if (object.equals(Boolean.FALSE)
-                || (object instanceof String && ((String) object)
-                        .equalsIgnoreCase("false"))) {
-            return false;
-        } else if (object.equals(Boolean.TRUE)
-                || (object instanceof String && ((String) object)
-                        .equalsIgnoreCase("true"))) {
-            return true;
-        }
-        throw wrongValueFormatException(index, "boolean", object, null);
+    try {
+      return Double.parseDouble(object.toString());
+    } catch (Exception e) {
+      throw wrongValueFormatException(index, "double", object, e);
     }
+  }
 
-    /**
-     * Get the double value associated with an index.
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @return The value.
-     * @throws JSONException
-     *             If the key is not found or if the value cannot be converted
-     *             to a number.
-     */
-    public double getDouble(int index) throws JSONException {
-        final Object object = this.get(index);
-        if(object instanceof Number) {
-            return ((Number)object).doubleValue();
-        }
-        try {
-            return Double.parseDouble(object.toString());
-        } catch (Exception e) {
-            throw wrongValueFormatException(index, "double", object, e);
-        }
+  /**
+   * Get the float value associated with a key.
+   *
+   * @param index The index must be between 0 and length() - 1.
+   * @return The numeric value.
+   * @throws JSONException if the key is not found or if the value is not a Number object and cannot
+   *         be converted to a number.
+   */
+  public float getFloat(int index) throws JSONException {
+    final Object object = this.get(index);
+    if (object instanceof Number) {
+      return ((Number) object).floatValue();
     }
-
-    /**
-     * Get the float value associated with a key.
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @return The numeric value.
-     * @throws JSONException
-     *             if the key is not found or if the value is not a Number
-     *             object and cannot be converted to a number.
-     */
-    public float getFloat(int index) throws JSONException {
-        final Object object = this.get(index);
-        if(object instanceof Number) {
-            return ((Number)object).floatValue();
-        }
-        try {
-            return Float.parseFloat(object.toString());
-        } catch (Exception e) {
-            throw wrongValueFormatException(index, "float", object, e);
-        }
+    try {
+      return Float.parseFloat(object.toString());
+    } catch (Exception e) {
+      throw wrongValueFormatException(index, "float", object, e);
     }
+  }
 
-    /**
-     * Get the Number value associated with a key.
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @return The numeric value.
-     * @throws JSONException
-     *             if the key is not found or if the value is not a Number
-     *             object and cannot be converted to a number.
-     */
-    public Number getNumber(int index) throws JSONException {
-        Object object = this.get(index);
-        try {
-            if (object instanceof Number) {
-                return (Number)object;
-            }
-            return JSONObject.stringToNumber(object.toString());
-        } catch (Exception e) {
-            throw wrongValueFormatException(index, "number", object, e);
-        }
+  /**
+   * Get the Number value associated with a key.
+   *
+   * @param index The index must be between 0 and length() - 1.
+   * @return The numeric value.
+   * @throws JSONException if the key is not found or if the value is not a Number object and cannot
+   *         be converted to a number.
+   */
+  public Number getNumber(int index) throws JSONException {
+    Object object = this.get(index);
+    try {
+      if (object instanceof Number) {
+        return (Number) object;
+      }
+      return JSONObject.stringToNumber(object.toString());
+    } catch (Exception e) {
+      throw wrongValueFormatException(index, "number", object, e);
     }
+  }
 
-    /**
-     * Get the enum value associated with an index.
-     * 
-     * @param <E>
-     *            Enum Type
-     * @param clazz
-     *            The type of enum to retrieve.
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @return The enum value at the index location
-     * @throws JSONException
-     *            if the key is not found or if the value cannot be converted
-     *            to an enum.
-     */
-    public <E extends Enum<E>> E getEnum(Class<E> clazz, int index) throws JSONException {
-        E val = optEnum(clazz, index);
-        if(val==null) {
-            // JSONException should really take a throwable argument.
-            // If it did, I would re-implement this with the Enum.valueOf
-            // method and place any thrown exception in the JSONException
-            throw wrongValueFormatException(index, "enum of type "
-                    + JSONObject.quote(clazz.getSimpleName()), opt(index), null);
-        }
-        return val;
+  /**
+   * Get the enum value associated with an index.
+   * 
+   * @param <E> Enum Type
+   * @param clazz The type of enum to retrieve.
+   * @param index The index must be between 0 and length() - 1.
+   * @return The enum value at the index location
+   * @throws JSONException if the key is not found or if the value cannot be converted to an enum.
+   */
+  public <E extends Enum<E>> E getEnum(Class<E> clazz, int index) throws JSONException {
+    E val = optEnum(clazz, index);
+    if (val == null) {
+      // JSONException should really take a throwable argument.
+      // If it did, I would re-implement this with the Enum.valueOf
+      // method and place any thrown exception in the JSONException
+      throw wrongValueFormatException(index, "enum of type "
+          + JSONObject.quote(clazz.getSimpleName()), opt(index), null);
     }
+    return val;
+  }
 
-    /**
-     * Get the BigDecimal value associated with an index. If the value is float
-     * or double, the {@link BigDecimal#BigDecimal(double)} constructor
-     * will be used. See notes on the constructor for conversion issues that
-     * may arise.
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @return The value.
-     * @throws JSONException
-     *             If the key is not found or if the value cannot be converted
-     *             to a BigDecimal.
-     */
-    public BigDecimal getBigDecimal (int index) throws JSONException {
-        Object object = this.get(index);
-        BigDecimal val = JSONObject.objectToBigDecimal(object, null);
-        if(val == null) {
-            throw wrongValueFormatException(index, "BigDecimal", object, null);
-        }
-        return val;
+  /**
+   * Get the BigDecimal value associated with an index. If the value is float or double, the
+   * {@link BigDecimal#BigDecimal(double)} constructor will be used. See notes on the constructor
+   * for conversion issues that may arise.
+   *
+   * @param index The index must be between 0 and length() - 1.
+   * @return The value.
+   * @throws JSONException If the key is not found or if the value cannot be converted to a
+   *         BigDecimal.
+   */
+  public BigDecimal getBigDecimal(int index) throws JSONException {
+    Object object = this.get(index);
+    BigDecimal val = JSONObject.objectToBigDecimal(object, null);
+    if (val == null) {
+      throw wrongValueFormatException(index, "BigDecimal", object, null);
     }
+    return val;
+  }
 
-    /**
-     * Get the BigInteger value associated with an index.
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @return The value.
-     * @throws JSONException
-     *             If the key is not found or if the value cannot be converted
-     *             to a BigInteger.
-     */
-    public BigInteger getBigInteger (int index) throws JSONException {
-        Object object = this.get(index);
-        BigInteger val = JSONObject.objectToBigInteger(object, null);
-        if(val == null) {
-            throw wrongValueFormatException(index, "BigInteger", object, null);
-        }
-        return val;
+  /**
+   * Get the BigInteger value associated with an index.
+   *
+   * @param index The index must be between 0 and length() - 1.
+   * @return The value.
+   * @throws JSONException If the key is not found or if the value cannot be converted to a
+   *         BigInteger.
+   */
+  public BigInteger getBigInteger(int index) throws JSONException {
+    Object object = this.get(index);
+    BigInteger val = JSONObject.objectToBigInteger(object, null);
+    if (val == null) {
+      throw wrongValueFormatException(index, "BigInteger", object, null);
     }
+    return val;
+  }
 
-    /**
-     * Get the int value associated with an index.
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @return The value.
-     * @throws JSONException
-     *             If the key is not found or if the value is not a number.
-     */
-    public int getInt(int index) throws JSONException {
-        final Object object = this.get(index);
-        if(object instanceof Number) {
-            return ((Number)object).intValue();
-        }
-        try {
-            return Integer.parseInt(object.toString());
-        } catch (Exception e) {
-            throw wrongValueFormatException(index, "int", object, e);
-        }
+  /**
+   * Get the int value associated with an index.
+   *
+   * @param index The index must be between 0 and length() - 1.
+   * @return The value.
+   * @throws JSONException If the key is not found or if the value is not a number.
+   */
+  public int getInt(int index) throws JSONException {
+    final Object object = this.get(index);
+    if (object instanceof Number) {
+      return ((Number) object).intValue();
     }
-
-    /**
-     * Get the JSONArray associated with an index.
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @return A JSONArray value.
-     * @throws JSONException
-     *             If there is no value for the index. or if the value is not a
-     *             JSONArray
-     */
-    public JSONArray getJSONArray(int index) throws JSONException {
-        Object object = this.get(index);
-        if (object instanceof JSONArray) {
-            return (JSONArray) object;
-        }
-        throw wrongValueFormatException(index, "JSONArray", object, null);
+    try {
+      return Integer.parseInt(object.toString());
+    } catch (Exception e) {
+      throw wrongValueFormatException(index, "int", object, e);
     }
+  }
 
-    /**
-     * Get the JSONObject associated with an index.
-     *
-     * @param index
-     *            subscript
-     * @return A JSONObject value.
-     * @throws JSONException
-     *             If there is no value for the index or if the value is not a
-     *             JSONObject
-     */
-    public JSONObject getJSONObject(int index) throws JSONException {
-        Object object = this.get(index);
-        if (object instanceof JSONObject) {
-            return (JSONObject) object;
-        }
-        throw wrongValueFormatException(index, "JSONObject", object, null);
+  /**
+   * Get the JSONArray associated with an index.
+   *
+   * @param index The index must be between 0 and length() - 1.
+   * @return A JSONArray value.
+   * @throws JSONException If there is no value for the index. or if the value is not a JSONArray
+   */
+  public JSONArray getJSONArray(int index) throws JSONException {
+    Object object = this.get(index);
+    if (object instanceof JSONArray) {
+      return (JSONArray) object;
     }
+    throw wrongValueFormatException(index, "JSONArray", object, null);
+  }
 
-    /**
-     * Get the long value associated with an index.
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @return The value.
-     * @throws JSONException
-     *             If the key is not found or if the value cannot be converted
-     *             to a number.
-     */
-    public long getLong(int index) throws JSONException {
-        final Object object = this.get(index);
-        if(object instanceof Number) {
-            return ((Number)object).longValue();
-        }
-        try {
-            return Long.parseLong(object.toString());
-        } catch (Exception e) {
-            throw wrongValueFormatException(index, "long", object, e);
-        }
+  /**
+   * Get the JSONObject associated with an index.
+   *
+   * @param index subscript
+   * @return A JSONObject value.
+   * @throws JSONException If there is no value for the index or if the value is not a JSONObject
+   */
+  public JSONObject getJSONObject(int index) throws JSONException {
+    Object object = this.get(index);
+    if (object instanceof JSONObject) {
+      return (JSONObject) object;
     }
+    throw wrongValueFormatException(index, "JSONObject", object, null);
+  }
 
-    /**
-     * Get the string associated with an index.
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @return A string value.
-     * @throws JSONException
-     *             If there is no string value for the index.
-     */
-    public String getString(int index) throws JSONException {
-        Object object = this.get(index);
-        if (object instanceof String) {
-            return (String) object;
-        }
-        throw wrongValueFormatException(index, "String", object, null);
+  /**
+   * Get the long value associated with an index.
+   *
+   * @param index The index must be between 0 and length() - 1.
+   * @return The value.
+   * @throws JSONException If the key is not found or if the value cannot be converted to a number.
+   */
+  public long getLong(int index) throws JSONException {
+    final Object object = this.get(index);
+    if (object instanceof Number) {
+      return ((Number) object).longValue();
     }
-
-    /**
-     * Determine if the value is <code>null</code>.
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @return true if the value at the index is <code>null</code>, or if there is no value.
-     */
-    public boolean isNull(int index) {
-        return JSONObject.NULL.equals(this.opt(index));
+    try {
+      return Long.parseLong(object.toString());
+    } catch (Exception e) {
+      throw wrongValueFormatException(index, "long", object, e);
     }
+  }
 
-    /**
-     * Get the number of elements in the JSONArray, included nulls.
-     *
-     * @return The length (or size).
-     */
-    public int length() {
-        return this.myArrayList.size();
+  /**
+   * Get the string associated with an index.
+   *
+   * @param index The index must be between 0 and length() - 1.
+   * @return A string value.
+   * @throws JSONException If there is no string value for the index.
+   */
+  public String getString(int index) throws JSONException {
+    Object object = this.get(index);
+    if (object instanceof String) {
+      return (String) object;
     }
+    throw wrongValueFormatException(index, "String", object, null);
+  }
 
-    /**
-     * Removes all of the elements from this JSONArray.
-     * The JSONArray will be empty after this call returns.
-     */
-    public void clear() {
-        this.myArrayList.clear();
+  /**
+   * Determine if the value is <code>null</code>.
+   *
+   * @param index The index must be between 0 and length() - 1.
+   * @return true if the value at the index is <code>null</code>, or if there is no value.
+   */
+  public boolean isNull(int index) {
+    return JSONObject.NULL.equals(this.opt(index));
+  }
+
+  /**
+   * Get the number of elements in the JSONArray, included nulls.
+   *
+   * @return The length (or size).
+   */
+  public int length() {
+    return this.myArrayList.size();
+  }
+
+  /**
+   * Removes all of the elements from this JSONArray. The JSONArray will be empty after this call
+   * returns.
+   */
+  public void clear() {
+    this.myArrayList.clear();
+  }
+
+  /**
+   * Get the optional object value associated with an index.
+   *
+   * @param index The index must be between 0 and length() - 1. If not, null is returned.
+   * @return An object value, or null if there is no object at that index.
+   */
+  public Object opt(int index) {
+    return (index < 0 || index >= this.length()) ? null
+        : this.myArrayList
+            .get(index);
+  }
+
+  /**
+   * Get the optional boolean value associated with an index. It returns false if there is no value
+   * at that index, or if the value is not Boolean.TRUE or the String "true".
+   *
+   * @param index The index must be between 0 and length() - 1.
+   * @return The truth.
+   */
+  public boolean optBoolean(int index) {
+    return this.optBoolean(index, false);
+  }
+
+  /**
+   * Get the optional boolean value associated with an index. It returns the defaultValue if there
+   * is no value at that index or if it is not a Boolean or the String "true" or "false" (case
+   * insensitive).
+   *
+   * @param index The index must be between 0 and length() - 1.
+   * @param defaultValue A boolean default.
+   * @return The truth.
+   */
+  public boolean optBoolean(int index, boolean defaultValue) {
+    try {
+      return this.getBoolean(index);
+    } catch (Exception e) {
+      return defaultValue;
     }
+  }
 
-    /**
-     * Get the optional object value associated with an index.
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1. If not, null is returned.
-     * @return An object value, or null if there is no object at that index.
-     */
-    public Object opt(int index) {
-        return (index < 0 || index >= this.length()) ? null : this.myArrayList
-                .get(index);
+  /**
+   * Get the optional double value associated with an index. NaN is returned if there is no value
+   * for the index, or if the value is not a number and cannot be converted to a number.
+   *
+   * @param index The index must be between 0 and length() - 1.
+   * @return The value.
+   */
+  public double optDouble(int index) {
+    return this.optDouble(index, Double.NaN);
+  }
+
+  /**
+   * Get the optional double value associated with an index. The defaultValue is returned if there
+   * is no value for the index, or if the value is not a number and cannot be converted to a number.
+   *
+   * @param index subscript
+   * @param defaultValue The default value.
+   * @return The value.
+   */
+  public double optDouble(int index, double defaultValue) {
+    final Number val = this.optNumber(index, null);
+    if (val == null) {
+      return defaultValue;
     }
+    final double doubleValue = val.doubleValue();
+    // if (Double.isNaN(doubleValue) || Double.isInfinite(doubleValue)) {
+    // return defaultValue;
+    // }
+    return doubleValue;
+  }
 
-    /**
-     * Get the optional boolean value associated with an index. It returns false
-     * if there is no value at that index, or if the value is not Boolean.TRUE
-     * or the String "true".
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @return The truth.
-     */
-    public boolean optBoolean(int index) {
-        return this.optBoolean(index, false);
+  /**
+   * Get the optional float value associated with an index. NaN is returned if there is no value for
+   * the index, or if the value is not a number and cannot be converted to a number.
+   *
+   * @param index The index must be between 0 and length() - 1.
+   * @return The value.
+   */
+  public float optFloat(int index) {
+    return this.optFloat(index, Float.NaN);
+  }
+
+  /**
+   * Get the optional float value associated with an index. The defaultValue is returned if there is
+   * no value for the index, or if the value is not a number and cannot be converted to a number.
+   *
+   * @param index subscript
+   * @param defaultValue The default value.
+   * @return The value.
+   */
+  public float optFloat(int index, float defaultValue) {
+    final Number val = this.optNumber(index, null);
+    if (val == null) {
+      return defaultValue;
     }
+    final float floatValue = val.floatValue();
+    // if (Float.isNaN(floatValue) || Float.isInfinite(floatValue)) {
+    // return floatValue;
+    // }
+    return floatValue;
+  }
 
-    /**
-     * Get the optional boolean value associated with an index. It returns the
-     * defaultValue if there is no value at that index or if it is not a Boolean
-     * or the String "true" or "false" (case insensitive).
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @param defaultValue
-     *            A boolean default.
-     * @return The truth.
-     */
-    public boolean optBoolean(int index, boolean defaultValue) {
-        try {
-            return this.getBoolean(index);
-        } catch (Exception e) {
-            return defaultValue;
-        }
+  /**
+   * Get the optional int value associated with an index. Zero is returned if there is no value for
+   * the index, or if the value is not a number and cannot be converted to a number.
+   *
+   * @param index The index must be between 0 and length() - 1.
+   * @return The value.
+   */
+  public int optInt(int index) {
+    return this.optInt(index, 0);
+  }
+
+  /**
+   * Get the optional int value associated with an index. The defaultValue is returned if there is
+   * no value for the index, or if the value is not a number and cannot be converted to a number.
+   *
+   * @param index The index must be between 0 and length() - 1.
+   * @param defaultValue The default value.
+   * @return The value.
+   */
+  public int optInt(int index, int defaultValue) {
+    final Number val = this.optNumber(index, null);
+    if (val == null) {
+      return defaultValue;
     }
+    return val.intValue();
+  }
 
-    /**
-     * Get the optional double value associated with an index. NaN is returned
-     * if there is no value for the index, or if the value is not a number and
-     * cannot be converted to a number.
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @return The value.
-     */
-    public double optDouble(int index) {
-        return this.optDouble(index, Double.NaN);
-    }
+  /**
+   * Get the enum value associated with a key.
+   * 
+   * @param <E> Enum Type
+   * @param clazz The type of enum to retrieve.
+   * @param index The index must be between 0 and length() - 1.
+   * @return The enum value at the index location or null if not found
+   */
+  public <E extends Enum<E>> E optEnum(Class<E> clazz, int index) {
+    return this.optEnum(clazz, index, null);
+  }
 
-    /**
-     * Get the optional double value associated with an index. The defaultValue
-     * is returned if there is no value for the index, or if the value is not a
-     * number and cannot be converted to a number.
-     *
-     * @param index
-     *            subscript
-     * @param defaultValue
-     *            The default value.
-     * @return The value.
-     */
-    public double optDouble(int index, double defaultValue) {
-        final Number val = this.optNumber(index, null);
-        if (val == null) {
-            return defaultValue;
-        }
-        final double doubleValue = val.doubleValue();
-        // if (Double.isNaN(doubleValue) || Double.isInfinite(doubleValue)) {
-        // return defaultValue;
-        // }
-        return doubleValue;
-    }
-
-    /**
-     * Get the optional float value associated with an index. NaN is returned
-     * if there is no value for the index, or if the value is not a number and
-     * cannot be converted to a number.
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @return The value.
-     */
-    public float optFloat(int index) {
-        return this.optFloat(index, Float.NaN);
-    }
-
-    /**
-     * Get the optional float value associated with an index. The defaultValue
-     * is returned if there is no value for the index, or if the value is not a
-     * number and cannot be converted to a number.
-     *
-     * @param index
-     *            subscript
-     * @param defaultValue
-     *            The default value.
-     * @return The value.
-     */
-    public float optFloat(int index, float defaultValue) {
-        final Number val = this.optNumber(index, null);
-        if (val == null) {
-            return defaultValue;
-        }
-        final float floatValue = val.floatValue();
-        // if (Float.isNaN(floatValue) || Float.isInfinite(floatValue)) {
-        // return floatValue;
-        // }
-        return floatValue;
-    }
-
-    /**
-     * Get the optional int value associated with an index. Zero is returned if
-     * there is no value for the index, or if the value is not a number and
-     * cannot be converted to a number.
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @return The value.
-     */
-    public int optInt(int index) {
-        return this.optInt(index, 0);
-    }
-
-    /**
-     * Get the optional int value associated with an index. The defaultValue is
-     * returned if there is no value for the index, or if the value is not a
-     * number and cannot be converted to a number.
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @param defaultValue
-     *            The default value.
-     * @return The value.
-     */
-    public int optInt(int index, int defaultValue) {
-        final Number val = this.optNumber(index, null);
-        if (val == null) {
-            return defaultValue;
-        }
-        return val.intValue();
-    }
-
-    /**
-     * Get the enum value associated with a key.
-     * 
-     * @param <E>
-     *            Enum Type
-     * @param clazz
-     *            The type of enum to retrieve.
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @return The enum value at the index location or null if not found
-     */
-    public <E extends Enum<E>> E optEnum(Class<E> clazz, int index) {
-        return this.optEnum(clazz, index, null);
-    }
-
-    /**
-     * Get the enum value associated with a key.
-     * 
-     * @param <E>
-     *            Enum Type
-     * @param clazz
-     *            The type of enum to retrieve.
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @param defaultValue
-     *            The default in case the value is not found
-     * @return The enum value at the index location or defaultValue if
-     *            the value is not found or cannot be assigned to clazz
-     */
-    public <E extends Enum<E>> E optEnum(Class<E> clazz, int index, E defaultValue) {
-        try {
-            Object val = this.opt(index);
-            if (JSONObject.NULL.equals(val)) {
-                return defaultValue;
-            }
-            if (clazz.isAssignableFrom(val.getClass())) {
-                // we just checked it!
-                @SuppressWarnings("unchecked")
-                E myE = (E) val;
-                return myE;
-            }
-            return Enum.valueOf(clazz, val.toString());
-        } catch (IllegalArgumentException e) {
-            return defaultValue;
-        } catch (NullPointerException e) {
-            return defaultValue;
-        }
-    }
-
-    /**
-     * Get the optional BigInteger value associated with an index. The 
-     * defaultValue is returned if there is no value for the index, or if the 
-     * value is not a number and cannot be converted to a number.
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @param defaultValue
-     *            The default value.
-     * @return The value.
-     */
-    public BigInteger optBigInteger(int index, BigInteger defaultValue) {
-        Object val = this.opt(index);
-        return JSONObject.objectToBigInteger(val, defaultValue);
-    }
-
-    /**
-     * Get the optional BigDecimal value associated with an index. The 
-     * defaultValue is returned if there is no value for the index, or if the 
-     * value is not a number and cannot be converted to a number. If the value
-     * is float or double, the {@link BigDecimal#BigDecimal(double)}
-     * constructor will be used. See notes on the constructor for conversion
-     * issues that may arise.
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @param defaultValue
-     *            The default value.
-     * @return The value.
-     */
-    public BigDecimal optBigDecimal(int index, BigDecimal defaultValue) {
-        Object val = this.opt(index);
-        return JSONObject.objectToBigDecimal(val, defaultValue);
-    }
-
-    /**
-     * Get the optional JSONArray associated with an index.
-     *
-     * @param index
-     *            subscript
-     * @return A JSONArray value, or null if the index has no value, or if the
-     *         value is not a JSONArray.
-     */
-    public JSONArray optJSONArray(int index) {
-        Object o = this.opt(index);
-        return o instanceof JSONArray ? (JSONArray) o : null;
-    }
-
-    /**
-     * Get the optional JSONObject associated with an index. Null is returned if
-     * the key is not found, or null if the index has no value, or if the value
-     * is not a JSONObject.
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @return A JSONObject value.
-     */
-    public JSONObject optJSONObject(int index) {
-        Object o = this.opt(index);
-        return o instanceof JSONObject ? (JSONObject) o : null;
-    }
-
-    /**
-     * Get the optional long value associated with an index. Zero is returned if
-     * there is no value for the index, or if the value is not a number and
-     * cannot be converted to a number.
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @return The value.
-     */
-    public long optLong(int index) {
-        return this.optLong(index, 0);
-    }
-
-    /**
-     * Get the optional long value associated with an index. The defaultValue is
-     * returned if there is no value for the index, or if the value is not a
-     * number and cannot be converted to a number.
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @param defaultValue
-     *            The default value.
-     * @return The value.
-     */
-    public long optLong(int index, long defaultValue) {
-        final Number val = this.optNumber(index, null);
-        if (val == null) {
-            return defaultValue;
-        }
-        return val.longValue();
-    }
-
-    /**
-     * Get an optional {@link Number} value associated with a key, or <code>null</code>
-     * if there is no such key or if the value is not a number. If the value is a string,
-     * an attempt will be made to evaluate it as a number ({@link BigDecimal}). This method
-     * would be used in cases where type coercion of the number value is unwanted.
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @return An object which is the value.
-     */
-    public Number optNumber(int index) {
-        return this.optNumber(index, null);
-    }
-
-    /**
-     * Get an optional {@link Number} value associated with a key, or the default if there
-     * is no such key or if the value is not a number. If the value is a string,
-     * an attempt will be made to evaluate it as a number ({@link BigDecimal}). This method
-     * would be used in cases where type coercion of the number value is unwanted.
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @param defaultValue
-     *            The default.
-     * @return An object which is the value.
-     */
-    public Number optNumber(int index, Number defaultValue) {
-        Object val = this.opt(index);
-        if (JSONObject.NULL.equals(val)) {
-            return defaultValue;
-        }
-        if (val instanceof Number){
-            return (Number) val;
-        }
-        
-        if (val instanceof String) {
-            try {
-                return JSONObject.stringToNumber((String) val);
-            } catch (Exception e) {
-                return defaultValue;
-            }
-        }
+  /**
+   * Get the enum value associated with a key.
+   * 
+   * @param <E> Enum Type
+   * @param clazz The type of enum to retrieve.
+   * @param index The index must be between 0 and length() - 1.
+   * @param defaultValue The default in case the value is not found
+   * @return The enum value at the index location or defaultValue if the value is not found or
+   *         cannot be assigned to clazz
+   */
+  public <E extends Enum<E>> E optEnum(Class<E> clazz, int index, E defaultValue) {
+    try {
+      Object val = this.opt(index);
+      if (JSONObject.NULL.equals(val)) {
         return defaultValue;
+      }
+      if (clazz.isAssignableFrom(val.getClass())) {
+        // we just checked it!
+        @SuppressWarnings("unchecked")
+        E myE = (E) val;
+        return myE;
+      }
+      return Enum.valueOf(clazz, val.toString());
+    } catch (IllegalArgumentException e) {
+      return defaultValue;
+    } catch (NullPointerException e) {
+      return defaultValue;
+    }
+  }
+
+  /**
+   * Get the optional BigInteger value associated with an index. The defaultValue is returned if
+   * there is no value for the index, or if the value is not a number and cannot be converted to a
+   * number.
+   *
+   * @param index The index must be between 0 and length() - 1.
+   * @param defaultValue The default value.
+   * @return The value.
+   */
+  public BigInteger optBigInteger(int index, BigInteger defaultValue) {
+    Object val = this.opt(index);
+    return JSONObject.objectToBigInteger(val, defaultValue);
+  }
+
+  /**
+   * Get the optional BigDecimal value associated with an index. The defaultValue is returned if
+   * there is no value for the index, or if the value is not a number and cannot be converted to a
+   * number. If the value is float or double, the {@link BigDecimal#BigDecimal(double)} constructor
+   * will be used. See notes on the constructor for conversion issues that may arise.
+   *
+   * @param index The index must be between 0 and length() - 1.
+   * @param defaultValue The default value.
+   * @return The value.
+   */
+  public BigDecimal optBigDecimal(int index, BigDecimal defaultValue) {
+    Object val = this.opt(index);
+    return JSONObject.objectToBigDecimal(val, defaultValue);
+  }
+
+  /**
+   * Get the optional JSONArray associated with an index.
+   *
+   * @param index subscript
+   * @return A JSONArray value, or null if the index has no value, or if the value is not a
+   *         JSONArray.
+   */
+  public JSONArray optJSONArray(int index) {
+    Object o = this.opt(index);
+    return o instanceof JSONArray ? (JSONArray) o : null;
+  }
+
+  /**
+   * Get the optional JSONObject associated with an index. Null is returned if the key is not found,
+   * or null if the index has no value, or if the value is not a JSONObject.
+   *
+   * @param index The index must be between 0 and length() - 1.
+   * @return A JSONObject value.
+   */
+  public JSONObject optJSONObject(int index) {
+    Object o = this.opt(index);
+    return o instanceof JSONObject ? (JSONObject) o : null;
+  }
+
+  /**
+   * Get the optional long value associated with an index. Zero is returned if there is no value for
+   * the index, or if the value is not a number and cannot be converted to a number.
+   *
+   * @param index The index must be between 0 and length() - 1.
+   * @return The value.
+   */
+  public long optLong(int index) {
+    return this.optLong(index, 0);
+  }
+
+  /**
+   * Get the optional long value associated with an index. The defaultValue is returned if there is
+   * no value for the index, or if the value is not a number and cannot be converted to a number.
+   *
+   * @param index The index must be between 0 and length() - 1.
+   * @param defaultValue The default value.
+   * @return The value.
+   */
+  public long optLong(int index, long defaultValue) {
+    final Number val = this.optNumber(index, null);
+    if (val == null) {
+      return defaultValue;
+    }
+    return val.longValue();
+  }
+
+  /**
+   * Get an optional {@link Number} value associated with a key, or <code>null</code> if there is no
+   * such key or if the value is not a number. If the value is a string, an attempt will be made to
+   * evaluate it as a number ({@link BigDecimal}). This method would be used in cases where type
+   * coercion of the number value is unwanted.
+   *
+   * @param index The index must be between 0 and length() - 1.
+   * @return An object which is the value.
+   */
+  public Number optNumber(int index) {
+    return this.optNumber(index, null);
+  }
+
+  /**
+   * Get an optional {@link Number} value associated with a key, or the default if there is no such
+   * key or if the value is not a number. If the value is a string, an attempt will be made to
+   * evaluate it as a number ({@link BigDecimal}). This method would be used in cases where type
+   * coercion of the number value is unwanted.
+   *
+   * @param index The index must be between 0 and length() - 1.
+   * @param defaultValue The default.
+   * @return An object which is the value.
+   */
+  public Number optNumber(int index, Number defaultValue) {
+    Object val = this.opt(index);
+    if (JSONObject.NULL.equals(val)) {
+      return defaultValue;
+    }
+    if (val instanceof Number) {
+      return (Number) val;
     }
 
-    /**
-     * Get the optional string value associated with an index. It returns an
-     * empty string if there is no value at that index. If the value is not a
-     * string and is not null, then it is converted to a string.
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @return A String value.
-     */
-    public String optString(int index) {
-        return this.optString(index, "");
+    if (val instanceof String) {
+      try {
+        return JSONObject.stringToNumber((String) val);
+      } catch (Exception e) {
+        return defaultValue;
+      }
     }
+    return defaultValue;
+  }
 
-    /**
-     * Get the optional string associated with an index. The defaultValue is
-     * returned if the key is not found.
-     *
-     * @param index
-     *            The index must be between 0 and length() - 1.
-     * @param defaultValue
-     *            The default value.
-     * @return A String value.
-     */
-    public String optString(int index, String defaultValue) {
-        Object object = this.opt(index);
-        return JSONObject.NULL.equals(object) ? defaultValue : object
-                .toString();
-    }
+  /**
+   * Get the optional string value associated with an index. It returns an empty string if there is
+   * no value at that index. If the value is not a string and is not null, then it is converted to a
+   * string.
+   *
+   * @param index The index must be between 0 and length() - 1.
+   * @return A String value.
+   */
+  public String optString(int index) {
+    return this.optString(index, "");
+  }
 
-    /**
-     * Append a boolean value. This increases the array's length by one.
-     *
-     * @param value
-     *            A boolean value.
-     * @return this.
-     */
-    public JSONArray put(boolean value) {
-        return this.put(value ? Boolean.TRUE : Boolean.FALSE);
-    }
+  /**
+   * Get the optional string associated with an index. The defaultValue is returned if the key is
+   * not found.
+   *
+   * @param index The index must be between 0 and length() - 1.
+   * @param defaultValue The default value.
+   * @return A String value.
+   */
+  public String optString(int index, String defaultValue) {
+    Object object = this.opt(index);
+    return JSONObject.NULL.equals(object) ? defaultValue
+        : object
+            .toString();
+  }
 
-    /**
-     * Append a double value. This increases the array's length by one.
-     *
-     * @param value
-     *            A double value.
-     * @return this.
-     * @throws JSONException
-     *             if the value is not finite.
-     */
-    public JSONArray put(double value) throws JSONException {
-        return this.put(Double.valueOf(value));
-    }
-    
-    /**
-     * Append a float value. This increases the array's length by one.
-     *
-     * @param value
-     *            A float value.
-     * @return this.
-     * @throws JSONException
-     *             if the value is not finite.
-     */
-    public JSONArray put(float value) throws JSONException {
-        return this.put(Float.valueOf(value));
-    }
+  /**
+   * Append a boolean value. This increases the array's length by one.
+   *
+   * @param value A boolean value.
+   * @return this.
+   */
+  public JSONArray put(boolean value) {
+    return this.put(value ? Boolean.TRUE : Boolean.FALSE);
+  }
 
-    /**
-     * Append an int value. This increases the array's length by one.
-     *
-     * @param value
-     *            An int value.
-     * @return this.
-     */
-    public JSONArray put(int value) {
-        return this.put(Integer.valueOf(value));
-    }
+  /**
+   * Append a double value. This increases the array's length by one.
+   *
+   * @param value A double value.
+   * @return this.
+   * @throws JSONException if the value is not finite.
+   */
+  public JSONArray put(double value) throws JSONException {
+    return this.put(Double.valueOf(value));
+  }
 
-    /**
-     * Append an long value. This increases the array's length by one.
-     *
-     * @param value
-     *            A long value.
-     * @return this.
-     */
-    public JSONArray put(long value) {
-        return this.put(Long.valueOf(value));
-    }
+  /**
+   * Append a float value. This increases the array's length by one.
+   *
+   * @param value A float value.
+   * @return this.
+   * @throws JSONException if the value is not finite.
+   */
+  public JSONArray put(float value) throws JSONException {
+    return this.put(Float.valueOf(value));
+  }
 
-    /**
-     * Put a value in the JSONArray, where the value will be a JSONObject which
-     * is produced from a Map.
-     *
-     * @param value
-     *            A Map value.
-     * @return this.
-     * @throws JSONException
-     *            If a value in the map is non-finite number.
-     * @throws NullPointerException
-     *            If a key in the map is <code>null</code>
-     */
-    public JSONArray put(Map<?, ?> value) {
-        return this.put(new JSONObject(value));
-    }
+  /**
+   * Append an int value. This increases the array's length by one.
+   *
+   * @param value An int value.
+   * @return this.
+   */
+  public JSONArray put(int value) {
+    return this.put(Integer.valueOf(value));
+  }
 
-    /**
-     * Append an object value. This increases the array's length by one.
-     *
-     * @param value
-     *            An object value. The value should be a Boolean, Double,
-     *            Integer, JSONArray, JSONObject, Long, or String, or the
-     *            JSONObject.NULL object.
-     * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
-     */
-    public JSONArray put(Object value) {
-        JSONObject.testValidity(value);
-        this.myArrayList.add(value);
-        return this;
-    }
+  /**
+   * Append an long value. This increases the array's length by one.
+   *
+   * @param value A long value.
+   * @return this.
+   */
+  public JSONArray put(long value) {
+    return this.put(Long.valueOf(value));
+  }
 
-    /**
-     * Put or replace a boolean value in the JSONArray. If the index is greater
-     * than the length of the JSONArray, then null elements will be added as
-     * necessary to pad it out.
-     *
-     * @param index
-     *            The subscript.
-     * @param value
-     *            A boolean value.
-     * @return this.
-     * @throws JSONException
-     *             If the index is negative.
-     */
-    public JSONArray put(int index, boolean value) throws JSONException {
-        return this.put(index, value ? Boolean.TRUE : Boolean.FALSE);
-    }
+  /**
+   * Put a value in the JSONArray, where the value will be a JSONObject which is produced from a
+   * Map.
+   *
+   * @param value A Map value.
+   * @return this.
+   * @throws JSONException If a value in the map is non-finite number.
+   * @throws NullPointerException If a key in the map is <code>null</code>
+   */
+  public JSONArray put(Map<?, ?> value) {
+    return this.put(new JSONObject(value));
+  }
 
-    /**
-     * Put or replace a double value. If the index is greater than the length of
-     * the JSONArray, then null elements will be added as necessary to pad it
-     * out.
-     *
-     * @param index
-     *            The subscript.
-     * @param value
-     *            A double value.
-     * @return this.
-     * @throws JSONException
-     *             If the index is negative or if the value is non-finite.
-     */
-    public JSONArray put(int index, double value) throws JSONException {
-        return this.put(index, Double.valueOf(value));
-    }
+  /**
+   * Append an object value. This increases the array's length by one.
+   *
+   * @param value An object value. The value should be a Boolean, Double, Integer, JSONArray,
+   *        JSONObject, Long, or String, or the JSONObject.NULL object.
+   * @return this.
+   * @throws JSONException If the value is non-finite number.
+   */
+  public JSONArray put(Object value) {
+    JSONObject.testValidity(value);
+    this.myArrayList.add(value);
+    return this;
+  }
 
-    /**
-     * Put or replace a float value. If the index is greater than the length of
-     * the JSONArray, then null elements will be added as necessary to pad it
-     * out.
-     *
-     * @param index
-     *            The subscript.
-     * @param value
-     *            A float value.
-     * @return this.
-     * @throws JSONException
-     *             If the index is negative or if the value is non-finite.
-     */
-    public JSONArray put(int index, float value) throws JSONException {
-        return this.put(index, Float.valueOf(value));
-    }
+  /**
+   * Put or replace a boolean value in the JSONArray. If the index is greater than the length of the
+   * JSONArray, then null elements will be added as necessary to pad it out.
+   *
+   * @param index The subscript.
+   * @param value A boolean value.
+   * @return this.
+   * @throws JSONException If the index is negative.
+   */
+  public JSONArray put(int index, boolean value) throws JSONException {
+    return this.put(index, value ? Boolean.TRUE : Boolean.FALSE);
+  }
 
-    /**
-     * Put or replace an int value. If the index is greater than the length of
-     * the JSONArray, then null elements will be added as necessary to pad it
-     * out.
-     *
-     * @param index
-     *            The subscript.
-     * @param value
-     *            An int value.
-     * @return this.
-     * @throws JSONException
-     *             If the index is negative.
-     */
-    public JSONArray put(int index, int value) throws JSONException {
-        return this.put(index, Integer.valueOf(value));
-    }
+  /**
+   * Put or replace a double value. If the index is greater than the length of the JSONArray, then
+   * null elements will be added as necessary to pad it out.
+   *
+   * @param index The subscript.
+   * @param value A double value.
+   * @return this.
+   * @throws JSONException If the index is negative or if the value is non-finite.
+   */
+  public JSONArray put(int index, double value) throws JSONException {
+    return this.put(index, Double.valueOf(value));
+  }
 
-    /**
-     * Put or replace a long value. If the index is greater than the length of
-     * the JSONArray, then null elements will be added as necessary to pad it
-     * out.
-     *
-     * @param index
-     *            The subscript.
-     * @param value
-     *            A long value.
-     * @return this.
-     * @throws JSONException
-     *             If the index is negative.
-     */
-    public JSONArray put(int index, long value) throws JSONException {
-        return this.put(index, Long.valueOf(value));
-    }
+  /**
+   * Put or replace a float value. If the index is greater than the length of the JSONArray, then
+   * null elements will be added as necessary to pad it out.
+   *
+   * @param index The subscript.
+   * @param value A float value.
+   * @return this.
+   * @throws JSONException If the index is negative or if the value is non-finite.
+   */
+  public JSONArray put(int index, float value) throws JSONException {
+    return this.put(index, Float.valueOf(value));
+  }
 
-    /**
-     * Put a value in the JSONArray, where the value will be a JSONObject that
-     * is produced from a Map.
-     *
-     * @param index
-     *            The subscript.
-     * @param value
-     *            The Map value.
-     * @return this.
-     * @throws JSONException
-     *             If the index is negative or if the value is an invalid
-     *             number.
-     * @throws NullPointerException
-     *             If a key in the map is <code>null</code>
-     */
-    public JSONArray put(int index, Map<?, ?> value) throws JSONException {
-        this.put(index, new JSONObject(value));
-        return this;
-    }
+  /**
+   * Put or replace an int value. If the index is greater than the length of the JSONArray, then
+   * null elements will be added as necessary to pad it out.
+   *
+   * @param index The subscript.
+   * @param value An int value.
+   * @return this.
+   * @throws JSONException If the index is negative.
+   */
+  public JSONArray put(int index, int value) throws JSONException {
+    return this.put(index, Integer.valueOf(value));
+  }
 
-    /**
-     * Put or replace an object value in the JSONArray. If the index is greater
-     * than the length of the JSONArray, then null elements will be added as
-     * necessary to pad it out.
-     *
-     * @param index
-     *            The subscript.
-     * @param value
-     *            The value to put into the array. The value should be a
-     *            Boolean, Double, Integer, JSONArray, JSONObject, Long, or
-     *            String, or the JSONObject.NULL object.
-     * @return this.
-     * @throws JSONException
-     *             If the index is negative or if the value is an invalid
-     *             number.
-     */
-    public JSONArray put(int index, Object value) throws JSONException {
-        if (index < 0) {
-            throw new JSONException("JSONArray[" + index + "] not found.");
-        }
-        if (index < this.length()) {
-            JSONObject.testValidity(value);
-            this.myArrayList.set(index, value);
-            return this;
-        }
-        if(index == this.length()){
-            // simple append
-            return this.put(value);
-        }
-        // if we are inserting past the length, we want to grow the array all at once
-        // instead of incrementally.
-        this.myArrayList.ensureCapacity(index + 1);
-        while (index != this.length()) {
-            // we don't need to test validity of NULL objects
-            this.myArrayList.add(JSONObject.NULL);
-        }
-        return this.put(value);
-    }
+  /**
+   * Put or replace a long value. If the index is greater than the length of the JSONArray, then
+   * null elements will be added as necessary to pad it out.
+   *
+   * @param index The subscript.
+   * @param value A long value.
+   * @return this.
+   * @throws JSONException If the index is negative.
+   */
+  public JSONArray put(int index, long value) throws JSONException {
+    return this.put(index, Long.valueOf(value));
+  }
 
-    /**
-     * Put a JSONArray's elements in to the JSONArray.
-     *
-     * @param array
-     *            A JSONArray.
-     * @return this. 
-     */
-    public JSONArray putAll(JSONArray array) {
-        // directly copy the elements from the source array to this one
-        // as all wrapping should have been done already in the source.
-        this.myArrayList.addAll(array.myArrayList);
-        return this;
-    }
+  /**
+   * Put a value in the JSONArray, where the value will be a JSONObject that is produced from a Map.
+   *
+   * @param index The subscript.
+   * @param value The Map value.
+   * @return this.
+   * @throws JSONException If the index is negative or if the value is an invalid number.
+   * @throws NullPointerException If a key in the map is <code>null</code>
+   */
+  public JSONArray put(int index, Map<?, ?> value) throws JSONException {
+    this.put(index, new JSONObject(value));
+    return this;
+  }
 
-    /**
-     * Remove an index and close the hole.
-     *
-     * @param index
-     *            The index of the element to be removed.
-     * @return The value that was associated with the index, or null if there
-     *         was no value.
-     */
-    public Object remove(int index) {
-        return index >= 0 && index < this.length()
-            ? this.myArrayList.remove(index)
-            : null;
+  /**
+   * Put or replace an object value in the JSONArray. If the index is greater than the length of the
+   * JSONArray, then null elements will be added as necessary to pad it out.
+   *
+   * @param index The subscript.
+   * @param value The value to put into the array. The value should be a Boolean, Double, Integer,
+   *        JSONArray, JSONObject, Long, or String, or the JSONObject.NULL object.
+   * @return this.
+   * @throws JSONException If the index is negative or if the value is an invalid number.
+   */
+  public JSONArray put(int index, Object value) throws JSONException {
+    if (index < 0) {
+      throw new JSONException("JSONArray[" + index + "] not found.");
     }
+    if (index < this.length()) {
+      JSONObject.testValidity(value);
+      this.myArrayList.set(index, value);
+      return this;
+    }
+    if (index == this.length()) {
+      // simple append
+      return this.put(value);
+    }
+    // if we are inserting past the length, we want to grow the array all at once
+    // instead of incrementally.
+    this.myArrayList.ensureCapacity(index + 1);
+    while (index != this.length()) {
+      // we don't need to test validity of NULL objects
+      this.myArrayList.add(JSONObject.NULL);
+    }
+    return this.put(value);
+  }
 
-    /**
-     * Produce a JSONObject by combining a JSONArray of names with the values of
-     * this JSONArray.
-     *
-     * @param names
-     *            A JSONArray containing a list of key strings. These will be
-     *            paired with the values.
-     * @return A JSONObject, or null if there are no names or if this JSONArray
-     *         has no values.
-     * @throws JSONException
-     *             If any of the names are null.
-     */
-    public JSONObject toJSONObject(JSONArray names) throws JSONException {
-        if (names == null || names.isEmpty() || this.isEmpty()) {
-            return null;
-        }
-        JSONObject jo = new JSONObject(names.length());
-        for (int i = 0; i < names.length(); i += 1) {
-            jo.put(names.getString(i), this.opt(i));
-        }
-        return jo;
-    }
+  /**
+   * Put a JSONArray's elements in to the JSONArray.
+   *
+   * @param array A JSONArray.
+   * @return this.
+   */
+  public JSONArray putAll(JSONArray array) {
+    // directly copy the elements from the source array to this one
+    // as all wrapping should have been done already in the source.
+    this.myArrayList.addAll(array.myArrayList);
+    return this;
+  }
 
-    /**
-     * Check if JSONArray is empty.
-     *
-     * @return true if JSONArray is empty, otherwise false.
-     */
-    public boolean isEmpty() {
-        return this.myArrayList.isEmpty();
+  /**
+   * Remove an index and close the hole.
+   *
+   * @param index The index of the element to be removed.
+   * @return The value that was associated with the index, or null if there was no value.
+   */
+  public Object remove(int index) {
+    return index >= 0 && index < this.length()
+        ? this.myArrayList.remove(index)
+        : null;
+  }
+
+  /**
+   * Produce a JSONObject by combining a JSONArray of names with the values of this JSONArray.
+   *
+   * @param names A JSONArray containing a list of key strings. These will be paired with the
+   *        values.
+   * @return A JSONObject, or null if there are no names or if this JSONArray has no values.
+   * @throws JSONException If any of the names are null.
+   */
+  public JSONObject toJSONObject(JSONArray names) throws JSONException {
+    if (names == null || names.isEmpty() || this.isEmpty()) {
+      return null;
     }
-    
-    /**
-     * Create a new JSONException in a common format for incorrect conversions.
-     * @param idx index of the item
-     * @param valueType the type of value being coerced to
-     * @param cause optional cause of the coercion failure
-     * @return JSONException that can be thrown.
-     */
-    private static JSONException wrongValueFormatException(
-            int idx,
-            String valueType,
-            Object value,
-            Throwable cause) {
-        if(value == null) {
-            return new JSONException(
-                    "JSONArray[" + idx + "] is not a " + valueType + " (null)."
-                    , cause);
-        }
-        // don't try to toString collections or known object types that could be large.
-        if(value instanceof Map || value instanceof Iterable || value instanceof JSONObject) {
-            return new JSONException(
-                    "JSONArray[" + idx + "] is not a " + valueType + " (" + value.getClass() + ")."
-                    , cause);
-        }
-        return new JSONException(
-                "JSONArray[" + idx + "] is not a " + valueType + " (" + value.getClass() + " : " + value + ")."
-                , cause);
+    JSONObject jo = new JSONObject(names.length());
+    for (int i = 0; i < names.length(); i += 1) {
+      jo.put(names.getString(i), this.opt(i));
     }
+    return jo;
+  }
+
+  /**
+   * Check if JSONArray is empty.
+   *
+   * @return true if JSONArray is empty, otherwise false.
+   */
+  public boolean isEmpty() {
+    return this.myArrayList.isEmpty();
+  }
+
+  /**
+   * Create a new JSONException in a common format for incorrect conversions.
+   * 
+   * @param idx index of the item
+   * @param valueType the type of value being coerced to
+   * @param cause optional cause of the coercion failure
+   * @return JSONException that can be thrown.
+   */
+  private static JSONException wrongValueFormatException(
+                                                         int idx,
+                                                         String valueType,
+                                                         Object value,
+                                                         Throwable cause) {
+    if (value == null) {
+      return new JSONException(
+          "JSONArray[" + idx + "] is not a " + valueType + " (null).", cause);
+    }
+    // don't try to toString collections or known object types that could be large.
+    if (value instanceof Map || value instanceof Iterable || value instanceof JSONObject) {
+      return new JSONException(
+          "JSONArray[" + idx + "] is not a " + valueType + " (" + value.getClass() + ").", cause);
+    }
+    return new JSONException(
+        "JSONArray[" + idx + "] is not a " + valueType + " (" + value.getClass() + " : " + value
+            + ").",
+        cause);
+  }
 
 }

--- a/core/src/main/java/feign/template/util/JSONArray.java
+++ b/core/src/main/java/feign/template/util/JSONArray.java
@@ -1,0 +1,1163 @@
+package feign.template.util;
+
+/*
+Public Domain.
+ */
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.Map;
+
+
+/**
+ * A JSONArray is an ordered sequence of values. Its external text form is a
+ * string wrapped in square brackets with commas separating the values. The
+ * internal form is an object having <code>get</code> and <code>opt</code>
+ * methods for accessing the values by index, and <code>put</code> methods for
+ * adding or replacing values. The values can be any of these types:
+ * <code>Boolean</code>, <code>JSONArray</code>, <code>JSONObject</code>,
+ * <code>Number</code>, <code>String</code>, or the
+ * <code>JSONObject.NULL object</code>.
+ * <p>
+ * The constructor can convert a JSON text into a Java object. The
+ * <code>toString</code> method converts to JSON text.
+ * <p>
+ * A <code>get</code> method returns a value if one can be found, and throws an
+ * exception if one cannot be found. An <code>opt</code> method returns a
+ * default value instead of throwing an exception, and so is useful for
+ * obtaining optional values.
+ * <p>
+ * The generic <code>get()</code> and <code>opt()</code> methods return an
+ * object which you can cast or query for type. There are also typed
+ * <code>get</code> and <code>opt</code> methods that do type checking and type
+ * coercion for you.
+ * <p>
+ * The texts produced by the <code>toString</code> methods strictly conform to
+ * JSON syntax rules. The constructors are more forgiving in the texts they will
+ * accept:
+ * <ul>
+ * <li>An extra <code>,</code>&nbsp;<small>(comma)</small> may appear just
+ * before the closing bracket.</li>
+ * <li>The <code>null</code> value will be inserted when there is <code>,</code>
+ * &nbsp;<small>(comma)</small> elision.</li>
+ * <li>Strings may be quoted with <code>'</code>&nbsp;<small>(single
+ * quote)</small>.</li>
+ * <li>Strings do not need to be quoted at all if they do not begin with a quote
+ * or single quote, and if they do not contain leading or trailing spaces, and
+ * if they do not contain any of these characters:
+ * <code>{ } [ ] / \ : , #</code> and if they do not look like numbers and
+ * if they are not the reserved words <code>true</code>, <code>false</code>, or
+ * <code>null</code>.</li>
+ * </ul>
+ *
+ * @author JSON.org
+ * @version 2016-08/15
+ */
+public class JSONArray implements Iterable<Object> {
+
+    /**
+     * The arrayList where the JSONArray's properties are kept.
+     */
+    private final ArrayList<Object> myArrayList;
+
+    /**
+     * Construct an empty JSONArray.
+     */
+    public JSONArray() {
+        this.myArrayList = new ArrayList<Object>();
+    }
+
+    /**
+     * Construct a JSONArray from a JSONTokener.
+     *
+     * @param x
+     *            A JSONTokener
+     * @throws JSONException
+     *             If there is a syntax error.
+     */
+    public JSONArray(JSONTokener x) throws JSONException {
+        this();
+        if (x.nextClean() != '[') {
+            throw x.syntaxError("A JSONArray text must start with '['");
+        }
+        
+        char nextChar = x.nextClean();
+        if (nextChar == 0) {
+            // array is unclosed. No ']' found, instead EOF
+            throw x.syntaxError("Expected a ',' or ']'");
+        }
+        if (nextChar != ']') {
+            x.back();
+            for (;;) {
+                if (x.nextClean() == ',') {
+                    x.back();
+                    this.myArrayList.add(JSONObject.NULL);
+                } else {
+                    x.back();
+                    this.myArrayList.add(x.nextValue());
+                }
+                switch (x.nextClean()) {
+                case 0:
+                    // array is unclosed. No ']' found, instead EOF
+                    throw x.syntaxError("Expected a ',' or ']'");
+                case ',':
+                    nextChar = x.nextClean();
+                    if (nextChar == 0) {
+                        // array is unclosed. No ']' found, instead EOF
+                        throw x.syntaxError("Expected a ',' or ']'");
+                    }
+                    if (nextChar == ']') {
+                        return;
+                    }
+                    x.back();
+                    break;
+                case ']':
+                    return;
+                default:
+                    throw x.syntaxError("Expected a ',' or ']'");
+                }
+            }
+        }
+    }
+
+    /**
+     * Construct a JSONArray from a source JSON text.
+     *
+     * @param source
+     *            A string that begins with <code>[</code>&nbsp;<small>(left
+     *            bracket)</small> and ends with <code>]</code>
+     *            &nbsp;<small>(right bracket)</small>.
+     * @throws JSONException
+     *             If there is a syntax error.
+     */
+    public JSONArray(String source) throws JSONException {
+        this(new JSONTokener(source));
+    }
+
+    /**
+     * Construct a JSONArray from another JSONArray. This is a shallow copy.
+     *
+     * @param array
+     *            A array.
+     */
+    public JSONArray(JSONArray array) {
+        if (array == null) {
+            this.myArrayList = new ArrayList<Object>();
+        } else {
+            // shallow copy directly the internal array lists as any wrapping
+            // should have been done already in the original JSONArray
+            this.myArrayList = new ArrayList<Object>(array.myArrayList);
+        }
+    }
+
+    /**
+     * Construct a JSONArray with the specified initial capacity.
+     *
+     * @param initialCapacity
+     *            the initial capacity of the JSONArray.
+     * @throws JSONException
+     *             If the initial capacity is negative.
+     */
+    public JSONArray(int initialCapacity) throws JSONException {
+    	if (initialCapacity < 0) {
+            throw new JSONException(
+                    "JSONArray initial capacity cannot be negative.");
+    	}
+    	this.myArrayList = new ArrayList<Object>(initialCapacity);
+    }
+
+    @Override
+    public Iterator<Object> iterator() {
+        return this.myArrayList.iterator();
+    }
+
+    /**
+     * Get the object value associated with an index.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return An object value.
+     * @throws JSONException
+     *             If there is no value for the index.
+     */
+    public Object get(int index) throws JSONException {
+        Object object = this.opt(index);
+        if (object == null) {
+            throw new JSONException("JSONArray[" + index + "] not found.");
+        }
+        return object;
+    }
+
+    /**
+     * Get the boolean value associated with an index. The string values "true"
+     * and "false" are converted to boolean.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return The truth.
+     * @throws JSONException
+     *             If there is no value for the index or if the value is not
+     *             convertible to boolean.
+     */
+    public boolean getBoolean(int index) throws JSONException {
+        Object object = this.get(index);
+        if (object.equals(Boolean.FALSE)
+                || (object instanceof String && ((String) object)
+                        .equalsIgnoreCase("false"))) {
+            return false;
+        } else if (object.equals(Boolean.TRUE)
+                || (object instanceof String && ((String) object)
+                        .equalsIgnoreCase("true"))) {
+            return true;
+        }
+        throw wrongValueFormatException(index, "boolean", object, null);
+    }
+
+    /**
+     * Get the double value associated with an index.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return The value.
+     * @throws JSONException
+     *             If the key is not found or if the value cannot be converted
+     *             to a number.
+     */
+    public double getDouble(int index) throws JSONException {
+        final Object object = this.get(index);
+        if(object instanceof Number) {
+            return ((Number)object).doubleValue();
+        }
+        try {
+            return Double.parseDouble(object.toString());
+        } catch (Exception e) {
+            throw wrongValueFormatException(index, "double", object, e);
+        }
+    }
+
+    /**
+     * Get the float value associated with a key.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return The numeric value.
+     * @throws JSONException
+     *             if the key is not found or if the value is not a Number
+     *             object and cannot be converted to a number.
+     */
+    public float getFloat(int index) throws JSONException {
+        final Object object = this.get(index);
+        if(object instanceof Number) {
+            return ((Number)object).floatValue();
+        }
+        try {
+            return Float.parseFloat(object.toString());
+        } catch (Exception e) {
+            throw wrongValueFormatException(index, "float", object, e);
+        }
+    }
+
+    /**
+     * Get the Number value associated with a key.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return The numeric value.
+     * @throws JSONException
+     *             if the key is not found or if the value is not a Number
+     *             object and cannot be converted to a number.
+     */
+    public Number getNumber(int index) throws JSONException {
+        Object object = this.get(index);
+        try {
+            if (object instanceof Number) {
+                return (Number)object;
+            }
+            return JSONObject.stringToNumber(object.toString());
+        } catch (Exception e) {
+            throw wrongValueFormatException(index, "number", object, e);
+        }
+    }
+
+    /**
+     * Get the enum value associated with an index.
+     * 
+     * @param <E>
+     *            Enum Type
+     * @param clazz
+     *            The type of enum to retrieve.
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return The enum value at the index location
+     * @throws JSONException
+     *            if the key is not found or if the value cannot be converted
+     *            to an enum.
+     */
+    public <E extends Enum<E>> E getEnum(Class<E> clazz, int index) throws JSONException {
+        E val = optEnum(clazz, index);
+        if(val==null) {
+            // JSONException should really take a throwable argument.
+            // If it did, I would re-implement this with the Enum.valueOf
+            // method and place any thrown exception in the JSONException
+            throw wrongValueFormatException(index, "enum of type "
+                    + JSONObject.quote(clazz.getSimpleName()), opt(index), null);
+        }
+        return val;
+    }
+
+    /**
+     * Get the BigDecimal value associated with an index. If the value is float
+     * or double, the {@link BigDecimal#BigDecimal(double)} constructor
+     * will be used. See notes on the constructor for conversion issues that
+     * may arise.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return The value.
+     * @throws JSONException
+     *             If the key is not found or if the value cannot be converted
+     *             to a BigDecimal.
+     */
+    public BigDecimal getBigDecimal (int index) throws JSONException {
+        Object object = this.get(index);
+        BigDecimal val = JSONObject.objectToBigDecimal(object, null);
+        if(val == null) {
+            throw wrongValueFormatException(index, "BigDecimal", object, null);
+        }
+        return val;
+    }
+
+    /**
+     * Get the BigInteger value associated with an index.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return The value.
+     * @throws JSONException
+     *             If the key is not found or if the value cannot be converted
+     *             to a BigInteger.
+     */
+    public BigInteger getBigInteger (int index) throws JSONException {
+        Object object = this.get(index);
+        BigInteger val = JSONObject.objectToBigInteger(object, null);
+        if(val == null) {
+            throw wrongValueFormatException(index, "BigInteger", object, null);
+        }
+        return val;
+    }
+
+    /**
+     * Get the int value associated with an index.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return The value.
+     * @throws JSONException
+     *             If the key is not found or if the value is not a number.
+     */
+    public int getInt(int index) throws JSONException {
+        final Object object = this.get(index);
+        if(object instanceof Number) {
+            return ((Number)object).intValue();
+        }
+        try {
+            return Integer.parseInt(object.toString());
+        } catch (Exception e) {
+            throw wrongValueFormatException(index, "int", object, e);
+        }
+    }
+
+    /**
+     * Get the JSONArray associated with an index.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return A JSONArray value.
+     * @throws JSONException
+     *             If there is no value for the index. or if the value is not a
+     *             JSONArray
+     */
+    public JSONArray getJSONArray(int index) throws JSONException {
+        Object object = this.get(index);
+        if (object instanceof JSONArray) {
+            return (JSONArray) object;
+        }
+        throw wrongValueFormatException(index, "JSONArray", object, null);
+    }
+
+    /**
+     * Get the JSONObject associated with an index.
+     *
+     * @param index
+     *            subscript
+     * @return A JSONObject value.
+     * @throws JSONException
+     *             If there is no value for the index or if the value is not a
+     *             JSONObject
+     */
+    public JSONObject getJSONObject(int index) throws JSONException {
+        Object object = this.get(index);
+        if (object instanceof JSONObject) {
+            return (JSONObject) object;
+        }
+        throw wrongValueFormatException(index, "JSONObject", object, null);
+    }
+
+    /**
+     * Get the long value associated with an index.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return The value.
+     * @throws JSONException
+     *             If the key is not found or if the value cannot be converted
+     *             to a number.
+     */
+    public long getLong(int index) throws JSONException {
+        final Object object = this.get(index);
+        if(object instanceof Number) {
+            return ((Number)object).longValue();
+        }
+        try {
+            return Long.parseLong(object.toString());
+        } catch (Exception e) {
+            throw wrongValueFormatException(index, "long", object, e);
+        }
+    }
+
+    /**
+     * Get the string associated with an index.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return A string value.
+     * @throws JSONException
+     *             If there is no string value for the index.
+     */
+    public String getString(int index) throws JSONException {
+        Object object = this.get(index);
+        if (object instanceof String) {
+            return (String) object;
+        }
+        throw wrongValueFormatException(index, "String", object, null);
+    }
+
+    /**
+     * Determine if the value is <code>null</code>.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return true if the value at the index is <code>null</code>, or if there is no value.
+     */
+    public boolean isNull(int index) {
+        return JSONObject.NULL.equals(this.opt(index));
+    }
+
+    /**
+     * Get the number of elements in the JSONArray, included nulls.
+     *
+     * @return The length (or size).
+     */
+    public int length() {
+        return this.myArrayList.size();
+    }
+
+    /**
+     * Removes all of the elements from this JSONArray.
+     * The JSONArray will be empty after this call returns.
+     */
+    public void clear() {
+        this.myArrayList.clear();
+    }
+
+    /**
+     * Get the optional object value associated with an index.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1. If not, null is returned.
+     * @return An object value, or null if there is no object at that index.
+     */
+    public Object opt(int index) {
+        return (index < 0 || index >= this.length()) ? null : this.myArrayList
+                .get(index);
+    }
+
+    /**
+     * Get the optional boolean value associated with an index. It returns false
+     * if there is no value at that index, or if the value is not Boolean.TRUE
+     * or the String "true".
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return The truth.
+     */
+    public boolean optBoolean(int index) {
+        return this.optBoolean(index, false);
+    }
+
+    /**
+     * Get the optional boolean value associated with an index. It returns the
+     * defaultValue if there is no value at that index or if it is not a Boolean
+     * or the String "true" or "false" (case insensitive).
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            A boolean default.
+     * @return The truth.
+     */
+    public boolean optBoolean(int index, boolean defaultValue) {
+        try {
+            return this.getBoolean(index);
+        } catch (Exception e) {
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Get the optional double value associated with an index. NaN is returned
+     * if there is no value for the index, or if the value is not a number and
+     * cannot be converted to a number.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return The value.
+     */
+    public double optDouble(int index) {
+        return this.optDouble(index, Double.NaN);
+    }
+
+    /**
+     * Get the optional double value associated with an index. The defaultValue
+     * is returned if there is no value for the index, or if the value is not a
+     * number and cannot be converted to a number.
+     *
+     * @param index
+     *            subscript
+     * @param defaultValue
+     *            The default value.
+     * @return The value.
+     */
+    public double optDouble(int index, double defaultValue) {
+        final Number val = this.optNumber(index, null);
+        if (val == null) {
+            return defaultValue;
+        }
+        final double doubleValue = val.doubleValue();
+        // if (Double.isNaN(doubleValue) || Double.isInfinite(doubleValue)) {
+        // return defaultValue;
+        // }
+        return doubleValue;
+    }
+
+    /**
+     * Get the optional float value associated with an index. NaN is returned
+     * if there is no value for the index, or if the value is not a number and
+     * cannot be converted to a number.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return The value.
+     */
+    public float optFloat(int index) {
+        return this.optFloat(index, Float.NaN);
+    }
+
+    /**
+     * Get the optional float value associated with an index. The defaultValue
+     * is returned if there is no value for the index, or if the value is not a
+     * number and cannot be converted to a number.
+     *
+     * @param index
+     *            subscript
+     * @param defaultValue
+     *            The default value.
+     * @return The value.
+     */
+    public float optFloat(int index, float defaultValue) {
+        final Number val = this.optNumber(index, null);
+        if (val == null) {
+            return defaultValue;
+        }
+        final float floatValue = val.floatValue();
+        // if (Float.isNaN(floatValue) || Float.isInfinite(floatValue)) {
+        // return floatValue;
+        // }
+        return floatValue;
+    }
+
+    /**
+     * Get the optional int value associated with an index. Zero is returned if
+     * there is no value for the index, or if the value is not a number and
+     * cannot be converted to a number.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return The value.
+     */
+    public int optInt(int index) {
+        return this.optInt(index, 0);
+    }
+
+    /**
+     * Get the optional int value associated with an index. The defaultValue is
+     * returned if there is no value for the index, or if the value is not a
+     * number and cannot be converted to a number.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            The default value.
+     * @return The value.
+     */
+    public int optInt(int index, int defaultValue) {
+        final Number val = this.optNumber(index, null);
+        if (val == null) {
+            return defaultValue;
+        }
+        return val.intValue();
+    }
+
+    /**
+     * Get the enum value associated with a key.
+     * 
+     * @param <E>
+     *            Enum Type
+     * @param clazz
+     *            The type of enum to retrieve.
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return The enum value at the index location or null if not found
+     */
+    public <E extends Enum<E>> E optEnum(Class<E> clazz, int index) {
+        return this.optEnum(clazz, index, null);
+    }
+
+    /**
+     * Get the enum value associated with a key.
+     * 
+     * @param <E>
+     *            Enum Type
+     * @param clazz
+     *            The type of enum to retrieve.
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            The default in case the value is not found
+     * @return The enum value at the index location or defaultValue if
+     *            the value is not found or cannot be assigned to clazz
+     */
+    public <E extends Enum<E>> E optEnum(Class<E> clazz, int index, E defaultValue) {
+        try {
+            Object val = this.opt(index);
+            if (JSONObject.NULL.equals(val)) {
+                return defaultValue;
+            }
+            if (clazz.isAssignableFrom(val.getClass())) {
+                // we just checked it!
+                @SuppressWarnings("unchecked")
+                E myE = (E) val;
+                return myE;
+            }
+            return Enum.valueOf(clazz, val.toString());
+        } catch (IllegalArgumentException e) {
+            return defaultValue;
+        } catch (NullPointerException e) {
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Get the optional BigInteger value associated with an index. The 
+     * defaultValue is returned if there is no value for the index, or if the 
+     * value is not a number and cannot be converted to a number.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            The default value.
+     * @return The value.
+     */
+    public BigInteger optBigInteger(int index, BigInteger defaultValue) {
+        Object val = this.opt(index);
+        return JSONObject.objectToBigInteger(val, defaultValue);
+    }
+
+    /**
+     * Get the optional BigDecimal value associated with an index. The 
+     * defaultValue is returned if there is no value for the index, or if the 
+     * value is not a number and cannot be converted to a number. If the value
+     * is float or double, the {@link BigDecimal#BigDecimal(double)}
+     * constructor will be used. See notes on the constructor for conversion
+     * issues that may arise.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            The default value.
+     * @return The value.
+     */
+    public BigDecimal optBigDecimal(int index, BigDecimal defaultValue) {
+        Object val = this.opt(index);
+        return JSONObject.objectToBigDecimal(val, defaultValue);
+    }
+
+    /**
+     * Get the optional JSONArray associated with an index.
+     *
+     * @param index
+     *            subscript
+     * @return A JSONArray value, or null if the index has no value, or if the
+     *         value is not a JSONArray.
+     */
+    public JSONArray optJSONArray(int index) {
+        Object o = this.opt(index);
+        return o instanceof JSONArray ? (JSONArray) o : null;
+    }
+
+    /**
+     * Get the optional JSONObject associated with an index. Null is returned if
+     * the key is not found, or null if the index has no value, or if the value
+     * is not a JSONObject.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return A JSONObject value.
+     */
+    public JSONObject optJSONObject(int index) {
+        Object o = this.opt(index);
+        return o instanceof JSONObject ? (JSONObject) o : null;
+    }
+
+    /**
+     * Get the optional long value associated with an index. Zero is returned if
+     * there is no value for the index, or if the value is not a number and
+     * cannot be converted to a number.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return The value.
+     */
+    public long optLong(int index) {
+        return this.optLong(index, 0);
+    }
+
+    /**
+     * Get the optional long value associated with an index. The defaultValue is
+     * returned if there is no value for the index, or if the value is not a
+     * number and cannot be converted to a number.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            The default value.
+     * @return The value.
+     */
+    public long optLong(int index, long defaultValue) {
+        final Number val = this.optNumber(index, null);
+        if (val == null) {
+            return defaultValue;
+        }
+        return val.longValue();
+    }
+
+    /**
+     * Get an optional {@link Number} value associated with a key, or <code>null</code>
+     * if there is no such key or if the value is not a number. If the value is a string,
+     * an attempt will be made to evaluate it as a number ({@link BigDecimal}). This method
+     * would be used in cases where type coercion of the number value is unwanted.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return An object which is the value.
+     */
+    public Number optNumber(int index) {
+        return this.optNumber(index, null);
+    }
+
+    /**
+     * Get an optional {@link Number} value associated with a key, or the default if there
+     * is no such key or if the value is not a number. If the value is a string,
+     * an attempt will be made to evaluate it as a number ({@link BigDecimal}). This method
+     * would be used in cases where type coercion of the number value is unwanted.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            The default.
+     * @return An object which is the value.
+     */
+    public Number optNumber(int index, Number defaultValue) {
+        Object val = this.opt(index);
+        if (JSONObject.NULL.equals(val)) {
+            return defaultValue;
+        }
+        if (val instanceof Number){
+            return (Number) val;
+        }
+        
+        if (val instanceof String) {
+            try {
+                return JSONObject.stringToNumber((String) val);
+            } catch (Exception e) {
+                return defaultValue;
+            }
+        }
+        return defaultValue;
+    }
+
+    /**
+     * Get the optional string value associated with an index. It returns an
+     * empty string if there is no value at that index. If the value is not a
+     * string and is not null, then it is converted to a string.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @return A String value.
+     */
+    public String optString(int index) {
+        return this.optString(index, "");
+    }
+
+    /**
+     * Get the optional string associated with an index. The defaultValue is
+     * returned if the key is not found.
+     *
+     * @param index
+     *            The index must be between 0 and length() - 1.
+     * @param defaultValue
+     *            The default value.
+     * @return A String value.
+     */
+    public String optString(int index, String defaultValue) {
+        Object object = this.opt(index);
+        return JSONObject.NULL.equals(object) ? defaultValue : object
+                .toString();
+    }
+
+    /**
+     * Append a boolean value. This increases the array's length by one.
+     *
+     * @param value
+     *            A boolean value.
+     * @return this.
+     */
+    public JSONArray put(boolean value) {
+        return this.put(value ? Boolean.TRUE : Boolean.FALSE);
+    }
+
+    /**
+     * Append a double value. This increases the array's length by one.
+     *
+     * @param value
+     *            A double value.
+     * @return this.
+     * @throws JSONException
+     *             if the value is not finite.
+     */
+    public JSONArray put(double value) throws JSONException {
+        return this.put(Double.valueOf(value));
+    }
+    
+    /**
+     * Append a float value. This increases the array's length by one.
+     *
+     * @param value
+     *            A float value.
+     * @return this.
+     * @throws JSONException
+     *             if the value is not finite.
+     */
+    public JSONArray put(float value) throws JSONException {
+        return this.put(Float.valueOf(value));
+    }
+
+    /**
+     * Append an int value. This increases the array's length by one.
+     *
+     * @param value
+     *            An int value.
+     * @return this.
+     */
+    public JSONArray put(int value) {
+        return this.put(Integer.valueOf(value));
+    }
+
+    /**
+     * Append an long value. This increases the array's length by one.
+     *
+     * @param value
+     *            A long value.
+     * @return this.
+     */
+    public JSONArray put(long value) {
+        return this.put(Long.valueOf(value));
+    }
+
+    /**
+     * Put a value in the JSONArray, where the value will be a JSONObject which
+     * is produced from a Map.
+     *
+     * @param value
+     *            A Map value.
+     * @return this.
+     * @throws JSONException
+     *            If a value in the map is non-finite number.
+     * @throws NullPointerException
+     *            If a key in the map is <code>null</code>
+     */
+    public JSONArray put(Map<?, ?> value) {
+        return this.put(new JSONObject(value));
+    }
+
+    /**
+     * Append an object value. This increases the array's length by one.
+     *
+     * @param value
+     *            An object value. The value should be a Boolean, Double,
+     *            Integer, JSONArray, JSONObject, Long, or String, or the
+     *            JSONObject.NULL object.
+     * @return this.
+     * @throws JSONException
+     *            If the value is non-finite number.
+     */
+    public JSONArray put(Object value) {
+        JSONObject.testValidity(value);
+        this.myArrayList.add(value);
+        return this;
+    }
+
+    /**
+     * Put or replace a boolean value in the JSONArray. If the index is greater
+     * than the length of the JSONArray, then null elements will be added as
+     * necessary to pad it out.
+     *
+     * @param index
+     *            The subscript.
+     * @param value
+     *            A boolean value.
+     * @return this.
+     * @throws JSONException
+     *             If the index is negative.
+     */
+    public JSONArray put(int index, boolean value) throws JSONException {
+        return this.put(index, value ? Boolean.TRUE : Boolean.FALSE);
+    }
+
+    /**
+     * Put or replace a double value. If the index is greater than the length of
+     * the JSONArray, then null elements will be added as necessary to pad it
+     * out.
+     *
+     * @param index
+     *            The subscript.
+     * @param value
+     *            A double value.
+     * @return this.
+     * @throws JSONException
+     *             If the index is negative or if the value is non-finite.
+     */
+    public JSONArray put(int index, double value) throws JSONException {
+        return this.put(index, Double.valueOf(value));
+    }
+
+    /**
+     * Put or replace a float value. If the index is greater than the length of
+     * the JSONArray, then null elements will be added as necessary to pad it
+     * out.
+     *
+     * @param index
+     *            The subscript.
+     * @param value
+     *            A float value.
+     * @return this.
+     * @throws JSONException
+     *             If the index is negative or if the value is non-finite.
+     */
+    public JSONArray put(int index, float value) throws JSONException {
+        return this.put(index, Float.valueOf(value));
+    }
+
+    /**
+     * Put or replace an int value. If the index is greater than the length of
+     * the JSONArray, then null elements will be added as necessary to pad it
+     * out.
+     *
+     * @param index
+     *            The subscript.
+     * @param value
+     *            An int value.
+     * @return this.
+     * @throws JSONException
+     *             If the index is negative.
+     */
+    public JSONArray put(int index, int value) throws JSONException {
+        return this.put(index, Integer.valueOf(value));
+    }
+
+    /**
+     * Put or replace a long value. If the index is greater than the length of
+     * the JSONArray, then null elements will be added as necessary to pad it
+     * out.
+     *
+     * @param index
+     *            The subscript.
+     * @param value
+     *            A long value.
+     * @return this.
+     * @throws JSONException
+     *             If the index is negative.
+     */
+    public JSONArray put(int index, long value) throws JSONException {
+        return this.put(index, Long.valueOf(value));
+    }
+
+    /**
+     * Put a value in the JSONArray, where the value will be a JSONObject that
+     * is produced from a Map.
+     *
+     * @param index
+     *            The subscript.
+     * @param value
+     *            The Map value.
+     * @return this.
+     * @throws JSONException
+     *             If the index is negative or if the value is an invalid
+     *             number.
+     * @throws NullPointerException
+     *             If a key in the map is <code>null</code>
+     */
+    public JSONArray put(int index, Map<?, ?> value) throws JSONException {
+        this.put(index, new JSONObject(value));
+        return this;
+    }
+
+    /**
+     * Put or replace an object value in the JSONArray. If the index is greater
+     * than the length of the JSONArray, then null elements will be added as
+     * necessary to pad it out.
+     *
+     * @param index
+     *            The subscript.
+     * @param value
+     *            The value to put into the array. The value should be a
+     *            Boolean, Double, Integer, JSONArray, JSONObject, Long, or
+     *            String, or the JSONObject.NULL object.
+     * @return this.
+     * @throws JSONException
+     *             If the index is negative or if the value is an invalid
+     *             number.
+     */
+    public JSONArray put(int index, Object value) throws JSONException {
+        if (index < 0) {
+            throw new JSONException("JSONArray[" + index + "] not found.");
+        }
+        if (index < this.length()) {
+            JSONObject.testValidity(value);
+            this.myArrayList.set(index, value);
+            return this;
+        }
+        if(index == this.length()){
+            // simple append
+            return this.put(value);
+        }
+        // if we are inserting past the length, we want to grow the array all at once
+        // instead of incrementally.
+        this.myArrayList.ensureCapacity(index + 1);
+        while (index != this.length()) {
+            // we don't need to test validity of NULL objects
+            this.myArrayList.add(JSONObject.NULL);
+        }
+        return this.put(value);
+    }
+
+    /**
+     * Put a JSONArray's elements in to the JSONArray.
+     *
+     * @param array
+     *            A JSONArray.
+     * @return this. 
+     */
+    public JSONArray putAll(JSONArray array) {
+        // directly copy the elements from the source array to this one
+        // as all wrapping should have been done already in the source.
+        this.myArrayList.addAll(array.myArrayList);
+        return this;
+    }
+
+    /**
+     * Remove an index and close the hole.
+     *
+     * @param index
+     *            The index of the element to be removed.
+     * @return The value that was associated with the index, or null if there
+     *         was no value.
+     */
+    public Object remove(int index) {
+        return index >= 0 && index < this.length()
+            ? this.myArrayList.remove(index)
+            : null;
+    }
+
+    /**
+     * Produce a JSONObject by combining a JSONArray of names with the values of
+     * this JSONArray.
+     *
+     * @param names
+     *            A JSONArray containing a list of key strings. These will be
+     *            paired with the values.
+     * @return A JSONObject, or null if there are no names or if this JSONArray
+     *         has no values.
+     * @throws JSONException
+     *             If any of the names are null.
+     */
+    public JSONObject toJSONObject(JSONArray names) throws JSONException {
+        if (names == null || names.isEmpty() || this.isEmpty()) {
+            return null;
+        }
+        JSONObject jo = new JSONObject(names.length());
+        for (int i = 0; i < names.length(); i += 1) {
+            jo.put(names.getString(i), this.opt(i));
+        }
+        return jo;
+    }
+
+    /**
+     * Check if JSONArray is empty.
+     *
+     * @return true if JSONArray is empty, otherwise false.
+     */
+    public boolean isEmpty() {
+        return this.myArrayList.isEmpty();
+    }
+    
+    /**
+     * Create a new JSONException in a common format for incorrect conversions.
+     * @param idx index of the item
+     * @param valueType the type of value being coerced to
+     * @param cause optional cause of the coercion failure
+     * @return JSONException that can be thrown.
+     */
+    private static JSONException wrongValueFormatException(
+            int idx,
+            String valueType,
+            Object value,
+            Throwable cause) {
+        if(value == null) {
+            return new JSONException(
+                    "JSONArray[" + idx + "] is not a " + valueType + " (null)."
+                    , cause);
+        }
+        // don't try to toString collections or known object types that could be large.
+        if(value instanceof Map || value instanceof Iterable || value instanceof JSONObject) {
+            return new JSONException(
+                    "JSONArray[" + idx + "] is not a " + valueType + " (" + value.getClass() + ")."
+                    , cause);
+        }
+        return new JSONException(
+                "JSONArray[" + idx + "] is not a " + valueType + " (" + value.getClass() + " : " + value + ")."
+                , cause);
+    }
+
+}

--- a/core/src/main/java/feign/template/util/JSONException.java
+++ b/core/src/main/java/feign/template/util/JSONException.java
@@ -1,8 +1,20 @@
-package feign.template.util;
-
 /*
- * Utilized with the Feign project via Public Domain
+ * Copyright 2012-2022 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
+/*
+ * Code Originally Sourced From the JSON.ORG project and utilized under Public Domain
+ */
+package feign.template.util;
 
 /**
  * The JSONException is thrown by the JSON.org classes when things are amiss.

--- a/core/src/main/java/feign/template/util/JSONException.java
+++ b/core/src/main/java/feign/template/util/JSONException.java
@@ -24,39 +24,35 @@ package feign.template.util;
  * @version 2022-09-21
  */
 public class JSONException extends RuntimeException {
-    /** Serialization ID */
-    private static final long serialVersionUID = 0;
+  /** Serialization ID */
+  private static final long serialVersionUID = 0;
 
-    /**
-     * Constructs a JSONException with an explanatory message.
-     *
-     * @param message
-     *            Detail about the reason for the exception.
-     */
-    public JSONException(final String message) {
-        super(message);
-    }
+  /**
+   * Constructs a JSONException with an explanatory message.
+   *
+   * @param message Detail about the reason for the exception.
+   */
+  public JSONException(final String message) {
+    super(message);
+  }
 
-    /**
-     * Constructs a JSONException with an explanatory message and cause.
-     * 
-     * @param message
-     *            Detail about the reason for the exception.
-     * @param cause
-     *            The cause.
-     */
-    public JSONException(final String message, final Throwable cause) {
-        super(message, cause);
-    }
+  /**
+   * Constructs a JSONException with an explanatory message and cause.
+   * 
+   * @param message Detail about the reason for the exception.
+   * @param cause The cause.
+   */
+  public JSONException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
 
-    /**
-     * Constructs a new JSONException with the specified cause.
-     * 
-     * @param cause
-     *            The cause.
-     */
-    public JSONException(final Throwable cause) {
-        super(cause.getMessage(), cause);
-    }
+  /**
+   * Constructs a new JSONException with the specified cause.
+   * 
+   * @param cause The cause.
+   */
+  public JSONException(final Throwable cause) {
+    super(cause.getMessage(), cause);
+  }
 
 }

--- a/core/src/main/java/feign/template/util/JSONException.java
+++ b/core/src/main/java/feign/template/util/JSONException.java
@@ -1,14 +1,15 @@
 package feign.template.util;
 
 /*
-Public Domain.
+ * Utilized with the Feign project via Public Domain
  */
 
 /**
  * The JSONException is thrown by the JSON.org classes when things are amiss.
  *
  * @author JSON.org
- * @version 2015-12-09
+ * @author Justin Ziegler
+ * @version 2022-09-21
  */
 public class JSONException extends RuntimeException {
     /** Serialization ID */

--- a/core/src/main/java/feign/template/util/JSONException.java
+++ b/core/src/main/java/feign/template/util/JSONException.java
@@ -1,0 +1,49 @@
+package feign.template.util;
+
+/*
+Public Domain.
+ */
+
+/**
+ * The JSONException is thrown by the JSON.org classes when things are amiss.
+ *
+ * @author JSON.org
+ * @version 2015-12-09
+ */
+public class JSONException extends RuntimeException {
+    /** Serialization ID */
+    private static final long serialVersionUID = 0;
+
+    /**
+     * Constructs a JSONException with an explanatory message.
+     *
+     * @param message
+     *            Detail about the reason for the exception.
+     */
+    public JSONException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a JSONException with an explanatory message and cause.
+     * 
+     * @param message
+     *            Detail about the reason for the exception.
+     * @param cause
+     *            The cause.
+     */
+    public JSONException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new JSONException with the specified cause.
+     * 
+     * @param cause
+     *            The cause.
+     */
+    public JSONException(final Throwable cause) {
+        super(cause.getMessage(), cause);
+    }
+
+}

--- a/core/src/main/java/feign/template/util/JSONObject.java
+++ b/core/src/main/java/feign/template/util/JSONObject.java
@@ -1,0 +1,1977 @@
+package feign.template.util;
+
+/*
+Public Domain.
+*/
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.ResourceBundle;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * A JSONObject is an unordered collection of name/value pairs. Its external
+ * form is a string wrapped in curly braces with colons between the names and
+ * values, and commas between the values and names. The internal form is an
+ * object having <code>get</code> and <code>opt</code> methods for accessing
+ * the values by name, and <code>put</code> methods for adding or replacing
+ * values by name. The values can be any of these types: <code>Boolean</code>,
+ * <code>JSONArray</code>, <code>JSONObject</code>, <code>Number</code>,
+ * <code>String</code>, or the <code>JSONObject.NULL</code> object. A
+ * JSONObject constructor can be used to convert an external form JSON text
+ * into an internal form whose values can be retrieved with the
+ * <code>get</code> and <code>opt</code> methods, or to convert values into a
+ * JSON text using the <code>put</code> and <code>toString</code> methods. A
+ * <code>get</code> method returns a value if one can be found, and throws an
+ * exception if one cannot be found. An <code>opt</code> method returns a
+ * default value instead of throwing an exception, and so is useful for
+ * obtaining optional values.
+ * <p>
+ * The generic <code>get()</code> and <code>opt()</code> methods return an
+ * object, which you can cast or query for type. There are also typed
+ * <code>get</code> and <code>opt</code> methods that do type checking and type
+ * coercion for you. The opt methods differ from the get methods in that they
+ * do not throw. Instead, they return a specified value, such as null.
+ * <p>
+ * The <code>put</code> methods add or replace values in an object. For
+ * example,
+ *
+ * <pre>
+ * myString = new JSONObject()
+ *         .put(&quot;JSON&quot;, &quot;Hello, World!&quot;).toString();
+ * </pre>
+ *
+ * produces the string <code>{"JSON": "Hello, World"}</code>.
+ * <p>
+ * The texts produced by the <code>toString</code> methods strictly conform to
+ * the JSON syntax rules. The constructors are more forgiving in the texts they
+ * will accept:
+ * <ul>
+ * <li>An extra <code>,</code>&nbsp;<small>(comma)</small> may appear just
+ * before the closing brace.</li>
+ * <li>Strings may be quoted with <code>'</code>&nbsp;<small>(single
+ * quote)</small>.</li>
+ * <li>Strings do not need to be quoted at all if they do not begin with a
+ * quote or single quote, and if they do not contain leading or trailing
+ * spaces, and if they do not contain any of these characters:
+ * <code>{ } [ ] / \ : , #</code> and if they do not look like numbers and
+ * if they are not the reserved words <code>true</code>, <code>false</code>,
+ * or <code>null</code>.</li>
+ * </ul>
+ *
+ * @author JSON.org
+ * @version 2016-08-15
+ */
+public class JSONObject {
+    /**
+     * JSONObject.NULL is equivalent to the value that JavaScript calls null,
+     * whilst Java's null is equivalent to the value that JavaScript calls
+     * undefined.
+     */
+    private static final class Null {
+
+        /**
+         * There is only intended to be a single instance of the NULL object,
+         * so the clone method returns itself.
+         *
+         * @return NULL.
+         */
+        @Override
+        protected final Object clone() {
+            return this;
+        }
+
+        /**
+         * A Null object is equal to the null value and to itself.
+         *
+         * @param object
+         *            An object to test for nullness.
+         * @return true if the object parameter is the JSONObject.NULL object or
+         *         null.
+         */
+        @Override
+        @SuppressWarnings("lgtm[java/unchecked-cast-in-equals]")
+        public boolean equals(Object object) {
+            return object == null || object == this;
+        }
+        /**
+         * A Null object is equal to the null value and to itself.
+         *
+         * @return always returns 0.
+         */
+        @Override
+        public int hashCode() {
+            return 0;
+        }
+
+        /**
+         * Get the "null" string value.
+         *
+         * @return The string "null".
+         */
+        @Override
+        public String toString() {
+            return "null";
+        }
+    }
+
+    /**
+     *  Regular Expression Pattern that matches JSON Numbers. This is primarily used for
+     *  output to guarantee that we are always writing valid JSON.
+     */
+    static final Pattern NUMBER_PATTERN = Pattern.compile("-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?");
+
+    /**
+     * The map where the JSONObject's properties are kept.
+     */
+    private final Map<String, Object> map;
+
+    public Class<? extends Map> getMapType() {
+        return map.getClass();
+    }
+
+    /**
+     * It is sometimes more convenient and less ambiguous to have a
+     * <code>NULL</code> object than to use Java's <code>null</code> value.
+     * <code>JSONObject.NULL.equals(null)</code> returns <code>true</code>.
+     * <code>JSONObject.NULL.toString()</code> returns <code>"null"</code>.
+     */
+    public static final Object NULL = new Null();
+
+    /**
+     * Construct an empty JSONObject.
+     */
+    public JSONObject() {
+        // HashMap is used on purpose to ensure that elements are unordered by
+        // the specification.
+        // JSON tends to be a portable transfer format to allows the container
+        // implementations to rearrange their items for a faster element
+        // retrieval based on associative access.
+        // Therefore, an implementation mustn't rely on the order of the item.
+        this.map = new HashMap<String, Object>();
+    }
+
+    /**
+     * Construct a JSONObject from a subset of another JSONObject. An array of
+     * strings is used to identify the keys that should be copied. Missing keys
+     * are ignored.
+     *
+     * @param jo
+     *            A JSONObject.
+     * @param names
+     *            An array of strings.
+     */
+    public JSONObject(JSONObject jo, String ... names) {
+        this(names.length);
+        for (int i = 0; i < names.length; i += 1) {
+            try {
+                this.putOnce(names[i], jo.opt(names[i]));
+            } catch (Exception ignore) {
+            }
+        }
+    }
+
+    /**
+     * Construct a JSONObject from a JSONTokener.
+     *
+     * @param x
+     *            A JSONTokener object containing the source string.
+     * @throws JSONException
+     *             If there is a syntax error in the source string or a
+     *             duplicated key.
+     */
+    public JSONObject(JSONTokener x) throws JSONException {
+        this();
+        char c;
+        String key;
+
+        if (x.nextClean() != '{') {
+            throw x.syntaxError("A JSONObject text must begin with '{'");
+        }
+        for (;;) {
+            char prev = x.getPrevious();
+            c = x.nextClean();
+            switch (c) {
+            case 0:
+                throw x.syntaxError("A JSONObject text must end with '}'");
+            case '}':
+                return;
+            case '{':
+            case '[':
+                if(prev=='{') {
+                    throw x.syntaxError("A JSON Object can not directly nest another JSON Object or JSON Array.");
+                }
+                // fall through
+            default:
+                x.back();
+                key = x.nextValue().toString();
+            }
+
+            // The key is followed by ':'.
+
+            c = x.nextClean();
+            if (c != ':') {
+                throw x.syntaxError("Expected a ':' after a key");
+            }
+
+            // Use syntaxError(..) to include error location
+
+            if (key != null) {
+                // Check if key exists
+                if (this.opt(key) != null) {
+                    // key already exists
+                    throw x.syntaxError("Duplicate key \"" + key + "\"");
+                }
+                // Only add value if non-null
+                Object value = x.nextValue();
+                if (value!=null) {
+                    this.put(key, value);
+                }
+            }
+
+            // Pairs are separated by ','.
+
+            switch (x.nextClean()) {
+            case ';':
+            case ',':
+                if (x.nextClean() == '}') {
+                    return;
+                }
+                x.back();
+                break;
+            case '}':
+                return;
+            default:
+                throw x.syntaxError("Expected a ',' or '}'");
+            }
+        }
+    }
+
+    /**
+     * Construct a JSONObject from a Map.
+     *
+     * @param m
+     *            A map object that can be used to initialize the contents of
+     *            the JSONObject.
+     * @throws JSONException
+     *            If a value in the map is non-finite number.
+     * @throws NullPointerException
+     *            If a key in the map is <code>null</code>
+     */
+    public JSONObject(Map<?, ?> m) {
+        if (m == null) {
+            this.map = new HashMap<String, Object>();
+        } else {
+            this.map = new HashMap<String, Object>(m.size());
+        	for (final Entry<?, ?> e : m.entrySet()) {
+        	    if(e.getKey() == null) {
+        	        throw new NullPointerException("Null key.");
+        	    }
+                final Object value = e.getValue();
+                if (value != null) {
+                    this.map.put(String.valueOf(e.getKey()), wrap(value));
+                }
+            }
+        }
+    }
+
+    /**
+     * Construct a JSONObject from an Object, using reflection to find the
+     * public members. The resulting JSONObject's keys will be the strings from
+     * the names array, and the values will be the field values associated with
+     * those keys in the object. If a key is not found or not visible, then it
+     * will not be copied into the new JSONObject.
+     *
+     * @param object
+     *            An object that has fields that should be used to make a
+     *            JSONObject.
+     * @param names
+     *            An array of strings, the names of the fields to be obtained
+     *            from the object.
+     */
+    public JSONObject(Object object, String ... names) {
+        this(names.length);
+        Class<?> c = object.getClass();
+        for (int i = 0; i < names.length; i += 1) {
+            String name = names[i];
+            try {
+                this.putOpt(name, c.getField(name).get(object));
+            } catch (Exception ignore) {
+            }
+        }
+    }
+
+    /**
+     * Construct a JSONObject from a source JSON text string. This is the most
+     * commonly used JSONObject constructor.
+     *
+     * @param source
+     *            A string beginning with <code>{</code>&nbsp;<small>(left
+     *            brace)</small> and ending with <code>}</code>
+     *            &nbsp;<small>(right brace)</small>.
+     * @exception JSONException
+     *                If there is a syntax error in the source string or a
+     *                duplicated key.
+     */
+    public JSONObject(String source) throws JSONException {
+        this(new JSONTokener(source));
+    }
+
+    /**
+     * Construct a JSONObject from a ResourceBundle.
+     *
+     * @param baseName
+     *            The ResourceBundle base name.
+     * @param locale
+     *            The Locale to load the ResourceBundle for.
+     * @throws JSONException
+     *             If any JSONExceptions are detected.
+     */
+    public JSONObject(String baseName, Locale locale) throws JSONException {
+        this();
+        ResourceBundle bundle = ResourceBundle.getBundle(baseName, locale,
+                Thread.currentThread().getContextClassLoader());
+
+// Iterate through the keys in the bundle.
+
+        Enumeration<String> keys = bundle.getKeys();
+        while (keys.hasMoreElements()) {
+            Object key = keys.nextElement();
+            if (key != null) {
+
+// Go through the path, ensuring that there is a nested JSONObject for each
+// segment except the last. Add the value using the last segment's name into
+// the deepest nested JSONObject.
+
+                String[] path = ((String) key).split("\\.");
+                int last = path.length - 1;
+                JSONObject target = this;
+                for (int i = 0; i < last; i += 1) {
+                    String segment = path[i];
+                    JSONObject nextTarget = target.optJSONObject(segment);
+                    if (nextTarget == null) {
+                        nextTarget = new JSONObject();
+                        target.put(segment, nextTarget);
+                    }
+                    target = nextTarget;
+                }
+                target.put(path[last], bundle.getString((String) key));
+            }
+        }
+    }
+
+    /**
+     * Constructor to specify an initial capacity of the internal map. Useful for library
+     * internal calls where we know, or at least can best guess, how big this JSONObject
+     * will be.
+     *
+     * @param initialCapacity initial capacity of the internal map.
+     */
+    protected JSONObject(int initialCapacity){
+        this.map = new HashMap<String, Object>(initialCapacity);
+    }
+
+    /**
+     * Accumulate values under a key. It is similar to the put method except
+     * that if there is already an object stored under the key then a JSONArray
+     * is stored under the key to hold all of the accumulated values. If there
+     * is already a JSONArray, then the new value is appended to it. In
+     * contrast, the put method replaces the previous value.
+     *
+     * If only one value is accumulated that is not a JSONArray, then the result
+     * will be the same as using put. But if multiple values are accumulated,
+     * then the result will be like append.
+     *
+     * @param key
+     *            A key string.
+     * @param value
+     *            An object to be accumulated under the key.
+     * @return this.
+     * @throws JSONException
+     *            If the value is non-finite number.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
+     */
+    public JSONObject accumulate(String key, Object value) throws JSONException {
+        testValidity(value);
+        Object object = this.opt(key);
+        if (object == null) {
+            this.put(key,
+                    value instanceof JSONArray ? new JSONArray().put(value)
+                            : value);
+        } else if (object instanceof JSONArray) {
+            ((JSONArray) object).put(value);
+        } else {
+            this.put(key, new JSONArray().put(object).put(value));
+        }
+        return this;
+    }
+
+    /**
+     * Append values to the array under a key. If the key does not exist in the
+     * JSONObject, then the key is put in the JSONObject with its value being a
+     * JSONArray containing the value parameter. If the key was already
+     * associated with a JSONArray, then the value parameter is appended to it.
+     *
+     * @param key
+     *            A key string.
+     * @param value
+     *            An object to be accumulated under the key.
+     * @return this.
+     * @throws JSONException
+     *            If the value is non-finite number or if the current value associated with
+     *             the key is not a JSONArray.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
+     */
+    public JSONObject append(String key, Object value) throws JSONException {
+        testValidity(value);
+        Object object = this.opt(key);
+        if (object == null) {
+            this.put(key, new JSONArray().put(value));
+        } else if (object instanceof JSONArray) {
+            this.put(key, ((JSONArray) object).put(value));
+        } else {
+            throw wrongValueFormatException(key, "JSONArray", null, null);
+        }
+        return this;
+    }
+
+    /**
+     * Produce a string from a double. The string "null" will be returned if the
+     * number is not finite.
+     *
+     * @param d
+     *            A double.
+     * @return A String.
+     */
+    public static String doubleToString(double d) {
+        if (Double.isInfinite(d) || Double.isNaN(d)) {
+            return "null";
+        }
+
+// Shave off trailing zeros and decimal point, if possible.
+
+        String string = Double.toString(d);
+        if (string.indexOf('.') > 0 && string.indexOf('e') < 0
+                && string.indexOf('E') < 0) {
+            while (string.endsWith("0")) {
+                string = string.substring(0, string.length() - 1);
+            }
+            if (string.endsWith(".")) {
+                string = string.substring(0, string.length() - 1);
+            }
+        }
+        return string;
+    }
+
+    /**
+     * Get the value object associated with a key.
+     *
+     * @param key
+     *            A key string.
+     * @return The object associated with the key.
+     * @throws JSONException
+     *             if the key is not found.
+     */
+    public Object get(String key) throws JSONException {
+        if (key == null) {
+            throw new JSONException("Null key.");
+        }
+        Object object = this.opt(key);
+        if (object == null) {
+            throw new JSONException("JSONObject[" + quote(key) + "] not found.");
+        }
+        return object;
+    }
+
+    /**
+     * Get the enum value associated with a key.
+     *
+     * @param <E>
+     *            Enum Type
+     * @param clazz
+     *           The type of enum to retrieve.
+     * @param key
+     *           A key string.
+     * @return The enum value associated with the key
+     * @throws JSONException
+     *             if the key is not found or if the value cannot be converted
+     *             to an enum.
+     */
+    public <E extends Enum<E>> E getEnum(Class<E> clazz, String key) throws JSONException {
+        E val = optEnum(clazz, key);
+        if(val==null) {
+            // JSONException should really take a throwable argument.
+            // If it did, I would re-implement this with the Enum.valueOf
+            // method and place any thrown exception in the JSONException
+            throw wrongValueFormatException(key, "enum of type " + quote(clazz.getSimpleName()), opt(key), null);
+        }
+        return val;
+    }
+
+    /**
+     * Get the boolean value associated with a key.
+     *
+     * @param key
+     *            A key string.
+     * @return The truth.
+     * @throws JSONException
+     *             if the value is not a Boolean or the String "true" or
+     *             "false".
+     */
+    public boolean getBoolean(String key) throws JSONException {
+        Object object = this.get(key);
+        if (object.equals(Boolean.FALSE)
+                || (object instanceof String && ((String) object)
+                        .equalsIgnoreCase("false"))) {
+            return false;
+        } else if (object.equals(Boolean.TRUE)
+                || (object instanceof String && ((String) object)
+                        .equalsIgnoreCase("true"))) {
+            return true;
+        }
+        throw wrongValueFormatException(key, "Boolean", object, null);
+    }
+
+    /**
+     * Get the BigInteger value associated with a key.
+     *
+     * @param key
+     *            A key string.
+     * @return The numeric value.
+     * @throws JSONException
+     *             if the key is not found or if the value cannot
+     *             be converted to BigInteger.
+     */
+    public BigInteger getBigInteger(String key) throws JSONException {
+        Object object = this.get(key);
+        BigInteger ret = objectToBigInteger(object, null);
+        if (ret != null) {
+            return ret;
+        }
+        throw wrongValueFormatException(key, "BigInteger", object, null);
+    }
+
+    /**
+     * Get the BigDecimal value associated with a key. If the value is float or
+     * double, the {@link BigDecimal#BigDecimal(double)} constructor will
+     * be used. See notes on the constructor for conversion issues that may
+     * arise.
+     *
+     * @param key
+     *            A key string.
+     * @return The numeric value.
+     * @throws JSONException
+     *             if the key is not found or if the value
+     *             cannot be converted to BigDecimal.
+     */
+    public BigDecimal getBigDecimal(String key) throws JSONException {
+        Object object = this.get(key);
+        BigDecimal ret = objectToBigDecimal(object, null);
+        if (ret != null) {
+            return ret;
+        }
+        throw wrongValueFormatException(key, "BigDecimal", object, null);
+    }
+
+    /**
+     * Get the double value associated with a key.
+     *
+     * @param key
+     *            A key string.
+     * @return The numeric value.
+     * @throws JSONException
+     *             if the key is not found or if the value is not a Number
+     *             object and cannot be converted to a number.
+     */
+    public double getDouble(String key) throws JSONException {
+        final Object object = this.get(key);
+        if(object instanceof Number) {
+            return ((Number)object).doubleValue();
+        }
+        try {
+            return Double.parseDouble(object.toString());
+        } catch (Exception e) {
+            throw wrongValueFormatException(key, "double", object, e);
+        }
+    }
+
+    /**
+     * Get the float value associated with a key.
+     *
+     * @param key
+     *            A key string.
+     * @return The numeric value.
+     * @throws JSONException
+     *             if the key is not found or if the value is not a Number
+     *             object and cannot be converted to a number.
+     */
+    public float getFloat(String key) throws JSONException {
+        final Object object = this.get(key);
+        if(object instanceof Number) {
+            return ((Number)object).floatValue();
+        }
+        try {
+            return Float.parseFloat(object.toString());
+        } catch (Exception e) {
+            throw wrongValueFormatException(key, "float", object, e);
+        }
+    }
+
+    /**
+     * Get the Number value associated with a key.
+     *
+     * @param key
+     *            A key string.
+     * @return The numeric value.
+     * @throws JSONException
+     *             if the key is not found or if the value is not a Number
+     *             object and cannot be converted to a number.
+     */
+    public Number getNumber(String key) throws JSONException {
+        Object object = this.get(key);
+        try {
+            if (object instanceof Number) {
+                return (Number)object;
+            }
+            return stringToNumber(object.toString());
+        } catch (Exception e) {
+            throw wrongValueFormatException(key, "number", object, e);
+        }
+    }
+
+    /**
+     * Get the int value associated with a key.
+     *
+     * @param key
+     *            A key string.
+     * @return The integer value.
+     * @throws JSONException
+     *             if the key is not found or if the value cannot be converted
+     *             to an integer.
+     */
+    public int getInt(String key) throws JSONException {
+        final Object object = this.get(key);
+        if(object instanceof Number) {
+            return ((Number)object).intValue();
+        }
+        try {
+            return Integer.parseInt(object.toString());
+        } catch (Exception e) {
+            throw wrongValueFormatException(key, "int", object, e);
+        }
+    }
+
+    /**
+     * Get the JSONArray value associated with a key.
+     *
+     * @param key
+     *            A key string.
+     * @return A JSONArray which is the value.
+     * @throws JSONException
+     *             if the key is not found or if the value is not a JSONArray.
+     */
+    public JSONArray getJSONArray(String key) throws JSONException {
+        Object object = this.get(key);
+        if (object instanceof JSONArray) {
+            return (JSONArray) object;
+        }
+        throw wrongValueFormatException(key, "JSONArray", object, null);
+    }
+
+    /**
+     * Get the JSONObject value associated with a key.
+     *
+     * @param key
+     *            A key string.
+     * @return A JSONObject which is the value.
+     * @throws JSONException
+     *             if the key is not found or if the value is not a JSONObject.
+     */
+    public JSONObject getJSONObject(String key) throws JSONException {
+        Object object = this.get(key);
+        if (object instanceof JSONObject) {
+            return (JSONObject) object;
+        }
+        throw wrongValueFormatException(key, "JSONObject", object, null);
+    }
+
+    /**
+     * Get the long value associated with a key.
+     *
+     * @param key
+     *            A key string.
+     * @return The long value.
+     * @throws JSONException
+     *             if the key is not found or if the value cannot be converted
+     *             to a long.
+     */
+    public long getLong(String key) throws JSONException {
+        final Object object = this.get(key);
+        if(object instanceof Number) {
+            return ((Number)object).longValue();
+        }
+        try {
+            return Long.parseLong(object.toString());
+        } catch (Exception e) {
+            throw wrongValueFormatException(key, "long", object, e);
+        }
+    }
+
+    /**
+     * Get an array of field names from a JSONObject.
+     *
+     * @param jo
+     *            JSON object
+     * @return An array of field names, or null if there are no names.
+     */
+    public static String[] getNames(JSONObject jo) {
+        if (jo.isEmpty()) {
+            return null;
+        }
+        return jo.keySet().toArray(new String[jo.length()]);
+    }
+
+    /**
+     * Get an array of public field names from an Object.
+     *
+     * @param object
+     *            object to read
+     * @return An array of field names, or null if there are no names.
+     */
+    public static String[] getNames(Object object) {
+        if (object == null) {
+            return null;
+        }
+        Class<?> klass = object.getClass();
+        Field[] fields = klass.getFields();
+        int length = fields.length;
+        if (length == 0) {
+            return null;
+        }
+        String[] names = new String[length];
+        for (int i = 0; i < length; i += 1) {
+            names[i] = fields[i].getName();
+        }
+        return names;
+    }
+
+    /**
+     * Get the string associated with a key.
+     *
+     * @param key
+     *            A key string.
+     * @return A string which is the value.
+     * @throws JSONException
+     *             if there is no string value for the key.
+     */
+    public String getString(String key) throws JSONException {
+        Object object = this.get(key);
+        if (object instanceof String) {
+            return (String) object;
+        }
+        throw wrongValueFormatException(key, "string", object, null);
+    }
+
+    /**
+     * Determine if the JSONObject contains a specific key.
+     *
+     * @param key
+     *            A key string.
+     * @return true if the key exists in the JSONObject.
+     */
+    public boolean has(String key) {
+        return this.map.containsKey(key);
+    }
+
+    /**
+     * Increment a property of a JSONObject. If there is no such property,
+     * create one with a value of 1 (Integer). If there is such a property, and if it is
+     * an Integer, Long, Double, Float, BigInteger, or BigDecimal then add one to it.
+     * No overflow bounds checking is performed, so callers should initialize the key
+     * prior to this call with an appropriate type that can handle the maximum expected
+     * value.
+     *
+     * @param key
+     *            A key string.
+     * @return this.
+     * @throws JSONException
+     *             If there is already a property with this name that is not an
+     *             Integer, Long, Double, or Float.
+     */
+    public JSONObject increment(String key) throws JSONException {
+        Object value = this.opt(key);
+        if (value == null) {
+            this.put(key, 1);
+        } else if (value instanceof Integer) {
+            this.put(key, ((Integer) value).intValue() + 1);
+        } else if (value instanceof Long) {
+            this.put(key, ((Long) value).longValue() + 1L);
+        } else if (value instanceof BigInteger) {
+            this.put(key, ((BigInteger)value).add(BigInteger.ONE));
+        } else if (value instanceof Float) {
+            this.put(key, ((Float) value).floatValue() + 1.0f);
+        } else if (value instanceof Double) {
+            this.put(key, ((Double) value).doubleValue() + 1.0d);
+        } else if (value instanceof BigDecimal) {
+            this.put(key, ((BigDecimal)value).add(BigDecimal.ONE));
+        } else {
+            throw new JSONException("Unable to increment [" + quote(key) + "].");
+        }
+        return this;
+    }
+
+    /**
+     * Determine if the value associated with the key is <code>null</code> or if there is no
+     * value.
+     *
+     * @param key
+     *            A key string.
+     * @return true if there is no value associated with the key or if the value
+     *        is the JSONObject.NULL object.
+     */
+    public boolean isNull(String key) {
+        return JSONObject.NULL.equals(this.opt(key));
+    }
+
+    /**
+     * Get an enumeration of the keys of the JSONObject. Modifying this key Set will also
+     * modify the JSONObject. Use with caution.
+     *
+     * @see Set#iterator()
+     *
+     * @return An iterator of the keys.
+     */
+    public Iterator<String> keys() {
+        return this.keySet().iterator();
+    }
+
+    /**
+     * Get a set of keys of the JSONObject. Modifying this key Set will also modify the
+     * JSONObject. Use with caution.
+     *
+     * @see Map#keySet()
+     *
+     * @return A keySet.
+     */
+    public Set<String> keySet() {
+        return this.map.keySet();
+    }
+
+    /**
+     * Get a set of entries of the JSONObject. These are raw values and may not
+     * match what is returned by the JSONObject get* and opt* functions. Modifying
+     * the returned EntrySet or the Entry objects contained therein will modify the
+     * backing JSONObject. This does not return a clone or a read-only view.
+     *
+     * Use with caution.
+     *
+     * @see Map#entrySet()
+     *
+     * @return An Entry Set
+     */
+    protected Set<Entry<String, Object>> entrySet() {
+        return this.map.entrySet();
+    }
+
+    /**
+     * Get the number of keys stored in the JSONObject.
+     *
+     * @return The number of keys in the JSONObject.
+     */
+    public int length() {
+        return this.map.size();
+    }
+
+    /**
+     * Removes all of the elements from this JSONObject.
+     * The JSONObject will be empty after this call returns.
+     */
+    public void clear() {
+        this.map.clear();
+    }
+
+    /**
+     * Check if JSONObject is empty.
+     *
+     * @return true if JSONObject is empty, otherwise false.
+     */
+    public boolean isEmpty() {
+        return this.map.isEmpty();
+    }
+
+    /**
+     * Produce a string from a Number.
+     *
+     * @param number
+     *            A Number
+     * @return A String.
+     * @throws JSONException
+     *             If n is a non-finite number.
+     */
+    public static String numberToString(Number number) throws JSONException {
+        if (number == null) {
+            throw new JSONException("Null pointer");
+        }
+        testValidity(number);
+
+        // Shave off trailing zeros and decimal point, if possible.
+
+        String string = number.toString();
+        if (string.indexOf('.') > 0 && string.indexOf('e') < 0
+                && string.indexOf('E') < 0) {
+            while (string.endsWith("0")) {
+                string = string.substring(0, string.length() - 1);
+            }
+            if (string.endsWith(".")) {
+                string = string.substring(0, string.length() - 1);
+            }
+        }
+        return string;
+    }
+
+    /**
+     * Get an optional value associated with a key.
+     *
+     * @param key
+     *            A key string.
+     * @return An object which is the value, or null if there is no value.
+     */
+    public Object opt(String key) {
+        return key == null ? null : this.map.get(key);
+    }
+
+    /**
+     * Get the enum value associated with a key.
+     *
+     * @param <E>
+     *            Enum Type
+     * @param clazz
+     *            The type of enum to retrieve.
+     * @param key
+     *            A key string.
+     * @return The enum value associated with the key or null if not found
+     */
+    public <E extends Enum<E>> E optEnum(Class<E> clazz, String key) {
+        return this.optEnum(clazz, key, null);
+    }
+
+    /**
+     * Get the enum value associated with a key.
+     *
+     * @param <E>
+     *            Enum Type
+     * @param clazz
+     *            The type of enum to retrieve.
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default in case the value is not found
+     * @return The enum value associated with the key or defaultValue
+     *            if the value is not found or cannot be assigned to <code>clazz</code>
+     */
+    public <E extends Enum<E>> E optEnum(Class<E> clazz, String key, E defaultValue) {
+        try {
+            Object val = this.opt(key);
+            if (NULL.equals(val)) {
+                return defaultValue;
+            }
+            if (clazz.isAssignableFrom(val.getClass())) {
+                // we just checked it!
+                @SuppressWarnings("unchecked")
+                E myE = (E) val;
+                return myE;
+            }
+            return Enum.valueOf(clazz, val.toString());
+        } catch (IllegalArgumentException e) {
+            return defaultValue;
+        } catch (NullPointerException e) {
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Get an optional boolean associated with a key. It returns false if there
+     * is no such key, or if the value is not Boolean.TRUE or the String "true".
+     *
+     * @param key
+     *            A key string.
+     * @return The truth.
+     */
+    public boolean optBoolean(String key) {
+        return this.optBoolean(key, false);
+    }
+
+    /**
+     * Get an optional boolean associated with a key. It returns the
+     * defaultValue if there is no such key, or if it is not a Boolean or the
+     * String "true" or "false" (case insensitive).
+     *
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
+     * @return The truth.
+     */
+    public boolean optBoolean(String key, boolean defaultValue) {
+        Object val = this.opt(key);
+        if (NULL.equals(val)) {
+            return defaultValue;
+        }
+        if (val instanceof Boolean){
+            return ((Boolean) val).booleanValue();
+        }
+        try {
+            // we'll use the get anyway because it does string conversion.
+            return this.getBoolean(key);
+        } catch (Exception e) {
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Get an optional BigDecimal associated with a key, or the defaultValue if
+     * there is no such key or if its value is not a number. If the value is a
+     * string, an attempt will be made to evaluate it as a number. If the value
+     * is float or double, then the {@link BigDecimal#BigDecimal(double)}
+     * constructor will be used. See notes on the constructor for conversion
+     * issues that may arise.
+     *
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
+     * @return An object which is the value.
+     */
+    public BigDecimal optBigDecimal(String key, BigDecimal defaultValue) {
+        Object val = this.opt(key);
+        return objectToBigDecimal(val, defaultValue);
+    }
+
+    /**
+     * @param val value to convert
+     * @param defaultValue default value to return is the conversion doesn't work or is null.
+     * @return BigDecimal conversion of the original value, or the defaultValue if unable
+     *          to convert.
+     */
+    static BigDecimal objectToBigDecimal(Object val, BigDecimal defaultValue) {
+        return objectToBigDecimal(val, defaultValue, true);
+    }
+    
+    /**
+     * @param val value to convert
+     * @param defaultValue default value to return is the conversion doesn't work or is null.
+     * @param exact When <code>true</code>, then {@link Double} and {@link Float} values will be converted exactly.
+     *      When <code>false</code>, they will be converted to {@link String} values before converting to {@link BigDecimal}.
+     * @return BigDecimal conversion of the original value, or the defaultValue if unable
+     *          to convert.
+     */
+    static BigDecimal objectToBigDecimal(Object val, BigDecimal defaultValue, boolean exact) {
+        if (NULL.equals(val)) {
+            return defaultValue;
+        }
+        if (val instanceof BigDecimal){
+            return (BigDecimal) val;
+        }
+        if (val instanceof BigInteger){
+            return new BigDecimal((BigInteger) val);
+        }
+        if (val instanceof Double || val instanceof Float){
+            if (!numberIsFinite((Number)val)) {
+                return defaultValue;
+            }
+            if (exact) {
+                return new BigDecimal(((Number)val).doubleValue());
+            }
+            // use the string constructor so that we maintain "nice" values for doubles and floats
+            // the double constructor will translate doubles to "exact" values instead of the likely
+            // intended representation
+            return new BigDecimal(val.toString());
+        }
+        if (val instanceof Long || val instanceof Integer
+                || val instanceof Short || val instanceof Byte){
+            return new BigDecimal(((Number) val).longValue());
+        }
+        // don't check if it's a string in case of unchecked Number subclasses
+        try {
+            return new BigDecimal(val.toString());
+        } catch (Exception e) {
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Get an optional BigInteger associated with a key, or the defaultValue if
+     * there is no such key or if its value is not a number. If the value is a
+     * string, an attempt will be made to evaluate it as a number.
+     *
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
+     * @return An object which is the value.
+     */
+    public BigInteger optBigInteger(String key, BigInteger defaultValue) {
+        Object val = this.opt(key);
+        return objectToBigInteger(val, defaultValue);
+    }
+
+    /**
+     * @param val value to convert
+     * @param defaultValue default value to return is the conversion doesn't work or is null.
+     * @return BigInteger conversion of the original value, or the defaultValue if unable
+     *          to convert.
+     */
+    static BigInteger objectToBigInteger(Object val, BigInteger defaultValue) {
+        if (NULL.equals(val)) {
+            return defaultValue;
+        }
+        if (val instanceof BigInteger){
+            return (BigInteger) val;
+        }
+        if (val instanceof BigDecimal){
+            return ((BigDecimal) val).toBigInteger();
+        }
+        if (val instanceof Double || val instanceof Float){
+            if (!numberIsFinite((Number)val)) {
+                return defaultValue;
+            }
+            return new BigDecimal(((Number) val).doubleValue()).toBigInteger();
+        }
+        if (val instanceof Long || val instanceof Integer
+                || val instanceof Short || val instanceof Byte){
+            return BigInteger.valueOf(((Number) val).longValue());
+        }
+        // don't check if it's a string in case of unchecked Number subclasses
+        try {
+            // the other opt functions handle implicit conversions, i.e.
+            // jo.put("double",1.1d);
+            // jo.optInt("double"); -- will return 1, not an error
+            // this conversion to BigDecimal then to BigInteger is to maintain
+            // that type cast support that may truncate the decimal.
+            final String valStr = val.toString();
+            if(isDecimalNotation(valStr)) {
+                return new BigDecimal(valStr).toBigInteger();
+            }
+            return new BigInteger(valStr);
+        } catch (Exception e) {
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Get an optional double associated with a key, or NaN if there is no such
+     * key or if its value is not a number. If the value is a string, an attempt
+     * will be made to evaluate it as a number.
+     *
+     * @param key
+     *            A string which is the key.
+     * @return An object which is the value.
+     */
+    public double optDouble(String key) {
+        return this.optDouble(key, Double.NaN);
+    }
+
+    /**
+     * Get an optional double associated with a key, or the defaultValue if
+     * there is no such key or if its value is not a number. If the value is a
+     * string, an attempt will be made to evaluate it as a number.
+     *
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
+     * @return An object which is the value.
+     */
+    public double optDouble(String key, double defaultValue) {
+        Number val = this.optNumber(key);
+        if (val == null) {
+            return defaultValue;
+        }
+        final double doubleValue = val.doubleValue();
+        // if (Double.isNaN(doubleValue) || Double.isInfinite(doubleValue)) {
+        // return defaultValue;
+        // }
+        return doubleValue;
+    }
+
+    /**
+     * Get the optional double value associated with an index. NaN is returned
+     * if there is no value for the index, or if the value is not a number and
+     * cannot be converted to a number.
+     *
+     * @param key
+     *            A key string.
+     * @return The value.
+     */
+    public float optFloat(String key) {
+        return this.optFloat(key, Float.NaN);
+    }
+
+    /**
+     * Get the optional double value associated with an index. The defaultValue
+     * is returned if there is no value for the index, or if the value is not a
+     * number and cannot be converted to a number.
+     *
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default value.
+     * @return The value.
+     */
+    public float optFloat(String key, float defaultValue) {
+        Number val = this.optNumber(key);
+        if (val == null) {
+            return defaultValue;
+        }
+        final float floatValue = val.floatValue();
+        // if (Float.isNaN(floatValue) || Float.isInfinite(floatValue)) {
+        // return defaultValue;
+        // }
+        return floatValue;
+    }
+
+    /**
+     * Get an optional int value associated with a key, or zero if there is no
+     * such key or if the value is not a number. If the value is a string, an
+     * attempt will be made to evaluate it as a number.
+     *
+     * @param key
+     *            A key string.
+     * @return An object which is the value.
+     */
+    public int optInt(String key) {
+        return this.optInt(key, 0);
+    }
+
+    /**
+     * Get an optional int value associated with a key, or the default if there
+     * is no such key or if the value is not a number. If the value is a string,
+     * an attempt will be made to evaluate it as a number.
+     *
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
+     * @return An object which is the value.
+     */
+    public int optInt(String key, int defaultValue) {
+        final Number val = this.optNumber(key, null);
+        if (val == null) {
+            return defaultValue;
+        }
+        return val.intValue();
+    }
+
+    /**
+     * Get an optional JSONArray associated with a key. It returns null if there
+     * is no such key, or if its value is not a JSONArray.
+     *
+     * @param key
+     *            A key string.
+     * @return A JSONArray which is the value.
+     */
+    public JSONArray optJSONArray(String key) {
+        Object o = this.opt(key);
+        return o instanceof JSONArray ? (JSONArray) o : null;
+    }
+
+    /**
+     * Get an optional JSONObject associated with a key. It returns null if
+     * there is no such key, or if its value is not a JSONObject.
+     *
+     * @param key
+     *            A key string.
+     * @return A JSONObject which is the value.
+     */
+    public JSONObject optJSONObject(String key) { return this.optJSONObject(key, null); }
+
+    /**
+     * Get an optional JSONObject associated with a key, or the default if there
+     * is no such key or if the value is not a JSONObject.
+     *
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
+     * @return An JSONObject which is the value.
+     */
+    public JSONObject optJSONObject(String key, JSONObject defaultValue) {
+        Object object = this.opt(key);
+        return object instanceof JSONObject ? (JSONObject) object : defaultValue;
+    }
+
+    /**
+     * Get an optional long value associated with a key, or zero if there is no
+     * such key or if the value is not a number. If the value is a string, an
+     * attempt will be made to evaluate it as a number.
+     *
+     * @param key
+     *            A key string.
+     * @return An object which is the value.
+     */
+    public long optLong(String key) {
+        return this.optLong(key, 0);
+    }
+
+    /**
+     * Get an optional long value associated with a key, or the default if there
+     * is no such key or if the value is not a number. If the value is a string,
+     * an attempt will be made to evaluate it as a number.
+     *
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
+     * @return An object which is the value.
+     */
+    public long optLong(String key, long defaultValue) {
+        final Number val = this.optNumber(key, null);
+        if (val == null) {
+            return defaultValue;
+        }
+
+        return val.longValue();
+    }
+
+    /**
+     * Get an optional {@link Number} value associated with a key, or <code>null</code>
+     * if there is no such key or if the value is not a number. If the value is a string,
+     * an attempt will be made to evaluate it as a number ({@link BigDecimal}). This method
+     * would be used in cases where type coercion of the number value is unwanted.
+     *
+     * @param key
+     *            A key string.
+     * @return An object which is the value.
+     */
+    public Number optNumber(String key) {
+        return this.optNumber(key, null);
+    }
+
+    /**
+     * Get an optional {@link Number} value associated with a key, or the default if there
+     * is no such key or if the value is not a number. If the value is a string,
+     * an attempt will be made to evaluate it as a number. This method
+     * would be used in cases where type coercion of the number value is unwanted.
+     *
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
+     * @return An object which is the value.
+     */
+    public Number optNumber(String key, Number defaultValue) {
+        Object val = this.opt(key);
+        if (NULL.equals(val)) {
+            return defaultValue;
+        }
+        if (val instanceof Number){
+            return (Number) val;
+        }
+
+        try {
+            return stringToNumber(val.toString());
+        } catch (Exception e) {
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Get an optional string associated with a key. It returns an empty string
+     * if there is no such key. If the value is not a string and is not null,
+     * then it is converted to a string.
+     *
+     * @param key
+     *            A key string.
+     * @return A string which is the value.
+     */
+    public String optString(String key) {
+        return this.optString(key, "");
+    }
+
+    /**
+     * Get an optional string associated with a key. It returns the defaultValue
+     * if there is no such key.
+     *
+     * @param key
+     *            A key string.
+     * @param defaultValue
+     *            The default.
+     * @return A string which is the value.
+     */
+    public String optString(String key, String defaultValue) {
+        Object object = this.opt(key);
+        return NULL.equals(object) ? defaultValue : object.toString();
+    }
+
+    /**
+     * Put a key/boolean pair in the JSONObject.
+     *
+     * @param key
+     *            A key string.
+     * @param value
+     *            A boolean which is the value.
+     * @return this.
+     * @throws JSONException
+     *            If the value is non-finite number.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
+     */
+    public JSONObject put(String key, boolean value) throws JSONException {
+        return this.put(key, value ? Boolean.TRUE : Boolean.FALSE);
+    }
+
+    /**
+     * Put a key/double pair in the JSONObject.
+     *
+     * @param key
+     *            A key string.
+     * @param value
+     *            A double which is the value.
+     * @return this.
+     * @throws JSONException
+     *            If the value is non-finite number.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
+     */
+    public JSONObject put(String key, double value) throws JSONException {
+        return this.put(key, Double.valueOf(value));
+    }
+
+    /**
+     * Put a key/float pair in the JSONObject.
+     *
+     * @param key
+     *            A key string.
+     * @param value
+     *            A float which is the value.
+     * @return this.
+     * @throws JSONException
+     *            If the value is non-finite number.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
+     */
+    public JSONObject put(String key, float value) throws JSONException {
+        return this.put(key, Float.valueOf(value));
+    }
+
+    /**
+     * Put a key/int pair in the JSONObject.
+     *
+     * @param key
+     *            A key string.
+     * @param value
+     *            An int which is the value.
+     * @return this.
+     * @throws JSONException
+     *            If the value is non-finite number.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
+     */
+    public JSONObject put(String key, int value) throws JSONException {
+        return this.put(key, Integer.valueOf(value));
+    }
+
+    /**
+     * Put a key/long pair in the JSONObject.
+     *
+     * @param key
+     *            A key string.
+     * @param value
+     *            A long which is the value.
+     * @return this.
+     * @throws JSONException
+     *            If the value is non-finite number.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
+     */
+    public JSONObject put(String key, long value) throws JSONException {
+        return this.put(key, Long.valueOf(value));
+    }
+
+    /**
+     * Put a key/value pair in the JSONObject, where the value will be a
+     * JSONObject which is produced from a Map.
+     *
+     * @param key
+     *            A key string.
+     * @param value
+     *            A Map value.
+     * @return this.
+     * @throws JSONException
+     *            If the value is non-finite number.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
+     */
+    public JSONObject put(String key, Map<?, ?> value) throws JSONException {
+        return this.put(key, new JSONObject(value));
+    }
+
+    /**
+     * Put a key/value pair in the JSONObject. If the value is <code>null</code>, then the
+     * key will be removed from the JSONObject if it is present.
+     *
+     * @param key
+     *            A key string.
+     * @param value
+     *            An object which is the value. It should be of one of these
+     *            types: Boolean, Double, Integer, JSONArray, JSONObject, Long,
+     *            String, or the JSONObject.NULL object.
+     * @return this.
+     * @throws JSONException
+     *            If the value is non-finite number.
+     * @throws NullPointerException
+     *            If the key is <code>null</code>.
+     */
+    public JSONObject put(String key, Object value) throws JSONException {
+        if (key == null) {
+            throw new NullPointerException("Null key.");
+        }
+        if (value != null) {
+            testValidity(value);
+            this.map.put(key, value);
+        } else {
+            this.remove(key);
+        }
+        return this;
+    }
+
+    /**
+     * Put a key/value pair in the JSONObject, but only if the key and the value
+     * are both non-null, and only if there is not already a member with that
+     * name.
+     *
+     * @param key
+     *            key to insert into
+     * @param value
+     *            value to insert
+     * @return this.
+     * @throws JSONException
+     *             if the key is a duplicate
+     */
+    public JSONObject putOnce(String key, Object value) throws JSONException {
+        if (key != null && value != null) {
+            if (this.opt(key) != null) {
+                throw new JSONException("Duplicate key \"" + key + "\"");
+            }
+            return this.put(key, value);
+        }
+        return this;
+    }
+
+    /**
+     * Put a key/value pair in the JSONObject, but only if the key and the value
+     * are both non-null.
+     *
+     * @param key
+     *            A key string.
+     * @param value
+     *            An object which is the value. It should be of one of these
+     *            types: Boolean, Double, Integer, JSONArray, JSONObject, Long,
+     *            String, or the JSONObject.NULL object.
+     * @return this.
+     * @throws JSONException
+     *             If the value is a non-finite number.
+     */
+    public JSONObject putOpt(String key, Object value) throws JSONException {
+        if (key != null && value != null) {
+            return this.put(key, value);
+        }
+        return this;
+    }
+
+    /**
+     * Produce a string in double quotes with backslash sequences in all the
+     * right places. A backslash will be inserted within &lt;/, producing
+     * &lt;\/, allowing JSON text to be delivered in HTML. In JSON text, a
+     * string cannot contain a control character or an unescaped quote or
+     * backslash.
+     *
+     * @param string
+     *            A String
+     * @return A String correctly formatted for insertion in a JSON text.
+     */
+    @SuppressWarnings("resource")
+    public static String quote(String string) {
+        StringWriter sw = new StringWriter();
+        synchronized (sw.getBuffer()) {
+            try {
+                return quote(string, sw).toString();
+            } catch (IOException ignored) {
+                // will never happen - we are writing to a string writer
+                return "";
+            }
+        }
+    }
+
+    public static Writer quote(String string, Writer w) throws IOException {
+        if (string == null || string.isEmpty()) {
+            w.write("\"\"");
+            return w;
+        }
+
+        char b;
+        char c = 0;
+        String hhhh;
+        int i;
+        int len = string.length();
+
+        w.write('"');
+        for (i = 0; i < len; i += 1) {
+            b = c;
+            c = string.charAt(i);
+            switch (c) {
+            case '\\':
+            case '"':
+                w.write('\\');
+                w.write(c);
+                break;
+            case '/':
+                if (b == '<') {
+                    w.write('\\');
+                }
+                w.write(c);
+                break;
+            case '\b':
+                w.write("\\b");
+                break;
+            case '\t':
+                w.write("\\t");
+                break;
+            case '\n':
+                w.write("\\n");
+                break;
+            case '\f':
+                w.write("\\f");
+                break;
+            case '\r':
+                w.write("\\r");
+                break;
+            default:
+                if (c < ' ' || (c >= '\u0080' && c < '\u00a0')
+                        || (c >= '\u2000' && c < '\u2100')) {
+                    w.write("\\u");
+                    hhhh = Integer.toHexString(c);
+                    w.write("0000", 0, 4 - hhhh.length());
+                    w.write(hhhh);
+                } else {
+                    w.write(c);
+                }
+            }
+        }
+        w.write('"');
+        return w;
+    }
+
+    /**
+     * Remove a name and its value, if present.
+     *
+     * @param key
+     *            The name to be removed.
+     * @return The value that was associated with the name, or null if there was
+     *         no value.
+     */
+    public Object remove(String key) {
+        return this.map.remove(key);
+    }
+    
+
+    /**
+     * Compares two numbers to see if they are similar.
+     *
+     * If either of the numbers are Double or Float instances, then they are checked to have
+     * a finite value. If either value is not finite (NaN or &#177;infinity), then this
+     * function will always return false. If both numbers are finite, they are first checked
+     * to be the same type and implement {@link Comparable}. If they do, then the actual
+     * {@link Comparable#compareTo(Object)} is called. If they are not the same type, or don't
+     * implement Comparable, then they are converted to {@link BigDecimal}s. Finally the
+     * BigDecimal values are compared using {@link BigDecimal#compareTo(BigDecimal)}.
+     *
+     * @param l the Left value to compare. Can not be <code>null</code>.
+     * @param r the right value to compare. Can not be <code>null</code>.
+     * @return true if the numbers are similar, false otherwise.
+     */
+    static boolean isNumberSimilar(Number l, Number r) {
+        if (!numberIsFinite(l) || !numberIsFinite(r)) {
+            // non-finite numbers are never similar
+            return false;
+        }
+
+        // if the classes are the same and implement Comparable
+        // then use the built in compare first.
+        if(l.getClass().equals(r.getClass()) && l instanceof Comparable) {
+            @SuppressWarnings({ "rawtypes", "unchecked" })
+            int compareTo = ((Comparable)l).compareTo(r);
+            return compareTo==0;
+        }
+
+        // BigDecimal should be able to handle all of our number types that we support through
+        // documentation. Convert to BigDecimal first, then use the Compare method to
+        // decide equality.
+        final BigDecimal lBigDecimal = objectToBigDecimal(l, null, false);
+        final BigDecimal rBigDecimal = objectToBigDecimal(r, null, false);
+        if (lBigDecimal == null || rBigDecimal == null) {
+            return false;
+        }
+        return lBigDecimal.compareTo(rBigDecimal) == 0;
+    }
+
+    private static boolean numberIsFinite(Number n) {
+        if (n instanceof Double && (((Double) n).isInfinite() || ((Double) n).isNaN())) {
+            return false;
+        } else if (n instanceof Float && (((Float) n).isInfinite() || ((Float) n).isNaN())) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Tests if the value should be tried as a decimal. It makes no test if there are actual digits.
+     *
+     * @param val value to test
+     * @return true if the string is "-0" or if it contains '.', 'e', or 'E', false otherwise.
+     */
+    protected static boolean isDecimalNotation(final String val) {
+        return val.indexOf('.') > -1 || val.indexOf('e') > -1
+                || val.indexOf('E') > -1 || "-0".equals(val);
+    }
+
+    /**
+     * Converts a string to a number using the narrowest possible type. Possible
+     * returns for this function are BigDecimal, Double, BigInteger, Long, and Integer.
+     * When a Double is returned, it should always be a valid Double and not NaN or +-infinity.
+     *
+     * @param val value to convert
+     * @return Number representation of the value.
+     * @throws NumberFormatException thrown if the value is not a valid number. A public
+     *      caller should catch this and wrap it in a {@link JSONException} if applicable.
+     */
+    protected static Number stringToNumber(final String val) throws NumberFormatException {
+        char initial = val.charAt(0);
+        if ((initial >= '0' && initial <= '9') || initial == '-') {
+            // decimal representation
+            if (isDecimalNotation(val)) {
+                // Use a BigDecimal all the time so we keep the original
+                // representation. BigDecimal doesn't support -0.0, ensure we
+                // keep that by forcing a decimal.
+                try {
+                    BigDecimal bd = new BigDecimal(val);
+                    if(initial == '-' && BigDecimal.ZERO.compareTo(bd)==0) {
+                        return Double.valueOf(-0.0);
+                    }
+                    return bd;
+                } catch (NumberFormatException retryAsDouble) {
+                    // this is to support "Hex Floats" like this: 0x1.0P-1074
+                    try {
+                        Double d = Double.valueOf(val);
+                        if(d.isNaN() || d.isInfinite()) {
+                            throw new NumberFormatException("val ["+val+"] is not a valid number.");
+                        }
+                        return d;
+                    } catch (NumberFormatException ignore) {
+                        throw new NumberFormatException("val ["+val+"] is not a valid number.");
+                    }
+                }
+            }
+            // block items like 00 01 etc. Java number parsers treat these as Octal.
+            if(initial == '0' && val.length() > 1) {
+                char at1 = val.charAt(1);
+                if(at1 >= '0' && at1 <= '9') {
+                    throw new NumberFormatException("val ["+val+"] is not a valid number.");
+                }
+            } else if (initial == '-' && val.length() > 2) {
+                char at1 = val.charAt(1);
+                char at2 = val.charAt(2);
+                if(at1 == '0' && at2 >= '0' && at2 <= '9') {
+                    throw new NumberFormatException("val ["+val+"] is not a valid number.");
+                }
+            }
+            // integer representation.
+            // This will narrow any values to the smallest reasonable Object representation
+            // (Integer, Long, or BigInteger)
+
+            // BigInteger down conversion: We use a similar bitLength compare as
+            // BigInteger#intValueExact uses. Increases GC, but objects hold
+            // only what they need. i.e. Less runtime overhead if the value is
+            // long lived.
+            BigInteger bi = new BigInteger(val);
+            if(bi.bitLength() <= 31){
+                return Integer.valueOf(bi.intValue());
+            }
+            if(bi.bitLength() <= 63){
+                return Long.valueOf(bi.longValue());
+            }
+            return bi;
+        }
+        throw new NumberFormatException("val ["+val+"] is not a valid number.");
+    }
+
+    /**
+     * Try to convert a string into a number, boolean, or null. If the string
+     * can't be converted, return the string.
+     *
+     * @param string
+     *            A String. can not be null.
+     * @return A simple JSON value.
+     * @throws NullPointerException
+     *             Thrown if the string is null.
+     */
+    // Changes to this method must be copied to the corresponding method in
+    // the XML class to keep full support for Android
+    public static Object stringToValue(String string) {
+        if ("".equals(string)) {
+            return string;
+        }
+
+        // check JSON key words true/false/null
+        if ("true".equalsIgnoreCase(string)) {
+            return Boolean.TRUE;
+        }
+        if ("false".equalsIgnoreCase(string)) {
+            return Boolean.FALSE;
+        }
+        if ("null".equalsIgnoreCase(string)) {
+            return JSONObject.NULL;
+        }
+
+        /*
+         * If it might be a number, try converting it. If a number cannot be
+         * produced, then the value will just be a string.
+         */
+
+        char initial = string.charAt(0);
+        if ((initial >= '0' && initial <= '9') || initial == '-') {
+            try {
+                return stringToNumber(string);
+            } catch (Exception ignore) {
+            }
+        }
+        return string;
+    }
+
+    /**
+     * Throw an exception if the object is a NaN or infinite number.
+     *
+     * @param o
+     *            The object to test.
+     * @throws JSONException
+     *             If o is a non-finite number.
+     */
+    public static void testValidity(Object o) throws JSONException {
+        if (o instanceof Number && !numberIsFinite((Number) o)) {
+            throw new JSONException("JSON does not allow non-finite numbers.");
+        }
+    }
+
+    /**
+     * Produce a JSONArray containing the values of the members of this
+     * JSONObject.
+     *
+     * @param names
+     *            A JSONArray containing a list of key strings. This determines
+     *            the sequence of the values in the result.
+     * @return A JSONArray of values.
+     * @throws JSONException
+     *             If any of the values are non-finite numbers.
+     */
+    public JSONArray toJSONArray(JSONArray names) throws JSONException {
+        if (names == null || names.isEmpty()) {
+            return null;
+        }
+        JSONArray ja = new JSONArray();
+        for (int i = 0; i < names.length(); i += 1) {
+            ja.put(this.opt(names.getString(i)));
+        }
+        return ja;
+    }
+
+    /**
+     * Wrap an object, if necessary. If the object is <code>null</code>, return the NULL
+     * object. If it is an array or collection, wrap it in a JSONArray. If it is
+     * a map, wrap it in a JSONObject. If it is a standard property (Double,
+     * String, et al) then it is already wrapped. Otherwise, if it comes from
+     * one of the java packages, turn it into a string. And if it doesn't, try
+     * to wrap it in a JSONObject. If the wrapping fails, then null is returned.
+     *
+     * @param object
+     *            The object to wrap
+     * @return The wrapped value
+     */
+    private static Object wrap(Object object) {
+        try {
+            if (NULL.equals(object)) {
+                return NULL;
+            }
+            if (object instanceof JSONObject || object instanceof JSONArray
+                    || NULL.equals(object)
+                    || object instanceof Byte || object instanceof Character
+                    || object instanceof Short || object instanceof Integer
+                    || object instanceof Long || object instanceof Boolean
+                    || object instanceof Float || object instanceof Double
+                    || object instanceof String || object instanceof BigInteger
+                    || object instanceof BigDecimal || object instanceof Enum) {
+                return object;
+            }
+
+            if (object instanceof Map) {
+                Map<?, ?> map = (Map<?, ?>) object;
+                return new JSONObject(map);
+            }
+            Package objectPackage = object.getClass().getPackage();
+            String objectPackageName = objectPackage != null ? objectPackage
+                    .getName() : "";
+            if (objectPackageName.startsWith("java.")
+                    || objectPackageName.startsWith("javax.")
+                    || object.getClass().getClassLoader() == null) {
+                return object.toString();
+            }
+            return new JSONObject(object);
+        }
+        catch (JSONException exception) {
+            throw exception;
+        } catch (Exception exception) {
+            return null;
+        }
+    }
+
+    /**
+     * Create a new JSONException in a common format for incorrect conversions.
+     * @param key name of the key
+     * @param valueType the type of value being coerced to
+     * @param cause optional cause of the coercion failure
+     * @return JSONException that can be thrown.
+     */
+    private static JSONException wrongValueFormatException(
+            String key,
+            String valueType,
+            Object value,
+            Throwable cause) {
+        if(value == null) {
+
+            return new JSONException(
+                    "JSONObject[" + quote(key) + "] is not a " + valueType + " (null)."
+                    , cause);
+        }
+        // don't try to toString collections or known object types that could be large.
+        if(value instanceof Map || value instanceof Iterable || value instanceof JSONObject) {
+            return new JSONException(
+                    "JSONObject[" + quote(key) + "] is not a " + valueType + " (" + value.getClass() + ")."
+                    , cause);
+        }
+        return new JSONException(
+                "JSONObject[" + quote(key) + "] is not a " + valueType + " (" + value.getClass() + " : " + value + ")."
+                , cause);
+    }
+}

--- a/core/src/main/java/feign/template/util/JSONObject.java
+++ b/core/src/main/java/feign/template/util/JSONObject.java
@@ -1,9 +1,5 @@
 package feign.template.util;
 
-/*
-Public Domain.
-*/
-
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
@@ -19,6 +15,10 @@ import java.util.Map.Entry;
 import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.regex.Pattern;
+
+/*
+ * Modified and Utilized with the Feign project via Public Domain
+ */
 
 /**
  * A JSONObject is an unordered collection of name/value pairs. Its external
@@ -71,7 +71,8 @@ import java.util.regex.Pattern;
  * </ul>
  *
  * @author JSON.org
- * @version 2016-08-15
+ * @author Justin Ziegler
+ * @version 2022-09-21
  */
 public class JSONObject {
     /**

--- a/core/src/main/java/feign/template/util/JSONObject.java
+++ b/core/src/main/java/feign/template/util/JSONObject.java
@@ -12,7 +12,7 @@
  * the License.
  */
 
- /*
+/*
  * Code Originally Sourced From the JSON.ORG project and utilized under Public Domain
  */
 package feign.template.util;
@@ -34,53 +34,43 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
- * A JSONObject is an unordered collection of name/value pairs. Its external
- * form is a string wrapped in curly braces with colons between the names and
- * values, and commas between the values and names. The internal form is an
- * object having <code>get</code> and <code>opt</code> methods for accessing
- * the values by name, and <code>put</code> methods for adding or replacing
- * values by name. The values can be any of these types: <code>Boolean</code>,
- * <code>JSONArray</code>, <code>JSONObject</code>, <code>Number</code>,
- * <code>String</code>, or the <code>JSONObject.NULL</code> object. A
- * JSONObject constructor can be used to convert an external form JSON text
- * into an internal form whose values can be retrieved with the
- * <code>get</code> and <code>opt</code> methods, or to convert values into a
- * JSON text using the <code>put</code> and <code>toString</code> methods. A
- * <code>get</code> method returns a value if one can be found, and throws an
- * exception if one cannot be found. An <code>opt</code> method returns a
- * default value instead of throwing an exception, and so is useful for
- * obtaining optional values.
+ * A JSONObject is an unordered collection of name/value pairs. Its external form is a string
+ * wrapped in curly braces with colons between the names and values, and commas between the values
+ * and names. The internal form is an object having <code>get</code> and <code>opt</code> methods
+ * for accessing the values by name, and <code>put</code> methods for adding or replacing values by
+ * name. The values can be any of these types: <code>Boolean</code>, <code>JSONArray</code>,
+ * <code>JSONObject</code>, <code>Number</code>, <code>String</code>, or the
+ * <code>JSONObject.NULL</code> object. A JSONObject constructor can be used to convert an external
+ * form JSON text into an internal form whose values can be retrieved with the <code>get</code> and
+ * <code>opt</code> methods, or to convert values into a JSON text using the <code>put</code> and
+ * <code>toString</code> methods. A <code>get</code> method returns a value if one can be found, and
+ * throws an exception if one cannot be found. An <code>opt</code> method returns a default value
+ * instead of throwing an exception, and so is useful for obtaining optional values.
  * <p>
- * The generic <code>get()</code> and <code>opt()</code> methods return an
- * object, which you can cast or query for type. There are also typed
- * <code>get</code> and <code>opt</code> methods that do type checking and type
- * coercion for you. The opt methods differ from the get methods in that they
- * do not throw. Instead, they return a specified value, such as null.
+ * The generic <code>get()</code> and <code>opt()</code> methods return an object, which you can
+ * cast or query for type. There are also typed <code>get</code> and <code>opt</code> methods that
+ * do type checking and type coercion for you. The opt methods differ from the get methods in that
+ * they do not throw. Instead, they return a specified value, such as null.
  * <p>
- * The <code>put</code> methods add or replace values in an object. For
- * example,
+ * The <code>put</code> methods add or replace values in an object. For example,
  *
  * <pre>
  * myString = new JSONObject()
- *         .put(&quot;JSON&quot;, &quot;Hello, World!&quot;).toString();
+ *     .put(&quot;JSON&quot;, &quot;Hello, World!&quot;).toString();
  * </pre>
  *
  * produces the string <code>{"JSON": "Hello, World"}</code>.
  * <p>
- * The texts produced by the <code>toString</code> methods strictly conform to
- * the JSON syntax rules. The constructors are more forgiving in the texts they
- * will accept:
+ * The texts produced by the <code>toString</code> methods strictly conform to the JSON syntax
+ * rules. The constructors are more forgiving in the texts they will accept:
  * <ul>
- * <li>An extra <code>,</code>&nbsp;<small>(comma)</small> may appear just
- * before the closing brace.</li>
- * <li>Strings may be quoted with <code>'</code>&nbsp;<small>(single
- * quote)</small>.</li>
- * <li>Strings do not need to be quoted at all if they do not begin with a
- * quote or single quote, and if they do not contain leading or trailing
- * spaces, and if they do not contain any of these characters:
- * <code>{ } [ ] / \ : , #</code> and if they do not look like numbers and
- * if they are not the reserved words <code>true</code>, <code>false</code>,
- * or <code>null</code>.</li>
+ * <li>An extra <code>,</code>&nbsp;<small>(comma)</small> may appear just before the closing
+ * brace.</li>
+ * <li>Strings may be quoted with <code>'</code>&nbsp;<small>(single quote)</small>.</li>
+ * <li>Strings do not need to be quoted at all if they do not begin with a quote or single quote,
+ * and if they do not contain leading or trailing spaces, and if they do not contain any of these
+ * characters: <code>{ } [ ] / \ : , #</code> and if they do not look like numbers and if they are
+ * not the reserved words <code>true</code>, <code>false</code>, or <code>null</code>.</li>
  * </ul>
  *
  * @author JSON.org
@@ -88,1904 +78,1730 @@ import java.util.regex.Pattern;
  * @version 2022-09-21
  */
 public class JSONObject {
-    /**
-     * JSONObject.NULL is equivalent to the value that JavaScript calls null,
-     * whilst Java's null is equivalent to the value that JavaScript calls
-     * undefined.
-     */
-    private static final class Null {
+  /**
+   * JSONObject.NULL is equivalent to the value that JavaScript calls null, whilst Java's null is
+   * equivalent to the value that JavaScript calls undefined.
+   */
+  private static final class Null {
 
-        /**
-         * There is only intended to be a single instance of the NULL object,
-         * so the clone method returns itself.
-         *
-         * @return NULL.
-         */
-        @Override
-        protected final Object clone() {
-            return this;
+    /**
+     * There is only intended to be a single instance of the NULL object, so the clone method
+     * returns itself.
+     *
+     * @return NULL.
+     */
+    @Override
+    protected final Object clone() {
+      return this;
+    }
+
+    /**
+     * A Null object is equal to the null value and to itself.
+     *
+     * @param object An object to test for nullness.
+     * @return true if the object parameter is the JSONObject.NULL object or null.
+     */
+    @Override
+    @SuppressWarnings("lgtm[java/unchecked-cast-in-equals]")
+    public boolean equals(Object object) {
+      return object == null || object == this;
+    }
+
+    /**
+     * A Null object is equal to the null value and to itself.
+     *
+     * @return always returns 0.
+     */
+    @Override
+    public int hashCode() {
+      return 0;
+    }
+
+    /**
+     * Get the "null" string value.
+     *
+     * @return The string "null".
+     */
+    @Override
+    public String toString() {
+      return "null";
+    }
+  }
+
+  /**
+   * Regular Expression Pattern that matches JSON Numbers. This is primarily used for output to
+   * guarantee that we are always writing valid JSON.
+   */
+  static final Pattern NUMBER_PATTERN =
+      Pattern.compile("-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?");
+
+  /**
+   * The map where the JSONObject's properties are kept.
+   */
+  private final Map<String, Object> map;
+
+  public Class<? extends Map> getMapType() {
+    return map.getClass();
+  }
+
+  /**
+   * It is sometimes more convenient and less ambiguous to have a <code>NULL</code> object than to
+   * use Java's <code>null</code> value. <code>JSONObject.NULL.equals(null)</code> returns
+   * <code>true</code>. <code>JSONObject.NULL.toString()</code> returns <code>"null"</code>.
+   */
+  public static final Object NULL = new Null();
+
+  /**
+   * Construct an empty JSONObject.
+   */
+  public JSONObject() {
+    // HashMap is used on purpose to ensure that elements are unordered by
+    // the specification.
+    // JSON tends to be a portable transfer format to allows the container
+    // implementations to rearrange their items for a faster element
+    // retrieval based on associative access.
+    // Therefore, an implementation mustn't rely on the order of the item.
+    this.map = new HashMap<String, Object>();
+  }
+
+  /**
+   * Construct a JSONObject from a subset of another JSONObject. An array of strings is used to
+   * identify the keys that should be copied. Missing keys are ignored.
+   *
+   * @param jo A JSONObject.
+   * @param names An array of strings.
+   */
+  public JSONObject(JSONObject jo, String... names) {
+    this(names.length);
+    for (int i = 0; i < names.length; i += 1) {
+      try {
+        this.putOnce(names[i], jo.opt(names[i]));
+      } catch (Exception ignore) {
+      }
+    }
+  }
+
+  /**
+   * Construct a JSONObject from a JSONTokener.
+   *
+   * @param x A JSONTokener object containing the source string.
+   * @throws JSONException If there is a syntax error in the source string or a duplicated key.
+   */
+  public JSONObject(JSONTokener x) throws JSONException {
+    this();
+    char c;
+    String key;
+
+    if (x.nextClean() != '{') {
+      throw x.syntaxError("A JSONObject text must begin with '{'");
+    }
+    for (;;) {
+      char prev = x.getPrevious();
+      c = x.nextClean();
+      switch (c) {
+        case 0:
+          throw x.syntaxError("A JSONObject text must end with '}'");
+        case '}':
+          return;
+        case '{':
+        case '[':
+          if (prev == '{') {
+            throw x.syntaxError(
+                "A JSON Object can not directly nest another JSON Object or JSON Array.");
+          }
+          // fall through
+        default:
+          x.back();
+          key = x.nextValue().toString();
+      }
+
+      // The key is followed by ':'.
+
+      c = x.nextClean();
+      if (c != ':') {
+        throw x.syntaxError("Expected a ':' after a key");
+      }
+
+      // Use syntaxError(..) to include error location
+
+      if (key != null) {
+        // Check if key exists
+        if (this.opt(key) != null) {
+          // key already exists
+          throw x.syntaxError("Duplicate key \"" + key + "\"");
         }
-
-        /**
-         * A Null object is equal to the null value and to itself.
-         *
-         * @param object
-         *            An object to test for nullness.
-         * @return true if the object parameter is the JSONObject.NULL object or
-         *         null.
-         */
-        @Override
-        @SuppressWarnings("lgtm[java/unchecked-cast-in-equals]")
-        public boolean equals(Object object) {
-            return object == null || object == this;
-        }
-        /**
-         * A Null object is equal to the null value and to itself.
-         *
-         * @return always returns 0.
-         */
-        @Override
-        public int hashCode() {
-            return 0;
-        }
-
-        /**
-         * Get the "null" string value.
-         *
-         * @return The string "null".
-         */
-        @Override
-        public String toString() {
-            return "null";
-        }
-    }
-
-    /**
-     *  Regular Expression Pattern that matches JSON Numbers. This is primarily used for
-     *  output to guarantee that we are always writing valid JSON.
-     */
-    static final Pattern NUMBER_PATTERN = Pattern.compile("-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?");
-
-    /**
-     * The map where the JSONObject's properties are kept.
-     */
-    private final Map<String, Object> map;
-
-    public Class<? extends Map> getMapType() {
-        return map.getClass();
-    }
-
-    /**
-     * It is sometimes more convenient and less ambiguous to have a
-     * <code>NULL</code> object than to use Java's <code>null</code> value.
-     * <code>JSONObject.NULL.equals(null)</code> returns <code>true</code>.
-     * <code>JSONObject.NULL.toString()</code> returns <code>"null"</code>.
-     */
-    public static final Object NULL = new Null();
-
-    /**
-     * Construct an empty JSONObject.
-     */
-    public JSONObject() {
-        // HashMap is used on purpose to ensure that elements are unordered by
-        // the specification.
-        // JSON tends to be a portable transfer format to allows the container
-        // implementations to rearrange their items for a faster element
-        // retrieval based on associative access.
-        // Therefore, an implementation mustn't rely on the order of the item.
-        this.map = new HashMap<String, Object>();
-    }
-
-    /**
-     * Construct a JSONObject from a subset of another JSONObject. An array of
-     * strings is used to identify the keys that should be copied. Missing keys
-     * are ignored.
-     *
-     * @param jo
-     *            A JSONObject.
-     * @param names
-     *            An array of strings.
-     */
-    public JSONObject(JSONObject jo, String ... names) {
-        this(names.length);
-        for (int i = 0; i < names.length; i += 1) {
-            try {
-                this.putOnce(names[i], jo.opt(names[i]));
-            } catch (Exception ignore) {
-            }
-        }
-    }
-
-    /**
-     * Construct a JSONObject from a JSONTokener.
-     *
-     * @param x
-     *            A JSONTokener object containing the source string.
-     * @throws JSONException
-     *             If there is a syntax error in the source string or a
-     *             duplicated key.
-     */
-    public JSONObject(JSONTokener x) throws JSONException {
-        this();
-        char c;
-        String key;
-
-        if (x.nextClean() != '{') {
-            throw x.syntaxError("A JSONObject text must begin with '{'");
-        }
-        for (;;) {
-            char prev = x.getPrevious();
-            c = x.nextClean();
-            switch (c) {
-            case 0:
-                throw x.syntaxError("A JSONObject text must end with '}'");
-            case '}':
-                return;
-            case '{':
-            case '[':
-                if(prev=='{') {
-                    throw x.syntaxError("A JSON Object can not directly nest another JSON Object or JSON Array.");
-                }
-                // fall through
-            default:
-                x.back();
-                key = x.nextValue().toString();
-            }
-
-            // The key is followed by ':'.
-
-            c = x.nextClean();
-            if (c != ':') {
-                throw x.syntaxError("Expected a ':' after a key");
-            }
-
-            // Use syntaxError(..) to include error location
-
-            if (key != null) {
-                // Check if key exists
-                if (this.opt(key) != null) {
-                    // key already exists
-                    throw x.syntaxError("Duplicate key \"" + key + "\"");
-                }
-                // Only add value if non-null
-                Object value = x.nextValue();
-                if (value!=null) {
-                    this.put(key, value);
-                }
-            }
-
-            // Pairs are separated by ','.
-
-            switch (x.nextClean()) {
-            case ';':
-            case ',':
-                if (x.nextClean() == '}') {
-                    return;
-                }
-                x.back();
-                break;
-            case '}':
-                return;
-            default:
-                throw x.syntaxError("Expected a ',' or '}'");
-            }
-        }
-    }
-
-    /**
-     * Construct a JSONObject from a Map.
-     *
-     * @param m
-     *            A map object that can be used to initialize the contents of
-     *            the JSONObject.
-     * @throws JSONException
-     *            If a value in the map is non-finite number.
-     * @throws NullPointerException
-     *            If a key in the map is <code>null</code>
-     */
-    public JSONObject(Map<?, ?> m) {
-        if (m == null) {
-            this.map = new HashMap<String, Object>();
-        } else {
-            this.map = new HashMap<String, Object>(m.size());
-        	for (final Entry<?, ?> e : m.entrySet()) {
-        	    if(e.getKey() == null) {
-        	        throw new NullPointerException("Null key.");
-        	    }
-                final Object value = e.getValue();
-                if (value != null) {
-                    this.map.put(String.valueOf(e.getKey()), wrap(value));
-                }
-            }
-        }
-    }
-
-    /**
-     * Construct a JSONObject from an Object, using reflection to find the
-     * public members. The resulting JSONObject's keys will be the strings from
-     * the names array, and the values will be the field values associated with
-     * those keys in the object. If a key is not found or not visible, then it
-     * will not be copied into the new JSONObject.
-     *
-     * @param object
-     *            An object that has fields that should be used to make a
-     *            JSONObject.
-     * @param names
-     *            An array of strings, the names of the fields to be obtained
-     *            from the object.
-     */
-    public JSONObject(Object object, String ... names) {
-        this(names.length);
-        Class<?> c = object.getClass();
-        for (int i = 0; i < names.length; i += 1) {
-            String name = names[i];
-            try {
-                this.putOpt(name, c.getField(name).get(object));
-            } catch (Exception ignore) {
-            }
-        }
-    }
-
-    /**
-     * Construct a JSONObject from a source JSON text string. This is the most
-     * commonly used JSONObject constructor.
-     *
-     * @param source
-     *            A string beginning with <code>{</code>&nbsp;<small>(left
-     *            brace)</small> and ending with <code>}</code>
-     *            &nbsp;<small>(right brace)</small>.
-     * @exception JSONException
-     *                If there is a syntax error in the source string or a
-     *                duplicated key.
-     */
-    public JSONObject(String source) throws JSONException {
-        this(new JSONTokener(source));
-    }
-
-    /**
-     * Construct a JSONObject from a ResourceBundle.
-     *
-     * @param baseName
-     *            The ResourceBundle base name.
-     * @param locale
-     *            The Locale to load the ResourceBundle for.
-     * @throws JSONException
-     *             If any JSONExceptions are detected.
-     */
-    public JSONObject(String baseName, Locale locale) throws JSONException {
-        this();
-        ResourceBundle bundle = ResourceBundle.getBundle(baseName, locale,
-                Thread.currentThread().getContextClassLoader());
-
-// Iterate through the keys in the bundle.
-
-        Enumeration<String> keys = bundle.getKeys();
-        while (keys.hasMoreElements()) {
-            Object key = keys.nextElement();
-            if (key != null) {
-
-// Go through the path, ensuring that there is a nested JSONObject for each
-// segment except the last. Add the value using the last segment's name into
-// the deepest nested JSONObject.
-
-                String[] path = ((String) key).split("\\.");
-                int last = path.length - 1;
-                JSONObject target = this;
-                for (int i = 0; i < last; i += 1) {
-                    String segment = path[i];
-                    JSONObject nextTarget = target.optJSONObject(segment);
-                    if (nextTarget == null) {
-                        nextTarget = new JSONObject();
-                        target.put(segment, nextTarget);
-                    }
-                    target = nextTarget;
-                }
-                target.put(path[last], bundle.getString((String) key));
-            }
-        }
-    }
-
-    /**
-     * Constructor to specify an initial capacity of the internal map. Useful for library
-     * internal calls where we know, or at least can best guess, how big this JSONObject
-     * will be.
-     *
-     * @param initialCapacity initial capacity of the internal map.
-     */
-    protected JSONObject(int initialCapacity){
-        this.map = new HashMap<String, Object>(initialCapacity);
-    }
-
-    /**
-     * Accumulate values under a key. It is similar to the put method except
-     * that if there is already an object stored under the key then a JSONArray
-     * is stored under the key to hold all of the accumulated values. If there
-     * is already a JSONArray, then the new value is appended to it. In
-     * contrast, the put method replaces the previous value.
-     *
-     * If only one value is accumulated that is not a JSONArray, then the result
-     * will be the same as using put. But if multiple values are accumulated,
-     * then the result will be like append.
-     *
-     * @param key
-     *            A key string.
-     * @param value
-     *            An object to be accumulated under the key.
-     * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
-     */
-    public JSONObject accumulate(String key, Object value) throws JSONException {
-        testValidity(value);
-        Object object = this.opt(key);
-        if (object == null) {
-            this.put(key,
-                    value instanceof JSONArray ? new JSONArray().put(value)
-                            : value);
-        } else if (object instanceof JSONArray) {
-            ((JSONArray) object).put(value);
-        } else {
-            this.put(key, new JSONArray().put(object).put(value));
-        }
-        return this;
-    }
-
-    /**
-     * Append values to the array under a key. If the key does not exist in the
-     * JSONObject, then the key is put in the JSONObject with its value being a
-     * JSONArray containing the value parameter. If the key was already
-     * associated with a JSONArray, then the value parameter is appended to it.
-     *
-     * @param key
-     *            A key string.
-     * @param value
-     *            An object to be accumulated under the key.
-     * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number or if the current value associated with
-     *             the key is not a JSONArray.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
-     */
-    public JSONObject append(String key, Object value) throws JSONException {
-        testValidity(value);
-        Object object = this.opt(key);
-        if (object == null) {
-            this.put(key, new JSONArray().put(value));
-        } else if (object instanceof JSONArray) {
-            this.put(key, ((JSONArray) object).put(value));
-        } else {
-            throw wrongValueFormatException(key, "JSONArray", null, null);
-        }
-        return this;
-    }
-
-    /**
-     * Produce a string from a double. The string "null" will be returned if the
-     * number is not finite.
-     *
-     * @param d
-     *            A double.
-     * @return A String.
-     */
-    public static String doubleToString(double d) {
-        if (Double.isInfinite(d) || Double.isNaN(d)) {
-            return "null";
-        }
-
-// Shave off trailing zeros and decimal point, if possible.
-
-        String string = Double.toString(d);
-        if (string.indexOf('.') > 0 && string.indexOf('e') < 0
-                && string.indexOf('E') < 0) {
-            while (string.endsWith("0")) {
-                string = string.substring(0, string.length() - 1);
-            }
-            if (string.endsWith(".")) {
-                string = string.substring(0, string.length() - 1);
-            }
-        }
-        return string;
-    }
-
-    /**
-     * Get the value object associated with a key.
-     *
-     * @param key
-     *            A key string.
-     * @return The object associated with the key.
-     * @throws JSONException
-     *             if the key is not found.
-     */
-    public Object get(String key) throws JSONException {
-        if (key == null) {
-            throw new JSONException("Null key.");
-        }
-        Object object = this.opt(key);
-        if (object == null) {
-            throw new JSONException("JSONObject[" + quote(key) + "] not found.");
-        }
-        return object;
-    }
-
-    /**
-     * Get the enum value associated with a key.
-     *
-     * @param <E>
-     *            Enum Type
-     * @param clazz
-     *           The type of enum to retrieve.
-     * @param key
-     *           A key string.
-     * @return The enum value associated with the key
-     * @throws JSONException
-     *             if the key is not found or if the value cannot be converted
-     *             to an enum.
-     */
-    public <E extends Enum<E>> E getEnum(Class<E> clazz, String key) throws JSONException {
-        E val = optEnum(clazz, key);
-        if(val==null) {
-            // JSONException should really take a throwable argument.
-            // If it did, I would re-implement this with the Enum.valueOf
-            // method and place any thrown exception in the JSONException
-            throw wrongValueFormatException(key, "enum of type " + quote(clazz.getSimpleName()), opt(key), null);
-        }
-        return val;
-    }
-
-    /**
-     * Get the boolean value associated with a key.
-     *
-     * @param key
-     *            A key string.
-     * @return The truth.
-     * @throws JSONException
-     *             if the value is not a Boolean or the String "true" or
-     *             "false".
-     */
-    public boolean getBoolean(String key) throws JSONException {
-        Object object = this.get(key);
-        if (object.equals(Boolean.FALSE)
-                || (object instanceof String && ((String) object)
-                        .equalsIgnoreCase("false"))) {
-            return false;
-        } else if (object.equals(Boolean.TRUE)
-                || (object instanceof String && ((String) object)
-                        .equalsIgnoreCase("true"))) {
-            return true;
-        }
-        throw wrongValueFormatException(key, "Boolean", object, null);
-    }
-
-    /**
-     * Get the BigInteger value associated with a key.
-     *
-     * @param key
-     *            A key string.
-     * @return The numeric value.
-     * @throws JSONException
-     *             if the key is not found or if the value cannot
-     *             be converted to BigInteger.
-     */
-    public BigInteger getBigInteger(String key) throws JSONException {
-        Object object = this.get(key);
-        BigInteger ret = objectToBigInteger(object, null);
-        if (ret != null) {
-            return ret;
-        }
-        throw wrongValueFormatException(key, "BigInteger", object, null);
-    }
-
-    /**
-     * Get the BigDecimal value associated with a key. If the value is float or
-     * double, the {@link BigDecimal#BigDecimal(double)} constructor will
-     * be used. See notes on the constructor for conversion issues that may
-     * arise.
-     *
-     * @param key
-     *            A key string.
-     * @return The numeric value.
-     * @throws JSONException
-     *             if the key is not found or if the value
-     *             cannot be converted to BigDecimal.
-     */
-    public BigDecimal getBigDecimal(String key) throws JSONException {
-        Object object = this.get(key);
-        BigDecimal ret = objectToBigDecimal(object, null);
-        if (ret != null) {
-            return ret;
-        }
-        throw wrongValueFormatException(key, "BigDecimal", object, null);
-    }
-
-    /**
-     * Get the double value associated with a key.
-     *
-     * @param key
-     *            A key string.
-     * @return The numeric value.
-     * @throws JSONException
-     *             if the key is not found or if the value is not a Number
-     *             object and cannot be converted to a number.
-     */
-    public double getDouble(String key) throws JSONException {
-        final Object object = this.get(key);
-        if(object instanceof Number) {
-            return ((Number)object).doubleValue();
-        }
-        try {
-            return Double.parseDouble(object.toString());
-        } catch (Exception e) {
-            throw wrongValueFormatException(key, "double", object, e);
-        }
-    }
-
-    /**
-     * Get the float value associated with a key.
-     *
-     * @param key
-     *            A key string.
-     * @return The numeric value.
-     * @throws JSONException
-     *             if the key is not found or if the value is not a Number
-     *             object and cannot be converted to a number.
-     */
-    public float getFloat(String key) throws JSONException {
-        final Object object = this.get(key);
-        if(object instanceof Number) {
-            return ((Number)object).floatValue();
-        }
-        try {
-            return Float.parseFloat(object.toString());
-        } catch (Exception e) {
-            throw wrongValueFormatException(key, "float", object, e);
-        }
-    }
-
-    /**
-     * Get the Number value associated with a key.
-     *
-     * @param key
-     *            A key string.
-     * @return The numeric value.
-     * @throws JSONException
-     *             if the key is not found or if the value is not a Number
-     *             object and cannot be converted to a number.
-     */
-    public Number getNumber(String key) throws JSONException {
-        Object object = this.get(key);
-        try {
-            if (object instanceof Number) {
-                return (Number)object;
-            }
-            return stringToNumber(object.toString());
-        } catch (Exception e) {
-            throw wrongValueFormatException(key, "number", object, e);
-        }
-    }
-
-    /**
-     * Get the int value associated with a key.
-     *
-     * @param key
-     *            A key string.
-     * @return The integer value.
-     * @throws JSONException
-     *             if the key is not found or if the value cannot be converted
-     *             to an integer.
-     */
-    public int getInt(String key) throws JSONException {
-        final Object object = this.get(key);
-        if(object instanceof Number) {
-            return ((Number)object).intValue();
-        }
-        try {
-            return Integer.parseInt(object.toString());
-        } catch (Exception e) {
-            throw wrongValueFormatException(key, "int", object, e);
-        }
-    }
-
-    /**
-     * Get the JSONArray value associated with a key.
-     *
-     * @param key
-     *            A key string.
-     * @return A JSONArray which is the value.
-     * @throws JSONException
-     *             if the key is not found or if the value is not a JSONArray.
-     */
-    public JSONArray getJSONArray(String key) throws JSONException {
-        Object object = this.get(key);
-        if (object instanceof JSONArray) {
-            return (JSONArray) object;
-        }
-        throw wrongValueFormatException(key, "JSONArray", object, null);
-    }
-
-    /**
-     * Get the JSONObject value associated with a key.
-     *
-     * @param key
-     *            A key string.
-     * @return A JSONObject which is the value.
-     * @throws JSONException
-     *             if the key is not found or if the value is not a JSONObject.
-     */
-    public JSONObject getJSONObject(String key) throws JSONException {
-        Object object = this.get(key);
-        if (object instanceof JSONObject) {
-            return (JSONObject) object;
-        }
-        throw wrongValueFormatException(key, "JSONObject", object, null);
-    }
-
-    /**
-     * Get the long value associated with a key.
-     *
-     * @param key
-     *            A key string.
-     * @return The long value.
-     * @throws JSONException
-     *             if the key is not found or if the value cannot be converted
-     *             to a long.
-     */
-    public long getLong(String key) throws JSONException {
-        final Object object = this.get(key);
-        if(object instanceof Number) {
-            return ((Number)object).longValue();
-        }
-        try {
-            return Long.parseLong(object.toString());
-        } catch (Exception e) {
-            throw wrongValueFormatException(key, "long", object, e);
-        }
-    }
-
-    /**
-     * Get an array of field names from a JSONObject.
-     *
-     * @param jo
-     *            JSON object
-     * @return An array of field names, or null if there are no names.
-     */
-    public static String[] getNames(JSONObject jo) {
-        if (jo.isEmpty()) {
-            return null;
-        }
-        return jo.keySet().toArray(new String[jo.length()]);
-    }
-
-    /**
-     * Get an array of public field names from an Object.
-     *
-     * @param object
-     *            object to read
-     * @return An array of field names, or null if there are no names.
-     */
-    public static String[] getNames(Object object) {
-        if (object == null) {
-            return null;
-        }
-        Class<?> klass = object.getClass();
-        Field[] fields = klass.getFields();
-        int length = fields.length;
-        if (length == 0) {
-            return null;
-        }
-        String[] names = new String[length];
-        for (int i = 0; i < length; i += 1) {
-            names[i] = fields[i].getName();
-        }
-        return names;
-    }
-
-    /**
-     * Get the string associated with a key.
-     *
-     * @param key
-     *            A key string.
-     * @return A string which is the value.
-     * @throws JSONException
-     *             if there is no string value for the key.
-     */
-    public String getString(String key) throws JSONException {
-        Object object = this.get(key);
-        if (object instanceof String) {
-            return (String) object;
-        }
-        throw wrongValueFormatException(key, "string", object, null);
-    }
-
-    /**
-     * Determine if the JSONObject contains a specific key.
-     *
-     * @param key
-     *            A key string.
-     * @return true if the key exists in the JSONObject.
-     */
-    public boolean has(String key) {
-        return this.map.containsKey(key);
-    }
-
-    /**
-     * Increment a property of a JSONObject. If there is no such property,
-     * create one with a value of 1 (Integer). If there is such a property, and if it is
-     * an Integer, Long, Double, Float, BigInteger, or BigDecimal then add one to it.
-     * No overflow bounds checking is performed, so callers should initialize the key
-     * prior to this call with an appropriate type that can handle the maximum expected
-     * value.
-     *
-     * @param key
-     *            A key string.
-     * @return this.
-     * @throws JSONException
-     *             If there is already a property with this name that is not an
-     *             Integer, Long, Double, or Float.
-     */
-    public JSONObject increment(String key) throws JSONException {
-        Object value = this.opt(key);
-        if (value == null) {
-            this.put(key, 1);
-        } else if (value instanceof Integer) {
-            this.put(key, ((Integer) value).intValue() + 1);
-        } else if (value instanceof Long) {
-            this.put(key, ((Long) value).longValue() + 1L);
-        } else if (value instanceof BigInteger) {
-            this.put(key, ((BigInteger)value).add(BigInteger.ONE));
-        } else if (value instanceof Float) {
-            this.put(key, ((Float) value).floatValue() + 1.0f);
-        } else if (value instanceof Double) {
-            this.put(key, ((Double) value).doubleValue() + 1.0d);
-        } else if (value instanceof BigDecimal) {
-            this.put(key, ((BigDecimal)value).add(BigDecimal.ONE));
-        } else {
-            throw new JSONException("Unable to increment [" + quote(key) + "].");
-        }
-        return this;
-    }
-
-    /**
-     * Determine if the value associated with the key is <code>null</code> or if there is no
-     * value.
-     *
-     * @param key
-     *            A key string.
-     * @return true if there is no value associated with the key or if the value
-     *        is the JSONObject.NULL object.
-     */
-    public boolean isNull(String key) {
-        return JSONObject.NULL.equals(this.opt(key));
-    }
-
-    /**
-     * Get an enumeration of the keys of the JSONObject. Modifying this key Set will also
-     * modify the JSONObject. Use with caution.
-     *
-     * @see Set#iterator()
-     *
-     * @return An iterator of the keys.
-     */
-    public Iterator<String> keys() {
-        return this.keySet().iterator();
-    }
-
-    /**
-     * Get a set of keys of the JSONObject. Modifying this key Set will also modify the
-     * JSONObject. Use with caution.
-     *
-     * @see Map#keySet()
-     *
-     * @return A keySet.
-     */
-    public Set<String> keySet() {
-        return this.map.keySet();
-    }
-
-    /**
-     * Get a set of entries of the JSONObject. These are raw values and may not
-     * match what is returned by the JSONObject get* and opt* functions. Modifying
-     * the returned EntrySet or the Entry objects contained therein will modify the
-     * backing JSONObject. This does not return a clone or a read-only view.
-     *
-     * Use with caution.
-     *
-     * @see Map#entrySet()
-     *
-     * @return An Entry Set
-     */
-    protected Set<Entry<String, Object>> entrySet() {
-        return this.map.entrySet();
-    }
-
-    /**
-     * Get the number of keys stored in the JSONObject.
-     *
-     * @return The number of keys in the JSONObject.
-     */
-    public int length() {
-        return this.map.size();
-    }
-
-    /**
-     * Removes all of the elements from this JSONObject.
-     * The JSONObject will be empty after this call returns.
-     */
-    public void clear() {
-        this.map.clear();
-    }
-
-    /**
-     * Check if JSONObject is empty.
-     *
-     * @return true if JSONObject is empty, otherwise false.
-     */
-    public boolean isEmpty() {
-        return this.map.isEmpty();
-    }
-
-    /**
-     * Produce a string from a Number.
-     *
-     * @param number
-     *            A Number
-     * @return A String.
-     * @throws JSONException
-     *             If n is a non-finite number.
-     */
-    public static String numberToString(Number number) throws JSONException {
-        if (number == null) {
-            throw new JSONException("Null pointer");
-        }
-        testValidity(number);
-
-        // Shave off trailing zeros and decimal point, if possible.
-
-        String string = number.toString();
-        if (string.indexOf('.') > 0 && string.indexOf('e') < 0
-                && string.indexOf('E') < 0) {
-            while (string.endsWith("0")) {
-                string = string.substring(0, string.length() - 1);
-            }
-            if (string.endsWith(".")) {
-                string = string.substring(0, string.length() - 1);
-            }
-        }
-        return string;
-    }
-
-    /**
-     * Get an optional value associated with a key.
-     *
-     * @param key
-     *            A key string.
-     * @return An object which is the value, or null if there is no value.
-     */
-    public Object opt(String key) {
-        return key == null ? null : this.map.get(key);
-    }
-
-    /**
-     * Get the enum value associated with a key.
-     *
-     * @param <E>
-     *            Enum Type
-     * @param clazz
-     *            The type of enum to retrieve.
-     * @param key
-     *            A key string.
-     * @return The enum value associated with the key or null if not found
-     */
-    public <E extends Enum<E>> E optEnum(Class<E> clazz, String key) {
-        return this.optEnum(clazz, key, null);
-    }
-
-    /**
-     * Get the enum value associated with a key.
-     *
-     * @param <E>
-     *            Enum Type
-     * @param clazz
-     *            The type of enum to retrieve.
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default in case the value is not found
-     * @return The enum value associated with the key or defaultValue
-     *            if the value is not found or cannot be assigned to <code>clazz</code>
-     */
-    public <E extends Enum<E>> E optEnum(Class<E> clazz, String key, E defaultValue) {
-        try {
-            Object val = this.opt(key);
-            if (NULL.equals(val)) {
-                return defaultValue;
-            }
-            if (clazz.isAssignableFrom(val.getClass())) {
-                // we just checked it!
-                @SuppressWarnings("unchecked")
-                E myE = (E) val;
-                return myE;
-            }
-            return Enum.valueOf(clazz, val.toString());
-        } catch (IllegalArgumentException e) {
-            return defaultValue;
-        } catch (NullPointerException e) {
-            return defaultValue;
-        }
-    }
-
-    /**
-     * Get an optional boolean associated with a key. It returns false if there
-     * is no such key, or if the value is not Boolean.TRUE or the String "true".
-     *
-     * @param key
-     *            A key string.
-     * @return The truth.
-     */
-    public boolean optBoolean(String key) {
-        return this.optBoolean(key, false);
-    }
-
-    /**
-     * Get an optional boolean associated with a key. It returns the
-     * defaultValue if there is no such key, or if it is not a Boolean or the
-     * String "true" or "false" (case insensitive).
-     *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
-     * @return The truth.
-     */
-    public boolean optBoolean(String key, boolean defaultValue) {
-        Object val = this.opt(key);
-        if (NULL.equals(val)) {
-            return defaultValue;
-        }
-        if (val instanceof Boolean){
-            return ((Boolean) val).booleanValue();
-        }
-        try {
-            // we'll use the get anyway because it does string conversion.
-            return this.getBoolean(key);
-        } catch (Exception e) {
-            return defaultValue;
-        }
-    }
-
-    /**
-     * Get an optional BigDecimal associated with a key, or the defaultValue if
-     * there is no such key or if its value is not a number. If the value is a
-     * string, an attempt will be made to evaluate it as a number. If the value
-     * is float or double, then the {@link BigDecimal#BigDecimal(double)}
-     * constructor will be used. See notes on the constructor for conversion
-     * issues that may arise.
-     *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
-     * @return An object which is the value.
-     */
-    public BigDecimal optBigDecimal(String key, BigDecimal defaultValue) {
-        Object val = this.opt(key);
-        return objectToBigDecimal(val, defaultValue);
-    }
-
-    /**
-     * @param val value to convert
-     * @param defaultValue default value to return is the conversion doesn't work or is null.
-     * @return BigDecimal conversion of the original value, or the defaultValue if unable
-     *          to convert.
-     */
-    static BigDecimal objectToBigDecimal(Object val, BigDecimal defaultValue) {
-        return objectToBigDecimal(val, defaultValue, true);
-    }
-    
-    /**
-     * @param val value to convert
-     * @param defaultValue default value to return is the conversion doesn't work or is null.
-     * @param exact When <code>true</code>, then {@link Double} and {@link Float} values will be converted exactly.
-     *      When <code>false</code>, they will be converted to {@link String} values before converting to {@link BigDecimal}.
-     * @return BigDecimal conversion of the original value, or the defaultValue if unable
-     *          to convert.
-     */
-    static BigDecimal objectToBigDecimal(Object val, BigDecimal defaultValue, boolean exact) {
-        if (NULL.equals(val)) {
-            return defaultValue;
-        }
-        if (val instanceof BigDecimal){
-            return (BigDecimal) val;
-        }
-        if (val instanceof BigInteger){
-            return new BigDecimal((BigInteger) val);
-        }
-        if (val instanceof Double || val instanceof Float){
-            if (!numberIsFinite((Number)val)) {
-                return defaultValue;
-            }
-            if (exact) {
-                return new BigDecimal(((Number)val).doubleValue());
-            }
-            // use the string constructor so that we maintain "nice" values for doubles and floats
-            // the double constructor will translate doubles to "exact" values instead of the likely
-            // intended representation
-            return new BigDecimal(val.toString());
-        }
-        if (val instanceof Long || val instanceof Integer
-                || val instanceof Short || val instanceof Byte){
-            return new BigDecimal(((Number) val).longValue());
-        }
-        // don't check if it's a string in case of unchecked Number subclasses
-        try {
-            return new BigDecimal(val.toString());
-        } catch (Exception e) {
-            return defaultValue;
-        }
-    }
-
-    /**
-     * Get an optional BigInteger associated with a key, or the defaultValue if
-     * there is no such key or if its value is not a number. If the value is a
-     * string, an attempt will be made to evaluate it as a number.
-     *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
-     * @return An object which is the value.
-     */
-    public BigInteger optBigInteger(String key, BigInteger defaultValue) {
-        Object val = this.opt(key);
-        return objectToBigInteger(val, defaultValue);
-    }
-
-    /**
-     * @param val value to convert
-     * @param defaultValue default value to return is the conversion doesn't work or is null.
-     * @return BigInteger conversion of the original value, or the defaultValue if unable
-     *          to convert.
-     */
-    static BigInteger objectToBigInteger(Object val, BigInteger defaultValue) {
-        if (NULL.equals(val)) {
-            return defaultValue;
-        }
-        if (val instanceof BigInteger){
-            return (BigInteger) val;
-        }
-        if (val instanceof BigDecimal){
-            return ((BigDecimal) val).toBigInteger();
-        }
-        if (val instanceof Double || val instanceof Float){
-            if (!numberIsFinite((Number)val)) {
-                return defaultValue;
-            }
-            return new BigDecimal(((Number) val).doubleValue()).toBigInteger();
-        }
-        if (val instanceof Long || val instanceof Integer
-                || val instanceof Short || val instanceof Byte){
-            return BigInteger.valueOf(((Number) val).longValue());
-        }
-        // don't check if it's a string in case of unchecked Number subclasses
-        try {
-            // the other opt functions handle implicit conversions, i.e.
-            // jo.put("double",1.1d);
-            // jo.optInt("double"); -- will return 1, not an error
-            // this conversion to BigDecimal then to BigInteger is to maintain
-            // that type cast support that may truncate the decimal.
-            final String valStr = val.toString();
-            if(isDecimalNotation(valStr)) {
-                return new BigDecimal(valStr).toBigInteger();
-            }
-            return new BigInteger(valStr);
-        } catch (Exception e) {
-            return defaultValue;
-        }
-    }
-
-    /**
-     * Get an optional double associated with a key, or NaN if there is no such
-     * key or if its value is not a number. If the value is a string, an attempt
-     * will be made to evaluate it as a number.
-     *
-     * @param key
-     *            A string which is the key.
-     * @return An object which is the value.
-     */
-    public double optDouble(String key) {
-        return this.optDouble(key, Double.NaN);
-    }
-
-    /**
-     * Get an optional double associated with a key, or the defaultValue if
-     * there is no such key or if its value is not a number. If the value is a
-     * string, an attempt will be made to evaluate it as a number.
-     *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
-     * @return An object which is the value.
-     */
-    public double optDouble(String key, double defaultValue) {
-        Number val = this.optNumber(key);
-        if (val == null) {
-            return defaultValue;
-        }
-        final double doubleValue = val.doubleValue();
-        // if (Double.isNaN(doubleValue) || Double.isInfinite(doubleValue)) {
-        // return defaultValue;
-        // }
-        return doubleValue;
-    }
-
-    /**
-     * Get the optional double value associated with an index. NaN is returned
-     * if there is no value for the index, or if the value is not a number and
-     * cannot be converted to a number.
-     *
-     * @param key
-     *            A key string.
-     * @return The value.
-     */
-    public float optFloat(String key) {
-        return this.optFloat(key, Float.NaN);
-    }
-
-    /**
-     * Get the optional double value associated with an index. The defaultValue
-     * is returned if there is no value for the index, or if the value is not a
-     * number and cannot be converted to a number.
-     *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default value.
-     * @return The value.
-     */
-    public float optFloat(String key, float defaultValue) {
-        Number val = this.optNumber(key);
-        if (val == null) {
-            return defaultValue;
-        }
-        final float floatValue = val.floatValue();
-        // if (Float.isNaN(floatValue) || Float.isInfinite(floatValue)) {
-        // return defaultValue;
-        // }
-        return floatValue;
-    }
-
-    /**
-     * Get an optional int value associated with a key, or zero if there is no
-     * such key or if the value is not a number. If the value is a string, an
-     * attempt will be made to evaluate it as a number.
-     *
-     * @param key
-     *            A key string.
-     * @return An object which is the value.
-     */
-    public int optInt(String key) {
-        return this.optInt(key, 0);
-    }
-
-    /**
-     * Get an optional int value associated with a key, or the default if there
-     * is no such key or if the value is not a number. If the value is a string,
-     * an attempt will be made to evaluate it as a number.
-     *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
-     * @return An object which is the value.
-     */
-    public int optInt(String key, int defaultValue) {
-        final Number val = this.optNumber(key, null);
-        if (val == null) {
-            return defaultValue;
-        }
-        return val.intValue();
-    }
-
-    /**
-     * Get an optional JSONArray associated with a key. It returns null if there
-     * is no such key, or if its value is not a JSONArray.
-     *
-     * @param key
-     *            A key string.
-     * @return A JSONArray which is the value.
-     */
-    public JSONArray optJSONArray(String key) {
-        Object o = this.opt(key);
-        return o instanceof JSONArray ? (JSONArray) o : null;
-    }
-
-    /**
-     * Get an optional JSONObject associated with a key. It returns null if
-     * there is no such key, or if its value is not a JSONObject.
-     *
-     * @param key
-     *            A key string.
-     * @return A JSONObject which is the value.
-     */
-    public JSONObject optJSONObject(String key) { return this.optJSONObject(key, null); }
-
-    /**
-     * Get an optional JSONObject associated with a key, or the default if there
-     * is no such key or if the value is not a JSONObject.
-     *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
-     * @return An JSONObject which is the value.
-     */
-    public JSONObject optJSONObject(String key, JSONObject defaultValue) {
-        Object object = this.opt(key);
-        return object instanceof JSONObject ? (JSONObject) object : defaultValue;
-    }
-
-    /**
-     * Get an optional long value associated with a key, or zero if there is no
-     * such key or if the value is not a number. If the value is a string, an
-     * attempt will be made to evaluate it as a number.
-     *
-     * @param key
-     *            A key string.
-     * @return An object which is the value.
-     */
-    public long optLong(String key) {
-        return this.optLong(key, 0);
-    }
-
-    /**
-     * Get an optional long value associated with a key, or the default if there
-     * is no such key or if the value is not a number. If the value is a string,
-     * an attempt will be made to evaluate it as a number.
-     *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
-     * @return An object which is the value.
-     */
-    public long optLong(String key, long defaultValue) {
-        final Number val = this.optNumber(key, null);
-        if (val == null) {
-            return defaultValue;
-        }
-
-        return val.longValue();
-    }
-
-    /**
-     * Get an optional {@link Number} value associated with a key, or <code>null</code>
-     * if there is no such key or if the value is not a number. If the value is a string,
-     * an attempt will be made to evaluate it as a number ({@link BigDecimal}). This method
-     * would be used in cases where type coercion of the number value is unwanted.
-     *
-     * @param key
-     *            A key string.
-     * @return An object which is the value.
-     */
-    public Number optNumber(String key) {
-        return this.optNumber(key, null);
-    }
-
-    /**
-     * Get an optional {@link Number} value associated with a key, or the default if there
-     * is no such key or if the value is not a number. If the value is a string,
-     * an attempt will be made to evaluate it as a number. This method
-     * would be used in cases where type coercion of the number value is unwanted.
-     *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
-     * @return An object which is the value.
-     */
-    public Number optNumber(String key, Number defaultValue) {
-        Object val = this.opt(key);
-        if (NULL.equals(val)) {
-            return defaultValue;
-        }
-        if (val instanceof Number){
-            return (Number) val;
-        }
-
-        try {
-            return stringToNumber(val.toString());
-        } catch (Exception e) {
-            return defaultValue;
-        }
-    }
-
-    /**
-     * Get an optional string associated with a key. It returns an empty string
-     * if there is no such key. If the value is not a string and is not null,
-     * then it is converted to a string.
-     *
-     * @param key
-     *            A key string.
-     * @return A string which is the value.
-     */
-    public String optString(String key) {
-        return this.optString(key, "");
-    }
-
-    /**
-     * Get an optional string associated with a key. It returns the defaultValue
-     * if there is no such key.
-     *
-     * @param key
-     *            A key string.
-     * @param defaultValue
-     *            The default.
-     * @return A string which is the value.
-     */
-    public String optString(String key, String defaultValue) {
-        Object object = this.opt(key);
-        return NULL.equals(object) ? defaultValue : object.toString();
-    }
-
-    /**
-     * Put a key/boolean pair in the JSONObject.
-     *
-     * @param key
-     *            A key string.
-     * @param value
-     *            A boolean which is the value.
-     * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
-     */
-    public JSONObject put(String key, boolean value) throws JSONException {
-        return this.put(key, value ? Boolean.TRUE : Boolean.FALSE);
-    }
-
-    /**
-     * Put a key/double pair in the JSONObject.
-     *
-     * @param key
-     *            A key string.
-     * @param value
-     *            A double which is the value.
-     * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
-     */
-    public JSONObject put(String key, double value) throws JSONException {
-        return this.put(key, Double.valueOf(value));
-    }
-
-    /**
-     * Put a key/float pair in the JSONObject.
-     *
-     * @param key
-     *            A key string.
-     * @param value
-     *            A float which is the value.
-     * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
-     */
-    public JSONObject put(String key, float value) throws JSONException {
-        return this.put(key, Float.valueOf(value));
-    }
-
-    /**
-     * Put a key/int pair in the JSONObject.
-     *
-     * @param key
-     *            A key string.
-     * @param value
-     *            An int which is the value.
-     * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
-     */
-    public JSONObject put(String key, int value) throws JSONException {
-        return this.put(key, Integer.valueOf(value));
-    }
-
-    /**
-     * Put a key/long pair in the JSONObject.
-     *
-     * @param key
-     *            A key string.
-     * @param value
-     *            A long which is the value.
-     * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
-     */
-    public JSONObject put(String key, long value) throws JSONException {
-        return this.put(key, Long.valueOf(value));
-    }
-
-    /**
-     * Put a key/value pair in the JSONObject, where the value will be a
-     * JSONObject which is produced from a Map.
-     *
-     * @param key
-     *            A key string.
-     * @param value
-     *            A Map value.
-     * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
-     */
-    public JSONObject put(String key, Map<?, ?> value) throws JSONException {
-        return this.put(key, new JSONObject(value));
-    }
-
-    /**
-     * Put a key/value pair in the JSONObject. If the value is <code>null</code>, then the
-     * key will be removed from the JSONObject if it is present.
-     *
-     * @param key
-     *            A key string.
-     * @param value
-     *            An object which is the value. It should be of one of these
-     *            types: Boolean, Double, Integer, JSONArray, JSONObject, Long,
-     *            String, or the JSONObject.NULL object.
-     * @return this.
-     * @throws JSONException
-     *            If the value is non-finite number.
-     * @throws NullPointerException
-     *            If the key is <code>null</code>.
-     */
-    public JSONObject put(String key, Object value) throws JSONException {
-        if (key == null) {
-            throw new NullPointerException("Null key.");
-        }
+        // Only add value if non-null
+        Object value = x.nextValue();
         if (value != null) {
-            testValidity(value);
-            this.map.put(key, value);
-        } else {
-            this.remove(key);
+          this.put(key, value);
         }
-        return this;
+      }
+
+      // Pairs are separated by ','.
+
+      switch (x.nextClean()) {
+        case ';':
+        case ',':
+          if (x.nextClean() == '}') {
+            return;
+          }
+          x.back();
+          break;
+        case '}':
+          return;
+        default:
+          throw x.syntaxError("Expected a ',' or '}'");
+      }
+    }
+  }
+
+  /**
+   * Construct a JSONObject from a Map.
+   *
+   * @param m A map object that can be used to initialize the contents of the JSONObject.
+   * @throws JSONException If a value in the map is non-finite number.
+   * @throws NullPointerException If a key in the map is <code>null</code>
+   */
+  public JSONObject(Map<?, ?> m) {
+    if (m == null) {
+      this.map = new HashMap<String, Object>();
+    } else {
+      this.map = new HashMap<String, Object>(m.size());
+      for (final Entry<?, ?> e : m.entrySet()) {
+        if (e.getKey() == null) {
+          throw new NullPointerException("Null key.");
+        }
+        final Object value = e.getValue();
+        if (value != null) {
+          this.map.put(String.valueOf(e.getKey()), wrap(value));
+        }
+      }
+    }
+  }
+
+  /**
+   * Construct a JSONObject from an Object, using reflection to find the public members. The
+   * resulting JSONObject's keys will be the strings from the names array, and the values will be
+   * the field values associated with those keys in the object. If a key is not found or not
+   * visible, then it will not be copied into the new JSONObject.
+   *
+   * @param object An object that has fields that should be used to make a JSONObject.
+   * @param names An array of strings, the names of the fields to be obtained from the object.
+   */
+  public JSONObject(Object object, String... names) {
+    this(names.length);
+    Class<?> c = object.getClass();
+    for (int i = 0; i < names.length; i += 1) {
+      String name = names[i];
+      try {
+        this.putOpt(name, c.getField(name).get(object));
+      } catch (Exception ignore) {
+      }
+    }
+  }
+
+  /**
+   * Construct a JSONObject from a source JSON text string. This is the most commonly used
+   * JSONObject constructor.
+   *
+   * @param source A string beginning with <code>{</code>&nbsp;<small>(left brace)</small> and
+   *        ending with <code>}</code> &nbsp;<small>(right brace)</small>.
+   * @exception JSONException If there is a syntax error in the source string or a duplicated key.
+   */
+  public JSONObject(String source) throws JSONException {
+    this(new JSONTokener(source));
+  }
+
+  /**
+   * Construct a JSONObject from a ResourceBundle.
+   *
+   * @param baseName The ResourceBundle base name.
+   * @param locale The Locale to load the ResourceBundle for.
+   * @throws JSONException If any JSONExceptions are detected.
+   */
+  public JSONObject(String baseName, Locale locale) throws JSONException {
+    this();
+    ResourceBundle bundle = ResourceBundle.getBundle(baseName, locale,
+        Thread.currentThread().getContextClassLoader());
+
+    // Iterate through the keys in the bundle.
+
+    Enumeration<String> keys = bundle.getKeys();
+    while (keys.hasMoreElements()) {
+      Object key = keys.nextElement();
+      if (key != null) {
+
+        // Go through the path, ensuring that there is a nested JSONObject for each
+        // segment except the last. Add the value using the last segment's name into
+        // the deepest nested JSONObject.
+
+        String[] path = ((String) key).split("\\.");
+        int last = path.length - 1;
+        JSONObject target = this;
+        for (int i = 0; i < last; i += 1) {
+          String segment = path[i];
+          JSONObject nextTarget = target.optJSONObject(segment);
+          if (nextTarget == null) {
+            nextTarget = new JSONObject();
+            target.put(segment, nextTarget);
+          }
+          target = nextTarget;
+        }
+        target.put(path[last], bundle.getString((String) key));
+      }
+    }
+  }
+
+  /**
+   * Constructor to specify an initial capacity of the internal map. Useful for library internal
+   * calls where we know, or at least can best guess, how big this JSONObject will be.
+   *
+   * @param initialCapacity initial capacity of the internal map.
+   */
+  protected JSONObject(int initialCapacity) {
+    this.map = new HashMap<String, Object>(initialCapacity);
+  }
+
+  /**
+   * Accumulate values under a key. It is similar to the put method except that if there is already
+   * an object stored under the key then a JSONArray is stored under the key to hold all of the
+   * accumulated values. If there is already a JSONArray, then the new value is appended to it. In
+   * contrast, the put method replaces the previous value.
+   *
+   * If only one value is accumulated that is not a JSONArray, then the result will be the same as
+   * using put. But if multiple values are accumulated, then the result will be like append.
+   *
+   * @param key A key string.
+   * @param value An object to be accumulated under the key.
+   * @return this.
+   * @throws JSONException If the value is non-finite number.
+   * @throws NullPointerException If the key is <code>null</code>.
+   */
+  public JSONObject accumulate(String key, Object value) throws JSONException {
+    testValidity(value);
+    Object object = this.opt(key);
+    if (object == null) {
+      this.put(key,
+          value instanceof JSONArray ? new JSONArray().put(value)
+              : value);
+    } else if (object instanceof JSONArray) {
+      ((JSONArray) object).put(value);
+    } else {
+      this.put(key, new JSONArray().put(object).put(value));
+    }
+    return this;
+  }
+
+  /**
+   * Append values to the array under a key. If the key does not exist in the JSONObject, then the
+   * key is put in the JSONObject with its value being a JSONArray containing the value parameter.
+   * If the key was already associated with a JSONArray, then the value parameter is appended to it.
+   *
+   * @param key A key string.
+   * @param value An object to be accumulated under the key.
+   * @return this.
+   * @throws JSONException If the value is non-finite number or if the current value associated with
+   *         the key is not a JSONArray.
+   * @throws NullPointerException If the key is <code>null</code>.
+   */
+  public JSONObject append(String key, Object value) throws JSONException {
+    testValidity(value);
+    Object object = this.opt(key);
+    if (object == null) {
+      this.put(key, new JSONArray().put(value));
+    } else if (object instanceof JSONArray) {
+      this.put(key, ((JSONArray) object).put(value));
+    } else {
+      throw wrongValueFormatException(key, "JSONArray", null, null);
+    }
+    return this;
+  }
+
+  /**
+   * Produce a string from a double. The string "null" will be returned if the number is not finite.
+   *
+   * @param d A double.
+   * @return A String.
+   */
+  public static String doubleToString(double d) {
+    if (Double.isInfinite(d) || Double.isNaN(d)) {
+      return "null";
     }
 
-    /**
-     * Put a key/value pair in the JSONObject, but only if the key and the value
-     * are both non-null, and only if there is not already a member with that
-     * name.
-     *
-     * @param key
-     *            key to insert into
-     * @param value
-     *            value to insert
-     * @return this.
-     * @throws JSONException
-     *             if the key is a duplicate
-     */
-    public JSONObject putOnce(String key, Object value) throws JSONException {
-        if (key != null && value != null) {
-            if (this.opt(key) != null) {
-                throw new JSONException("Duplicate key \"" + key + "\"");
-            }
-            return this.put(key, value);
-        }
-        return this;
+    // Shave off trailing zeros and decimal point, if possible.
+
+    String string = Double.toString(d);
+    if (string.indexOf('.') > 0 && string.indexOf('e') < 0
+        && string.indexOf('E') < 0) {
+      while (string.endsWith("0")) {
+        string = string.substring(0, string.length() - 1);
+      }
+      if (string.endsWith(".")) {
+        string = string.substring(0, string.length() - 1);
+      }
+    }
+    return string;
+  }
+
+  /**
+   * Get the value object associated with a key.
+   *
+   * @param key A key string.
+   * @return The object associated with the key.
+   * @throws JSONException if the key is not found.
+   */
+  public Object get(String key) throws JSONException {
+    if (key == null) {
+      throw new JSONException("Null key.");
+    }
+    Object object = this.opt(key);
+    if (object == null) {
+      throw new JSONException("JSONObject[" + quote(key) + "] not found.");
+    }
+    return object;
+  }
+
+  /**
+   * Get the enum value associated with a key.
+   *
+   * @param <E> Enum Type
+   * @param clazz The type of enum to retrieve.
+   * @param key A key string.
+   * @return The enum value associated with the key
+   * @throws JSONException if the key is not found or if the value cannot be converted to an enum.
+   */
+  public <E extends Enum<E>> E getEnum(Class<E> clazz, String key) throws JSONException {
+    E val = optEnum(clazz, key);
+    if (val == null) {
+      // JSONException should really take a throwable argument.
+      // If it did, I would re-implement this with the Enum.valueOf
+      // method and place any thrown exception in the JSONException
+      throw wrongValueFormatException(key, "enum of type " + quote(clazz.getSimpleName()), opt(key),
+          null);
+    }
+    return val;
+  }
+
+  /**
+   * Get the boolean value associated with a key.
+   *
+   * @param key A key string.
+   * @return The truth.
+   * @throws JSONException if the value is not a Boolean or the String "true" or "false".
+   */
+  public boolean getBoolean(String key) throws JSONException {
+    Object object = this.get(key);
+    if (object.equals(Boolean.FALSE)
+        || (object instanceof String && ((String) object)
+            .equalsIgnoreCase("false"))) {
+      return false;
+    } else if (object.equals(Boolean.TRUE)
+        || (object instanceof String && ((String) object)
+            .equalsIgnoreCase("true"))) {
+      return true;
+    }
+    throw wrongValueFormatException(key, "Boolean", object, null);
+  }
+
+  /**
+   * Get the BigInteger value associated with a key.
+   *
+   * @param key A key string.
+   * @return The numeric value.
+   * @throws JSONException if the key is not found or if the value cannot be converted to
+   *         BigInteger.
+   */
+  public BigInteger getBigInteger(String key) throws JSONException {
+    Object object = this.get(key);
+    BigInteger ret = objectToBigInteger(object, null);
+    if (ret != null) {
+      return ret;
+    }
+    throw wrongValueFormatException(key, "BigInteger", object, null);
+  }
+
+  /**
+   * Get the BigDecimal value associated with a key. If the value is float or double, the
+   * {@link BigDecimal#BigDecimal(double)} constructor will be used. See notes on the constructor
+   * for conversion issues that may arise.
+   *
+   * @param key A key string.
+   * @return The numeric value.
+   * @throws JSONException if the key is not found or if the value cannot be converted to
+   *         BigDecimal.
+   */
+  public BigDecimal getBigDecimal(String key) throws JSONException {
+    Object object = this.get(key);
+    BigDecimal ret = objectToBigDecimal(object, null);
+    if (ret != null) {
+      return ret;
+    }
+    throw wrongValueFormatException(key, "BigDecimal", object, null);
+  }
+
+  /**
+   * Get the double value associated with a key.
+   *
+   * @param key A key string.
+   * @return The numeric value.
+   * @throws JSONException if the key is not found or if the value is not a Number object and cannot
+   *         be converted to a number.
+   */
+  public double getDouble(String key) throws JSONException {
+    final Object object = this.get(key);
+    if (object instanceof Number) {
+      return ((Number) object).doubleValue();
+    }
+    try {
+      return Double.parseDouble(object.toString());
+    } catch (Exception e) {
+      throw wrongValueFormatException(key, "double", object, e);
+    }
+  }
+
+  /**
+   * Get the float value associated with a key.
+   *
+   * @param key A key string.
+   * @return The numeric value.
+   * @throws JSONException if the key is not found or if the value is not a Number object and cannot
+   *         be converted to a number.
+   */
+  public float getFloat(String key) throws JSONException {
+    final Object object = this.get(key);
+    if (object instanceof Number) {
+      return ((Number) object).floatValue();
+    }
+    try {
+      return Float.parseFloat(object.toString());
+    } catch (Exception e) {
+      throw wrongValueFormatException(key, "float", object, e);
+    }
+  }
+
+  /**
+   * Get the Number value associated with a key.
+   *
+   * @param key A key string.
+   * @return The numeric value.
+   * @throws JSONException if the key is not found or if the value is not a Number object and cannot
+   *         be converted to a number.
+   */
+  public Number getNumber(String key) throws JSONException {
+    Object object = this.get(key);
+    try {
+      if (object instanceof Number) {
+        return (Number) object;
+      }
+      return stringToNumber(object.toString());
+    } catch (Exception e) {
+      throw wrongValueFormatException(key, "number", object, e);
+    }
+  }
+
+  /**
+   * Get the int value associated with a key.
+   *
+   * @param key A key string.
+   * @return The integer value.
+   * @throws JSONException if the key is not found or if the value cannot be converted to an
+   *         integer.
+   */
+  public int getInt(String key) throws JSONException {
+    final Object object = this.get(key);
+    if (object instanceof Number) {
+      return ((Number) object).intValue();
+    }
+    try {
+      return Integer.parseInt(object.toString());
+    } catch (Exception e) {
+      throw wrongValueFormatException(key, "int", object, e);
+    }
+  }
+
+  /**
+   * Get the JSONArray value associated with a key.
+   *
+   * @param key A key string.
+   * @return A JSONArray which is the value.
+   * @throws JSONException if the key is not found or if the value is not a JSONArray.
+   */
+  public JSONArray getJSONArray(String key) throws JSONException {
+    Object object = this.get(key);
+    if (object instanceof JSONArray) {
+      return (JSONArray) object;
+    }
+    throw wrongValueFormatException(key, "JSONArray", object, null);
+  }
+
+  /**
+   * Get the JSONObject value associated with a key.
+   *
+   * @param key A key string.
+   * @return A JSONObject which is the value.
+   * @throws JSONException if the key is not found or if the value is not a JSONObject.
+   */
+  public JSONObject getJSONObject(String key) throws JSONException {
+    Object object = this.get(key);
+    if (object instanceof JSONObject) {
+      return (JSONObject) object;
+    }
+    throw wrongValueFormatException(key, "JSONObject", object, null);
+  }
+
+  /**
+   * Get the long value associated with a key.
+   *
+   * @param key A key string.
+   * @return The long value.
+   * @throws JSONException if the key is not found or if the value cannot be converted to a long.
+   */
+  public long getLong(String key) throws JSONException {
+    final Object object = this.get(key);
+    if (object instanceof Number) {
+      return ((Number) object).longValue();
+    }
+    try {
+      return Long.parseLong(object.toString());
+    } catch (Exception e) {
+      throw wrongValueFormatException(key, "long", object, e);
+    }
+  }
+
+  /**
+   * Get an array of field names from a JSONObject.
+   *
+   * @param jo JSON object
+   * @return An array of field names, or null if there are no names.
+   */
+  public static String[] getNames(JSONObject jo) {
+    if (jo.isEmpty()) {
+      return null;
+    }
+    return jo.keySet().toArray(new String[jo.length()]);
+  }
+
+  /**
+   * Get an array of public field names from an Object.
+   *
+   * @param object object to read
+   * @return An array of field names, or null if there are no names.
+   */
+  public static String[] getNames(Object object) {
+    if (object == null) {
+      return null;
+    }
+    Class<?> klass = object.getClass();
+    Field[] fields = klass.getFields();
+    int length = fields.length;
+    if (length == 0) {
+      return null;
+    }
+    String[] names = new String[length];
+    for (int i = 0; i < length; i += 1) {
+      names[i] = fields[i].getName();
+    }
+    return names;
+  }
+
+  /**
+   * Get the string associated with a key.
+   *
+   * @param key A key string.
+   * @return A string which is the value.
+   * @throws JSONException if there is no string value for the key.
+   */
+  public String getString(String key) throws JSONException {
+    Object object = this.get(key);
+    if (object instanceof String) {
+      return (String) object;
+    }
+    throw wrongValueFormatException(key, "string", object, null);
+  }
+
+  /**
+   * Determine if the JSONObject contains a specific key.
+   *
+   * @param key A key string.
+   * @return true if the key exists in the JSONObject.
+   */
+  public boolean has(String key) {
+    return this.map.containsKey(key);
+  }
+
+  /**
+   * Increment a property of a JSONObject. If there is no such property, create one with a value of
+   * 1 (Integer). If there is such a property, and if it is an Integer, Long, Double, Float,
+   * BigInteger, or BigDecimal then add one to it. No overflow bounds checking is performed, so
+   * callers should initialize the key prior to this call with an appropriate type that can handle
+   * the maximum expected value.
+   *
+   * @param key A key string.
+   * @return this.
+   * @throws JSONException If there is already a property with this name that is not an Integer,
+   *         Long, Double, or Float.
+   */
+  public JSONObject increment(String key) throws JSONException {
+    Object value = this.opt(key);
+    if (value == null) {
+      this.put(key, 1);
+    } else if (value instanceof Integer) {
+      this.put(key, ((Integer) value).intValue() + 1);
+    } else if (value instanceof Long) {
+      this.put(key, ((Long) value).longValue() + 1L);
+    } else if (value instanceof BigInteger) {
+      this.put(key, ((BigInteger) value).add(BigInteger.ONE));
+    } else if (value instanceof Float) {
+      this.put(key, ((Float) value).floatValue() + 1.0f);
+    } else if (value instanceof Double) {
+      this.put(key, ((Double) value).doubleValue() + 1.0d);
+    } else if (value instanceof BigDecimal) {
+      this.put(key, ((BigDecimal) value).add(BigDecimal.ONE));
+    } else {
+      throw new JSONException("Unable to increment [" + quote(key) + "].");
+    }
+    return this;
+  }
+
+  /**
+   * Determine if the value associated with the key is <code>null</code> or if there is no value.
+   *
+   * @param key A key string.
+   * @return true if there is no value associated with the key or if the value is the
+   *         JSONObject.NULL object.
+   */
+  public boolean isNull(String key) {
+    return JSONObject.NULL.equals(this.opt(key));
+  }
+
+  /**
+   * Get an enumeration of the keys of the JSONObject. Modifying this key Set will also modify the
+   * JSONObject. Use with caution.
+   *
+   * @see Set#iterator()
+   *
+   * @return An iterator of the keys.
+   */
+  public Iterator<String> keys() {
+    return this.keySet().iterator();
+  }
+
+  /**
+   * Get a set of keys of the JSONObject. Modifying this key Set will also modify the JSONObject.
+   * Use with caution.
+   *
+   * @see Map#keySet()
+   *
+   * @return A keySet.
+   */
+  public Set<String> keySet() {
+    return this.map.keySet();
+  }
+
+  /**
+   * Get a set of entries of the JSONObject. These are raw values and may not match what is returned
+   * by the JSONObject get* and opt* functions. Modifying the returned EntrySet or the Entry objects
+   * contained therein will modify the backing JSONObject. This does not return a clone or a
+   * read-only view.
+   *
+   * Use with caution.
+   *
+   * @see Map#entrySet()
+   *
+   * @return An Entry Set
+   */
+  protected Set<Entry<String, Object>> entrySet() {
+    return this.map.entrySet();
+  }
+
+  /**
+   * Get the number of keys stored in the JSONObject.
+   *
+   * @return The number of keys in the JSONObject.
+   */
+  public int length() {
+    return this.map.size();
+  }
+
+  /**
+   * Removes all of the elements from this JSONObject. The JSONObject will be empty after this call
+   * returns.
+   */
+  public void clear() {
+    this.map.clear();
+  }
+
+  /**
+   * Check if JSONObject is empty.
+   *
+   * @return true if JSONObject is empty, otherwise false.
+   */
+  public boolean isEmpty() {
+    return this.map.isEmpty();
+  }
+
+  /**
+   * Produce a string from a Number.
+   *
+   * @param number A Number
+   * @return A String.
+   * @throws JSONException If n is a non-finite number.
+   */
+  public static String numberToString(Number number) throws JSONException {
+    if (number == null) {
+      throw new JSONException("Null pointer");
+    }
+    testValidity(number);
+
+    // Shave off trailing zeros and decimal point, if possible.
+
+    String string = number.toString();
+    if (string.indexOf('.') > 0 && string.indexOf('e') < 0
+        && string.indexOf('E') < 0) {
+      while (string.endsWith("0")) {
+        string = string.substring(0, string.length() - 1);
+      }
+      if (string.endsWith(".")) {
+        string = string.substring(0, string.length() - 1);
+      }
+    }
+    return string;
+  }
+
+  /**
+   * Get an optional value associated with a key.
+   *
+   * @param key A key string.
+   * @return An object which is the value, or null if there is no value.
+   */
+  public Object opt(String key) {
+    return key == null ? null : this.map.get(key);
+  }
+
+  /**
+   * Get the enum value associated with a key.
+   *
+   * @param <E> Enum Type
+   * @param clazz The type of enum to retrieve.
+   * @param key A key string.
+   * @return The enum value associated with the key or null if not found
+   */
+  public <E extends Enum<E>> E optEnum(Class<E> clazz, String key) {
+    return this.optEnum(clazz, key, null);
+  }
+
+  /**
+   * Get the enum value associated with a key.
+   *
+   * @param <E> Enum Type
+   * @param clazz The type of enum to retrieve.
+   * @param key A key string.
+   * @param defaultValue The default in case the value is not found
+   * @return The enum value associated with the key or defaultValue if the value is not found or
+   *         cannot be assigned to <code>clazz</code>
+   */
+  public <E extends Enum<E>> E optEnum(Class<E> clazz, String key, E defaultValue) {
+    try {
+      Object val = this.opt(key);
+      if (NULL.equals(val)) {
+        return defaultValue;
+      }
+      if (clazz.isAssignableFrom(val.getClass())) {
+        // we just checked it!
+        @SuppressWarnings("unchecked")
+        E myE = (E) val;
+        return myE;
+      }
+      return Enum.valueOf(clazz, val.toString());
+    } catch (IllegalArgumentException e) {
+      return defaultValue;
+    } catch (NullPointerException e) {
+      return defaultValue;
+    }
+  }
+
+  /**
+   * Get an optional boolean associated with a key. It returns false if there is no such key, or if
+   * the value is not Boolean.TRUE or the String "true".
+   *
+   * @param key A key string.
+   * @return The truth.
+   */
+  public boolean optBoolean(String key) {
+    return this.optBoolean(key, false);
+  }
+
+  /**
+   * Get an optional boolean associated with a key. It returns the defaultValue if there is no such
+   * key, or if it is not a Boolean or the String "true" or "false" (case insensitive).
+   *
+   * @param key A key string.
+   * @param defaultValue The default.
+   * @return The truth.
+   */
+  public boolean optBoolean(String key, boolean defaultValue) {
+    Object val = this.opt(key);
+    if (NULL.equals(val)) {
+      return defaultValue;
+    }
+    if (val instanceof Boolean) {
+      return ((Boolean) val).booleanValue();
+    }
+    try {
+      // we'll use the get anyway because it does string conversion.
+      return this.getBoolean(key);
+    } catch (Exception e) {
+      return defaultValue;
+    }
+  }
+
+  /**
+   * Get an optional BigDecimal associated with a key, or the defaultValue if there is no such key
+   * or if its value is not a number. If the value is a string, an attempt will be made to evaluate
+   * it as a number. If the value is float or double, then the {@link BigDecimal#BigDecimal(double)}
+   * constructor will be used. See notes on the constructor for conversion issues that may arise.
+   *
+   * @param key A key string.
+   * @param defaultValue The default.
+   * @return An object which is the value.
+   */
+  public BigDecimal optBigDecimal(String key, BigDecimal defaultValue) {
+    Object val = this.opt(key);
+    return objectToBigDecimal(val, defaultValue);
+  }
+
+  /**
+   * @param val value to convert
+   * @param defaultValue default value to return is the conversion doesn't work or is null.
+   * @return BigDecimal conversion of the original value, or the defaultValue if unable to convert.
+   */
+  static BigDecimal objectToBigDecimal(Object val, BigDecimal defaultValue) {
+    return objectToBigDecimal(val, defaultValue, true);
+  }
+
+  /**
+   * @param val value to convert
+   * @param defaultValue default value to return is the conversion doesn't work or is null.
+   * @param exact When <code>true</code>, then {@link Double} and {@link Float} values will be
+   *        converted exactly. When <code>false</code>, they will be converted to {@link String}
+   *        values before converting to {@link BigDecimal}.
+   * @return BigDecimal conversion of the original value, or the defaultValue if unable to convert.
+   */
+  static BigDecimal objectToBigDecimal(Object val, BigDecimal defaultValue, boolean exact) {
+    if (NULL.equals(val)) {
+      return defaultValue;
+    }
+    if (val instanceof BigDecimal) {
+      return (BigDecimal) val;
+    }
+    if (val instanceof BigInteger) {
+      return new BigDecimal((BigInteger) val);
+    }
+    if (val instanceof Double || val instanceof Float) {
+      if (!numberIsFinite((Number) val)) {
+        return defaultValue;
+      }
+      if (exact) {
+        return new BigDecimal(((Number) val).doubleValue());
+      }
+      // use the string constructor so that we maintain "nice" values for doubles and floats
+      // the double constructor will translate doubles to "exact" values instead of the likely
+      // intended representation
+      return new BigDecimal(val.toString());
+    }
+    if (val instanceof Long || val instanceof Integer
+        || val instanceof Short || val instanceof Byte) {
+      return new BigDecimal(((Number) val).longValue());
+    }
+    // don't check if it's a string in case of unchecked Number subclasses
+    try {
+      return new BigDecimal(val.toString());
+    } catch (Exception e) {
+      return defaultValue;
+    }
+  }
+
+  /**
+   * Get an optional BigInteger associated with a key, or the defaultValue if there is no such key
+   * or if its value is not a number. If the value is a string, an attempt will be made to evaluate
+   * it as a number.
+   *
+   * @param key A key string.
+   * @param defaultValue The default.
+   * @return An object which is the value.
+   */
+  public BigInteger optBigInteger(String key, BigInteger defaultValue) {
+    Object val = this.opt(key);
+    return objectToBigInteger(val, defaultValue);
+  }
+
+  /**
+   * @param val value to convert
+   * @param defaultValue default value to return is the conversion doesn't work or is null.
+   * @return BigInteger conversion of the original value, or the defaultValue if unable to convert.
+   */
+  static BigInteger objectToBigInteger(Object val, BigInteger defaultValue) {
+    if (NULL.equals(val)) {
+      return defaultValue;
+    }
+    if (val instanceof BigInteger) {
+      return (BigInteger) val;
+    }
+    if (val instanceof BigDecimal) {
+      return ((BigDecimal) val).toBigInteger();
+    }
+    if (val instanceof Double || val instanceof Float) {
+      if (!numberIsFinite((Number) val)) {
+        return defaultValue;
+      }
+      return new BigDecimal(((Number) val).doubleValue()).toBigInteger();
+    }
+    if (val instanceof Long || val instanceof Integer
+        || val instanceof Short || val instanceof Byte) {
+      return BigInteger.valueOf(((Number) val).longValue());
+    }
+    // don't check if it's a string in case of unchecked Number subclasses
+    try {
+      // the other opt functions handle implicit conversions, i.e.
+      // jo.put("double",1.1d);
+      // jo.optInt("double"); -- will return 1, not an error
+      // this conversion to BigDecimal then to BigInteger is to maintain
+      // that type cast support that may truncate the decimal.
+      final String valStr = val.toString();
+      if (isDecimalNotation(valStr)) {
+        return new BigDecimal(valStr).toBigInteger();
+      }
+      return new BigInteger(valStr);
+    } catch (Exception e) {
+      return defaultValue;
+    }
+  }
+
+  /**
+   * Get an optional double associated with a key, or NaN if there is no such key or if its value is
+   * not a number. If the value is a string, an attempt will be made to evaluate it as a number.
+   *
+   * @param key A string which is the key.
+   * @return An object which is the value.
+   */
+  public double optDouble(String key) {
+    return this.optDouble(key, Double.NaN);
+  }
+
+  /**
+   * Get an optional double associated with a key, or the defaultValue if there is no such key or if
+   * its value is not a number. If the value is a string, an attempt will be made to evaluate it as
+   * a number.
+   *
+   * @param key A key string.
+   * @param defaultValue The default.
+   * @return An object which is the value.
+   */
+  public double optDouble(String key, double defaultValue) {
+    Number val = this.optNumber(key);
+    if (val == null) {
+      return defaultValue;
+    }
+    final double doubleValue = val.doubleValue();
+    // if (Double.isNaN(doubleValue) || Double.isInfinite(doubleValue)) {
+    // return defaultValue;
+    // }
+    return doubleValue;
+  }
+
+  /**
+   * Get the optional double value associated with an index. NaN is returned if there is no value
+   * for the index, or if the value is not a number and cannot be converted to a number.
+   *
+   * @param key A key string.
+   * @return The value.
+   */
+  public float optFloat(String key) {
+    return this.optFloat(key, Float.NaN);
+  }
+
+  /**
+   * Get the optional double value associated with an index. The defaultValue is returned if there
+   * is no value for the index, or if the value is not a number and cannot be converted to a number.
+   *
+   * @param key A key string.
+   * @param defaultValue The default value.
+   * @return The value.
+   */
+  public float optFloat(String key, float defaultValue) {
+    Number val = this.optNumber(key);
+    if (val == null) {
+      return defaultValue;
+    }
+    final float floatValue = val.floatValue();
+    // if (Float.isNaN(floatValue) || Float.isInfinite(floatValue)) {
+    // return defaultValue;
+    // }
+    return floatValue;
+  }
+
+  /**
+   * Get an optional int value associated with a key, or zero if there is no such key or if the
+   * value is not a number. If the value is a string, an attempt will be made to evaluate it as a
+   * number.
+   *
+   * @param key A key string.
+   * @return An object which is the value.
+   */
+  public int optInt(String key) {
+    return this.optInt(key, 0);
+  }
+
+  /**
+   * Get an optional int value associated with a key, or the default if there is no such key or if
+   * the value is not a number. If the value is a string, an attempt will be made to evaluate it as
+   * a number.
+   *
+   * @param key A key string.
+   * @param defaultValue The default.
+   * @return An object which is the value.
+   */
+  public int optInt(String key, int defaultValue) {
+    final Number val = this.optNumber(key, null);
+    if (val == null) {
+      return defaultValue;
+    }
+    return val.intValue();
+  }
+
+  /**
+   * Get an optional JSONArray associated with a key. It returns null if there is no such key, or if
+   * its value is not a JSONArray.
+   *
+   * @param key A key string.
+   * @return A JSONArray which is the value.
+   */
+  public JSONArray optJSONArray(String key) {
+    Object o = this.opt(key);
+    return o instanceof JSONArray ? (JSONArray) o : null;
+  }
+
+  /**
+   * Get an optional JSONObject associated with a key. It returns null if there is no such key, or
+   * if its value is not a JSONObject.
+   *
+   * @param key A key string.
+   * @return A JSONObject which is the value.
+   */
+  public JSONObject optJSONObject(String key) {
+    return this.optJSONObject(key, null);
+  }
+
+  /**
+   * Get an optional JSONObject associated with a key, or the default if there is no such key or if
+   * the value is not a JSONObject.
+   *
+   * @param key A key string.
+   * @param defaultValue The default.
+   * @return An JSONObject which is the value.
+   */
+  public JSONObject optJSONObject(String key, JSONObject defaultValue) {
+    Object object = this.opt(key);
+    return object instanceof JSONObject ? (JSONObject) object : defaultValue;
+  }
+
+  /**
+   * Get an optional long value associated with a key, or zero if there is no such key or if the
+   * value is not a number. If the value is a string, an attempt will be made to evaluate it as a
+   * number.
+   *
+   * @param key A key string.
+   * @return An object which is the value.
+   */
+  public long optLong(String key) {
+    return this.optLong(key, 0);
+  }
+
+  /**
+   * Get an optional long value associated with a key, or the default if there is no such key or if
+   * the value is not a number. If the value is a string, an attempt will be made to evaluate it as
+   * a number.
+   *
+   * @param key A key string.
+   * @param defaultValue The default.
+   * @return An object which is the value.
+   */
+  public long optLong(String key, long defaultValue) {
+    final Number val = this.optNumber(key, null);
+    if (val == null) {
+      return defaultValue;
     }
 
-    /**
-     * Put a key/value pair in the JSONObject, but only if the key and the value
-     * are both non-null.
-     *
-     * @param key
-     *            A key string.
-     * @param value
-     *            An object which is the value. It should be of one of these
-     *            types: Boolean, Double, Integer, JSONArray, JSONObject, Long,
-     *            String, or the JSONObject.NULL object.
-     * @return this.
-     * @throws JSONException
-     *             If the value is a non-finite number.
-     */
-    public JSONObject putOpt(String key, Object value) throws JSONException {
-        if (key != null && value != null) {
-            return this.put(key, value);
-        }
-        return this;
+    return val.longValue();
+  }
+
+  /**
+   * Get an optional {@link Number} value associated with a key, or <code>null</code> if there is no
+   * such key or if the value is not a number. If the value is a string, an attempt will be made to
+   * evaluate it as a number ({@link BigDecimal}). This method would be used in cases where type
+   * coercion of the number value is unwanted.
+   *
+   * @param key A key string.
+   * @return An object which is the value.
+   */
+  public Number optNumber(String key) {
+    return this.optNumber(key, null);
+  }
+
+  /**
+   * Get an optional {@link Number} value associated with a key, or the default if there is no such
+   * key or if the value is not a number. If the value is a string, an attempt will be made to
+   * evaluate it as a number. This method would be used in cases where type coercion of the number
+   * value is unwanted.
+   *
+   * @param key A key string.
+   * @param defaultValue The default.
+   * @return An object which is the value.
+   */
+  public Number optNumber(String key, Number defaultValue) {
+    Object val = this.opt(key);
+    if (NULL.equals(val)) {
+      return defaultValue;
+    }
+    if (val instanceof Number) {
+      return (Number) val;
     }
 
-    /**
-     * Produce a string in double quotes with backslash sequences in all the
-     * right places. A backslash will be inserted within &lt;/, producing
-     * &lt;\/, allowing JSON text to be delivered in HTML. In JSON text, a
-     * string cannot contain a control character or an unescaped quote or
-     * backslash.
-     *
-     * @param string
-     *            A String
-     * @return A String correctly formatted for insertion in a JSON text.
-     */
-    @SuppressWarnings("resource")
-    public static String quote(String string) {
-        StringWriter sw = new StringWriter();
-        synchronized (sw.getBuffer()) {
-            try {
-                return quote(string, sw).toString();
-            } catch (IOException ignored) {
-                // will never happen - we are writing to a string writer
-                return "";
-            }
-        }
+    try {
+      return stringToNumber(val.toString());
+    } catch (Exception e) {
+      return defaultValue;
+    }
+  }
+
+  /**
+   * Get an optional string associated with a key. It returns an empty string if there is no such
+   * key. If the value is not a string and is not null, then it is converted to a string.
+   *
+   * @param key A key string.
+   * @return A string which is the value.
+   */
+  public String optString(String key) {
+    return this.optString(key, "");
+  }
+
+  /**
+   * Get an optional string associated with a key. It returns the defaultValue if there is no such
+   * key.
+   *
+   * @param key A key string.
+   * @param defaultValue The default.
+   * @return A string which is the value.
+   */
+  public String optString(String key, String defaultValue) {
+    Object object = this.opt(key);
+    return NULL.equals(object) ? defaultValue : object.toString();
+  }
+
+  /**
+   * Put a key/boolean pair in the JSONObject.
+   *
+   * @param key A key string.
+   * @param value A boolean which is the value.
+   * @return this.
+   * @throws JSONException If the value is non-finite number.
+   * @throws NullPointerException If the key is <code>null</code>.
+   */
+  public JSONObject put(String key, boolean value) throws JSONException {
+    return this.put(key, value ? Boolean.TRUE : Boolean.FALSE);
+  }
+
+  /**
+   * Put a key/double pair in the JSONObject.
+   *
+   * @param key A key string.
+   * @param value A double which is the value.
+   * @return this.
+   * @throws JSONException If the value is non-finite number.
+   * @throws NullPointerException If the key is <code>null</code>.
+   */
+  public JSONObject put(String key, double value) throws JSONException {
+    return this.put(key, Double.valueOf(value));
+  }
+
+  /**
+   * Put a key/float pair in the JSONObject.
+   *
+   * @param key A key string.
+   * @param value A float which is the value.
+   * @return this.
+   * @throws JSONException If the value is non-finite number.
+   * @throws NullPointerException If the key is <code>null</code>.
+   */
+  public JSONObject put(String key, float value) throws JSONException {
+    return this.put(key, Float.valueOf(value));
+  }
+
+  /**
+   * Put a key/int pair in the JSONObject.
+   *
+   * @param key A key string.
+   * @param value An int which is the value.
+   * @return this.
+   * @throws JSONException If the value is non-finite number.
+   * @throws NullPointerException If the key is <code>null</code>.
+   */
+  public JSONObject put(String key, int value) throws JSONException {
+    return this.put(key, Integer.valueOf(value));
+  }
+
+  /**
+   * Put a key/long pair in the JSONObject.
+   *
+   * @param key A key string.
+   * @param value A long which is the value.
+   * @return this.
+   * @throws JSONException If the value is non-finite number.
+   * @throws NullPointerException If the key is <code>null</code>.
+   */
+  public JSONObject put(String key, long value) throws JSONException {
+    return this.put(key, Long.valueOf(value));
+  }
+
+  /**
+   * Put a key/value pair in the JSONObject, where the value will be a JSONObject which is produced
+   * from a Map.
+   *
+   * @param key A key string.
+   * @param value A Map value.
+   * @return this.
+   * @throws JSONException If the value is non-finite number.
+   * @throws NullPointerException If the key is <code>null</code>.
+   */
+  public JSONObject put(String key, Map<?, ?> value) throws JSONException {
+    return this.put(key, new JSONObject(value));
+  }
+
+  /**
+   * Put a key/value pair in the JSONObject. If the value is <code>null</code>, then the key will be
+   * removed from the JSONObject if it is present.
+   *
+   * @param key A key string.
+   * @param value An object which is the value. It should be of one of these types: Boolean, Double,
+   *        Integer, JSONArray, JSONObject, Long, String, or the JSONObject.NULL object.
+   * @return this.
+   * @throws JSONException If the value is non-finite number.
+   * @throws NullPointerException If the key is <code>null</code>.
+   */
+  public JSONObject put(String key, Object value) throws JSONException {
+    if (key == null) {
+      throw new NullPointerException("Null key.");
+    }
+    if (value != null) {
+      testValidity(value);
+      this.map.put(key, value);
+    } else {
+      this.remove(key);
+    }
+    return this;
+  }
+
+  /**
+   * Put a key/value pair in the JSONObject, but only if the key and the value are both non-null,
+   * and only if there is not already a member with that name.
+   *
+   * @param key key to insert into
+   * @param value value to insert
+   * @return this.
+   * @throws JSONException if the key is a duplicate
+   */
+  public JSONObject putOnce(String key, Object value) throws JSONException {
+    if (key != null && value != null) {
+      if (this.opt(key) != null) {
+        throw new JSONException("Duplicate key \"" + key + "\"");
+      }
+      return this.put(key, value);
+    }
+    return this;
+  }
+
+  /**
+   * Put a key/value pair in the JSONObject, but only if the key and the value are both non-null.
+   *
+   * @param key A key string.
+   * @param value An object which is the value. It should be of one of these types: Boolean, Double,
+   *        Integer, JSONArray, JSONObject, Long, String, or the JSONObject.NULL object.
+   * @return this.
+   * @throws JSONException If the value is a non-finite number.
+   */
+  public JSONObject putOpt(String key, Object value) throws JSONException {
+    if (key != null && value != null) {
+      return this.put(key, value);
+    }
+    return this;
+  }
+
+  /**
+   * Produce a string in double quotes with backslash sequences in all the right places. A backslash
+   * will be inserted within &lt;/, producing &lt;\/, allowing JSON text to be delivered in HTML. In
+   * JSON text, a string cannot contain a control character or an unescaped quote or backslash.
+   *
+   * @param string A String
+   * @return A String correctly formatted for insertion in a JSON text.
+   */
+  @SuppressWarnings("resource")
+  public static String quote(String string) {
+    StringWriter sw = new StringWriter();
+    synchronized (sw.getBuffer()) {
+      try {
+        return quote(string, sw).toString();
+      } catch (IOException ignored) {
+        // will never happen - we are writing to a string writer
+        return "";
+      }
+    }
+  }
+
+  public static Writer quote(String string, Writer w) throws IOException {
+    if (string == null || string.isEmpty()) {
+      w.write("\"\"");
+      return w;
     }
 
-    public static Writer quote(String string, Writer w) throws IOException {
-        if (string == null || string.isEmpty()) {
-            w.write("\"\"");
-            return w;
-        }
+    char b;
+    char c = 0;
+    String hhhh;
+    int i;
+    int len = string.length();
 
-        char b;
-        char c = 0;
-        String hhhh;
-        int i;
-        int len = string.length();
+    w.write('"');
+    for (i = 0; i < len; i += 1) {
+      b = c;
+      c = string.charAt(i);
+      switch (c) {
+        case '\\':
+        case '"':
+          w.write('\\');
+          w.write(c);
+          break;
+        case '/':
+          if (b == '<') {
+            w.write('\\');
+          }
+          w.write(c);
+          break;
+        case '\b':
+          w.write("\\b");
+          break;
+        case '\t':
+          w.write("\\t");
+          break;
+        case '\n':
+          w.write("\\n");
+          break;
+        case '\f':
+          w.write("\\f");
+          break;
+        case '\r':
+          w.write("\\r");
+          break;
+        default:
+          if (c < ' ' || (c >= '\u0080' && c < '\u00a0')
+              || (c >= '\u2000' && c < '\u2100')) {
+            w.write("\\u");
+            hhhh = Integer.toHexString(c);
+            w.write("0000", 0, 4 - hhhh.length());
+            w.write(hhhh);
+          } else {
+            w.write(c);
+          }
+      }
+    }
+    w.write('"');
+    return w;
+  }
 
-        w.write('"');
-        for (i = 0; i < len; i += 1) {
-            b = c;
-            c = string.charAt(i);
-            switch (c) {
-            case '\\':
-            case '"':
-                w.write('\\');
-                w.write(c);
-                break;
-            case '/':
-                if (b == '<') {
-                    w.write('\\');
-                }
-                w.write(c);
-                break;
-            case '\b':
-                w.write("\\b");
-                break;
-            case '\t':
-                w.write("\\t");
-                break;
-            case '\n':
-                w.write("\\n");
-                break;
-            case '\f':
-                w.write("\\f");
-                break;
-            case '\r':
-                w.write("\\r");
-                break;
-            default:
-                if (c < ' ' || (c >= '\u0080' && c < '\u00a0')
-                        || (c >= '\u2000' && c < '\u2100')) {
-                    w.write("\\u");
-                    hhhh = Integer.toHexString(c);
-                    w.write("0000", 0, 4 - hhhh.length());
-                    w.write(hhhh);
-                } else {
-                    w.write(c);
-                }
-            }
-        }
-        w.write('"');
-        return w;
+  /**
+   * Remove a name and its value, if present.
+   *
+   * @param key The name to be removed.
+   * @return The value that was associated with the name, or null if there was no value.
+   */
+  public Object remove(String key) {
+    return this.map.remove(key);
+  }
+
+
+  /**
+   * Compares two numbers to see if they are similar.
+   *
+   * If either of the numbers are Double or Float instances, then they are checked to have a finite
+   * value. If either value is not finite (NaN or &#177;infinity), then this function will always
+   * return false. If both numbers are finite, they are first checked to be the same type and
+   * implement {@link Comparable}. If they do, then the actual {@link Comparable#compareTo(Object)}
+   * is called. If they are not the same type, or don't implement Comparable, then they are
+   * converted to {@link BigDecimal}s. Finally the BigDecimal values are compared using
+   * {@link BigDecimal#compareTo(BigDecimal)}.
+   *
+   * @param l the Left value to compare. Can not be <code>null</code>.
+   * @param r the right value to compare. Can not be <code>null</code>.
+   * @return true if the numbers are similar, false otherwise.
+   */
+  static boolean isNumberSimilar(Number l, Number r) {
+    if (!numberIsFinite(l) || !numberIsFinite(r)) {
+      // non-finite numbers are never similar
+      return false;
     }
 
-    /**
-     * Remove a name and its value, if present.
-     *
-     * @param key
-     *            The name to be removed.
-     * @return The value that was associated with the name, or null if there was
-     *         no value.
-     */
-    public Object remove(String key) {
-        return this.map.remove(key);
-    }
-    
-
-    /**
-     * Compares two numbers to see if they are similar.
-     *
-     * If either of the numbers are Double or Float instances, then they are checked to have
-     * a finite value. If either value is not finite (NaN or &#177;infinity), then this
-     * function will always return false. If both numbers are finite, they are first checked
-     * to be the same type and implement {@link Comparable}. If they do, then the actual
-     * {@link Comparable#compareTo(Object)} is called. If they are not the same type, or don't
-     * implement Comparable, then they are converted to {@link BigDecimal}s. Finally the
-     * BigDecimal values are compared using {@link BigDecimal#compareTo(BigDecimal)}.
-     *
-     * @param l the Left value to compare. Can not be <code>null</code>.
-     * @param r the right value to compare. Can not be <code>null</code>.
-     * @return true if the numbers are similar, false otherwise.
-     */
-    static boolean isNumberSimilar(Number l, Number r) {
-        if (!numberIsFinite(l) || !numberIsFinite(r)) {
-            // non-finite numbers are never similar
-            return false;
-        }
-
-        // if the classes are the same and implement Comparable
-        // then use the built in compare first.
-        if(l.getClass().equals(r.getClass()) && l instanceof Comparable) {
-            @SuppressWarnings({ "rawtypes", "unchecked" })
-            int compareTo = ((Comparable)l).compareTo(r);
-            return compareTo==0;
-        }
-
-        // BigDecimal should be able to handle all of our number types that we support through
-        // documentation. Convert to BigDecimal first, then use the Compare method to
-        // decide equality.
-        final BigDecimal lBigDecimal = objectToBigDecimal(l, null, false);
-        final BigDecimal rBigDecimal = objectToBigDecimal(r, null, false);
-        if (lBigDecimal == null || rBigDecimal == null) {
-            return false;
-        }
-        return lBigDecimal.compareTo(rBigDecimal) == 0;
+    // if the classes are the same and implement Comparable
+    // then use the built in compare first.
+    if (l.getClass().equals(r.getClass()) && l instanceof Comparable) {
+      @SuppressWarnings({"rawtypes", "unchecked"})
+      int compareTo = ((Comparable) l).compareTo(r);
+      return compareTo == 0;
     }
 
-    private static boolean numberIsFinite(Number n) {
-        if (n instanceof Double && (((Double) n).isInfinite() || ((Double) n).isNaN())) {
-            return false;
-        } else if (n instanceof Float && (((Float) n).isInfinite() || ((Float) n).isNaN())) {
-            return false;
-        }
-        return true;
+    // BigDecimal should be able to handle all of our number types that we support through
+    // documentation. Convert to BigDecimal first, then use the Compare method to
+    // decide equality.
+    final BigDecimal lBigDecimal = objectToBigDecimal(l, null, false);
+    final BigDecimal rBigDecimal = objectToBigDecimal(r, null, false);
+    if (lBigDecimal == null || rBigDecimal == null) {
+      return false;
     }
+    return lBigDecimal.compareTo(rBigDecimal) == 0;
+  }
 
-    /**
-     * Tests if the value should be tried as a decimal. It makes no test if there are actual digits.
-     *
-     * @param val value to test
-     * @return true if the string is "-0" or if it contains '.', 'e', or 'E', false otherwise.
-     */
-    protected static boolean isDecimalNotation(final String val) {
-        return val.indexOf('.') > -1 || val.indexOf('e') > -1
-                || val.indexOf('E') > -1 || "-0".equals(val);
+  private static boolean numberIsFinite(Number n) {
+    if (n instanceof Double && (((Double) n).isInfinite() || ((Double) n).isNaN())) {
+      return false;
+    } else if (n instanceof Float && (((Float) n).isInfinite() || ((Float) n).isNaN())) {
+      return false;
     }
+    return true;
+  }
 
-    /**
-     * Converts a string to a number using the narrowest possible type. Possible
-     * returns for this function are BigDecimal, Double, BigInteger, Long, and Integer.
-     * When a Double is returned, it should always be a valid Double and not NaN or +-infinity.
-     *
-     * @param val value to convert
-     * @return Number representation of the value.
-     * @throws NumberFormatException thrown if the value is not a valid number. A public
-     *      caller should catch this and wrap it in a {@link JSONException} if applicable.
-     */
-    protected static Number stringToNumber(final String val) throws NumberFormatException {
-        char initial = val.charAt(0);
-        if ((initial >= '0' && initial <= '9') || initial == '-') {
-            // decimal representation
-            if (isDecimalNotation(val)) {
-                // Use a BigDecimal all the time so we keep the original
-                // representation. BigDecimal doesn't support -0.0, ensure we
-                // keep that by forcing a decimal.
-                try {
-                    BigDecimal bd = new BigDecimal(val);
-                    if(initial == '-' && BigDecimal.ZERO.compareTo(bd)==0) {
-                        return Double.valueOf(-0.0);
-                    }
-                    return bd;
-                } catch (NumberFormatException retryAsDouble) {
-                    // this is to support "Hex Floats" like this: 0x1.0P-1074
-                    try {
-                        Double d = Double.valueOf(val);
-                        if(d.isNaN() || d.isInfinite()) {
-                            throw new NumberFormatException("val ["+val+"] is not a valid number.");
-                        }
-                        return d;
-                    } catch (NumberFormatException ignore) {
-                        throw new NumberFormatException("val ["+val+"] is not a valid number.");
-                    }
-                }
-            }
-            // block items like 00 01 etc. Java number parsers treat these as Octal.
-            if(initial == '0' && val.length() > 1) {
-                char at1 = val.charAt(1);
-                if(at1 >= '0' && at1 <= '9') {
-                    throw new NumberFormatException("val ["+val+"] is not a valid number.");
-                }
-            } else if (initial == '-' && val.length() > 2) {
-                char at1 = val.charAt(1);
-                char at2 = val.charAt(2);
-                if(at1 == '0' && at2 >= '0' && at2 <= '9') {
-                    throw new NumberFormatException("val ["+val+"] is not a valid number.");
-                }
-            }
-            // integer representation.
-            // This will narrow any values to the smallest reasonable Object representation
-            // (Integer, Long, or BigInteger)
+  /**
+   * Tests if the value should be tried as a decimal. It makes no test if there are actual digits.
+   *
+   * @param val value to test
+   * @return true if the string is "-0" or if it contains '.', 'e', or 'E', false otherwise.
+   */
+  protected static boolean isDecimalNotation(final String val) {
+    return val.indexOf('.') > -1 || val.indexOf('e') > -1
+        || val.indexOf('E') > -1 || "-0".equals(val);
+  }
 
-            // BigInteger down conversion: We use a similar bitLength compare as
-            // BigInteger#intValueExact uses. Increases GC, but objects hold
-            // only what they need. i.e. Less runtime overhead if the value is
-            // long lived.
-            BigInteger bi = new BigInteger(val);
-            if(bi.bitLength() <= 31){
-                return Integer.valueOf(bi.intValue());
-            }
-            if(bi.bitLength() <= 63){
-                return Long.valueOf(bi.longValue());
-            }
-            return bi;
-        }
-        throw new NumberFormatException("val ["+val+"] is not a valid number.");
-    }
-
-    /**
-     * Try to convert a string into a number, boolean, or null. If the string
-     * can't be converted, return the string.
-     *
-     * @param string
-     *            A String. can not be null.
-     * @return A simple JSON value.
-     * @throws NullPointerException
-     *             Thrown if the string is null.
-     */
-    // Changes to this method must be copied to the corresponding method in
-    // the XML class to keep full support for Android
-    public static Object stringToValue(String string) {
-        if ("".equals(string)) {
-            return string;
-        }
-
-        // check JSON key words true/false/null
-        if ("true".equalsIgnoreCase(string)) {
-            return Boolean.TRUE;
-        }
-        if ("false".equalsIgnoreCase(string)) {
-            return Boolean.FALSE;
-        }
-        if ("null".equalsIgnoreCase(string)) {
-            return JSONObject.NULL;
-        }
-
-        /*
-         * If it might be a number, try converting it. If a number cannot be
-         * produced, then the value will just be a string.
-         */
-
-        char initial = string.charAt(0);
-        if ((initial >= '0' && initial <= '9') || initial == '-') {
-            try {
-                return stringToNumber(string);
-            } catch (Exception ignore) {
-            }
-        }
-        return string;
-    }
-
-    /**
-     * Throw an exception if the object is a NaN or infinite number.
-     *
-     * @param o
-     *            The object to test.
-     * @throws JSONException
-     *             If o is a non-finite number.
-     */
-    public static void testValidity(Object o) throws JSONException {
-        if (o instanceof Number && !numberIsFinite((Number) o)) {
-            throw new JSONException("JSON does not allow non-finite numbers.");
-        }
-    }
-
-    /**
-     * Produce a JSONArray containing the values of the members of this
-     * JSONObject.
-     *
-     * @param names
-     *            A JSONArray containing a list of key strings. This determines
-     *            the sequence of the values in the result.
-     * @return A JSONArray of values.
-     * @throws JSONException
-     *             If any of the values are non-finite numbers.
-     */
-    public JSONArray toJSONArray(JSONArray names) throws JSONException {
-        if (names == null || names.isEmpty()) {
-            return null;
-        }
-        JSONArray ja = new JSONArray();
-        for (int i = 0; i < names.length(); i += 1) {
-            ja.put(this.opt(names.getString(i)));
-        }
-        return ja;
-    }
-
-    /**
-     * Wrap an object, if necessary. If the object is <code>null</code>, return the NULL
-     * object. If it is an array or collection, wrap it in a JSONArray. If it is
-     * a map, wrap it in a JSONObject. If it is a standard property (Double,
-     * String, et al) then it is already wrapped. Otherwise, if it comes from
-     * one of the java packages, turn it into a string. And if it doesn't, try
-     * to wrap it in a JSONObject. If the wrapping fails, then null is returned.
-     *
-     * @param object
-     *            The object to wrap
-     * @return The wrapped value
-     */
-    private static Object wrap(Object object) {
+  /**
+   * Converts a string to a number using the narrowest possible type. Possible returns for this
+   * function are BigDecimal, Double, BigInteger, Long, and Integer. When a Double is returned, it
+   * should always be a valid Double and not NaN or +-infinity.
+   *
+   * @param val value to convert
+   * @return Number representation of the value.
+   * @throws NumberFormatException thrown if the value is not a valid number. A public caller should
+   *         catch this and wrap it in a {@link JSONException} if applicable.
+   */
+  protected static Number stringToNumber(final String val) throws NumberFormatException {
+    char initial = val.charAt(0);
+    if ((initial >= '0' && initial <= '9') || initial == '-') {
+      // decimal representation
+      if (isDecimalNotation(val)) {
+        // Use a BigDecimal all the time so we keep the original
+        // representation. BigDecimal doesn't support -0.0, ensure we
+        // keep that by forcing a decimal.
         try {
-            if (NULL.equals(object)) {
-                return NULL;
+          BigDecimal bd = new BigDecimal(val);
+          if (initial == '-' && BigDecimal.ZERO.compareTo(bd) == 0) {
+            return Double.valueOf(-0.0);
+          }
+          return bd;
+        } catch (NumberFormatException retryAsDouble) {
+          // this is to support "Hex Floats" like this: 0x1.0P-1074
+          try {
+            Double d = Double.valueOf(val);
+            if (d.isNaN() || d.isInfinite()) {
+              throw new NumberFormatException("val [" + val + "] is not a valid number.");
             }
-            if (object instanceof JSONObject || object instanceof JSONArray
-                    || NULL.equals(object)
-                    || object instanceof Byte || object instanceof Character
-                    || object instanceof Short || object instanceof Integer
-                    || object instanceof Long || object instanceof Boolean
-                    || object instanceof Float || object instanceof Double
-                    || object instanceof String || object instanceof BigInteger
-                    || object instanceof BigDecimal || object instanceof Enum) {
-                return object;
-            }
+            return d;
+          } catch (NumberFormatException ignore) {
+            throw new NumberFormatException("val [" + val + "] is not a valid number.");
+          }
+        }
+      }
+      // block items like 00 01 etc. Java number parsers treat these as Octal.
+      if (initial == '0' && val.length() > 1) {
+        char at1 = val.charAt(1);
+        if (at1 >= '0' && at1 <= '9') {
+          throw new NumberFormatException("val [" + val + "] is not a valid number.");
+        }
+      } else if (initial == '-' && val.length() > 2) {
+        char at1 = val.charAt(1);
+        char at2 = val.charAt(2);
+        if (at1 == '0' && at2 >= '0' && at2 <= '9') {
+          throw new NumberFormatException("val [" + val + "] is not a valid number.");
+        }
+      }
+      // integer representation.
+      // This will narrow any values to the smallest reasonable Object representation
+      // (Integer, Long, or BigInteger)
 
-            if (object instanceof Map) {
-                Map<?, ?> map = (Map<?, ?>) object;
-                return new JSONObject(map);
-            }
-            Package objectPackage = object.getClass().getPackage();
-            String objectPackageName = objectPackage != null ? objectPackage
-                    .getName() : "";
-            if (objectPackageName.startsWith("java.")
-                    || objectPackageName.startsWith("javax.")
-                    || object.getClass().getClassLoader() == null) {
-                return object.toString();
-            }
-            return new JSONObject(object);
-        }
-        catch (JSONException exception) {
-            throw exception;
-        } catch (Exception exception) {
-            return null;
-        }
+      // BigInteger down conversion: We use a similar bitLength compare as
+      // BigInteger#intValueExact uses. Increases GC, but objects hold
+      // only what they need. i.e. Less runtime overhead if the value is
+      // long lived.
+      BigInteger bi = new BigInteger(val);
+      if (bi.bitLength() <= 31) {
+        return Integer.valueOf(bi.intValue());
+      }
+      if (bi.bitLength() <= 63) {
+        return Long.valueOf(bi.longValue());
+      }
+      return bi;
+    }
+    throw new NumberFormatException("val [" + val + "] is not a valid number.");
+  }
+
+  /**
+   * Try to convert a string into a number, boolean, or null. If the string can't be converted,
+   * return the string.
+   *
+   * @param string A String. can not be null.
+   * @return A simple JSON value.
+   * @throws NullPointerException Thrown if the string is null.
+   */
+  // Changes to this method must be copied to the corresponding method in
+  // the XML class to keep full support for Android
+  public static Object stringToValue(String string) {
+    if ("".equals(string)) {
+      return string;
     }
 
-    /**
-     * Create a new JSONException in a common format for incorrect conversions.
-     * @param key name of the key
-     * @param valueType the type of value being coerced to
-     * @param cause optional cause of the coercion failure
-     * @return JSONException that can be thrown.
+    // check JSON key words true/false/null
+    if ("true".equalsIgnoreCase(string)) {
+      return Boolean.TRUE;
+    }
+    if ("false".equalsIgnoreCase(string)) {
+      return Boolean.FALSE;
+    }
+    if ("null".equalsIgnoreCase(string)) {
+      return JSONObject.NULL;
+    }
+
+    /*
+     * If it might be a number, try converting it. If a number cannot be produced, then the value
+     * will just be a string.
      */
-    private static JSONException wrongValueFormatException(
-            String key,
-            String valueType,
-            Object value,
-            Throwable cause) {
-        if(value == null) {
 
-            return new JSONException(
-                    "JSONObject[" + quote(key) + "] is not a " + valueType + " (null)."
-                    , cause);
-        }
-        // don't try to toString collections or known object types that could be large.
-        if(value instanceof Map || value instanceof Iterable || value instanceof JSONObject) {
-            return new JSONException(
-                    "JSONObject[" + quote(key) + "] is not a " + valueType + " (" + value.getClass() + ")."
-                    , cause);
-        }
-        return new JSONException(
-                "JSONObject[" + quote(key) + "] is not a " + valueType + " (" + value.getClass() + " : " + value + ")."
-                , cause);
+    char initial = string.charAt(0);
+    if ((initial >= '0' && initial <= '9') || initial == '-') {
+      try {
+        return stringToNumber(string);
+      } catch (Exception ignore) {
+      }
     }
+    return string;
+  }
+
+  /**
+   * Throw an exception if the object is a NaN or infinite number.
+   *
+   * @param o The object to test.
+   * @throws JSONException If o is a non-finite number.
+   */
+  public static void testValidity(Object o) throws JSONException {
+    if (o instanceof Number && !numberIsFinite((Number) o)) {
+      throw new JSONException("JSON does not allow non-finite numbers.");
+    }
+  }
+
+  /**
+   * Produce a JSONArray containing the values of the members of this JSONObject.
+   *
+   * @param names A JSONArray containing a list of key strings. This determines the sequence of the
+   *        values in the result.
+   * @return A JSONArray of values.
+   * @throws JSONException If any of the values are non-finite numbers.
+   */
+  public JSONArray toJSONArray(JSONArray names) throws JSONException {
+    if (names == null || names.isEmpty()) {
+      return null;
+    }
+    JSONArray ja = new JSONArray();
+    for (int i = 0; i < names.length(); i += 1) {
+      ja.put(this.opt(names.getString(i)));
+    }
+    return ja;
+  }
+
+  /**
+   * Wrap an object, if necessary. If the object is <code>null</code>, return the NULL object. If it
+   * is an array or collection, wrap it in a JSONArray. If it is a map, wrap it in a JSONObject. If
+   * it is a standard property (Double, String, et al) then it is already wrapped. Otherwise, if it
+   * comes from one of the java packages, turn it into a string. And if it doesn't, try to wrap it
+   * in a JSONObject. If the wrapping fails, then null is returned.
+   *
+   * @param object The object to wrap
+   * @return The wrapped value
+   */
+  private static Object wrap(Object object) {
+    try {
+      if (NULL.equals(object)) {
+        return NULL;
+      }
+      if (object instanceof JSONObject || object instanceof JSONArray
+          || NULL.equals(object)
+          || object instanceof Byte || object instanceof Character
+          || object instanceof Short || object instanceof Integer
+          || object instanceof Long || object instanceof Boolean
+          || object instanceof Float || object instanceof Double
+          || object instanceof String || object instanceof BigInteger
+          || object instanceof BigDecimal || object instanceof Enum) {
+        return object;
+      }
+
+      if (object instanceof Map) {
+        Map<?, ?> map = (Map<?, ?>) object;
+        return new JSONObject(map);
+      }
+      Package objectPackage = object.getClass().getPackage();
+      String objectPackageName = objectPackage != null ? objectPackage
+          .getName() : "";
+      if (objectPackageName.startsWith("java.")
+          || objectPackageName.startsWith("javax.")
+          || object.getClass().getClassLoader() == null) {
+        return object.toString();
+      }
+      return new JSONObject(object);
+    } catch (JSONException exception) {
+      throw exception;
+    } catch (Exception exception) {
+      return null;
+    }
+  }
+
+  /**
+   * Create a new JSONException in a common format for incorrect conversions.
+   * 
+   * @param key name of the key
+   * @param valueType the type of value being coerced to
+   * @param cause optional cause of the coercion failure
+   * @return JSONException that can be thrown.
+   */
+  private static JSONException wrongValueFormatException(
+                                                         String key,
+                                                         String valueType,
+                                                         Object value,
+                                                         Throwable cause) {
+    if (value == null) {
+
+      return new JSONException(
+          "JSONObject[" + quote(key) + "] is not a " + valueType + " (null).", cause);
+    }
+    // don't try to toString collections or known object types that could be large.
+    if (value instanceof Map || value instanceof Iterable || value instanceof JSONObject) {
+      return new JSONException(
+          "JSONObject[" + quote(key) + "] is not a " + valueType + " (" + value.getClass() + ").",
+          cause);
+    }
+    return new JSONException(
+        "JSONObject[" + quote(key) + "] is not a " + valueType + " (" + value.getClass() + " : "
+            + value + ").",
+        cause);
+  }
 }

--- a/core/src/main/java/feign/template/util/JSONObject.java
+++ b/core/src/main/java/feign/template/util/JSONObject.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2012-2022 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+ /*
+ * Code Originally Sourced From the JSON.ORG project and utilized under Public Domain
+ */
 package feign.template.util;
 
 import java.io.IOException;
@@ -15,10 +32,6 @@ import java.util.Map.Entry;
 import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.regex.Pattern;
-
-/*
- * Modified and Utilized with the Feign project via Public Domain
- */
 
 /**
  * A JSONObject is an unordered collection of name/value pairs. Its external

--- a/core/src/main/java/feign/template/util/JSONTokener.java
+++ b/core/src/main/java/feign/template/util/JSONTokener.java
@@ -25,515 +25,504 @@ import java.io.Reader;
 import java.io.StringReader;
 
 /**
- * A JSONTokener takes a source string and extracts characters and tokens from
- * it. It is used by the JSONObject and JSONArray constructors to parse
- * JSON source strings.
+ * A JSONTokener takes a source string and extracts characters and tokens from it. It is used by the
+ * JSONObject and JSONArray constructors to parse JSON source strings.
+ * 
  * @author JSON.org
  * @author Justin Ziegler
  * @version 2022-09-21
  */
 public class JSONTokener {
-    /** current read character position on the current line. */
-    private long character;
-    /** flag to indicate if the end of the input has been found. */
-    private boolean eof;
-    /** current read index of the input. */
-    private long index;
-    /** current line of the input. */
-    private long line;
-    /** previous character read from the input. */
-    private char previous;
-    /** Reader for the input. */
-    private final Reader reader;
-    /** flag to indicate that a previous character was requested. */
-    private boolean usePrevious;
-    /** the number of characters read in the previous line. */
-    private long characterPreviousLine;
+  /** current read character position on the current line. */
+  private long character;
+  /** flag to indicate if the end of the input has been found. */
+  private boolean eof;
+  /** current read index of the input. */
+  private long index;
+  /** current line of the input. */
+  private long line;
+  /** previous character read from the input. */
+  private char previous;
+  /** Reader for the input. */
+  private final Reader reader;
+  /** flag to indicate that a previous character was requested. */
+  private boolean usePrevious;
+  /** the number of characters read in the previous line. */
+  private long characterPreviousLine;
 
+  /**
+   * Construct a JSONTokener from a Reader. The caller must close the Reader.
+   *
+   * @param reader A reader.
+   */
+  public JSONTokener(Reader reader) {
+    this.reader = reader.markSupported()
+        ? reader
+        : new BufferedReader(reader);
+    this.eof = false;
+    this.usePrevious = false;
+    this.previous = 0;
+    this.index = 0;
+    this.character = 1;
+    this.characterPreviousLine = 0;
+    this.line = 1;
+  }
 
-    /**
-     * Construct a JSONTokener from a Reader. The caller must close the Reader.
-     *
-     * @param reader     A reader.
-     */
-    public JSONTokener(Reader reader) {
-        this.reader = reader.markSupported()
-                ? reader
-                        : new BufferedReader(reader);
-        this.eof = false;
-        this.usePrevious = false;
-        this.previous = 0;
-        this.index = 0;
-        this.character = 1;
-        this.characterPreviousLine = 0;
-        this.line = 1;
+  /**
+   * Construct a JSONTokener from an InputStream. The caller must close the input stream.
+   * 
+   * @param inputStream The source.
+   */
+  public JSONTokener(InputStream inputStream) {
+    this(new InputStreamReader(inputStream));
+  }
+
+  /**
+   * Construct a JSONTokener from a string.
+   *
+   * @param s A source string.
+   */
+  public JSONTokener(String s) {
+    this(new StringReader(s));
+  }
+
+  /**
+   * Back up one character. This provides a sort of lookahead capability, so that you can test for a
+   * digit or letter before attempting to parse the next number or identifier.
+   * 
+   * @throws JSONException Thrown if trying to step back more than 1 step or if already at the start
+   *         of the string
+   */
+  public void back() throws JSONException {
+    if (this.usePrevious || this.index <= 0) {
+      throw new JSONException("Stepping back two steps is not supported");
+    }
+    this.decrementIndexes();
+    this.usePrevious = true;
+    this.eof = false;
+  }
+
+  /**
+   * Decrements the indexes for the {@link #back()} method based on the previous character read.
+   */
+  private void decrementIndexes() {
+    this.index--;
+    if (this.previous == '\r' || this.previous == '\n') {
+      this.line--;
+      this.character = this.characterPreviousLine;
+    } else if (this.character > 0) {
+      this.character--;
+    }
+  }
+
+  /**
+   * Get the hex value of a character (base16).
+   * 
+   * @param c A character between '0' and '9' or between 'A' and 'F' or between 'a' and 'f'.
+   * @return An int between 0 and 15, or -1 if c was not a hex digit.
+   */
+  public static int dehexchar(char c) {
+    if (c >= '0' && c <= '9') {
+      return c - '0';
+    }
+    if (c >= 'A' && c <= 'F') {
+      return c - ('A' - 10);
+    }
+    if (c >= 'a' && c <= 'f') {
+      return c - ('a' - 10);
+    }
+    return -1;
+  }
+
+  /**
+   * Checks if the end of the input has been reached.
+   * 
+   * @return true if at the end of the file and we didn't step back
+   */
+  public boolean end() {
+    return this.eof && !this.usePrevious;
+  }
+
+  /**
+   * Determine if the source string still contains characters that next() can consume.
+   * 
+   * @return true if not yet at the end of the source.
+   * @throws JSONException thrown if there is an error stepping forward or backward while checking
+   *         for more data.
+   */
+  public boolean more() throws JSONException {
+    if (this.usePrevious) {
+      return true;
+    }
+    try {
+      this.reader.mark(1);
+    } catch (IOException e) {
+      throw new JSONException("Unable to preserve stream position", e);
+    }
+    try {
+      // -1 is EOF, but next() can not consume the null character '\0'
+      if (this.reader.read() <= 0) {
+        this.eof = true;
+        return false;
+      }
+      this.reader.reset();
+    } catch (IOException e) {
+      throw new JSONException("Unable to read the next character from the stream", e);
+    }
+    return true;
+  }
+
+  /**
+   * Get the next character in the source string.
+   *
+   * @return The next character, or 0 if past the end of the source string.
+   * @throws JSONException Thrown if there is an error reading the source string.
+   */
+  public char next() throws JSONException {
+    int c;
+    if (this.usePrevious) {
+      this.usePrevious = false;
+      c = this.previous;
+    } else {
+      try {
+        c = this.reader.read();
+      } catch (IOException exception) {
+        throw new JSONException(exception);
+      }
+    }
+    if (c <= 0) { // End of stream
+      this.eof = true;
+      return 0;
+    }
+    this.incrementIndexes(c);
+    this.previous = (char) c;
+    return this.previous;
+  }
+
+  /**
+   * Get the last character read from the input or '\0' if nothing has been read yet.
+   * 
+   * @return the last character read from the input.
+   */
+  protected char getPrevious() {
+    return this.previous;
+  }
+
+  /**
+   * Increments the internal indexes according to the previous character read and the character
+   * passed as the current character.
+   * 
+   * @param c the current character read.
+   */
+  private void incrementIndexes(int c) {
+    if (c > 0) {
+      this.index++;
+      if (c == '\r') {
+        this.line++;
+        this.characterPreviousLine = this.character;
+        this.character = 0;
+      } else if (c == '\n') {
+        if (this.previous != '\r') {
+          this.line++;
+          this.characterPreviousLine = this.character;
+        }
+        this.character = 0;
+      } else {
+        this.character++;
+      }
+    }
+  }
+
+  /**
+   * Consume the next character, and check that it matches a specified character.
+   * 
+   * @param c The character to match.
+   * @return The character.
+   * @throws JSONException if the character does not match.
+   */
+  public char next(char c) throws JSONException {
+    char n = this.next();
+    if (n != c) {
+      if (n > 0) {
+        throw this.syntaxError("Expected '" + c + "' and instead saw '" +
+            n + "'");
+      }
+      throw this.syntaxError("Expected '" + c + "' and instead saw ''");
+    }
+    return n;
+  }
+
+  /**
+   * Get the next n characters.
+   *
+   * @param n The number of characters to take.
+   * @return A string of n characters.
+   * @throws JSONException Substring bounds error if there are not n characters remaining in the
+   *         source string.
+   */
+  public String next(int n) throws JSONException {
+    if (n == 0) {
+      return "";
     }
 
+    char[] chars = new char[n];
+    int pos = 0;
 
-    /**
-     * Construct a JSONTokener from an InputStream. The caller must close the input stream.
-     * @param inputStream The source.
-     */
-    public JSONTokener(InputStream inputStream) {
-        this(new InputStreamReader(inputStream));
+    while (pos < n) {
+      chars[pos] = this.next();
+      if (this.end()) {
+        throw this.syntaxError("Substring bounds error");
+      }
+      pos += 1;
     }
+    return new String(chars);
+  }
 
-
-    /**
-     * Construct a JSONTokener from a string.
-     *
-     * @param s     A source string.
-     */
-    public JSONTokener(String s) {
-        this(new StringReader(s));
-    }
-
-
-    /**
-     * Back up one character. This provides a sort of lookahead capability,
-     * so that you can test for a digit or letter before attempting to parse
-     * the next number or identifier.
-     * @throws JSONException Thrown if trying to step back more than 1 step
-     *  or if already at the start of the string
-     */
-    public void back() throws JSONException {
-        if (this.usePrevious || this.index <= 0) {
-            throw new JSONException("Stepping back two steps is not supported");
-        }
-        this.decrementIndexes();
-        this.usePrevious = true;
-        this.eof = false;
-    }
-
-    /**
-     * Decrements the indexes for the {@link #back()} method based on the previous character read.
-     */
-    private void decrementIndexes() {
-        this.index--;
-        if(this.previous=='\r' || this.previous == '\n') {
-            this.line--;
-            this.character=this.characterPreviousLine ;
-        } else if(this.character > 0){
-            this.character--;
-        }
-    }
-
-    /**
-     * Get the hex value of a character (base16).
-     * @param c A character between '0' and '9' or between 'A' and 'F' or
-     * between 'a' and 'f'.
-     * @return  An int between 0 and 15, or -1 if c was not a hex digit.
-     */
-    public static int dehexchar(char c) {
-        if (c >= '0' && c <= '9') {
-            return c - '0';
-        }
-        if (c >= 'A' && c <= 'F') {
-            return c - ('A' - 10);
-        }
-        if (c >= 'a' && c <= 'f') {
-            return c - ('a' - 10);
-        }
-        return -1;
-    }
-
-    /**
-     * Checks if the end of the input has been reached.
-     *  
-     * @return true if at the end of the file and we didn't step back
-     */
-    public boolean end() {
-        return this.eof && !this.usePrevious;
-    }
-
-
-    /**
-     * Determine if the source string still contains characters that next()
-     * can consume.
-     * @return true if not yet at the end of the source.
-     * @throws JSONException thrown if there is an error stepping forward
-     *  or backward while checking for more data.
-     */
-    public boolean more() throws JSONException {
-        if(this.usePrevious) {
-            return true;
-        }
-        try {
-            this.reader.mark(1);
-        } catch (IOException e) {
-            throw new JSONException("Unable to preserve stream position", e);
-        }
-        try {
-            // -1 is EOF, but next() can not consume the null character '\0'
-            if(this.reader.read() <= 0) {
-                this.eof = true;
-                return false;
-            }
-            this.reader.reset();
-        } catch (IOException e) {
-            throw new JSONException("Unable to read the next character from the stream", e);
-        }
-        return true;
-    }
-
-
-    /**
-     * Get the next character in the source string.
-     *
-     * @return The next character, or 0 if past the end of the source string.
-     * @throws JSONException Thrown if there is an error reading the source string.
-     */
-    public char next() throws JSONException {
-        int c;
-        if (this.usePrevious) {
-            this.usePrevious = false;
-            c = this.previous;
-        } else {
-            try {
-                c = this.reader.read();
-            } catch (IOException exception) {
-                throw new JSONException(exception);
-            }
-        }
-        if (c <= 0) { // End of stream
-            this.eof = true;
-            return 0;
-        }
-        this.incrementIndexes(c);
-        this.previous = (char) c;
-        return this.previous;
-    }
-    
-    /**
-     * Get the last character read from the input or '\0' if nothing has been read yet.
-     * @return the last character read from the input.
-     */
-    protected char getPrevious() { return this.previous;}
-
-    /**
-     * Increments the internal indexes according to the previous character
-     * read and the character passed as the current character.
-     * @param c the current character read.
-     */
-    private void incrementIndexes(int c) {
-        if(c > 0) {
-            this.index++;
-            if(c=='\r') {
-                this.line++;
-                this.characterPreviousLine = this.character;
-                this.character=0;
-            }else if (c=='\n') {
-                if(this.previous != '\r') {
-                    this.line++;
-                    this.characterPreviousLine = this.character;
-                }
-                this.character=0;
-            } else {
-                this.character++;
-            }
-        }
-    }
-
-    /**
-     * Consume the next character, and check that it matches a specified
-     * character.
-     * @param c The character to match.
-     * @return The character.
-     * @throws JSONException if the character does not match.
-     */
-    public char next(char c) throws JSONException {
-        char n = this.next();
-        if (n != c) {
-            if(n > 0) {
-                throw this.syntaxError("Expected '" + c + "' and instead saw '" +
-                        n + "'");
-            }
-            throw this.syntaxError("Expected '" + c + "' and instead saw ''");
-        }
-        return n;
-    }
-
-
-    /**
-     * Get the next n characters.
-     *
-     * @param n     The number of characters to take.
-     * @return      A string of n characters.
-     * @throws JSONException
-     *   Substring bounds error if there are not
-     *   n characters remaining in the source string.
-     */
-    public String next(int n) throws JSONException {
-        if (n == 0) {
-            return "";
-        }
-
-        char[] chars = new char[n];
-        int pos = 0;
-
-        while (pos < n) {
-            chars[pos] = this.next();
-            if (this.end()) {
-                throw this.syntaxError("Substring bounds error");
-            }
-            pos += 1;
-        }
-        return new String(chars);
-    }
-
-
-    /**
-     * Get the next char in the string, skipping whitespace.
-     * @throws JSONException Thrown if there is an error reading the source string.
-     * @return  A character, or 0 if there are no more characters.
-     */
-    public char nextClean() throws JSONException {
-        for (;;) {
-            char c = this.next();
-            if (c == 0 || c > ' ') {
-                return c;
-            }
-        }
-    }
-
-
-    /**
-     * Return the characters up to the next close quote character.
-     * Backslash processing is done. The formal JSON format does not
-     * allow strings in single quotes, but an implementation is allowed to
-     * accept them.
-     * @param quote The quoting character, either
-     *      <code>"</code>&nbsp;<small>(double quote)</small> or
-     *      <code>'</code>&nbsp;<small>(single quote)</small>.
-     * @return      A String.
-     * @throws JSONException Unterminated string.
-     */
-    public String nextString(char quote) throws JSONException {
-        char c;
-        StringBuilder sb = new StringBuilder();
-        for (;;) {
-            c = this.next();
-            switch (c) {
-            case 0:
-            case '\n':
-            case '\r':
-                throw this.syntaxError("Unterminated string");
-            case '\\':
-                c = this.next();
-                switch (c) {
-                case 'b':
-                    sb.append('\b');
-                    break;
-                case 't':
-                    sb.append('\t');
-                    break;
-                case 'n':
-                    sb.append('\n');
-                    break;
-                case 'f':
-                    sb.append('\f');
-                    break;
-                case 'r':
-                    sb.append('\r');
-                    break;
-                case 'u':
-                    try {
-                        sb.append((char)Integer.parseInt(this.next(4), 16));
-                    } catch (NumberFormatException e) {
-                        throw this.syntaxError("Illegal escape.", e);
-                    }
-                    break;
-                case '"':
-                case '\'':
-                case '\\':
-                case '/':
-                    sb.append(c);
-                    break;
-                default:
-                    throw this.syntaxError("Illegal escape.");
-                }
-                break;
-            default:
-                if (c == quote) {
-                    return sb.toString();
-                }
-                sb.append(c);
-            }
-        }
-    }
-
-
-    /**
-     * Get the text up but not including the specified character or the
-     * end of line, whichever comes first.
-     * @param  delimiter A delimiter character.
-     * @return   A string.
-     * @throws JSONException Thrown if there is an error while searching
-     *  for the delimiter
-     */
-    public String nextTo(char delimiter) throws JSONException {
-        StringBuilder sb = new StringBuilder();
-        for (;;) {
-            char c = this.next();
-            if (c == delimiter || c == 0 || c == '\n' || c == '\r') {
-                if (c != 0) {
-                    this.back();
-                }
-                return sb.toString().trim();
-            }
-            sb.append(c);
-        }
-    }
-
-
-    /**
-     * Get the text up but not including one of the specified delimiter
-     * characters or the end of line, whichever comes first.
-     * @param delimiters A set of delimiter characters.
-     * @return A string, trimmed.
-     * @throws JSONException Thrown if there is an error while searching
-     *  for the delimiter
-     */
-    public String nextTo(String delimiters) throws JSONException {
-        char c;
-        StringBuilder sb = new StringBuilder();
-        for (;;) {
-            c = this.next();
-            if (delimiters.indexOf(c) >= 0 || c == 0 ||
-                    c == '\n' || c == '\r') {
-                if (c != 0) {
-                    this.back();
-                }
-                return sb.toString().trim();
-            }
-            sb.append(c);
-        }
-    }
-
-
-    /**
-     * Get the next value. The value can be a Boolean, Double, Integer,
-     * JSONArray, JSONObject, Long, or String, or the JSONObject.NULL object.
-     * @throws JSONException If syntax error.
-     *
-     * @return An object.
-     */
-    public Object nextValue() throws JSONException {
-        char c = this.nextClean();
-        String string;
-
-        switch (c) {
-        case '"':
-        case '\'':
-            return this.nextString(c);
-        case '{':
-            this.back();
-            try {
-                return new JSONObject(this);
-            } catch (StackOverflowError e) {
-                throw new JSONException("JSON Array or Object depth too large to process.", e);
-            }
-        case '[':
-            this.back();
-            try {
-                return new JSONArray(this);
-            } catch (StackOverflowError e) {
-                throw new JSONException("JSON Array or Object depth too large to process.", e);
-            }
-        }
-
-        /*
-         * Handle unquoted text. This could be the values true, false, or
-         * null, or it can be a number. An implementation (such as this one)
-         * is allowed to also accept non-standard forms.
-         *
-         * Accumulate characters until we reach the end of the text or a
-         * formatting character.
-         */
-
-        StringBuilder sb = new StringBuilder();
-        while (c >= ' ' && ",:]}/\\\"[{;=#".indexOf(c) < 0) {
-            sb.append(c);
-            c = this.next();
-        }
-        if (!this.eof) {
-            this.back();
-        }
-
-        string = sb.toString().trim();
-        if ("".equals(string)) {
-            throw this.syntaxError("Missing value");
-        }
-        return JSONObject.stringToValue(string);
-    }
-
-
-    /**
-     * Skip characters until the next character is the requested character.
-     * If the requested character is not found, no characters are skipped.
-     * @param to A character to skip to.
-     * @return The requested character, or zero if the requested character
-     * is not found.
-     * @throws JSONException Thrown if there is an error while searching
-     *  for the to character
-     */
-    public char skipTo(char to) throws JSONException {
-        char c;
-        try {
-            long startIndex = this.index;
-            long startCharacter = this.character;
-            long startLine = this.line;
-            this.reader.mark(1000000);
-            do {
-                c = this.next();
-                if (c == 0) {
-                    // in some readers, reset() may throw an exception if
-                    // the remaining portion of the input is greater than
-                    // the mark size (1,000,000 above).
-                    this.reader.reset();
-                    this.index = startIndex;
-                    this.character = startCharacter;
-                    this.line = startLine;
-                    return 0;
-                }
-            } while (c != to);
-            this.reader.mark(1);
-        } catch (IOException exception) {
-            throw new JSONException(exception);
-        }
-        this.back();
+  /**
+   * Get the next char in the string, skipping whitespace.
+   * 
+   * @throws JSONException Thrown if there is an error reading the source string.
+   * @return A character, or 0 if there are no more characters.
+   */
+  public char nextClean() throws JSONException {
+    for (;;) {
+      char c = this.next();
+      if (c == 0 || c > ' ') {
         return c;
+      }
+    }
+  }
+
+  /**
+   * Return the characters up to the next close quote character. Backslash processing is done. The
+   * formal JSON format does not allow strings in single quotes, but an implementation is allowed to
+   * accept them.
+   * 
+   * @param quote The quoting character, either <code>"</code>&nbsp;<small>(double quote)</small> or
+   *        <code>'</code>&nbsp;<small>(single quote)</small>.
+   * @return A String.
+   * @throws JSONException Unterminated string.
+   */
+  public String nextString(char quote) throws JSONException {
+    char c;
+    StringBuilder sb = new StringBuilder();
+    for (;;) {
+      c = this.next();
+      switch (c) {
+        case 0:
+        case '\n':
+        case '\r':
+          throw this.syntaxError("Unterminated string");
+        case '\\':
+          c = this.next();
+          switch (c) {
+            case 'b':
+              sb.append('\b');
+              break;
+            case 't':
+              sb.append('\t');
+              break;
+            case 'n':
+              sb.append('\n');
+              break;
+            case 'f':
+              sb.append('\f');
+              break;
+            case 'r':
+              sb.append('\r');
+              break;
+            case 'u':
+              try {
+                sb.append((char) Integer.parseInt(this.next(4), 16));
+              } catch (NumberFormatException e) {
+                throw this.syntaxError("Illegal escape.", e);
+              }
+              break;
+            case '"':
+            case '\'':
+            case '\\':
+            case '/':
+              sb.append(c);
+              break;
+            default:
+              throw this.syntaxError("Illegal escape.");
+          }
+          break;
+        default:
+          if (c == quote) {
+            return sb.toString();
+          }
+          sb.append(c);
+      }
+    }
+  }
+
+  /**
+   * Get the text up but not including the specified character or the end of line, whichever comes
+   * first.
+   * 
+   * @param delimiter A delimiter character.
+   * @return A string.
+   * @throws JSONException Thrown if there is an error while searching for the delimiter
+   */
+  public String nextTo(char delimiter) throws JSONException {
+    StringBuilder sb = new StringBuilder();
+    for (;;) {
+      char c = this.next();
+      if (c == delimiter || c == 0 || c == '\n' || c == '\r') {
+        if (c != 0) {
+          this.back();
+        }
+        return sb.toString().trim();
+      }
+      sb.append(c);
+    }
+  }
+
+  /**
+   * Get the text up but not including one of the specified delimiter characters or the end of line,
+   * whichever comes first.
+   * 
+   * @param delimiters A set of delimiter characters.
+   * @return A string, trimmed.
+   * @throws JSONException Thrown if there is an error while searching for the delimiter
+   */
+  public String nextTo(String delimiters) throws JSONException {
+    char c;
+    StringBuilder sb = new StringBuilder();
+    for (;;) {
+      c = this.next();
+      if (delimiters.indexOf(c) >= 0 || c == 0 ||
+          c == '\n' || c == '\r') {
+        if (c != 0) {
+          this.back();
+        }
+        return sb.toString().trim();
+      }
+      sb.append(c);
+    }
+  }
+
+  /**
+   * Get the next value. The value can be a Boolean, Double, Integer, JSONArray, JSONObject, Long,
+   * or String, or the JSONObject.NULL object.
+   * 
+   * @throws JSONException If syntax error.
+   *
+   * @return An object.
+   */
+  public Object nextValue() throws JSONException {
+    char c = this.nextClean();
+    String string;
+
+    switch (c) {
+      case '"':
+      case '\'':
+        return this.nextString(c);
+      case '{':
+        this.back();
+        try {
+          return new JSONObject(this);
+        } catch (StackOverflowError e) {
+          throw new JSONException("JSON Array or Object depth too large to process.", e);
+        }
+      case '[':
+        this.back();
+        try {
+          return new JSONArray(this);
+        } catch (StackOverflowError e) {
+          throw new JSONException("JSON Array or Object depth too large to process.", e);
+        }
     }
 
-    /**
-     * Make a JSONException to signal a syntax error.
+    /*
+     * Handle unquoted text. This could be the values true, false, or null, or it can be a number.
+     * An implementation (such as this one) is allowed to also accept non-standard forms.
      *
-     * @param message The error message.
-     * @return  A JSONException object, suitable for throwing
+     * Accumulate characters until we reach the end of the text or a formatting character.
      */
-    public JSONException syntaxError(String message) {
-        return new JSONException(message + this.toString());
+
+    StringBuilder sb = new StringBuilder();
+    while (c >= ' ' && ",:]}/\\\"[{;=#".indexOf(c) < 0) {
+      sb.append(c);
+      c = this.next();
+    }
+    if (!this.eof) {
+      this.back();
     }
 
-    /**
-     * Make a JSONException to signal a syntax error.
-     *
-     * @param message The error message.
-     * @param causedBy The throwable that caused the error.
-     * @return  A JSONException object, suitable for throwing
-     */
-    public JSONException syntaxError(String message, Throwable causedBy) {
-        return new JSONException(message + this.toString(), causedBy);
+    string = sb.toString().trim();
+    if ("".equals(string)) {
+      throw this.syntaxError("Missing value");
     }
+    return JSONObject.stringToValue(string);
+  }
 
-    /**
-     * Make a printable string of this JSONTokener.
-     *
-     * @return " at {index} [character {character} line {line}]"
-     */
-    @Override
-    public String toString() {
-        return " at " + this.index + " [character " + this.character + " line " +
-                this.line + "]";
+  /**
+   * Skip characters until the next character is the requested character. If the requested character
+   * is not found, no characters are skipped.
+   * 
+   * @param to A character to skip to.
+   * @return The requested character, or zero if the requested character is not found.
+   * @throws JSONException Thrown if there is an error while searching for the to character
+   */
+  public char skipTo(char to) throws JSONException {
+    char c;
+    try {
+      long startIndex = this.index;
+      long startCharacter = this.character;
+      long startLine = this.line;
+      this.reader.mark(1000000);
+      do {
+        c = this.next();
+        if (c == 0) {
+          // in some readers, reset() may throw an exception if
+          // the remaining portion of the input is greater than
+          // the mark size (1,000,000 above).
+          this.reader.reset();
+          this.index = startIndex;
+          this.character = startCharacter;
+          this.line = startLine;
+          return 0;
+        }
+      } while (c != to);
+      this.reader.mark(1);
+    } catch (IOException exception) {
+      throw new JSONException(exception);
     }
+    this.back();
+    return c;
+  }
+
+  /**
+   * Make a JSONException to signal a syntax error.
+   *
+   * @param message The error message.
+   * @return A JSONException object, suitable for throwing
+   */
+  public JSONException syntaxError(String message) {
+    return new JSONException(message + this.toString());
+  }
+
+  /**
+   * Make a JSONException to signal a syntax error.
+   *
+   * @param message The error message.
+   * @param causedBy The throwable that caused the error.
+   * @return A JSONException object, suitable for throwing
+   */
+  public JSONException syntaxError(String message, Throwable causedBy) {
+    return new JSONException(message + this.toString(), causedBy);
+  }
+
+  /**
+   * Make a printable string of this JSONTokener.
+   *
+   * @return " at {index} [character {character} line {line}]"
+   */
+  @Override
+  public String toString() {
+    return " at " + this.index + " [character " + this.character + " line " +
+        this.line + "]";
+  }
 }

--- a/core/src/main/java/feign/template/util/JSONTokener.java
+++ b/core/src/main/java/feign/template/util/JSONTokener.java
@@ -1,8 +1,21 @@
-package feign.template.util;
+/*
+ * Copyright 2012-2022 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 
 /*
- * Utilized with the Feign project via Public Domain
+ * Code Originally Sourced From the JSON.ORG project and utilized under Public Domain
  */
+package feign.template.util;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -16,7 +29,8 @@ import java.io.StringReader;
  * it. It is used by the JSONObject and JSONArray constructors to parse
  * JSON source strings.
  * @author JSON.org
- * @version 2014-05-03
+ * @author Justin Ziegler
+ * @version 2022-09-21
  */
 public class JSONTokener {
     /** current read character position on the current line. */

--- a/core/src/main/java/feign/template/util/JSONTokener.java
+++ b/core/src/main/java/feign/template/util/JSONTokener.java
@@ -1,15 +1,15 @@
 package feign.template.util;
 
+/*
+ * Utilized with the Feign project via Public Domain
+ */
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
-
-/*
-Public Domain.
- */
 
 /**
  * A JSONTokener takes a source string and extracts characters and tokens from

--- a/core/src/main/java/feign/template/util/JSONTokener.java
+++ b/core/src/main/java/feign/template/util/JSONTokener.java
@@ -1,0 +1,525 @@
+package feign.template.util;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringReader;
+
+/*
+Public Domain.
+ */
+
+/**
+ * A JSONTokener takes a source string and extracts characters and tokens from
+ * it. It is used by the JSONObject and JSONArray constructors to parse
+ * JSON source strings.
+ * @author JSON.org
+ * @version 2014-05-03
+ */
+public class JSONTokener {
+    /** current read character position on the current line. */
+    private long character;
+    /** flag to indicate if the end of the input has been found. */
+    private boolean eof;
+    /** current read index of the input. */
+    private long index;
+    /** current line of the input. */
+    private long line;
+    /** previous character read from the input. */
+    private char previous;
+    /** Reader for the input. */
+    private final Reader reader;
+    /** flag to indicate that a previous character was requested. */
+    private boolean usePrevious;
+    /** the number of characters read in the previous line. */
+    private long characterPreviousLine;
+
+
+    /**
+     * Construct a JSONTokener from a Reader. The caller must close the Reader.
+     *
+     * @param reader     A reader.
+     */
+    public JSONTokener(Reader reader) {
+        this.reader = reader.markSupported()
+                ? reader
+                        : new BufferedReader(reader);
+        this.eof = false;
+        this.usePrevious = false;
+        this.previous = 0;
+        this.index = 0;
+        this.character = 1;
+        this.characterPreviousLine = 0;
+        this.line = 1;
+    }
+
+
+    /**
+     * Construct a JSONTokener from an InputStream. The caller must close the input stream.
+     * @param inputStream The source.
+     */
+    public JSONTokener(InputStream inputStream) {
+        this(new InputStreamReader(inputStream));
+    }
+
+
+    /**
+     * Construct a JSONTokener from a string.
+     *
+     * @param s     A source string.
+     */
+    public JSONTokener(String s) {
+        this(new StringReader(s));
+    }
+
+
+    /**
+     * Back up one character. This provides a sort of lookahead capability,
+     * so that you can test for a digit or letter before attempting to parse
+     * the next number or identifier.
+     * @throws JSONException Thrown if trying to step back more than 1 step
+     *  or if already at the start of the string
+     */
+    public void back() throws JSONException {
+        if (this.usePrevious || this.index <= 0) {
+            throw new JSONException("Stepping back two steps is not supported");
+        }
+        this.decrementIndexes();
+        this.usePrevious = true;
+        this.eof = false;
+    }
+
+    /**
+     * Decrements the indexes for the {@link #back()} method based on the previous character read.
+     */
+    private void decrementIndexes() {
+        this.index--;
+        if(this.previous=='\r' || this.previous == '\n') {
+            this.line--;
+            this.character=this.characterPreviousLine ;
+        } else if(this.character > 0){
+            this.character--;
+        }
+    }
+
+    /**
+     * Get the hex value of a character (base16).
+     * @param c A character between '0' and '9' or between 'A' and 'F' or
+     * between 'a' and 'f'.
+     * @return  An int between 0 and 15, or -1 if c was not a hex digit.
+     */
+    public static int dehexchar(char c) {
+        if (c >= '0' && c <= '9') {
+            return c - '0';
+        }
+        if (c >= 'A' && c <= 'F') {
+            return c - ('A' - 10);
+        }
+        if (c >= 'a' && c <= 'f') {
+            return c - ('a' - 10);
+        }
+        return -1;
+    }
+
+    /**
+     * Checks if the end of the input has been reached.
+     *  
+     * @return true if at the end of the file and we didn't step back
+     */
+    public boolean end() {
+        return this.eof && !this.usePrevious;
+    }
+
+
+    /**
+     * Determine if the source string still contains characters that next()
+     * can consume.
+     * @return true if not yet at the end of the source.
+     * @throws JSONException thrown if there is an error stepping forward
+     *  or backward while checking for more data.
+     */
+    public boolean more() throws JSONException {
+        if(this.usePrevious) {
+            return true;
+        }
+        try {
+            this.reader.mark(1);
+        } catch (IOException e) {
+            throw new JSONException("Unable to preserve stream position", e);
+        }
+        try {
+            // -1 is EOF, but next() can not consume the null character '\0'
+            if(this.reader.read() <= 0) {
+                this.eof = true;
+                return false;
+            }
+            this.reader.reset();
+        } catch (IOException e) {
+            throw new JSONException("Unable to read the next character from the stream", e);
+        }
+        return true;
+    }
+
+
+    /**
+     * Get the next character in the source string.
+     *
+     * @return The next character, or 0 if past the end of the source string.
+     * @throws JSONException Thrown if there is an error reading the source string.
+     */
+    public char next() throws JSONException {
+        int c;
+        if (this.usePrevious) {
+            this.usePrevious = false;
+            c = this.previous;
+        } else {
+            try {
+                c = this.reader.read();
+            } catch (IOException exception) {
+                throw new JSONException(exception);
+            }
+        }
+        if (c <= 0) { // End of stream
+            this.eof = true;
+            return 0;
+        }
+        this.incrementIndexes(c);
+        this.previous = (char) c;
+        return this.previous;
+    }
+    
+    /**
+     * Get the last character read from the input or '\0' if nothing has been read yet.
+     * @return the last character read from the input.
+     */
+    protected char getPrevious() { return this.previous;}
+
+    /**
+     * Increments the internal indexes according to the previous character
+     * read and the character passed as the current character.
+     * @param c the current character read.
+     */
+    private void incrementIndexes(int c) {
+        if(c > 0) {
+            this.index++;
+            if(c=='\r') {
+                this.line++;
+                this.characterPreviousLine = this.character;
+                this.character=0;
+            }else if (c=='\n') {
+                if(this.previous != '\r') {
+                    this.line++;
+                    this.characterPreviousLine = this.character;
+                }
+                this.character=0;
+            } else {
+                this.character++;
+            }
+        }
+    }
+
+    /**
+     * Consume the next character, and check that it matches a specified
+     * character.
+     * @param c The character to match.
+     * @return The character.
+     * @throws JSONException if the character does not match.
+     */
+    public char next(char c) throws JSONException {
+        char n = this.next();
+        if (n != c) {
+            if(n > 0) {
+                throw this.syntaxError("Expected '" + c + "' and instead saw '" +
+                        n + "'");
+            }
+            throw this.syntaxError("Expected '" + c + "' and instead saw ''");
+        }
+        return n;
+    }
+
+
+    /**
+     * Get the next n characters.
+     *
+     * @param n     The number of characters to take.
+     * @return      A string of n characters.
+     * @throws JSONException
+     *   Substring bounds error if there are not
+     *   n characters remaining in the source string.
+     */
+    public String next(int n) throws JSONException {
+        if (n == 0) {
+            return "";
+        }
+
+        char[] chars = new char[n];
+        int pos = 0;
+
+        while (pos < n) {
+            chars[pos] = this.next();
+            if (this.end()) {
+                throw this.syntaxError("Substring bounds error");
+            }
+            pos += 1;
+        }
+        return new String(chars);
+    }
+
+
+    /**
+     * Get the next char in the string, skipping whitespace.
+     * @throws JSONException Thrown if there is an error reading the source string.
+     * @return  A character, or 0 if there are no more characters.
+     */
+    public char nextClean() throws JSONException {
+        for (;;) {
+            char c = this.next();
+            if (c == 0 || c > ' ') {
+                return c;
+            }
+        }
+    }
+
+
+    /**
+     * Return the characters up to the next close quote character.
+     * Backslash processing is done. The formal JSON format does not
+     * allow strings in single quotes, but an implementation is allowed to
+     * accept them.
+     * @param quote The quoting character, either
+     *      <code>"</code>&nbsp;<small>(double quote)</small> or
+     *      <code>'</code>&nbsp;<small>(single quote)</small>.
+     * @return      A String.
+     * @throws JSONException Unterminated string.
+     */
+    public String nextString(char quote) throws JSONException {
+        char c;
+        StringBuilder sb = new StringBuilder();
+        for (;;) {
+            c = this.next();
+            switch (c) {
+            case 0:
+            case '\n':
+            case '\r':
+                throw this.syntaxError("Unterminated string");
+            case '\\':
+                c = this.next();
+                switch (c) {
+                case 'b':
+                    sb.append('\b');
+                    break;
+                case 't':
+                    sb.append('\t');
+                    break;
+                case 'n':
+                    sb.append('\n');
+                    break;
+                case 'f':
+                    sb.append('\f');
+                    break;
+                case 'r':
+                    sb.append('\r');
+                    break;
+                case 'u':
+                    try {
+                        sb.append((char)Integer.parseInt(this.next(4), 16));
+                    } catch (NumberFormatException e) {
+                        throw this.syntaxError("Illegal escape.", e);
+                    }
+                    break;
+                case '"':
+                case '\'':
+                case '\\':
+                case '/':
+                    sb.append(c);
+                    break;
+                default:
+                    throw this.syntaxError("Illegal escape.");
+                }
+                break;
+            default:
+                if (c == quote) {
+                    return sb.toString();
+                }
+                sb.append(c);
+            }
+        }
+    }
+
+
+    /**
+     * Get the text up but not including the specified character or the
+     * end of line, whichever comes first.
+     * @param  delimiter A delimiter character.
+     * @return   A string.
+     * @throws JSONException Thrown if there is an error while searching
+     *  for the delimiter
+     */
+    public String nextTo(char delimiter) throws JSONException {
+        StringBuilder sb = new StringBuilder();
+        for (;;) {
+            char c = this.next();
+            if (c == delimiter || c == 0 || c == '\n' || c == '\r') {
+                if (c != 0) {
+                    this.back();
+                }
+                return sb.toString().trim();
+            }
+            sb.append(c);
+        }
+    }
+
+
+    /**
+     * Get the text up but not including one of the specified delimiter
+     * characters or the end of line, whichever comes first.
+     * @param delimiters A set of delimiter characters.
+     * @return A string, trimmed.
+     * @throws JSONException Thrown if there is an error while searching
+     *  for the delimiter
+     */
+    public String nextTo(String delimiters) throws JSONException {
+        char c;
+        StringBuilder sb = new StringBuilder();
+        for (;;) {
+            c = this.next();
+            if (delimiters.indexOf(c) >= 0 || c == 0 ||
+                    c == '\n' || c == '\r') {
+                if (c != 0) {
+                    this.back();
+                }
+                return sb.toString().trim();
+            }
+            sb.append(c);
+        }
+    }
+
+
+    /**
+     * Get the next value. The value can be a Boolean, Double, Integer,
+     * JSONArray, JSONObject, Long, or String, or the JSONObject.NULL object.
+     * @throws JSONException If syntax error.
+     *
+     * @return An object.
+     */
+    public Object nextValue() throws JSONException {
+        char c = this.nextClean();
+        String string;
+
+        switch (c) {
+        case '"':
+        case '\'':
+            return this.nextString(c);
+        case '{':
+            this.back();
+            try {
+                return new JSONObject(this);
+            } catch (StackOverflowError e) {
+                throw new JSONException("JSON Array or Object depth too large to process.", e);
+            }
+        case '[':
+            this.back();
+            try {
+                return new JSONArray(this);
+            } catch (StackOverflowError e) {
+                throw new JSONException("JSON Array or Object depth too large to process.", e);
+            }
+        }
+
+        /*
+         * Handle unquoted text. This could be the values true, false, or
+         * null, or it can be a number. An implementation (such as this one)
+         * is allowed to also accept non-standard forms.
+         *
+         * Accumulate characters until we reach the end of the text or a
+         * formatting character.
+         */
+
+        StringBuilder sb = new StringBuilder();
+        while (c >= ' ' && ",:]}/\\\"[{;=#".indexOf(c) < 0) {
+            sb.append(c);
+            c = this.next();
+        }
+        if (!this.eof) {
+            this.back();
+        }
+
+        string = sb.toString().trim();
+        if ("".equals(string)) {
+            throw this.syntaxError("Missing value");
+        }
+        return JSONObject.stringToValue(string);
+    }
+
+
+    /**
+     * Skip characters until the next character is the requested character.
+     * If the requested character is not found, no characters are skipped.
+     * @param to A character to skip to.
+     * @return The requested character, or zero if the requested character
+     * is not found.
+     * @throws JSONException Thrown if there is an error while searching
+     *  for the to character
+     */
+    public char skipTo(char to) throws JSONException {
+        char c;
+        try {
+            long startIndex = this.index;
+            long startCharacter = this.character;
+            long startLine = this.line;
+            this.reader.mark(1000000);
+            do {
+                c = this.next();
+                if (c == 0) {
+                    // in some readers, reset() may throw an exception if
+                    // the remaining portion of the input is greater than
+                    // the mark size (1,000,000 above).
+                    this.reader.reset();
+                    this.index = startIndex;
+                    this.character = startCharacter;
+                    this.line = startLine;
+                    return 0;
+                }
+            } while (c != to);
+            this.reader.mark(1);
+        } catch (IOException exception) {
+            throw new JSONException(exception);
+        }
+        this.back();
+        return c;
+    }
+
+    /**
+     * Make a JSONException to signal a syntax error.
+     *
+     * @param message The error message.
+     * @return  A JSONException object, suitable for throwing
+     */
+    public JSONException syntaxError(String message) {
+        return new JSONException(message + this.toString());
+    }
+
+    /**
+     * Make a JSONException to signal a syntax error.
+     *
+     * @param message The error message.
+     * @param causedBy The throwable that caused the error.
+     * @return  A JSONException object, suitable for throwing
+     */
+    public JSONException syntaxError(String message, Throwable causedBy) {
+        return new JSONException(message + this.toString(), causedBy);
+    }
+
+    /**
+     * Make a printable string of this JSONTokener.
+     *
+     * @return " at {index} [character {character} line {line}]"
+     */
+    @Override
+    public String toString() {
+        return " at " + this.index + " [character " + this.character + " line " +
+                this.line + "]";
+    }
+}

--- a/core/src/test/java/feign/template/HeaderTemplateTest.java
+++ b/core/src/test/java/feign/template/HeaderTemplateTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class HeaderTemplateTest {
 
@@ -112,5 +113,15 @@ public class HeaderTemplateTest {
     assertEquals("Wed, 4 Jul 2001 12:08:56 -0700",
         headerTemplate.expand(
             Collections.singletonMap("expires", "Wed, 4 Jul 2001 12:08:56 -0700")));
+  }
+
+  @Test
+  public void it_should_support_json_literal_values() {
+    HeaderTemplate headerTemplate =
+        HeaderTemplate.create("CustomHeader", Collections.singletonList(
+            "{\"key0\":\"value0\",\"key1\":\"value1\",\"key2\":\"value2\",\"nested\":{\"key3\":\"value3\"}}"));
+    assertTrue(
+        headerTemplate.getValues().contains(
+            "{\"key0\":\"value0\",\"key1\":\"value1\",\"key2\":\"value2\",\"nested\":{\"key3\":\"value3\"}}"));
   }
 }


### PR DESCRIPTION
Submitted as a resolution of #1464 
Compared to previous attempts to solve the issue, this PR utilizes truncated versions of the Public Domain org.json classes to perform JSON validation locally in an efficient manner. This addresses the need to validate JSON as well as the possibility of multiple values existing in the array of headers, not all of which may be JSON literals.