### PR TITLE
Added error decoder to async builder

### DIFF
--- a/kotlin/src/main/java/feign/kotlin/CoroutineFeign.java
+++ b/kotlin/src/main/java/feign/kotlin/CoroutineFeign.java
@@ -164,6 +164,7 @@ public class CoroutineFeign<C> {
           .logLevel(logLevel)
           .client((AsyncClient<Object>) client)
           .decoder(decoder)
+          .errorDecoder(errorDecoder)
           .contract(contract)
           .retryer(retryer)
           .logger(logger)


### PR DESCRIPTION
This add a error decoder to the async builder when building from the coroutine builder

This was fixed by adding the error decoder to the async builder

**How to replicate**

Create a feign client with a custom error decoder 

`val feignClient: FeignPriceClient = CoroutineFeign.builder<Unit>().errorDecoder(CustomErrorDecoder())
        .target(FeignPriceClient::class.java, "http://localhost:8080/")`

The custom error decoder is lost when building the async client
