### PR TITLE
Added support to add literals directly to the header

### DIFF
--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -15,6 +15,12 @@ package feign;
 
 import static feign.Util.CONTENT_LENGTH;
 import static feign.Util.checkNotNull;
+import feign.Request.HttpMethod;
+import feign.template.BodyTemplate;
+import feign.template.HeaderTemplate;
+import feign.template.QueryTemplate;
+import feign.template.UriTemplate;
+import feign.template.UriUtils;
 import java.io.Serializable;
 import java.net.URI;
 import java.nio.charset.Charset;
@@ -33,12 +39,6 @@ import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import feign.Request.HttpMethod;
-import feign.template.BodyTemplate;
-import feign.template.HeaderTemplate;
-import feign.template.QueryTemplate;
-import feign.template.UriTemplate;
-import feign.template.UriUtils;
 
 /**
  * Request Builder for an HTTP Target.

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -15,13 +15,10 @@ package feign;
 
 import static feign.assertj.FeignAssertions.assertThat;
 import static java.util.Arrays.asList;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import feign.Request.HttpMethod;
-import feign.template.UriUtils;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -30,6 +27,8 @@ import java.util.Map;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import feign.Request.HttpMethod;
+import feign.template.UriUtils;
 
 public class RequestTemplateTest {
 
@@ -241,6 +240,18 @@ public class RequestTemplateTest {
 
     assertThat(template)
         .hasHeaders(entry("A-Header", Collections.singletonList(json)));
+  }
+
+  @Test
+  public void shouldNotResolveTemplateWithHeaderWithJsonLiteral() {
+    String json = "{ \"foo\": \"bar\", \"hello\": \"world\"}";
+    RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)
+        .headerLiteral("A-Header", "{aHeader}");
+
+    template = template.resolve(mapOf("aHeader", json));
+
+    assertThat(template)
+        .hasHeaders(entry("A-Header", Collections.singletonList("{aHeader}")));
   }
 
   /**

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -19,6 +19,8 @@ import static org.assertj.core.data.MapEntry.entry;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import feign.Request.HttpMethod;
+import feign.template.UriUtils;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -27,8 +29,6 @@ import java.util.Map;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import feign.Request.HttpMethod;
-import feign.template.UriUtils;
 
 public class RequestTemplateTest {
 


### PR DESCRIPTION
Added support to add literals directly to the header. 

In short, I exposed a public method that will provide a way to add literals directly to the header. Beforehand, a literal would never be evaluated/seen as one up until we try to create the `Template` [object.](https://github.com/OpenFeign/feign/blob/9b5d27a0e88474f5b419e9297285fb59e63a6c53/core/src/main/java/feign/template/Template.java#L218), it would be beneficial to have such a method call as it will prevent extra processing with trying to match a complex regex expression with something that wishes to be processed as literal and not an expression. This will provide a clearer and simpler way for end users to send literals, especially for json strings. 

Properly fixes [#1464](https://github.com/OpenFeign/feign/issues/1464)   