### PR TITLE
Fix illegal HTTP status code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Version 12.0
+
+* Ability to customize http status code when service unavailable by regyl (#1773)
+
 ### Version 11.9
 
 * `OkHttpClient` now implements `AsyncClient`

--- a/core/src/main/java/feign/FeignException.java
+++ b/core/src/main/java/feign/FeignException.java
@@ -261,9 +261,11 @@ public class FeignException extends RuntimeException {
     }
   }
 
-  static FeignException errorExecuting(Request request, IOException cause) {
+  static FeignException errorExecuting(Request request,
+                                       IOException cause,
+                                       int connectExceptionStatus) {
     return new RetryableException(
-        -1,
+        connectExceptionStatus,
         format("%s executing %s %s", cause.getMessage(), request.httpMethod(), request.url()),
         request.httpMethod(),
         cause,

--- a/core/src/main/java/feign/Request.java
+++ b/core/src/main/java/feign/Request.java
@@ -264,6 +264,7 @@ public final class Request implements Serializable {
     private final long readTimeout;
     private final TimeUnit readTimeoutUnit;
     private final boolean followRedirects;
+    private final int connectExceptionStatus;
 
     /**
      * Creates a new Options instance.
@@ -278,7 +279,7 @@ public final class Request implements Serializable {
     public Options(int connectTimeoutMillis, int readTimeoutMillis, boolean followRedirects) {
       this(connectTimeoutMillis, TimeUnit.MILLISECONDS,
           readTimeoutMillis, TimeUnit.MILLISECONDS,
-          followRedirects);
+          followRedirects, 500);
     }
 
     /**
@@ -289,7 +290,10 @@ public final class Request implements Serializable {
      * @param readTimeout value.
      * @param readTimeoutUnit with the TimeUnit for the timeout value.
      * @param followRedirects if the request should follow 3xx redirections.
+     *
+     * @deprecated please use {@link #Options(long, TimeUnit, long, TimeUnit, boolean, int)}
      */
+    @Deprecated
     public Options(long connectTimeout, TimeUnit connectTimeoutUnit,
         long readTimeout, TimeUnit readTimeoutUnit,
         boolean followRedirects) {
@@ -299,6 +303,32 @@ public final class Request implements Serializable {
       this.readTimeout = readTimeout;
       this.readTimeoutUnit = readTimeoutUnit;
       this.followRedirects = followRedirects;
+      this.connectExceptionStatus = 500;
+    }
+
+    /**
+     * Creates a new Options Instance.
+     *
+     * @param connectTimeout value.
+     * @param connectTimeoutUnit with the TimeUnit for the timeout value.
+     * @param readTimeout value.
+     * @param readTimeoutUnit with the TimeUnit for the timeout value.
+     * @param followRedirects if the request should follow 3xx redirections.
+     * @param connectExceptionStatus status from exception
+     */
+    public Options(long connectTimeout, TimeUnit connectTimeoutUnit,
+        long readTimeout, TimeUnit readTimeoutUnit,
+        boolean followRedirects, int connectExceptionStatus) {
+      super();
+      if (connectExceptionStatus < 0) {
+        throw new IllegalArgumentException("ConnectException status must be a non negative number");
+      }
+      this.connectTimeout = connectTimeout;
+      this.connectTimeoutUnit = connectTimeoutUnit;
+      this.readTimeout = readTimeout;
+      this.readTimeoutUnit = readTimeoutUnit;
+      this.followRedirects = followRedirects;
+      this.connectExceptionStatus = connectExceptionStatus;
     }
 
     /**
@@ -323,7 +353,7 @@ public final class Request implements Serializable {
      * </ul>
      */
     public Options() {
-      this(10, TimeUnit.SECONDS, 60, TimeUnit.SECONDS, true);
+      this(10, TimeUnit.SECONDS, 60, TimeUnit.SECONDS, true, 500);
     }
 
     /**
@@ -388,6 +418,15 @@ public final class Request implements Serializable {
      */
     public TimeUnit readTimeoutUnit() {
       return readTimeoutUnit;
+    }
+
+    /**
+     * HTTP status code for connect exception value.
+     *
+     * @return HTTP status code for connect exceptions
+     */
+    public int connectExceptionStatus() {
+      return connectExceptionStatus;
     }
 
   }

--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -128,7 +128,7 @@ final class SynchronousMethodHandler implements MethodHandler {
       if (logLevel != Logger.Level.NONE) {
         logger.logIOException(metadata.configKey(), logLevel, e, elapsedTime(start));
       }
-      throw errorExecuting(request, e);
+      throw errorExecuting(request, e, options.connectExceptionStatus());
     }
     long elapsedTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
 

--- a/core/src/test/java/feign/FeignExceptionTest.java
+++ b/core/src/test/java/feign/FeignExceptionTest.java
@@ -51,11 +51,31 @@ public class FeignExceptionTest {
         null);
 
     FeignException exception =
-        FeignException.errorExecuting(request, new IOException("connection timeout"));
+        FeignException.errorExecuting(request, new IOException("connection timeout"), 500);
     assertThat(exception.responseBody()).isEmpty();
     assertThat(exception.content()).isNullOrEmpty();
     assertThat(exception.hasRequest()).isTrue();
     assertThat(exception.request()).isNotNull();
+  }
+
+  @Test
+  public void shouldThrowCustomHttpStatusCode() {
+    Request request = Request.create(Request.HttpMethod.GET,
+        "/home", Collections.emptyMap(),
+        "data".getBytes(StandardCharsets.UTF_8),
+        StandardCharsets.UTF_8,
+        null);
+
+    int connectExceptionStatus = 0;
+
+    FeignException exception =
+        FeignException.errorExecuting(request, new IOException("connection timeout"),
+            connectExceptionStatus);
+    assertThat(exception.responseBody()).isEmpty();
+    assertThat(exception.content()).isNullOrEmpty();
+    assertThat(exception.hasRequest()).isTrue();
+    assertThat(exception.request()).isNotNull();
+    assertThat(exception.status()).isEqualTo(connectExceptionStatus);
   }
 
   @Test

--- a/core/src/test/java/feign/OptionsTest.java
+++ b/core/src/test/java/feign/OptionsTest.java
@@ -87,4 +87,10 @@ public class OptionsTest {
 
     assertThat(api.getChildOptions(new ChildOptions(1000, 4 * 1000))).isEqualTo("foo");
   }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldNotAcceptNegativeConnectExceptionStatus() {
+    new Request.Options(1000, TimeUnit.MILLISECONDS,
+        1000, TimeUnit.MILLISECONDS, Boolean.TRUE, -1);
+  }
 }


### PR DESCRIPTION
Changes:
- Add connectExceptionStatus to the Options class which contains configurations for each FeignClient
- Switch from wrong status code to the connectExceptionStatus above (by default 500)
- Add tests

Fixes #1773