### PR TITLE
fix(sec): upgrade io.netty:netty-codec-http to 4.1.86.final

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -30,7 +30,7 @@
     <jmh.version>1.36</jmh.version>
     <rx.netty.version>0.5.3</rx.netty.version>
     <rx.java.version>1.3.8</rx.java.version>
-    <netty.version>4.1.86.Final</netty.version>
+    <netty.version>4.1.86.final</netty.version>
     <main.basedir>${project.basedir}/..</main.basedir>
   </properties>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.netty:netty-codec-http 4.1.86.Final
- [CVE-2022-41915](https://www.oscs1024.com/hd/CVE-2022-41915)


### What did I do？
Upgrade io.netty:netty-codec-http from 4.1.86.Final to 4.1.86.final for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS