### PR TITLE
Issue-1833: Bump Sundr Maven Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
     <maven-bundle-plugin.version>5.1.8</maven-bundle-plugin.version>
     <centralsync-maven-plugin.version>0.1.1</centralsync-maven-plugin.version>
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-    <bom-generator.version>0.40.1</bom-generator.version>
+    <bom-generator.version>0.93.1</bom-generator.version>
     <bom.template.file.path>file://${project.basedir}/src/config/bom.xml</bom.template.file.path>
     <maven-scm-plugin.version>1.13.0</maven-scm-plugin.version>
     <maven-versions-plugin.version>2.13.0</maven-versions-plugin.version>
@@ -717,19 +717,6 @@
             </goals>
           </execution>
         </executions>
-        <dependencies>
-          <dependency>
-            <groupId>io.sundr</groupId>
-            <artifactId>sundr-codegen</artifactId>
-            <version>${bom-generator.version}</version>
-            <exclusions>
-              <exclusion>
-                <groupId>com.sun</groupId>
-                <artifactId>tools</artifactId>
-              </exclusion>
-            </exclusions>
-          </dependency>
-        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
A small change to fix a build failure I was having after a recent update to my machine.

Removes dependency exclusion for `com.sun:tools` from the plugin. That no longer appears in the current version dependency tree from what I could find.

fixes #1833 
