### PR TITLE
Re-format the overview mindmap

### DIFF
--- a/src/docs/overview-mindmap.iuml
+++ b/src/docs/overview-mindmap.iuml
@@ -20,6 +20,9 @@
 *** Spring 4
 *** SOAP
 *** Spring boot (3rd party)
+
+left side
+
 ** encoders/decoders
 *** GSON
 *** JAXB


### PR DESCRIPTION
Balances it out visually by splitting the first level in two sides, i.e., it will look like this:

![mindmap-with-left-side](https://github.com/OpenFeign/feign/assets/3391093/9757fa34-ad6c-4fae-af5c-32019f377406)
