### PR TITLE
Unknown hostnames correspond to reserved ones in RFC 2602

### DIFF
--- a/core/src/test/java/feign/LoggerTest.java
+++ b/core/src/test/java/feign/LoggerTest.java
@@ -267,23 +267,23 @@ public class LoggerTest {
       return Arrays.asList(new Object[][] {
           {Level.NONE, Collections.emptyList()},
           {Level.BASIC, Arrays.asList(
-              "\\[SendsStuff#login\\] ---> POST http://robofu.abc/ HTTP/1.1",
-              "\\[SendsStuff#login\\] <--- ERROR UnknownHostException: robofu.abc \\([0-9]+ms\\)")},
+              "\\[SendsStuff#login\\] ---> POST http://non-exist.invalid/ HTTP/1.1",
+              "\\[SendsStuff#login\\] <--- ERROR UnknownHostException: non-exist.invalid \\([0-9]+ms\\)")},
           {Level.HEADERS, Arrays.asList(
-              "\\[SendsStuff#login\\] ---> POST http://robofu.abc/ HTTP/1.1",
+              "\\[SendsStuff#login\\] ---> POST http://non-exist.invalid/ HTTP/1.1",
               "\\[SendsStuff#login\\] Content-Length: 80",
               "\\[SendsStuff#login\\] Content-Type: application/json",
               "\\[SendsStuff#login\\] ---> END HTTP \\(80-byte body\\)",
-              "\\[SendsStuff#login\\] <--- ERROR UnknownHostException: robofu.abc \\([0-9]+ms\\)")},
+              "\\[SendsStuff#login\\] <--- ERROR UnknownHostException: non-exist.invalid \\([0-9]+ms\\)")},
           {Level.FULL, Arrays.asList(
-              "\\[SendsStuff#login\\] ---> POST http://robofu.abc/ HTTP/1.1",
+              "\\[SendsStuff#login\\] ---> POST http://non-exist.invalid/ HTTP/1.1",
               "\\[SendsStuff#login\\] Content-Length: 80",
               "\\[SendsStuff#login\\] Content-Type: application/json",
               "\\[SendsStuff#login\\] ",
               "\\[SendsStuff#login\\] \\{\"customer_name\": \"netflix\", \"user_name\": \"denominator\", \"password\": \"password\"\\}",
               "\\[SendsStuff#login\\] ---> END HTTP \\(80-byte body\\)",
-              "\\[SendsStuff#login\\] <--- ERROR UnknownHostException: robofu.abc \\([0-9]+ms\\)",
-              "(?s)\\[SendsStuff#login\\] java.net.UnknownHostException: robofu.abc.*",
+              "\\[SendsStuff#login\\] <--- ERROR UnknownHostException: non-exist.invalid \\([0-9]+ms\\)",
+              "(?s)\\[SendsStuff#login\\] java.net.UnknownHostException: non-exist.invalid.*",
               "\\[SendsStuff#login\\] <--- END ERROR")}
       });
     }
@@ -304,7 +304,7 @@ public class LoggerTest {
               return this;
             }
           })
-          .target(SendsStuff.class, "http://robofu.abc");
+          .target(SendsStuff.class, "http://non-exist.invalid");
 
       thrown.expect(FeignException.class);
 
@@ -329,23 +329,23 @@ public class LoggerTest {
       return Arrays.asList(new Object[][] {
           {Level.NONE, Collections.emptyList()},
           {Level.BASIC, Arrays.asList(
-              "\\[SendsStuff#login\\] ---> POST http://sna%fu.abc/ HTTP/1.1",
-              "\\[SendsStuff#login\\] <--- ERROR UnknownHostException: sna%fu.abc \\([0-9]+ms\\)")},
+              "\\[SendsStuff#login\\] ---> POST http://non-exist.invalid/ HTTP/1.1",
+              "\\[SendsStuff#login\\] <--- ERROR UnknownHostException: non-exist.invalid \\([0-9]+ms\\)")},
           {Level.HEADERS, Arrays.asList(
-              "\\[SendsStuff#login\\] ---> POST http://sna%fu.abc/ HTTP/1.1",
+              "\\[SendsStuff#login\\] ---> POST http://non-exist.invalid/ HTTP/1.1",
               "\\[SendsStuff#login\\] Content-Length: 80",
               "\\[SendsStuff#login\\] Content-Type: application/json",
               "\\[SendsStuff#login\\] ---> END HTTP \\(80-byte body\\)",
-              "\\[SendsStuff#login\\] <--- ERROR UnknownHostException: sna%fu.abc \\([0-9]+ms\\)")},
+              "\\[SendsStuff#login\\] <--- ERROR UnknownHostException: non-exist.invalid \\([0-9]+ms\\)")},
           {Level.FULL, Arrays.asList(
-              "\\[SendsStuff#login\\] ---> POST http://sna%fu.abc/ HTTP/1.1",
+              "\\[SendsStuff#login\\] ---> POST http://non-exist.invalid/ HTTP/1.1",
               "\\[SendsStuff#login\\] Content-Length: 80",
               "\\[SendsStuff#login\\] Content-Type: application/json",
               "\\[SendsStuff#login\\] ",
               "\\[SendsStuff#login\\] \\{\"customer_name\": \"netflix\", \"user_name\": \"denominator\", \"password\": \"password\"\\}",
               "\\[SendsStuff#login\\] ---> END HTTP \\(80-byte body\\)",
-              "\\[SendsStuff#login\\] <--- ERROR UnknownHostException: sna%fu.abc \\([0-9]+ms\\)",
-              "(?s)\\[SendsStuff#login\\] java.net.UnknownHostException: sna%fu.abc.*",
+              "\\[SendsStuff#login\\] <--- ERROR UnknownHostException: non-exist.invalid \\([0-9]+ms\\)",
+              "(?s)\\[SendsStuff#login\\] java.net.UnknownHostException: non-exist.invalid.*",
               "\\[SendsStuff#login\\] <--- END ERROR")}
       });
     }
@@ -366,7 +366,7 @@ public class LoggerTest {
               return this;
             }
           })
-          .target(SendsStuff.class, "http://sna%25fu.abc");
+          .target(SendsStuff.class, "http://non-exist.invalid");
 
       thrown.expect(FeignException.class);
 
@@ -390,11 +390,11 @@ public class LoggerTest {
       return Arrays.asList(new Object[][] {
           {Level.NONE, Collections.emptyList()},
           {Level.BASIC, Arrays.asList(
-              "\\[SendsStuff#login\\] ---> POST http://robofu.abc/ HTTP/1.1",
-              "\\[SendsStuff#login\\] <--- ERROR UnknownHostException: robofu.abc \\([0-9]+ms\\)",
+              "\\[SendsStuff#login\\] ---> POST http://non-exist.invalid/ HTTP/1.1",
+              "\\[SendsStuff#login\\] <--- ERROR UnknownHostException: non-exist.invalid \\([0-9]+ms\\)",
               "\\[SendsStuff#login\\] ---> RETRYING",
-              "\\[SendsStuff#login\\] ---> POST http://robofu.abc/ HTTP/1.1",
-              "\\[SendsStuff#login\\] <--- ERROR UnknownHostException: robofu.abc \\([0-9]+ms\\)")}
+              "\\[SendsStuff#login\\] ---> POST http://non-exist.invalid/ HTTP/1.1",
+              "\\[SendsStuff#login\\] <--- ERROR UnknownHostException: non-exist.invalid \\([0-9]+ms\\)")}
       });
     }
 
@@ -422,7 +422,7 @@ public class LoggerTest {
               return this;
             }
           })
-          .target(SendsStuff.class, "http://robofu.abc");
+          .target(SendsStuff.class, "http://non-exist.invalid");
 
       api.login("netflix", "denominator", "password");
     }

--- a/pom.xml
+++ b/pom.xml
@@ -421,11 +421,13 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${maven-compiler-plugin.version}</version>
         </plugin>
 
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <version>${maven-jar-plugin.version}</version>
           <configuration>
@@ -531,6 +533,7 @@
       </plugin>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <inherited>true</inherited>
         <configuration>
@@ -569,11 +572,13 @@
       </plugin>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-install-plugin</artifactId>
         <version>${maven-install-plugin.version}</version>
       </plugin>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <version>${maven-release-plugin.version}</version>
         <configuration>


### PR DESCRIPTION
Fixes #2081

The Ukrainian mobile operator Lifecell resolves non-existent hostnames and returns fake 404 pages for some reason. There is a possibility that some other providers can do such strange things as well.

[RFC 2602](https://www.rfc-editor.org/rfc/rfc2606.html) reserves some top level domain names for test purpose. To avoid such issues like #2081 I propose to replace all non-existent domain names in LoggerTest.