### PR TITLE
Rollback Jackson 2.15.1 due to module incompatibilities

### DIFF
--- a/jackson-jaxb/pom.xml
+++ b/jackson-jaxb/pom.xml
@@ -42,7 +42,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
 
     <dependency>

--- a/jackson/pom.xml
+++ b/jackson/pom.xml
@@ -40,7 +40,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -91,8 +91,7 @@
 
     <junit.version>4.13.2</junit.version>
     <junit5.version>5.9.3</junit5.version>
-    <jackson.version>2.15.1</jackson.version>
-    <jackson-databind.version>2.15.1</jackson-databind.version>
+    <jackson.version>2.15.0</jackson.version>
     <assertj.version>3.24.2</assertj.version>
     <hamcrest.version>2.2</hamcrest.version>
     <mockito.version>5.3.1</mockito.version>
@@ -355,7 +354,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${jackson-databind.version}</version>
+        <version>${jackson.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Jackson Core 2.15.1 includes a shaded version of the Fast Double Parser that doesn't play nicely with moditect and jdeps, so our builds are failing.  This doesn't mean you can't use 2.15.1 in your project, just that we won't require it.

Also, removed the duplicate version properties since it's no longer required.