### PR TITLE
add a way to pass param to RequestInterceptor

### DIFF
--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -321,6 +321,11 @@ public interface Contract {
             "HeaderMap annotation was present on multiple parameters.");
         data.headerMapIndex(paramIndex);
       });
+      super.registerParameterAnnotation(ExtraParam.class, (queryMap, data, paramIndex) -> {
+        checkState(data.extraParamIndex() == null,
+            "HeaderMap annotation was present on multiple parameters.");
+        data.extraParamIndex(paramIndex);
+      });
     }
 
     private static Map<String, Collection<String>> toMap(String[] input) {

--- a/core/src/main/java/feign/ExtraParam.java
+++ b/core/src/main/java/feign/ExtraParam.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign;
+
+import java.lang.annotation.Retention;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@java.lang.annotation.Target(PARAMETER)
+public @interface ExtraParam {
+}

--- a/core/src/main/java/feign/MethodMetadata.java
+++ b/core/src/main/java/feign/MethodMetadata.java
@@ -29,6 +29,7 @@ public final class MethodMetadata implements Serializable {
   private Integer bodyIndex;
   private Integer headerMapIndex;
   private Integer queryMapIndex;
+  private Integer extraParamIndex;
   private boolean alwaysEncodeBody;
   private transient Type bodyType;
   private final RequestTemplate template = new RequestTemplate();
@@ -106,6 +107,15 @@ public final class MethodMetadata implements Serializable {
 
   public MethodMetadata queryMapIndex(Integer queryMapIndex) {
     this.queryMapIndex = queryMapIndex;
+    return this;
+  }
+
+  public Integer extraParamIndex() {
+    return extraParamIndex;
+  }
+
+  public MethodMetadata extraParamIndex(Integer extraParamIndex) {
+    this.extraParamIndex = extraParamIndex;
     return this;
   }
 

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -65,6 +65,7 @@ public final class RequestTemplate implements Serializable {
   private CollectionFormat collectionFormat = CollectionFormat.EXPLODED;
   private MethodMetadata methodMetadata;
   private Target<?> feignTarget;
+  private Object extraParam;
 
   /**
    * Create a new Request Template.
@@ -98,7 +99,8 @@ public final class RequestTemplate implements Serializable {
       boolean decodeSlash,
       CollectionFormat collectionFormat,
       MethodMetadata methodMetadata,
-      Target<?> feignTarget) {
+      Target<?> feignTarget,
+      Object extraParam) {
     this.target = target;
     this.fragment = fragment;
     this.uriTemplate = uriTemplate;
@@ -111,6 +113,7 @@ public final class RequestTemplate implements Serializable {
         (collectionFormat != null) ? collectionFormat : CollectionFormat.EXPLODED;
     this.methodMetadata = methodMetadata;
     this.feignTarget = feignTarget;
+    this.extraParam = extraParam;
   }
 
   /**
@@ -132,7 +135,8 @@ public final class RequestTemplate implements Serializable {
             requestTemplate.decodeSlash,
             requestTemplate.collectionFormat,
             requestTemplate.methodMetadata,
-            requestTemplate.feignTarget);
+            requestTemplate.feignTarget,
+            requestTemplate.extraParam);
 
     if (!requestTemplate.queries().isEmpty()) {
       template.queries.putAll(requestTemplate.queries);
@@ -169,6 +173,7 @@ public final class RequestTemplate implements Serializable {
     this.methodMetadata = toCopy.methodMetadata;
     this.target = toCopy.target;
     this.feignTarget = toCopy.feignTarget;
+    this.extraParam = toCopy.extraParam;
   }
 
   /**
@@ -1044,6 +1049,12 @@ public final class RequestTemplate implements Serializable {
   }
 
   @Experimental
+  public RequestTemplate extraParam(Object extraParam) {
+    this.extraParam = extraParam;
+    return this;
+  }
+
+  @Experimental
   public MethodMetadata methodMetadata() {
     return methodMetadata;
   }
@@ -1051,6 +1062,11 @@ public final class RequestTemplate implements Serializable {
   @Experimental
   public Target<?> feignTarget() {
     return feignTarget;
+  }
+
+  @Experimental
+  public Object extraParam() {
+    return extraParam;
   }
 
   /**

--- a/core/src/main/java/feign/RequestTemplateFactoryResolver.java
+++ b/core/src/main/java/feign/RequestTemplateFactoryResolver.java
@@ -119,6 +119,11 @@ final class RequestTemplateFactoryResolver {
         template = addHeaderMapHeaders(headerMap, template);
       }
 
+      if (metadata.extraParamIndex() != null) {
+        Object value = argv[metadata.extraParamIndex()];
+        template = template.extraParam(value);
+      }
+
       return template;
     }
 

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -45,7 +45,7 @@ import static feign.Util.UTF_8;
 import static feign.assertj.MockWebServerAssertions.assertThat;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 @SuppressWarnings("deprecation")
 public class FeignTest {
@@ -689,6 +689,24 @@ public class FeignTest {
     });
   }
 
+  @Test
+  public void extraParam() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
+
+    Object originExtraParam = new Object();
+    Map<String, Object> extraParamHolder = new HashMap<>();
+    extraParamHolder.put("originExtraParam", originExtraParam);
+    TestInterface api = new TestInterfaceBuilder()
+        .requestInterceptor(
+            template -> extraParamHolder.put("interceptorExtraParam", template.extraParam()))
+        .target("http://localhost:" + server.getPort());
+
+    api.extraParam(originExtraParam);
+
+    assertSame(extraParamHolder.get("originExtraParam"),
+        extraParamHolder.get("interceptorExtraParam"));
+  }
+
   private static class MockRetryer implements Retryer {
 
     boolean tripped;
@@ -1096,6 +1114,9 @@ public class FeignTest {
     @RequestLine("GET /settings")
     @Headers("Custom: {complex}")
     void supportComplexHttpHeaders(@Param("complex") String complex);
+
+    @RequestLine("POST /")
+    void extraParam(@ExtraParam Object extraParam) throws TestInterfaceException;
 
     class DateToMillis implements Param.Expander {
 

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <jackson-databind.version>2.14.2</jackson-databind.version>
     <assertj.version>3.24.2</assertj.version>
     <hamcrest.version>2.2</hamcrest.version>
-    <mockito.version>5.1.1</mockito.version>
+    <mockito.version>5.2.0</mockito.version>
 
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     <maven-install-plugin.version>3.1.0</maven-install-plugin.version>


### PR DESCRIPTION
I want to pass param to the RequestInterceptor but found RequestTemplate only has the infos to build the http request.
I add a new annotation so that the method param it marked can be accessed through RequestTemplate in the RequestInterceptor.It can only mark one method param and can only be accessed as java.lang.Object for now.