### PR TITLE
Allow usage of GET with body in java11 Module

### DIFF
--- a/java11/src/main/java/feign/http2client/Http2Client.java
+++ b/java11/src/main/java/feign/http2client/Http2Client.java
@@ -190,20 +190,7 @@ public class Http2Client implements Client, AsyncClient<Object> {
       requestBuilder.headers(asString(headers));
     }
 
-    switch (request.httpMethod()) {
-      case GET:
-        return requestBuilder.GET();
-      case POST:
-        return requestBuilder.POST(body);
-      case PUT:
-        return requestBuilder.PUT(body);
-      case DELETE:
-        return requestBuilder.DELETE();
-      default:
-        // fall back scenario, http implementations may restrict some methods
-        return requestBuilder.method(request.httpMethod().toString(), body);
-    }
-
+    return requestBuilder.method(request.httpMethod().toString(), body);
   }
 
   /**

--- a/java11/src/test/java/feign/http2client/test/Http2ClientTest.java
+++ b/java11/src/test/java/feign/http2client/test/Http2ClientTest.java
@@ -44,6 +44,14 @@ public class Http2ClientTest extends AbstractClientTest {
     @RequestLine("POST /timeout")
     @Headers({"Accept: text/plain"})
     String timeout();
+
+    @RequestLine("GET /anything")
+    @Body("some request body")
+    String getWithBody();
+
+    @RequestLine("DELETE /anything")
+    @Body("some request body")
+    String deleteWithBody();
   }
 
   @Override
@@ -113,6 +121,24 @@ public class Http2ClientTest extends AbstractClientTest {
     thrown.expectCause(CoreMatchers.isA(HttpTimeoutException.class));
 
     api.timeout();
+  }
+
+  @Test
+  public void testGetWithRequestBody() {
+    final TestInterface api =
+        newBuilder().target(TestInterface.class, "https://nghttp2.org/httpbin/");
+    String result = api.getWithBody();
+    Assertions.assertThat(result)
+        .contains("\"data\": \"some request body\"");
+  }
+
+  @Test
+  public void testDeleteWithRequestBody() {
+    final TestInterface api =
+        newBuilder().target(TestInterface.class, "https://nghttp2.org/httpbin/");
+    String result = api.deleteWithBody();
+    Assertions.assertThat(result)
+        .contains("\"data\": \"some request body\"");
   }
 
   @Override


### PR DESCRIPTION
Although discouraged there are unfortunately some web services that require a body to be sent with GET requests. Java 11's integrated http client allows this under the hood, but feigns java11 module currently does not. This PR adds support for bodys with any request method.