### PR TITLE
The HTTP protocol version: it misses in AsyncApacheHttp5Client's response and hardcoded in Request.toString()

### DIFF
--- a/core/src/main/java/feign/Request.java
+++ b/core/src/main/java/feign/Request.java
@@ -276,7 +276,8 @@ public final class Request implements Serializable {
   @Override
   public String toString() {
     final StringBuilder builder = new StringBuilder();
-    builder.append(httpMethod).append(' ').append(url).append(" HTTP/1.1\n");
+    builder.append(httpMethod).append(' ').append(url).append(' ').append(protocolVersion)
+        .append('\n');
     for (final String field : headers.keySet()) {
       for (final String value : valuesOrEmpty(headers, field)) {
         builder.append(field).append(": ").append(value).append('\n');

--- a/hc5/src/main/java/feign/hc5/AsyncApacheHttp5Client.java
+++ b/hc5/src/main/java/feign/hc5/AsyncApacheHttp5Client.java
@@ -29,6 +29,8 @@ import java.util.concurrent.CompletableFuture;
 import feign.*;
 import feign.Request.Options;
 
+import static feign.Util.enumForName;
+
 /**
  * This module directs Feign's http requests to Apache's
  * <a href="https://hc.apache.org/httpcomponents-client-5.0.x/index.html">HttpClient 5</a>. Ex.
@@ -179,6 +181,8 @@ public final class AsyncApacheHttp5Client implements AsyncClient<HttpClientConte
     }
 
     return Response.builder()
+        .protocolVersion(
+            enumForName(Request.ProtocolVersion.class, httpResponse.getVersion().format()))
         .status(statusCode)
         .reason(reason)
         .headers(headers)

--- a/hc5/src/main/java/feign/hc5/AsyncApacheHttp5Client.java
+++ b/hc5/src/main/java/feign/hc5/AsyncApacheHttp5Client.java
@@ -28,7 +28,6 @@ import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import feign.*;
 import feign.Request.Options;
-
 import static feign.Util.enumForName;
 
 /**


### PR DESCRIPTION
I have found some issues related to the HTTP protocol version while investigated #2064.

They both are minor.