### PR TITLE
Make Slf4jLogger constructors public

### DIFF
--- a/slf4j/src/main/java/feign/slf4j/Slf4jLogger.java
+++ b/slf4j/src/main/java/feign/slf4j/Slf4jLogger.java
@@ -40,7 +40,7 @@ public class Slf4jLogger extends feign.Logger {
     this(LoggerFactory.getLogger(name));
   }
 
-  Slf4jLogger(Logger logger) {
+  public Slf4jLogger(Logger logger) {
     this.logger = logger;
   }
 


### PR DESCRIPTION
Change the visibility of the `Slf4jLogger` constructor to `public` to provide a customized `Logger` instance.