### PR TITLE
Add RemoteService to FeignContext

### DIFF
--- a/micrometer/src/main/java/feign/micrometer/FeignContext.java
+++ b/micrometer/src/main/java/feign/micrometer/FeignContext.java
@@ -13,10 +13,14 @@
  */
 package feign.micrometer;
 
-import feign.Request;
-import feign.Response;
+import io.micrometer.common.util.StringUtils;
 import io.micrometer.observation.transport.RequestReplySenderContext;
 import io.micrometer.observation.transport.SenderContext;
+
+import java.net.URL;
+
+import feign.Request;
+import feign.Response;
 
 /**
  * A {@link SenderContext} for Feign.
@@ -29,6 +33,15 @@ public class FeignContext extends RequestReplySenderContext<Request, Response> {
   public FeignContext(Request request) {
     super(Request::header);
     setCarrier(request);
+    setRemoteServiceName(request.requestTemplate().feignTarget().name());
+    try {
+      URL url = new URL(request.requestTemplate().feignTarget().url());
+      if (StringUtils.isNotBlank(url.getProtocol()) && StringUtils.isNotBlank(url.getHost())) {
+        setRemoteServiceAddress(url.getProtocol() + "://" + url.getHost() + ":" + url.getPort());
+      }
+    } catch (Exception ignored) {
+
+    }
   }
 
 }

--- a/micrometer/src/main/java/feign/micrometer/FeignContext.java
+++ b/micrometer/src/main/java/feign/micrometer/FeignContext.java
@@ -13,14 +13,12 @@
  */
 package feign.micrometer;
 
+import feign.Request;
+import feign.Response;
+import java.net.URL;
 import io.micrometer.common.util.StringUtils;
 import io.micrometer.observation.transport.RequestReplySenderContext;
 import io.micrometer.observation.transport.SenderContext;
-
-import java.net.URL;
-
-import feign.Request;
-import feign.Response;
 
 /**
  * A {@link SenderContext} for Feign.

--- a/micrometer/src/test/java/feign/micrometer/FeignContextTest.java
+++ b/micrometer/src/test/java/feign/micrometer/FeignContextTest.java
@@ -13,35 +13,34 @@
  */
 package feign.micrometer;
 
-import java.util.HashMap;
-
-import org.junit.jupiter.api.Test;
-
+import static org.assertj.core.api.Assertions.assertThat;
 import feign.Request;
 import feign.RequestTemplate;
 import feign.Target;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import java.util.HashMap;
+import org.junit.jupiter.api.Test;
 
 public class FeignContextTest {
 
-    @Test
-    public void testRemoteServiceNotNull() {
-        Request request = Request.create(Request.HttpMethod.GET, "http://example.com",
-            new HashMap<>(), Request.Body.empty(), new RequestTemplate().feignTarget(
-                new Target.HardCodedTarget<>(FeignContextTest.class, "RemoteServiceName", "http://example.com")));
-        FeignContext feignContext = new FeignContext(request);
-        assertThat(feignContext.getRemoteServiceName()).isEqualTo("RemoteServiceName");
-        assertThat(feignContext.getRemoteServiceAddress()).isEqualTo("http://example.com:-1");
-    }
+  @Test
+  public void testRemoteServiceNotNull() {
+    Request request = Request.create(Request.HttpMethod.GET, "http://example.com",
+        new HashMap<>(), Request.Body.empty(), new RequestTemplate().feignTarget(
+            new Target.HardCodedTarget<>(FeignContextTest.class, "RemoteServiceName",
+                "http://example.com")));
+    FeignContext feignContext = new FeignContext(request);
+    assertThat(feignContext.getRemoteServiceName()).isEqualTo("RemoteServiceName");
+    assertThat(feignContext.getRemoteServiceAddress()).isEqualTo("http://example.com:-1");
+  }
 
-    @Test
-    public void testMalformedRemoteServiceURL() {
-        Request request = Request.create(Request.HttpMethod.GET, "http://example.com",
-            new HashMap<>(), Request.Body.empty(), new RequestTemplate().feignTarget(
-                new Target.HardCodedTarget<>(FeignContextTest.class, "RemoteServiceName", "example.com")));
-        FeignContext feignContext = new FeignContext(request);
-        assertThat(feignContext.getRemoteServiceAddress()).isNull();
-    }
+  @Test
+  public void testMalformedRemoteServiceURL() {
+    Request request = Request.create(Request.HttpMethod.GET, "http://example.com",
+        new HashMap<>(), Request.Body.empty(), new RequestTemplate().feignTarget(
+            new Target.HardCodedTarget<>(FeignContextTest.class, "RemoteServiceName",
+                "example.com")));
+    FeignContext feignContext = new FeignContext(request);
+    assertThat(feignContext.getRemoteServiceAddress()).isNull();
+  }
 
 }

--- a/micrometer/src/test/java/feign/micrometer/FeignContextTest.java
+++ b/micrometer/src/test/java/feign/micrometer/FeignContextTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.micrometer;
+
+import java.util.HashMap;
+
+import org.junit.jupiter.api.Test;
+
+import feign.Request;
+import feign.RequestTemplate;
+import feign.Target;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FeignContextTest {
+
+    @Test
+    public void testRemoteServiceNotNull() {
+        Request request = Request.create(Request.HttpMethod.GET, "http://example.com",
+            new HashMap<>(), Request.Body.empty(), new RequestTemplate().feignTarget(
+                new Target.HardCodedTarget<>(FeignContextTest.class, "RemoteServiceName", "http://example.com")));
+        FeignContext feignContext = new FeignContext(request);
+        assertThat(feignContext.getRemoteServiceName()).isEqualTo("RemoteServiceName");
+        assertThat(feignContext.getRemoteServiceAddress()).isEqualTo("http://example.com:-1");
+    }
+
+    @Test
+    public void testMalformedRemoteServiceURL() {
+        Request request = Request.create(Request.HttpMethod.GET, "http://example.com",
+            new HashMap<>(), Request.Body.empty(), new RequestTemplate().feignTarget(
+                new Target.HardCodedTarget<>(FeignContextTest.class, "RemoteServiceName", "example.com")));
+        FeignContext feignContext = new FeignContext(request);
+        assertThat(feignContext.getRemoteServiceAddress()).isNull();
+    }
+
+}


### PR DESCRIPTION
As mentioned in #2040, i think RemoteService should be set to FeignContext, so components like Skywalking could retrieve the host and port as the peer instead of using templated URL path.

@marcingrzejszczak Please review this draft PR.