### PR TITLE
Add a way to choose between class or package instantiation mode for JaxbContext

### DIFF
--- a/jaxb/src/main/java/feign/jaxb/JAXBContextCacheKey.java
+++ b/jaxb/src/main/java/feign/jaxb/JAXBContextCacheKey.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.jaxb;
+
+/**
+ * Encapsulate data used to build the cache key of JAXBContext.
+ */
+interface JAXBContextCacheKey {
+}

--- a/jaxb/src/main/java/feign/jaxb/JAXBContextClassCacheKey.java
+++ b/jaxb/src/main/java/feign/jaxb/JAXBContextClassCacheKey.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.jaxb;
+
+import java.util.Objects;
+
+/**
+ * Encapsulate data used to build the cache key of JAXBContext when created using class mode.
+ */
+final class JAXBContextClassCacheKey implements JAXBContextCacheKey {
+
+  private final Class<?> clazz;
+
+  JAXBContextClassCacheKey(Class<?> clazz) {
+    this.clazz = clazz;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+    JAXBContextClassCacheKey that = (JAXBContextClassCacheKey) o;
+    return clazz.equals(that.clazz);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(clazz);
+  }
+}

--- a/jaxb/src/main/java/feign/jaxb/JAXBContextInstantationMode.java
+++ b/jaxb/src/main/java/feign/jaxb/JAXBContextInstantationMode.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.jaxb;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+
+/**
+ * Provides differents ways to instantiate a JAXB Context.
+ */
+public enum JAXBContextInstantationMode {
+
+  CLASS {
+    @Override
+    JAXBContextCacheKey getJAXBContextCacheKey(Class<?> clazz) {
+      return new JAXBContextClassCacheKey(clazz);
+    }
+
+    @Override
+    JAXBContext getJAXBContext(Class<?> clazz) throws JAXBException {
+      return JAXBContext.newInstance(clazz);
+    }
+  },
+
+  PACKAGE {
+    @Override
+    JAXBContextCacheKey getJAXBContextCacheKey(Class<?> clazz) {
+      return new JAXBContextPackageCacheKey(clazz.getPackage().getName(), clazz.getClassLoader());
+    }
+
+    @Override
+    JAXBContext getJAXBContext(Class<?> clazz) throws JAXBException {
+      return JAXBContext.newInstance(clazz.getPackage().getName(), clazz.getClassLoader());
+    }
+  };
+
+  abstract JAXBContextCacheKey getJAXBContextCacheKey(Class<?> clazz);
+
+  abstract JAXBContext getJAXBContext(Class<?> clazz) throws JAXBException;
+}

--- a/jaxb/src/main/java/feign/jaxb/JAXBContextPackageCacheKey.java
+++ b/jaxb/src/main/java/feign/jaxb/JAXBContextPackageCacheKey.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.jaxb;
+
+import java.util.Objects;
+
+/**
+ * Encapsulate data used to build the cache key of JAXBContext when created using package mode.
+ */
+final class JAXBContextPackageCacheKey implements JAXBContextCacheKey {
+
+  private final String packageName;
+
+  private final ClassLoader classLoader;
+
+  JAXBContextPackageCacheKey(String packageName, ClassLoader classLoader) {
+    this.packageName = packageName;
+    this.classLoader = classLoader;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+    JAXBContextPackageCacheKey that = (JAXBContextPackageCacheKey) o;
+    return packageName.equals(that.packageName) && classLoader.equals(that.classLoader);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(packageName, classLoader);
+  }
+}

--- a/jaxb/src/test/java/feign/jaxb/JAXBContextFactoryTest.java
+++ b/jaxb/src/test/java/feign/jaxb/JAXBContextFactoryTest.java
@@ -13,16 +13,15 @@
  */
 package feign.jaxb;
 
+import feign.jaxb.mock.onepackage.AnotherMockedJAXBObject;
+import feign.jaxb.mock.onepackage.MockedJAXBObject;
+import org.junit.Test;
+import javax.xml.bind.Marshaller;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
-import javax.xml.bind.Marshaller;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class JAXBContextFactoryTest {
 
@@ -88,9 +87,65 @@ public class JAXBContextFactoryTest {
     Map internalCache = (Map) f.get(factory); // IllegalAccessException
     assertFalse(internalCache.isEmpty());
     assertTrue(internalCache.size() == classes.size());
-    assertNotNull(internalCache.get(String.class));
-    assertNotNull(internalCache.get(Integer.class));
+    assertNotNull(internalCache.get(new JAXBContextClassCacheKey(String.class)));
+    assertNotNull(internalCache.get(new JAXBContextClassCacheKey(Integer.class)));
 
   }
 
+  @Test
+  public void testClassModeInstantiation() throws Exception {
+
+    List<Class<?>> classes = Arrays.asList(String.class, Integer.class);
+    JAXBContextFactory factory =
+        new JAXBContextFactory.Builder()
+            .withJAXBContextInstantiationMode(JAXBContextInstantationMode.CLASS)
+            .build(classes);
+
+    Field f = factory.getClass().getDeclaredField("jaxbContexts"); // NoSuchFieldException
+    f.setAccessible(true);
+    Map internalCache = (Map) f.get(factory); // IllegalAccessException
+    assertFalse(internalCache.isEmpty());
+    assertEquals(internalCache.size(), classes.size());
+    assertNotNull(internalCache.get(new JAXBContextClassCacheKey(String.class)));
+    assertNotNull(internalCache.get(new JAXBContextClassCacheKey(Integer.class)));
+
+  }
+
+  @Test
+  public void testPackageModeInstantiationUsingSamePackage() throws Exception {
+
+    JAXBContextFactory factory = new JAXBContextFactory.Builder()
+        .withJAXBContextInstantiationMode(JAXBContextInstantationMode.PACKAGE)
+        .build(Arrays.asList(MockedJAXBObject.class, AnotherMockedJAXBObject.class));
+
+    Field f = factory.getClass().getDeclaredField("jaxbContexts"); // NoSuchFieldException
+    f.setAccessible(true);
+    Map internalCache = (Map) f.get(factory); // IllegalAccessException
+    assertFalse(internalCache.isEmpty());
+    assertEquals(1, internalCache.size());
+    assertNotNull(internalCache.get(new JAXBContextPackageCacheKey("feign.jaxb.mock.onepackage",
+        AnotherMockedJAXBObject.class.getClassLoader())));
+
+  }
+
+  @Test
+  public void testPackageModeInstantiationUsingMultiplePackages() throws Exception {
+
+    JAXBContextFactory factory = new JAXBContextFactory.Builder()
+        .withJAXBContextInstantiationMode(JAXBContextInstantationMode.PACKAGE)
+        .build(Arrays.asList(MockedJAXBObject.class,
+            feign.jaxb.mock.anotherpackage.MockedJAXBObject.class));
+
+    Field f = factory.getClass().getDeclaredField("jaxbContexts"); // NoSuchFieldException
+    f.setAccessible(true);
+    Map internalCache = (Map) f.get(factory); // IllegalAccessException
+    assertFalse(internalCache.isEmpty());
+    assertEquals(2, internalCache.size());
+    assertNotNull(internalCache.get(new JAXBContextPackageCacheKey("feign.jaxb.mock.onepackage",
+        MockedJAXBObject.class.getClassLoader())));
+    assertNotNull(internalCache.get(new JAXBContextPackageCacheKey("feign.jaxb.mock.anotherpackage",
+        feign.jaxb.mock.anotherpackage.MockedJAXBObject.class.getClassLoader())));
+
+
+  }
 }

--- a/jaxb/src/test/java/feign/jaxb/mock/anotherpackage/MockedJAXBObject.java
+++ b/jaxb/src/test/java/feign/jaxb/mock/anotherpackage/MockedJAXBObject.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.jaxb.mock.anotherpackage;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "anothertest")
+public class MockedJAXBObject {
+}

--- a/jaxb/src/test/java/feign/jaxb/mock/anotherpackage/ObjectFactory.java
+++ b/jaxb/src/test/java/feign/jaxb/mock/anotherpackage/ObjectFactory.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.jaxb.mock.anotherpackage;
+
+import javax.xml.bind.annotation.XmlRegistry;
+
+@XmlRegistry
+public class ObjectFactory {
+
+  public MockedJAXBObject createMockedJAXBObject() {
+    return new MockedJAXBObject();
+  }
+}

--- a/jaxb/src/test/java/feign/jaxb/mock/onepackage/AnotherMockedJAXBObject.java
+++ b/jaxb/src/test/java/feign/jaxb/mock/onepackage/AnotherMockedJAXBObject.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.jaxb.mock.onepackage;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+public class AnotherMockedJAXBObject {
+}

--- a/jaxb/src/test/java/feign/jaxb/mock/onepackage/MockedJAXBObject.java
+++ b/jaxb/src/test/java/feign/jaxb/mock/onepackage/MockedJAXBObject.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.jaxb.mock.onepackage;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "test")
+public class MockedJAXBObject {
+}

--- a/jaxb/src/test/java/feign/jaxb/mock/onepackage/ObjectFactory.java
+++ b/jaxb/src/test/java/feign/jaxb/mock/onepackage/ObjectFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.jaxb.mock.onepackage;
+
+import javax.xml.bind.annotation.XmlRegistry;
+
+@XmlRegistry
+public class ObjectFactory {
+
+  public MockedJAXBObject createMockedJAXBObject() {
+    return new MockedJAXBObject();
+  }
+
+  public AnotherMockedJAXBObject createAnotherMockedJAXBObject() {
+    return new AnotherMockedJAXBObject();
+  }
+}


### PR DESCRIPTION
I suggest to add a way to choose between class or package instantiation for JaxbContext (class mode is still used by default).

To allow this, the builder of JaxbContextFactory has a new optional method "withJAXBContextInstantiationMode" to provide an enum for the choice between class and package mode. No call to this method = usage of class mode (backward compatible).

Benefits of a package way can be : 
- a better usage of the JAXBContext cache : one entry for all class of the package instead of one entry (one JaxbContext) per class
- a usage of the ObjectFactory class with all elements available to be loaded (using class mode needs an analyze to every dependents elements)
- this precedent point can also be a workaround to some problems with class loading mode (for example with Jaxb Moxy implementation, see https://github.com/eclipse-ee4j/eclipselink/issues/1856)