### PR TITLE
Remove the unused code from the MethodInfo

### DIFF
--- a/core/src/main/java/feign/MethodInfo.java
+++ b/core/src/main/java/feign/MethodInfo.java
@@ -20,19 +20,15 @@ import java.util.concurrent.CompletableFuture;
 
 @Experimental
 public class MethodInfo {
-  private final String configKey;
   private final Type underlyingReturnType;
   private final boolean asyncReturnType;
 
-  protected MethodInfo(String configKey, Type underlyingReturnType, boolean asyncReturnType) {
-    this.configKey = configKey;
+  protected MethodInfo(Type underlyingReturnType, boolean asyncReturnType) {
     this.underlyingReturnType = underlyingReturnType;
     this.asyncReturnType = asyncReturnType;
   }
 
   MethodInfo(Class<?> targetType, Method method) {
-    this.configKey = Feign.configKey(targetType, method);
-
     final Type type = Types.resolve(targetType, targetType, method.getGenericReturnType());
 
     if (type instanceof ParameterizedType
@@ -43,10 +39,6 @@ public class MethodInfo {
       this.asyncReturnType = false;
       this.underlyingReturnType = type;
     }
-  }
-
-  String configKey() {
-    return configKey;
   }
 
   Type underlyingReturnType() {

--- a/core/src/test/java/feign/MethodInfoTest.java
+++ b/core/src/test/java/feign/MethodInfoTest.java
@@ -33,7 +33,6 @@ public class MethodInfoTest {
     @Test
     public void testCompletableFutureOfString() throws Exception {
       MethodInfo mi = new MethodInfo(AsyncClient.class, AsyncClient.class.getMethod("log"));
-      assertEquals("AsyncClient#log()", mi.configKey());
       assertTrue(mi.isAsyncReturnType());
       assertEquals(String.class, mi.underlyingReturnType());
     }
@@ -50,7 +49,6 @@ public class MethodInfoTest {
     @Test
     public void testGenericCompletableFutureOfString() throws Exception {
       MethodInfo mi = new MethodInfo(AsyncClient.class, AsyncClient.class.getMethod("log"));
-      assertEquals("AsyncClient#log()", mi.configKey());
       assertTrue(mi.isAsyncReturnType());
       assertEquals(String.class, mi.underlyingReturnType());
     }
@@ -64,7 +62,6 @@ public class MethodInfoTest {
     @Test
     public void testString() throws Exception {
       MethodInfo mi = new MethodInfo(SyncClient.class, SyncClient.class.getMethod("log"));
-      assertEquals("SyncClient#log()", mi.configKey());
       assertFalse(mi.isAsyncReturnType());
       assertEquals(String.class, mi.underlyingReturnType());
     }
@@ -98,7 +95,6 @@ public class MethodInfoTest {
     @Test
     public void testListOfStrings() throws Exception {
       MethodInfo mi = new MethodInfo(SyncClient.class, SyncClient.class.getMethod("log"));
-      assertEquals("SyncClient#log()", mi.configKey());
       assertFalse(mi.isAsyncReturnType());
       assertTrue(Types.equals(new ListOfStrings(), mi.underlyingReturnType()));
     }

--- a/kotlin/src/main/java/feign/kotlin/KotlinMethodInfo.java
+++ b/kotlin/src/main/java/feign/kotlin/KotlinMethodInfo.java
@@ -23,13 +23,11 @@ import java.util.concurrent.CompletableFuture;
 
 class KotlinMethodInfo extends MethodInfo {
 
-  KotlinMethodInfo(String configKey, Type underlyingReturnType, boolean asyncReturnType) {
-    super(configKey, underlyingReturnType, asyncReturnType);
+  KotlinMethodInfo(Type underlyingReturnType, boolean asyncReturnType) {
+    super(underlyingReturnType, asyncReturnType);
   }
 
   static KotlinMethodInfo createInstance(Class<?> targetType, Method method) {
-    String configKey = Feign.configKey(targetType, method);
-
     final Type type = Types.resolve(targetType, targetType, method.getGenericReturnType());
 
     Type underlyingReturnType;
@@ -38,6 +36,7 @@ class KotlinMethodInfo extends MethodInfo {
       asyncReturnType = true;
       underlyingReturnType = MethodKt.getKotlinMethodReturnType(method);
       if (underlyingReturnType == null) {
+        String configKey = Feign.configKey(targetType, method);
         throw new IllegalArgumentException(
             String.format(
                 "Method %s can't have continuation argument, only kotlin method is allowed",
@@ -52,6 +51,6 @@ class KotlinMethodInfo extends MethodInfo {
       underlyingReturnType = type;
     }
 
-    return new KotlinMethodInfo(configKey, underlyingReturnType, asyncReturnType);
+    return new KotlinMethodInfo(underlyingReturnType, asyncReturnType);
   }
 }


### PR DESCRIPTION
The MethodInfo.configKey field is not more used since PR #1757 removing AsyncInvocation