### PR TITLE
Adds convenient overloaded constructor for Request.Options

### DIFF
--- a/core/src/main/java/feign/Request.java
+++ b/core/src/main/java/feign/Request.java
@@ -18,6 +18,7 @@ import static feign.Util.valuesOrEmpty;
 import java.io.Serializable;
 import java.net.HttpURLConnection;
 import java.nio.charset.Charset;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -347,6 +348,18 @@ public final class Request implements Serializable {
     @Deprecated
     public Options(int connectTimeoutMillis, int readTimeoutMillis) {
       this(connectTimeoutMillis, readTimeoutMillis, true);
+    }
+
+    /**
+     * Creates a new Options Instance.
+     *
+     * @param connectTimeout value.
+     * @param readTimeout value.
+     * @param followRedirects if the request should follow 3xx redirections.
+     */
+    public Options(Duration connectTimeout, Duration readTimeout, boolean followRedirects) {
+      this(connectTimeout.toMillis(), TimeUnit.MILLISECONDS, readTimeout.toMillis(),
+          TimeUnit.MILLISECONDS, followRedirects);
     }
 
     /**


### PR DESCRIPTION
This proposes adding new convenient constructor for Request.Options that enables us to pass timeout as duration. In my apps timeout is very often passed around as duration, which is imo better than moving it around as magic number without explicit unit attached. This constructor overload simply feels like it should be there from user perspective.