### PR TITLE
GH-2047: Exclude okio from module info

### DIFF
--- a/example-wikipedia-with-springboot/pom.xml
+++ b/example-wikipedia-with-springboot/pom.xml
@@ -14,7 +14,9 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -23,15 +25,13 @@
     <version>12.4-SNAPSHOT</version>
   </parent>
 
-  <groupId>io.github.openfeign</groupId>
   <artifactId>feign-example-wikipedia-with-springboot</artifactId>
   <packaging>jar</packaging>
-  <name>Wikipedia Example</name>
+  <name>Wikipedia Example with Spring Boot</name>
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
     <main.java.version>17</main.java.version>
-
     <moditect.skip>true</moditect.skip>
   </properties>
 
@@ -68,53 +68,63 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <defaultGoal>package</defaultGoal>
-    <plugins>
-      <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-          <mainClass>example.wikipedia.WikipediaApplication</mainClass>
-          <layout>ZIP</layout>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>repackage</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+  <profiles>
+    <profile>
+      <id>active-on-jdk17</id>
+      <activation>
+        <jdk>17</jdk>
+      </activation>
 
-      <plugin>
-        <groupId>org.skife.maven</groupId>
-        <artifactId>really-executable-jar-maven-plugin</artifactId>
-        <version>2.1.1</version>
-        <configuration>
-          <programFile>wikipedia</programFile>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>really-executable-jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
+      <build>
+        <defaultGoal>package</defaultGoal>
+        <plugins>
+          <plugin>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-maven-plugin</artifactId>
+            <configuration>
+              <mainClass>example.wikipedia.WikipediaApplication</mainClass>
+              <layout>ZIP</layout>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>repackage</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.skife.maven</groupId>
+            <artifactId>really-executable-jar-maven-plugin</artifactId>
+            <version>2.1.1</version>
+            <configuration>
+              <programFile>wikipedia</programFile>
+            </configuration>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>really-executable-jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -14,7 +14,9 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -29,6 +31,8 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
+    <!-- see https://github.com/square/okhttp/issues/4184 -->
+    <!-- <moditect.skip>true</moditect.skip> -->
   </properties>
 
   <dependencies>
@@ -61,4 +65,29 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-module-infos</id>
+            <phase>package</phase>
+            <goals>
+              <goal>add-module-info</goal>
+            </goals>
+            <configuration>
+              <exclusions>
+                <exclusion>
+                  <groupId>com.squareup.okio</groupId>
+                  <artifactId>okio</artifactId>
+                </exclusion>
+              </exclusions>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -799,7 +799,7 @@
             <configuration>
               <rules>
                 <requireNoRepositories>
-                  <message>Feign should only depend on artifacts readly available on maven central</message>
+                  <message>Feign should only depend on artifacts readily available on maven central</message>
                 </requireNoRepositories>
               </rules>
             </configuration>


### PR DESCRIPTION
This change updates the module info generation for feign-okhttp, excluding `okio` from the tree since it does not conform to JPMS standards and results in duplicate module entries.  See https://github.com/square/okhttp/issues/4184 for information from Square about it.

Additional Changes
---
* Ensure Wikipedia with Spring Boot only uses JDK 17
* Renamed Wikipedia with Spring Boot to be unique