### PR TITLE
Allow override of maxBodyBytesLength in ErrorDecoder

### DIFF
--- a/core/src/main/java/feign/codec/ErrorDecoder.java
+++ b/core/src/main/java/feign/codec/ErrorDecoder.java
@@ -82,6 +82,10 @@ public interface ErrorDecoder {
    *         retryable, it should be wrapped, or a subtype of {@link RetryableException}
    */
   public Exception decode(String methodKey, Response response);
+  default Exception decode(String methodKey, Response response, Integer maxBodyBytesLength,
+      Integer maxBodyCharsLength) {
+    return decode(methodKey, response);
+  }
 
   public static class Default implements ErrorDecoder {
 
@@ -89,7 +93,14 @@ public interface ErrorDecoder {
 
     @Override
     public Exception decode(String methodKey, Response response) {
-      FeignException exception = errorStatus(methodKey, response);
+      return decode(methodKey, response, null, null);
+    }
+
+    @Override
+    public Exception decode(String methodKey, Response response, Integer maxBodyBytesLength,
+        Integer maxBodyCharsLength) {
+      FeignException exception = errorStatus(methodKey, response, maxBodyBytesLength,
+          maxBodyCharsLength);
       Date retryAfter = retryAfterDecoder.apply(firstOrNull(response.headers(), RETRY_AFTER));
       if (retryAfter != null) {
         return new RetryableException(

--- a/core/src/main/java/feign/codec/ErrorDecoder.java
+++ b/core/src/main/java/feign/codec/ErrorDecoder.java
@@ -83,27 +83,25 @@ public interface ErrorDecoder {
    */
   public Exception decode(String methodKey, Response response);
 
-  default Exception decode(String methodKey,
-                           Response response,
-                           Integer maxBodyBytesLength,
-                           Integer maxBodyCharsLength) {
-    return decode(methodKey, response);
-  }
-
-  public static class Default implements ErrorDecoder {
+  public class Default implements ErrorDecoder {
 
     private final RetryAfterDecoder retryAfterDecoder = new RetryAfterDecoder();
+    private Integer maxBodyBytesLength;
+    private Integer maxBodyCharsLength;
 
-    @Override
-    public Exception decode(String methodKey, Response response) {
-      return decode(methodKey, response, null, null);
+    public Default() {
+      this.maxBodyBytesLength = null;
+      this.maxBodyCharsLength = null;
+    }
+
+    public Default(Integer maxBodyBytesLength, Integer maxBodyCharsLength) {
+      this.maxBodyBytesLength = maxBodyBytesLength;
+      this.maxBodyCharsLength = maxBodyCharsLength;
     }
 
     @Override
     public Exception decode(String methodKey,
-                            Response response,
-                            Integer maxBodyBytesLength,
-                            Integer maxBodyCharsLength) {
+                            Response response) {
       FeignException exception = errorStatus(methodKey, response, maxBodyBytesLength,
           maxBodyCharsLength);
       Date retryAfter = retryAfterDecoder.apply(firstOrNull(response.headers(), RETRY_AFTER));

--- a/core/src/main/java/feign/codec/ErrorDecoder.java
+++ b/core/src/main/java/feign/codec/ErrorDecoder.java
@@ -100,8 +100,7 @@ public interface ErrorDecoder {
     }
 
     @Override
-    public Exception decode(String methodKey,
-                            Response response) {
+    public Exception decode(String methodKey, Response response) {
       FeignException exception = errorStatus(methodKey, response, maxBodyBytesLength,
           maxBodyCharsLength);
       Date retryAfter = retryAfterDecoder.apply(firstOrNull(response.headers(), RETRY_AFTER));

--- a/core/src/main/java/feign/codec/ErrorDecoder.java
+++ b/core/src/main/java/feign/codec/ErrorDecoder.java
@@ -82,8 +82,11 @@ public interface ErrorDecoder {
    *         retryable, it should be wrapped, or a subtype of {@link RetryableException}
    */
   public Exception decode(String methodKey, Response response);
-  default Exception decode(String methodKey, Response response, Integer maxBodyBytesLength,
-      Integer maxBodyCharsLength) {
+
+  default Exception decode(String methodKey,
+                           Response response,
+                           Integer maxBodyBytesLength,
+                           Integer maxBodyCharsLength) {
     return decode(methodKey, response);
   }
 
@@ -97,8 +100,10 @@ public interface ErrorDecoder {
     }
 
     @Override
-    public Exception decode(String methodKey, Response response, Integer maxBodyBytesLength,
-        Integer maxBodyCharsLength) {
+    public Exception decode(String methodKey,
+                            Response response,
+                            Integer maxBodyBytesLength,
+                            Integer maxBodyCharsLength) {
       FeignException exception = errorStatus(methodKey, response, maxBodyBytesLength,
           maxBodyCharsLength);
       Date retryAfter = retryAfterDecoder.apply(firstOrNull(response.headers(), RETRY_AFTER));

--- a/core/src/test/java/feign/codec/DefaultErrorDecoderTest.java
+++ b/core/src/test/java/feign/codec/DefaultErrorDecoderTest.java
@@ -145,7 +145,8 @@ public class DefaultErrorDecoderTest {
     Exception defaultException = errorDecoder.decode("Service#foo()", response);
     assertThat(defaultException.getMessage().length()).isLessThan(response.body().length());
 
-    Exception customizedException = errorDecoder.decode("Service#foo()", response, 4000, 2000);
+    ErrorDecoder customizedErrorDecoder = new ErrorDecoder.Default(4000, 2000);
+    Exception customizedException = customizedErrorDecoder.decode("Service#foo()", response);
     assertThat(customizedException.getMessage().length())
         .isGreaterThanOrEqualTo(response.body().length());
   }


### PR DESCRIPTION
Allow override of maxBodyBytesLength, maxBodyCharsLength in ErrorDecoder

Currently if we use Default error decoder from this lib it will cut error messages so we cant really see them in the logs. This will allow us to configure max error message length.

Added ability to specify our own max values in Default error decoder.

Let me know what you think about this