### PR TITLE
fix(sec): upgrade io.netty:netty-handler to 5.0.0

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -30,7 +30,7 @@
     <jmh.version>1.36</jmh.version>
     <rx.netty.version>0.5.3</rx.netty.version>
     <rx.java.version>1.3.8</rx.java.version>
-    <netty.version>4.1.91.Final</netty.version>
+    <netty.version>5.0.0</netty.version>
     <main.basedir>${project.basedir}/..</main.basedir>
 
     <moditect.skip>true</moditect.skip>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.netty:netty-handler 4.1.91.Final
- [MPS-2022-12067](https://www.oscs1024.com/hd/MPS-2022-12067)


### What did I do？
Upgrade io.netty:netty-handler from 4.1.91.Final to 5.0.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS