### PR TITLE
Apache HC5 Client uses Request.Options to manage follow redirects

### DIFF
--- a/hc5/src/main/java/feign/hc5/ApacheHttp5Client.java
+++ b/hc5/src/main/java/feign/hc5/ApacheHttp5Client.java
@@ -96,6 +96,7 @@ public final class ApacheHttp5Client implements Client {
         (client instanceof Configurable
             ? RequestConfig.copy(((Configurable) client).getConfig())
             : RequestConfig.custom())
+                .setRedirectsEnabled(options.isFollowRedirects())
                 .setConnectTimeout(options.connectTimeout(), options.connectTimeoutUnit())
                 .setResponseTimeout(options.readTimeout(), options.readTimeoutUnit())
                 .build();

--- a/hc5/src/main/java/feign/hc5/AsyncApacheHttp5Client.java
+++ b/hc5/src/main/java/feign/hc5/AsyncApacheHttp5Client.java
@@ -99,6 +99,7 @@ public final class AsyncApacheHttp5Client implements AsyncClient<HttpClientConte
         (client instanceof Configurable
             ? RequestConfig.copy(((Configurable) client).getConfig())
             : RequestConfig.custom())
+                .setRedirectsEnabled(options.isFollowRedirects())
                 .setConnectTimeout(options.connectTimeout(), options.connectTimeoutUnit())
                 .setResponseTimeout(options.readTimeout(), options.readTimeoutUnit())
                 .build();


### PR DESCRIPTION
Fixes #2060 

