### PR TITLE
Java-JSON Decoder can decode (return) String too

### DIFF
--- a/json/src/main/java/feign/json/JsonDecoder.java
+++ b/json/src/main/java/feign/json/JsonDecoder.java
@@ -14,6 +14,7 @@
 package feign.json;
 
 import feign.Response;
+import feign.Util;
 import feign.codec.DecodeException;
 import feign.codec.Decoder;
 import org.json.JSONArray;
@@ -57,6 +58,8 @@ public class JsonDecoder implements Decoder {
         return new JSONObject();
       else if (JSONArray.class.isAssignableFrom((Class<?>) type))
         return new JSONArray();
+      else if (String.class.equals(type))
+        return null;
       else
         throw new DecodeException(response.status(),
             format("%s is not a type supported by this decoder.", type), response.request());
@@ -69,7 +72,7 @@ public class JsonDecoder implements Decoder {
         return null; // Empty body
       }
       bodyReader.reset();
-      return decodeJSON(response, type, bodyReader);
+      return decodeBody(response, type, bodyReader);
     } catch (JSONException jsonException) {
       if (jsonException.getCause() != null && jsonException.getCause() instanceof IOException) {
         throw (IOException) jsonException.getCause();
@@ -79,7 +82,9 @@ public class JsonDecoder implements Decoder {
     }
   }
 
-  private Object decodeJSON(Response response, Type type, Reader reader) {
+  private Object decodeBody(Response response, Type type, Reader reader) throws IOException {
+    if (String.class.equals(type))
+      return Util.toString(reader);
     JSONTokener tokenizer = new JSONTokener(reader);
     if (JSONObject.class.isAssignableFrom((Class<?>) type))
       return new JSONObject(tokenizer);

--- a/json/src/test/java/feign/json/JsonDecoderTest.java
+++ b/json/src/test/java/feign/json/JsonDecoderTest.java
@@ -79,6 +79,19 @@ public class JsonDecoderTest {
   }
 
   @Test
+  public void decodesString() throws IOException {
+    String json = "qwerty";
+    Response response = Response.builder()
+        .status(200)
+        .reason("OK")
+        .headers(Collections.emptyMap())
+        .body(json, UTF_8)
+        .request(request)
+        .build();
+    assertEquals("qwerty", new JsonDecoder().decode(response, String.class));
+  }
+
+  @Test
   public void notFoundDecodesToEmpty() throws IOException {
     Response response = Response.builder()
         .status(404)
@@ -98,6 +111,17 @@ public class JsonDecoderTest {
         .request(request)
         .build();
     assertTrue(((JSONObject) new JsonDecoder().decode(response, JSONObject.class)).isEmpty());
+  }
+
+  @Test
+  public void nullBodyDecodesToNullString() throws IOException {
+    Response response = Response.builder()
+        .status(204)
+        .reason("OK")
+        .headers(Collections.emptyMap())
+        .request(request)
+        .build();
+    assertNull(new JsonDecoder().decode(response, String.class));
   }
 
   @Test


### PR DESCRIPTION
This is not a bug, but a small improvement.

On some special cases a remote API can return not only JSON but a plain strings, e.g. ipinfo.io can returns a large JSON object as well as a string field of that object. We cannot set different decoders for different methods. I propose to allow the decoder returns a raw string according to the type that a method returns.