### PR TITLE
Adds explicit module descriptors to a subset of modules

### DIFF
--- a/annotation-error-decoder/pom.xml
+++ b/annotation-error-decoder/pom.xml
@@ -50,4 +50,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -74,6 +74,10 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
           <execution>

--- a/dropwizard-metrics4/pom.xml
+++ b/dropwizard-metrics4/pom.xml
@@ -56,4 +56,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/dropwizard-metrics5/pom.xml
+++ b/dropwizard-metrics5/pom.xml
@@ -56,4 +56,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/googlehttpclient/pom.xml
+++ b/googlehttpclient/pom.xml
@@ -55,4 +55,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/gson/pom.xml
+++ b/gson/pom.xml
@@ -49,4 +49,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/hc5/pom.xml
+++ b/hc5/pom.xml
@@ -68,4 +68,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/httpclient/pom.xml
+++ b/httpclient/pom.xml
@@ -75,4 +75,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/jackson-jaxb/pom.xml
+++ b/jackson-jaxb/pom.xml
@@ -80,6 +80,7 @@
 
   <profiles>
     <profile>
+      <id>java11</id>
       <activation>
         <jdk>11</jdk>
       </activation>

--- a/jackson-jr/pom.xml
+++ b/jackson-jr/pom.xml
@@ -55,4 +55,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/jackson/pom.xml
+++ b/jackson/pom.xml
@@ -50,4 +50,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/jakarta/pom.xml
+++ b/jakarta/pom.xml
@@ -63,4 +63,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/java11/pom.xml
+++ b/java11/pom.xml
@@ -69,6 +69,10 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
         <configuration>

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -45,6 +45,15 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>java11</id>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -61,6 +61,10 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
           <execution>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -63,4 +63,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -80,6 +80,10 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-maven-plugin</artifactId>
         <version>${kotlin.version}</version>

--- a/micrometer/pom.xml
+++ b/micrometer/pom.xml
@@ -73,6 +73,10 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
           <execution>

--- a/mock/pom.xml
+++ b/mock/pom.xml
@@ -49,4 +49,12 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -61,4 +61,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,7 @@
     <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
     <maven-deploy-plugin.version>3.1.0</maven-deploy-plugin.version>
     <docker-maven-plugin.version>1.2.2</docker-maven-plugin.version>
+    <moditect-maven-plugin.version>1.0.0.RC2</moditect-maven-plugin.version>
   </properties>
   <url>https://github.com/openfeign/feign</url>
   <inceptionYear>2012</inceptionYear>
@@ -454,6 +455,36 @@
               <version>9.4</version>
             </dependency>
           </dependencies>
+        </plugin>
+
+        <plugin>
+          <groupId>org.moditect</groupId>
+          <artifactId>moditect-maven-plugin</artifactId>
+          <version>${moditect-maven-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>add-module-infos</id>
+              <phase>package</phase>
+              <goals>
+                <goal>add-module-info</goal>
+              </goals>
+              <configuration>
+                <overwriteExistingFiles>true</overwriteExistingFiles>
+                <module>
+                  <moduleInfo>
+                    <!-- module name will be derived from filename -->
+                    <!-- export everything -->
+                    <exports>*;</exports>
+                    <!-- declare services consumed by the artifact -->
+                    <addServiceUses>true</addServiceUses>
+                  </moduleInfo>
+                </module>
+                <jdepsExtraArgs>
+                  <arg>--multi-release=9</arg>
+                </jdepsExtraArgs>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/reactive/pom.xml
+++ b/reactive/pom.xml
@@ -95,4 +95,12 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/sax/pom.xml
+++ b/sax/pom.xml
@@ -44,4 +44,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/slf4j/pom.xml
+++ b/slf4j/pom.xml
@@ -57,4 +57,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/spring4/pom.xml
+++ b/spring4/pom.xml
@@ -62,4 +62,12 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
Applies the ModiTect Maven plugin to a select number of Maven modules.
Exports all packages by default as that's the current behavior when Automatic module names are in place.
Fine grained control of exported packages may be added at a later stage.

Fixes #1357