### PR TITLE
updates reactor-core dependency for the feign-reactive-wrappers

### DIFF
--- a/reactive/pom.xml
+++ b/reactive/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-    <reactor.version>3.4.24</reactor.version>
+    <reactor.version>3.5.2</reactor.version>
     <reactive.streams.version>1.0.4</reactive.streams.version>
     <reactivex.version>2.2.21</reactivex.version>
   </properties>

--- a/reactive/src/main/java/feign/reactive/ReactorFeign.java
+++ b/reactive/src/main/java/feign/reactive/ReactorFeign.java
@@ -25,12 +25,20 @@ import feign.Target;
 public class ReactorFeign extends ReactiveFeign {
 
   public static Builder builder() {
-    return new Builder();
+    return new Builder(Schedulers.boundedElastic());
+  }
+
+  public static Builder builder(Scheduler scheduler) {
+    return new Builder(scheduler);
   }
 
   public static class Builder extends ReactiveFeign.Builder {
 
-    private Scheduler scheduler = Schedulers.boundedElastic();
+    private final Scheduler scheduler;
+
+    Builder(Scheduler scheduler) {
+      this.scheduler = scheduler;
+    }
 
     @Override
     public Feign build() {
@@ -42,11 +50,6 @@ public class ReactorFeign extends ReactiveFeign {
     public Builder invocationHandlerFactory(InvocationHandlerFactory invocationHandlerFactory) {
       throw new UnsupportedOperationException(
           "Invocation Handler Factory overrides are not supported.");
-    }
-
-    public Builder scheduleOn(Scheduler scheduler) {
-      this.scheduler = scheduler;
-      return this;
     }
   }
 

--- a/reactive/src/main/java/feign/reactive/ReactorFeign.java
+++ b/reactive/src/main/java/feign/reactive/ReactorFeign.java
@@ -30,7 +30,7 @@ public class ReactorFeign extends ReactiveFeign {
 
   public static class Builder extends ReactiveFeign.Builder {
 
-    private Scheduler scheduler = Schedulers.elastic();
+    private Scheduler scheduler = Schedulers.boundedElastic();
 
     @Override
     public Feign build() {

--- a/reactive/src/test/java/feign/reactive/ReactiveInvocationHandlerTest.java
+++ b/reactive/src/test/java/feign/reactive/ReactiveInvocationHandlerTest.java
@@ -56,7 +56,7 @@ public class ReactiveInvocationHandlerTest {
   public void invokeOnSubscribeReactor() throws Throwable {
     given(this.methodHandler.invoke(any())).willReturn("Result");
     ReactorInvocationHandler handler = new ReactorInvocationHandler(this.target,
-        Collections.singletonMap(method, this.methodHandler), Schedulers.elastic());
+        Collections.singletonMap(method, this.methodHandler), Schedulers.boundedElastic());
 
     Object result = handler.invoke(method, this.methodHandler, new Object[] {});
     assertThat(result).isInstanceOf(Mono.class);
@@ -74,7 +74,7 @@ public class ReactiveInvocationHandlerTest {
   public void invokeOnSubscribeEmptyReactor() throws Throwable {
     given(this.methodHandler.invoke(any())).willReturn(null);
     ReactorInvocationHandler handler = new ReactorInvocationHandler(this.target,
-        Collections.singletonMap(method, this.methodHandler), Schedulers.elastic());
+        Collections.singletonMap(method, this.methodHandler), Schedulers.boundedElastic());
 
     Object result = handler.invoke(method, this.methodHandler, new Object[] {});
     assertThat(result).isInstanceOf(Mono.class);
@@ -91,7 +91,7 @@ public class ReactiveInvocationHandlerTest {
   public void invokeFailureReactor() throws Throwable {
     given(this.methodHandler.invoke(any())).willThrow(new IOException("Could Not Decode"));
     ReactorInvocationHandler handler = new ReactorInvocationHandler(this.target,
-        Collections.singletonMap(this.method, this.methodHandler), Schedulers.elastic());
+        Collections.singletonMap(this.method, this.methodHandler), Schedulers.boundedElastic());
 
     Object result = handler.invoke(this.method, this.methodHandler, new Object[] {});
     assertThat(result).isInstanceOf(Mono.class);


### PR DESCRIPTION
removed deprecated usage of <code>Schedulers.elastic()</code> and using <code>Schedulers.boundedElastic()</code> instead

Fixes #1711