### PR TITLE
Add Unit Test For Json Literals Being Passed as Header Values

### DIFF
--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -207,6 +207,17 @@ public class RequestTemplateTest {
   }
 
   @Test
+  public void resolveTemplateWithHeaderContainingJsonLiteral() {
+    String json = "{\"A\":{\"B\":\"C\"}}";
+    RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)
+        .header("A-Header", json);
+
+    template.resolve(new LinkedHashMap<>());
+    assertThat(template)
+        .hasHeaders(entry("A-Header", Collections.singletonList(json)));
+  }
+
+  @Test
   public void resolveTemplateWithHeaderWithJson() {
     String json = "{ \"string\": \"val\", \"string2\": \"this should not be truncated\"}";
     RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)


### PR DESCRIPTION
Adding a unit test to cover the case described in issue 1305.

That issue is fixed. This test *should* prevent future regressions.