### PR TITLE
Move responsibility for resolving RequestTemplateFactory

### DIFF
--- a/core/src/main/java/feign/AsyncFeign.java
+++ b/core/src/main/java/feign/AsyncFeign.java
@@ -210,7 +210,6 @@ public final class AsyncFeign<C> {
               options, decoder, errorDecoder);
       final ParseHandlersByName<C> handlersByName =
           new ParseHandlersByName<>(contract,
-              new RequestTemplateFactoryResolver(encoder, queryMapEncoder),
               methodHandlerFactory);
       final ReflectiveFeign<C> feign =
           new ReflectiveFeign<>(handlersByName, invocationHandlerFactory, defaultContextSupplier);

--- a/core/src/main/java/feign/AsyncFeign.java
+++ b/core/src/main/java/feign/AsyncFeign.java
@@ -206,6 +206,7 @@ public final class AsyncFeign<C> {
               client, retryer, requestInterceptors,
               responseHandler, logger, logLevel,
               propagationPolicy, methodInfoResolver,
+              new RequestTemplateFactoryResolver(encoder, queryMapEncoder),
               options, decoder, errorDecoder);
       final ParseHandlersByName<C> handlersByName =
           new ParseHandlersByName<>(contract,

--- a/core/src/main/java/feign/AsyncFeign.java
+++ b/core/src/main/java/feign/AsyncFeign.java
@@ -208,7 +208,9 @@ public final class AsyncFeign<C> {
               propagationPolicy, methodInfoResolver,
               options, decoder, errorDecoder);
       final ParseHandlersByName<C> handlersByName =
-          new ParseHandlersByName<>(contract, encoder, queryMapEncoder, methodHandlerFactory);
+          new ParseHandlersByName<>(contract,
+              new RequestTemplateFactoryResolver(encoder, queryMapEncoder),
+              methodHandlerFactory);
       final ReflectiveFeign<C> feign =
           new ReflectiveFeign<>(handlersByName, invocationHandlerFactory, defaultContextSupplier);
       return new AsyncFeign<>(feign);

--- a/core/src/main/java/feign/AsynchronousMethodHandler.java
+++ b/core/src/main/java/feign/AsynchronousMethodHandler.java
@@ -277,8 +277,9 @@ final class AsynchronousMethodHandler<C> implements MethodHandler {
 
     public MethodHandler create(Target<?> target,
                                 MethodMetadata md,
-                                RequestTemplate.Factory buildTemplateFromArgs,
                                 C requestContext) {
+      final RequestTemplate.Factory buildTemplateFromArgs =
+          requestTemplateFactoryResolver.resolve(target, md);
       return new AsynchronousMethodHandler<C>(target, client, retryer, requestInterceptors,
           logger, logLevel, md, buildTemplateFromArgs, options, responseHandler,
           propagationPolicy, requestContext,

--- a/core/src/main/java/feign/AsynchronousMethodHandler.java
+++ b/core/src/main/java/feign/AsynchronousMethodHandler.java
@@ -246,6 +246,7 @@ final class AsynchronousMethodHandler<C> implements MethodHandler {
     private final Logger.Level logLevel;
     private final ExceptionPropagationPolicy propagationPolicy;
     private final MethodInfoResolver methodInfoResolver;
+    private final RequestTemplateFactoryResolver requestTemplateFactoryResolver;
     private final Options options;
     private final Decoder decoder;
     private final ErrorDecoder errorDecoder;
@@ -255,6 +256,7 @@ final class AsynchronousMethodHandler<C> implements MethodHandler {
         Logger logger, Logger.Level logLevel,
         ExceptionPropagationPolicy propagationPolicy,
         MethodInfoResolver methodInfoResolver,
+        RequestTemplateFactoryResolver requestTemplateFactoryResolver,
         Options options,
         Decoder decoder,
         ErrorDecoder errorDecoder) {
@@ -266,6 +268,8 @@ final class AsynchronousMethodHandler<C> implements MethodHandler {
       this.logLevel = checkNotNull(logLevel, "logLevel");
       this.propagationPolicy = propagationPolicy;
       this.methodInfoResolver = methodInfoResolver;
+      this.requestTemplateFactoryResolver =
+          checkNotNull(requestTemplateFactoryResolver, "requestTemplateFactoryResolver");
       this.options = checkNotNull(options, "options");
       this.errorDecoder = checkNotNull(errorDecoder, "errorDecoder");
       this.decoder = checkNotNull(decoder, "decoder");

--- a/core/src/main/java/feign/Feign.java
+++ b/core/src/main/java/feign/Feign.java
@@ -205,7 +205,9 @@ public abstract class Feign {
               dismiss404, closeAfterDecode, responseInterceptor);
       MethodHandler.Factory<Object> synchronousMethodHandlerFactory =
           new SynchronousMethodHandler.Factory(client, retryer, requestInterceptors,
-              responseHandler, logger, logLevel, propagationPolicy, options);
+              responseHandler, logger, logLevel, propagationPolicy,
+              new RequestTemplateFactoryResolver(encoder, queryMapEncoder),
+              options);
       ParseHandlersByName<Object> handlersByName =
           new ParseHandlersByName<>(contract,
               new RequestTemplateFactoryResolver(encoder, queryMapEncoder),

--- a/core/src/main/java/feign/Feign.java
+++ b/core/src/main/java/feign/Feign.java
@@ -207,7 +207,8 @@ public abstract class Feign {
           new SynchronousMethodHandler.Factory(client, retryer, requestInterceptors,
               responseHandler, logger, logLevel, propagationPolicy, options);
       ParseHandlersByName<Object> handlersByName =
-          new ParseHandlersByName<>(contract, encoder, queryMapEncoder,
+          new ParseHandlersByName<>(contract,
+              new RequestTemplateFactoryResolver(encoder, queryMapEncoder),
               synchronousMethodHandlerFactory);
       return new ReflectiveFeign<>(handlersByName, invocationHandlerFactory, () -> null);
     }

--- a/core/src/main/java/feign/Feign.java
+++ b/core/src/main/java/feign/Feign.java
@@ -210,7 +210,6 @@ public abstract class Feign {
               options);
       ParseHandlersByName<Object> handlersByName =
           new ParseHandlersByName<>(contract,
-              new RequestTemplateFactoryResolver(encoder, queryMapEncoder),
               synchronousMethodHandlerFactory);
       return new ReflectiveFeign<>(handlersByName, invocationHandlerFactory, () -> null);
     }

--- a/core/src/main/java/feign/InvocationHandlerFactory.java
+++ b/core/src/main/java/feign/InvocationHandlerFactory.java
@@ -37,7 +37,6 @@ public interface InvocationHandlerFactory {
     interface Factory<C> {
       MethodHandler create(Target<?> target,
                            MethodMetadata md,
-                           RequestTemplate.Factory buildTemplateFromArgs,
                            C requestContext);
     }
   }

--- a/core/src/main/java/feign/ReflectiveFeign.java
+++ b/core/src/main/java/feign/ReflectiveFeign.java
@@ -13,7 +13,6 @@
  */
 package feign;
 
-import static feign.Util.checkArgument;
 import static feign.Util.checkNotNull;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
@@ -22,12 +21,8 @@ import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
 import java.lang.reflect.WildcardType;
 import java.util.*;
-import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import feign.InvocationHandlerFactory.MethodHandler;
-import feign.Param.Expander;
-import feign.codec.*;
-import feign.template.UriUtils;
 
 public class ReflectiveFeign<C> extends Feign {
 
@@ -121,19 +116,16 @@ public class ReflectiveFeign<C> extends Feign {
   static final class ParseHandlersByName<C> {
 
     private final Contract contract;
-    private final Encoder encoder;
-    private final QueryMapEncoder queryMapEncoder;
+    private final RequestTemplateFactoryResolver requestTemplateFactoryResolver;
     private final MethodHandler.Factory<C> factory;
 
     ParseHandlersByName(
         Contract contract,
-        Encoder encoder,
-        QueryMapEncoder queryMapEncoder,
+        RequestTemplateFactoryResolver requestTemplateFactoryResolver,
         MethodHandler.Factory<C> factory) {
       this.contract = contract;
+      this.requestTemplateFactoryResolver = requestTemplateFactoryResolver;
       this.factory = factory;
-      this.queryMapEncoder = queryMapEncoder;
-      this.encoder = checkNotNull(encoder, "encoder");
     }
 
     public Map<Method, MethodHandler> apply(Target target, C requestContext) {
@@ -169,250 +161,8 @@ public class ReflectiveFeign<C> extends Feign {
         };
       }
 
-      BuildTemplateByResolvingArgs buildTemplate = getBuildTemplate(target, md);
+      RequestTemplate.Factory buildTemplate = requestTemplateFactoryResolver.resolve(target, md);
       return factory.create(target, md, buildTemplate, requestContext);
-    }
-
-    private BuildTemplateByResolvingArgs getBuildTemplate(Target target, MethodMetadata md) {
-      if (!md.formParams().isEmpty() && md.template().bodyTemplate() == null) {
-        return new BuildFormEncodedTemplateFromArgs(md, encoder, queryMapEncoder, target);
-      } else if (md.bodyIndex() != null || md.alwaysEncodeBody()) {
-        return new BuildEncodedTemplateFromArgs(md, encoder, queryMapEncoder, target);
-      } else {
-        return new BuildTemplateByResolvingArgs(md, queryMapEncoder, target);
-      }
-    }
-  }
-
-  private static class BuildTemplateByResolvingArgs implements RequestTemplate.Factory {
-
-    private final QueryMapEncoder queryMapEncoder;
-
-    protected final MethodMetadata metadata;
-    protected final Target<?> target;
-    private final Map<Integer, Expander> indexToExpander = new LinkedHashMap<Integer, Expander>();
-
-    private BuildTemplateByResolvingArgs(MethodMetadata metadata, QueryMapEncoder queryMapEncoder,
-        Target target) {
-      this.metadata = metadata;
-      this.target = target;
-      this.queryMapEncoder = queryMapEncoder;
-      if (metadata.indexToExpander() != null) {
-        indexToExpander.putAll(metadata.indexToExpander());
-        return;
-      }
-      if (metadata.indexToExpanderClass().isEmpty()) {
-        return;
-      }
-      for (Entry<Integer, Class<? extends Expander>> indexToExpanderClass : metadata
-          .indexToExpanderClass().entrySet()) {
-        try {
-          indexToExpander
-              .put(indexToExpanderClass.getKey(), indexToExpanderClass.getValue().newInstance());
-        } catch (InstantiationException e) {
-          throw new IllegalStateException(e);
-        } catch (IllegalAccessException e) {
-          throw new IllegalStateException(e);
-        }
-      }
-    }
-
-    @Override
-    public RequestTemplate create(Object[] argv) {
-      RequestTemplate mutable = RequestTemplate.from(metadata.template());
-      mutable.feignTarget(target);
-      if (metadata.urlIndex() != null) {
-        int urlIndex = metadata.urlIndex();
-        checkArgument(argv[urlIndex] != null, "URI parameter %s was null", urlIndex);
-        mutable.target(String.valueOf(argv[urlIndex]));
-      }
-      Map<String, Object> varBuilder = new LinkedHashMap<String, Object>();
-      for (Entry<Integer, Collection<String>> entry : metadata.indexToName().entrySet()) {
-        int i = entry.getKey();
-        Object value = argv[entry.getKey()];
-        if (value != null) { // Null values are skipped.
-          if (indexToExpander.containsKey(i)) {
-            value = expandElements(indexToExpander.get(i), value);
-          }
-          for (String name : entry.getValue()) {
-            varBuilder.put(name, value);
-          }
-        }
-      }
-
-      RequestTemplate template = resolve(argv, mutable, varBuilder);
-      if (metadata.queryMapIndex() != null) {
-        // add query map parameters after initial resolve so that they take
-        // precedence over any predefined values
-        Object value = argv[metadata.queryMapIndex()];
-        Map<String, Object> queryMap = toQueryMap(value);
-        template = addQueryMapQueryParameters(queryMap, template);
-      }
-
-      if (metadata.headerMapIndex() != null) {
-        // add header map parameters for a resolution of the user pojo object
-        Object value = argv[metadata.headerMapIndex()];
-        Map<String, Object> headerMap = toQueryMap(value);
-        template = addHeaderMapHeaders(headerMap, template);
-      }
-
-      return template;
-    }
-
-    private Map<String, Object> toQueryMap(Object value) {
-      if (value instanceof Map) {
-        return (Map<String, Object>) value;
-      }
-      try {
-        return queryMapEncoder.encode(value);
-      } catch (EncodeException e) {
-        throw new IllegalStateException(e);
-      }
-    }
-
-    private Object expandElements(Expander expander, Object value) {
-      if (value instanceof Iterable) {
-        return expandIterable(expander, (Iterable) value);
-      }
-      return expander.expand(value);
-    }
-
-    private List<String> expandIterable(Expander expander, Iterable value) {
-      List<String> values = new ArrayList<String>();
-      for (Object element : value) {
-        if (element != null) {
-          values.add(expander.expand(element));
-        }
-      }
-      return values;
-    }
-
-    @SuppressWarnings("unchecked")
-    private RequestTemplate addHeaderMapHeaders(Map<String, Object> headerMap,
-                                                RequestTemplate mutable) {
-      for (Entry<String, Object> currEntry : headerMap.entrySet()) {
-        Collection<String> values = new ArrayList<String>();
-
-        Object currValue = currEntry.getValue();
-        if (currValue instanceof Iterable<?>) {
-          Iterator<?> iter = ((Iterable<?>) currValue).iterator();
-          while (iter.hasNext()) {
-            Object nextObject = iter.next();
-            values.add(nextObject == null ? null : nextObject.toString());
-          }
-        } else {
-          values.add(currValue == null ? null : currValue.toString());
-        }
-
-        mutable.header(currEntry.getKey(), values);
-      }
-      return mutable;
-    }
-
-    @SuppressWarnings("unchecked")
-    private RequestTemplate addQueryMapQueryParameters(Map<String, Object> queryMap,
-                                                       RequestTemplate mutable) {
-      for (Entry<String, Object> currEntry : queryMap.entrySet()) {
-        Collection<String> values = new ArrayList<String>();
-
-        Object currValue = currEntry.getValue();
-        if (currValue instanceof Iterable<?>) {
-          Iterator<?> iter = ((Iterable<?>) currValue).iterator();
-          while (iter.hasNext()) {
-            Object nextObject = iter.next();
-            values.add(nextObject == null ? null : UriUtils.encode(nextObject.toString()));
-          }
-        } else if (currValue instanceof Object[]) {
-          for (Object value : (Object[]) currValue) {
-            values.add(value == null ? null : UriUtils.encode(value.toString()));
-          }
-        } else {
-          if (currValue != null) {
-            values.add(UriUtils.encode(currValue.toString()));
-          }
-        }
-
-        if (values.size() > 0) {
-          mutable.query(UriUtils.encode(currEntry.getKey()), values);
-        }
-      }
-      return mutable;
-    }
-
-    protected RequestTemplate resolve(Object[] argv,
-                                      RequestTemplate mutable,
-                                      Map<String, Object> variables) {
-      return mutable.resolve(variables);
-    }
-  }
-
-  private static class BuildFormEncodedTemplateFromArgs extends BuildTemplateByResolvingArgs {
-
-    private final Encoder encoder;
-
-    private BuildFormEncodedTemplateFromArgs(MethodMetadata metadata, Encoder encoder,
-        QueryMapEncoder queryMapEncoder, Target target) {
-      super(metadata, queryMapEncoder, target);
-      this.encoder = encoder;
-    }
-
-    @Override
-    protected RequestTemplate resolve(Object[] argv,
-                                      RequestTemplate mutable,
-                                      Map<String, Object> variables) {
-      Map<String, Object> formVariables = new LinkedHashMap<String, Object>();
-      for (Entry<String, Object> entry : variables.entrySet()) {
-        if (metadata.formParams().contains(entry.getKey())) {
-          formVariables.put(entry.getKey(), entry.getValue());
-        }
-      }
-      try {
-        encoder.encode(formVariables, Encoder.MAP_STRING_WILDCARD, mutable);
-      } catch (EncodeException e) {
-        throw e;
-      } catch (RuntimeException e) {
-        throw new EncodeException(e.getMessage(), e);
-      }
-      return super.resolve(argv, mutable, variables);
-    }
-  }
-
-  private static class BuildEncodedTemplateFromArgs extends BuildTemplateByResolvingArgs {
-
-    private final Encoder encoder;
-
-    private BuildEncodedTemplateFromArgs(MethodMetadata metadata, Encoder encoder,
-        QueryMapEncoder queryMapEncoder, Target target) {
-      super(metadata, queryMapEncoder, target);
-      this.encoder = encoder;
-    }
-
-    @Override
-    protected RequestTemplate resolve(Object[] argv,
-                                      RequestTemplate mutable,
-                                      Map<String, Object> variables) {
-
-      boolean alwaysEncodeBody = mutable.methodMetadata().alwaysEncodeBody();
-
-      Object body = null;
-      if (!alwaysEncodeBody) {
-        body = argv[metadata.bodyIndex()];
-        checkArgument(body != null, "Body parameter %s was null", metadata.bodyIndex());
-      }
-
-      try {
-        if (alwaysEncodeBody) {
-          body = argv == null ? new Object[0] : argv;
-          encoder.encode(body, Object[].class, mutable);
-        } else {
-          encoder.encode(body, metadata.bodyType(), mutable);
-        }
-      } catch (EncodeException e) {
-        throw e;
-      } catch (RuntimeException e) {
-        throw new EncodeException(e.getMessage(), e);
-      }
-      return super.resolve(argv, mutable, variables);
     }
   }
 

--- a/core/src/main/java/feign/ReflectiveFeign.java
+++ b/core/src/main/java/feign/ReflectiveFeign.java
@@ -116,15 +116,12 @@ public class ReflectiveFeign<C> extends Feign {
   static final class ParseHandlersByName<C> {
 
     private final Contract contract;
-    private final RequestTemplateFactoryResolver requestTemplateFactoryResolver;
     private final MethodHandler.Factory<C> factory;
 
     ParseHandlersByName(
         Contract contract,
-        RequestTemplateFactoryResolver requestTemplateFactoryResolver,
         MethodHandler.Factory<C> factory) {
       this.contract = contract;
-      this.requestTemplateFactoryResolver = requestTemplateFactoryResolver;
       this.factory = factory;
     }
 

--- a/core/src/main/java/feign/ReflectiveFeign.java
+++ b/core/src/main/java/feign/ReflectiveFeign.java
@@ -161,8 +161,7 @@ public class ReflectiveFeign<C> extends Feign {
         };
       }
 
-      RequestTemplate.Factory buildTemplate = requestTemplateFactoryResolver.resolve(target, md);
-      return factory.create(target, md, buildTemplate, requestContext);
+      return factory.create(target, md, requestContext);
     }
   }
 

--- a/core/src/main/java/feign/RequestTemplateFactoryResolver.java
+++ b/core/src/main/java/feign/RequestTemplateFactoryResolver.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2012-2022 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign;
+
+import static feign.Util.checkArgument;
+import static feign.Util.checkNotNull;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import feign.codec.EncodeException;
+import feign.codec.Encoder;
+import feign.template.UriUtils;
+
+final class RequestTemplateFactoryResolver {
+  private final Encoder encoder;
+  private final QueryMapEncoder queryMapEncoder;
+
+  RequestTemplateFactoryResolver(
+      Encoder encoder,
+      QueryMapEncoder queryMapEncoder) {
+    this.encoder = checkNotNull(encoder, "encoder");
+    this.queryMapEncoder = checkNotNull(queryMapEncoder, "queryMapEncoder");
+  }
+
+  public RequestTemplate.Factory resolve(Target<?> target, MethodMetadata md) {
+    if (!md.formParams().isEmpty() && md.template().bodyTemplate() == null) {
+      return new BuildFormEncodedTemplateFromArgs(md, encoder, queryMapEncoder, target);
+    } else if (md.bodyIndex() != null || md.alwaysEncodeBody()) {
+      return new BuildEncodedTemplateFromArgs(md, encoder, queryMapEncoder, target);
+    } else {
+      return new BuildTemplateByResolvingArgs(md, queryMapEncoder, target);
+    }
+  }
+
+  private static class BuildTemplateByResolvingArgs implements RequestTemplate.Factory {
+
+    private final QueryMapEncoder queryMapEncoder;
+
+    protected final MethodMetadata metadata;
+    protected final Target<?> target;
+    private final Map<Integer, Param.Expander> indexToExpander =
+        new LinkedHashMap<Integer, Param.Expander>();
+
+    private BuildTemplateByResolvingArgs(MethodMetadata metadata, QueryMapEncoder queryMapEncoder,
+        Target target) {
+      this.metadata = metadata;
+      this.target = target;
+      this.queryMapEncoder = queryMapEncoder;
+      if (metadata.indexToExpander() != null) {
+        indexToExpander.putAll(metadata.indexToExpander());
+        return;
+      }
+      if (metadata.indexToExpanderClass().isEmpty()) {
+        return;
+      }
+      for (Map.Entry<Integer, Class<? extends Param.Expander>> indexToExpanderClass : metadata
+          .indexToExpanderClass().entrySet()) {
+        try {
+          indexToExpander
+              .put(indexToExpanderClass.getKey(), indexToExpanderClass.getValue().newInstance());
+        } catch (InstantiationException e) {
+          throw new IllegalStateException(e);
+        } catch (IllegalAccessException e) {
+          throw new IllegalStateException(e);
+        }
+      }
+    }
+
+    @Override
+    public RequestTemplate create(Object[] argv) {
+      RequestTemplate mutable = RequestTemplate.from(metadata.template());
+      mutable.feignTarget(target);
+      if (metadata.urlIndex() != null) {
+        int urlIndex = metadata.urlIndex();
+        checkArgument(argv[urlIndex] != null, "URI parameter %s was null", urlIndex);
+        mutable.target(String.valueOf(argv[urlIndex]));
+      }
+      Map<String, Object> varBuilder = new LinkedHashMap<String, Object>();
+      for (Map.Entry<Integer, Collection<String>> entry : metadata.indexToName().entrySet()) {
+        int i = entry.getKey();
+        Object value = argv[entry.getKey()];
+        if (value != null) { // Null values are skipped.
+          if (indexToExpander.containsKey(i)) {
+            value = expandElements(indexToExpander.get(i), value);
+          }
+          for (String name : entry.getValue()) {
+            varBuilder.put(name, value);
+          }
+        }
+      }
+
+      RequestTemplate template = resolve(argv, mutable, varBuilder);
+      if (metadata.queryMapIndex() != null) {
+        // add query map parameters after initial resolve so that they take
+        // precedence over any predefined values
+        Object value = argv[metadata.queryMapIndex()];
+        Map<String, Object> queryMap = toQueryMap(value);
+        template = addQueryMapQueryParameters(queryMap, template);
+      }
+
+      if (metadata.headerMapIndex() != null) {
+        // add header map parameters for a resolution of the user pojo object
+        Object value = argv[metadata.headerMapIndex()];
+        Map<String, Object> headerMap = toQueryMap(value);
+        template = addHeaderMapHeaders(headerMap, template);
+      }
+
+      return template;
+    }
+
+    private Map<String, Object> toQueryMap(Object value) {
+      if (value instanceof Map) {
+        return (Map<String, Object>) value;
+      }
+      try {
+        return queryMapEncoder.encode(value);
+      } catch (EncodeException e) {
+        throw new IllegalStateException(e);
+      }
+    }
+
+    private Object expandElements(Param.Expander expander, Object value) {
+      if (value instanceof Iterable) {
+        return expandIterable(expander, (Iterable) value);
+      }
+      return expander.expand(value);
+    }
+
+    private List<String> expandIterable(Param.Expander expander, Iterable value) {
+      List<String> values = new ArrayList<String>();
+      for (Object element : value) {
+        if (element != null) {
+          values.add(expander.expand(element));
+        }
+      }
+      return values;
+    }
+
+    @SuppressWarnings("unchecked")
+    private RequestTemplate addHeaderMapHeaders(Map<String, Object> headerMap,
+                                                RequestTemplate mutable) {
+      for (Map.Entry<String, Object> currEntry : headerMap.entrySet()) {
+        Collection<String> values = new ArrayList<String>();
+
+        Object currValue = currEntry.getValue();
+        if (currValue instanceof Iterable<?>) {
+          Iterator<?> iter = ((Iterable<?>) currValue).iterator();
+          while (iter.hasNext()) {
+            Object nextObject = iter.next();
+            values.add(nextObject == null ? null : nextObject.toString());
+          }
+        } else {
+          values.add(currValue == null ? null : currValue.toString());
+        }
+
+        mutable.header(currEntry.getKey(), values);
+      }
+      return mutable;
+    }
+
+    @SuppressWarnings("unchecked")
+    private RequestTemplate addQueryMapQueryParameters(Map<String, Object> queryMap,
+                                                       RequestTemplate mutable) {
+      for (Map.Entry<String, Object> currEntry : queryMap.entrySet()) {
+        Collection<String> values = new ArrayList<String>();
+
+        Object currValue = currEntry.getValue();
+        if (currValue instanceof Iterable<?>) {
+          Iterator<?> iter = ((Iterable<?>) currValue).iterator();
+          while (iter.hasNext()) {
+            Object nextObject = iter.next();
+            values.add(nextObject == null ? null : UriUtils.encode(nextObject.toString()));
+          }
+        } else if (currValue instanceof Object[]) {
+          for (Object value : (Object[]) currValue) {
+            values.add(value == null ? null : UriUtils.encode(value.toString()));
+          }
+        } else {
+          if (currValue != null) {
+            values.add(UriUtils.encode(currValue.toString()));
+          }
+        }
+
+        if (values.size() > 0) {
+          mutable.query(UriUtils.encode(currEntry.getKey()), values);
+        }
+      }
+      return mutable;
+    }
+
+    protected RequestTemplate resolve(Object[] argv,
+                                      RequestTemplate mutable,
+                                      Map<String, Object> variables) {
+      return mutable.resolve(variables);
+    }
+  }
+
+  private static class BuildFormEncodedTemplateFromArgs extends BuildTemplateByResolvingArgs {
+
+    private final Encoder encoder;
+
+    private BuildFormEncodedTemplateFromArgs(MethodMetadata metadata, Encoder encoder,
+        QueryMapEncoder queryMapEncoder, Target target) {
+      super(metadata, queryMapEncoder, target);
+      this.encoder = encoder;
+    }
+
+    @Override
+    protected RequestTemplate resolve(Object[] argv,
+                                      RequestTemplate mutable,
+                                      Map<String, Object> variables) {
+      Map<String, Object> formVariables = new LinkedHashMap<String, Object>();
+      for (Map.Entry<String, Object> entry : variables.entrySet()) {
+        if (metadata.formParams().contains(entry.getKey())) {
+          formVariables.put(entry.getKey(), entry.getValue());
+        }
+      }
+      try {
+        encoder.encode(formVariables, Encoder.MAP_STRING_WILDCARD, mutable);
+      } catch (EncodeException e) {
+        throw e;
+      } catch (RuntimeException e) {
+        throw new EncodeException(e.getMessage(), e);
+      }
+      return super.resolve(argv, mutable, variables);
+    }
+  }
+
+  private static class BuildEncodedTemplateFromArgs extends BuildTemplateByResolvingArgs {
+
+    private final Encoder encoder;
+
+    private BuildEncodedTemplateFromArgs(MethodMetadata metadata, Encoder encoder,
+        QueryMapEncoder queryMapEncoder, Target target) {
+      super(metadata, queryMapEncoder, target);
+      this.encoder = encoder;
+    }
+
+    @Override
+    protected RequestTemplate resolve(Object[] argv,
+                                      RequestTemplate mutable,
+                                      Map<String, Object> variables) {
+
+      boolean alwaysEncodeBody = mutable.methodMetadata().alwaysEncodeBody();
+
+      Object body = null;
+      if (!alwaysEncodeBody) {
+        body = argv[metadata.bodyIndex()];
+        checkArgument(body != null, "Body parameter %s was null", metadata.bodyIndex());
+      }
+
+      try {
+        if (alwaysEncodeBody) {
+          body = argv == null ? new Object[0] : argv;
+          encoder.encode(body, Object[].class, mutable);
+        } else {
+          encoder.encode(body, metadata.bodyType(), mutable);
+        }
+      } catch (EncodeException e) {
+        throw e;
+      } catch (RuntimeException e) {
+        throw new EncodeException(e.getMessage(), e);
+      }
+      return super.resolve(argv, mutable, variables);
+    }
+  }
+}

--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -169,8 +169,9 @@ final class SynchronousMethodHandler implements MethodHandler {
 
     public MethodHandler create(Target<?> target,
                                 MethodMetadata md,
-                                RequestTemplate.Factory buildTemplateFromArgs,
                                 Object requestContext) {
+      final RequestTemplate.Factory buildTemplateFromArgs =
+          requestTemplateFactoryResolver.resolve(target, md);
       return new SynchronousMethodHandler(target, client, retryer, requestInterceptors,
           logger, logLevel, md, buildTemplateFromArgs, options,
           responseHandler, propagationPolicy);

--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -146,12 +146,14 @@ final class SynchronousMethodHandler implements MethodHandler {
     private final Logger logger;
     private final Logger.Level logLevel;
     private final ExceptionPropagationPolicy propagationPolicy;
+    private final RequestTemplateFactoryResolver requestTemplateFactoryResolver;
     private final Options options;
 
     Factory(Client client, Retryer retryer, List<RequestInterceptor> requestInterceptors,
         ResponseHandler responseHandler,
         Logger logger, Logger.Level logLevel,
         ExceptionPropagationPolicy propagationPolicy,
+        RequestTemplateFactoryResolver requestTemplateFactoryResolver,
         Options options) {
       this.client = checkNotNull(client, "client");
       this.retryer = checkNotNull(retryer, "retryer");
@@ -160,6 +162,8 @@ final class SynchronousMethodHandler implements MethodHandler {
       this.logger = checkNotNull(logger, "logger");
       this.logLevel = checkNotNull(logLevel, "logLevel");
       this.propagationPolicy = propagationPolicy;
+      this.requestTemplateFactoryResolver =
+          checkNotNull(requestTemplateFactoryResolver, "requestTemplateFactoryResolver");
       this.options = checkNotNull(options, "options");
     }
 


### PR DESCRIPTION
## Changes

- Extract RequestTemplateFactoryResolver
- Move responsibility for RequestTemplateFactory creation from `ParseHandlersByName` to `MethodHandler.Factory`

## Review Guide

- Review commit by commit. I've broken down the commits to make the diff easier to understand.