### PR TITLE
The builder clones itself before enrichment

### DIFF
--- a/core/src/main/java/feign/AsyncFeign.java
+++ b/core/src/main/java/feign/AsyncFeign.java
@@ -186,30 +186,32 @@ public final class AsyncFeign<C> {
     }
 
     public AsyncFeign<C> build() {
-      super.enrich();
+      AsyncBuilder<C> enrichedBuilder = super.enrich();
 
       AsyncResponseHandler responseHandler =
           (AsyncResponseHandler) Capability.enrich(
               new AsyncResponseHandler(
-                  logLevel,
-                  logger,
-                  decoder,
-                  errorDecoder,
-                  dismiss404,
-                  closeAfterDecode, responseInterceptor),
+                  enrichedBuilder.logLevel,
+                  enrichedBuilder.logger,
+                  enrichedBuilder.decoder,
+                  enrichedBuilder.errorDecoder,
+                  enrichedBuilder.dismiss404,
+                  enrichedBuilder.closeAfterDecode, enrichedBuilder.responseInterceptor),
               AsyncResponseHandler.class,
-              capabilities);
+              enrichedBuilder.capabilities);
 
       final MethodHandler.Factory<C> methodHandlerFactory =
           new AsynchronousMethodHandler.Factory<>(
-              client, retryer, requestInterceptors,
-              responseHandler, logger, logLevel,
-              propagationPolicy, methodInfoResolver,
-              new RequestTemplateFactoryResolver(encoder, queryMapEncoder),
-              options, decoder, errorDecoder);
+              enrichedBuilder.client, enrichedBuilder.retryer, enrichedBuilder.requestInterceptors,
+              responseHandler, enrichedBuilder.logger, enrichedBuilder.logLevel,
+              enrichedBuilder.propagationPolicy, enrichedBuilder.methodInfoResolver,
+              new RequestTemplateFactoryResolver(enrichedBuilder.encoder,
+                  enrichedBuilder.queryMapEncoder),
+              enrichedBuilder.options, enrichedBuilder.decoder, enrichedBuilder.errorDecoder);
       final ReflectiveFeign<C> feign =
-          new ReflectiveFeign<>(contract, methodHandlerFactory, invocationHandlerFactory,
-              defaultContextSupplier);
+          new ReflectiveFeign<>(enrichedBuilder.contract, methodHandlerFactory,
+              enrichedBuilder.invocationHandlerFactory,
+              enrichedBuilder.defaultContextSupplier);
       return new AsyncFeign<>(feign);
     }
   }

--- a/core/src/main/java/feign/Feign.java
+++ b/core/src/main/java/feign/Feign.java
@@ -197,17 +197,23 @@ public abstract class Feign {
     }
 
     public Feign build() {
-      super.enrich();
+      Builder enrichedBuilder = super.enrich();
 
       final ResponseHandler responseHandler =
-          new ResponseHandler(logLevel, logger, decoder, errorDecoder,
-              dismiss404, closeAfterDecode, responseInterceptor);
+          new ResponseHandler(enrichedBuilder.logLevel, enrichedBuilder.logger,
+              enrichedBuilder.decoder, enrichedBuilder.errorDecoder,
+              enrichedBuilder.dismiss404, enrichedBuilder.closeAfterDecode,
+              enrichedBuilder.responseInterceptor);
       MethodHandler.Factory<Object> methodHandlerFactory =
-          new SynchronousMethodHandler.Factory(client, retryer, requestInterceptors,
-              responseHandler, logger, logLevel, propagationPolicy,
-              new RequestTemplateFactoryResolver(encoder, queryMapEncoder),
-              options);
-      return new ReflectiveFeign<>(contract, methodHandlerFactory, invocationHandlerFactory,
+          new SynchronousMethodHandler.Factory(enrichedBuilder.client, enrichedBuilder.retryer,
+              enrichedBuilder.requestInterceptors,
+              responseHandler, enrichedBuilder.logger, enrichedBuilder.logLevel,
+              enrichedBuilder.propagationPolicy,
+              new RequestTemplateFactoryResolver(enrichedBuilder.encoder,
+                  enrichedBuilder.queryMapEncoder),
+              enrichedBuilder.options);
+      return new ReflectiveFeign<>(enrichedBuilder.contract, methodHandlerFactory,
+          enrichedBuilder.invocationHandlerFactory,
           () -> null);
     }
   }

--- a/core/src/test/java/feign/BaseBuilderTest.java
+++ b/core/src/test/java/feign/BaseBuilderTest.java
@@ -14,6 +14,7 @@
 package feign;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.RETURNS_MOCKS;
 import java.lang.reflect.Field;
@@ -46,6 +47,7 @@ public class BaseBuilderTest {
       }
       assertTrue("Field was not enriched " + field, Mockito.mockingDetails(mockedValue)
           .isMock());
+      assertNotSame(builder, enriched);
     }
 
   }

--- a/hystrix/src/main/java/feign/hystrix/HystrixFeign.java
+++ b/hystrix/src/main/java/feign/hystrix/HystrixFeign.java
@@ -148,7 +148,7 @@ public final class HystrixFeign {
         }
       });
       super.contract(new HystrixDelegatingContract(contract));
-      return super.build();
+      return super.internalBuild();
     }
 
     // Covariant overrides to support chaining to new fallback method.

--- a/kotlin/src/main/java/feign/kotlin/CoroutineFeign.java
+++ b/kotlin/src/main/java/feign/kotlin/CoroutineFeign.java
@@ -158,24 +158,25 @@ public class CoroutineFeign<C> {
 
     @SuppressWarnings("unchecked")
     public CoroutineFeign<C> build() {
-      super.enrich();
+      CoroutineBuilder<C> enrichedBuilder = super.enrich();
 
       AsyncFeign<C> asyncFeign = (AsyncFeign<C>) AsyncFeign.builder()
-          .logLevel(logLevel)
-          .client((AsyncClient<Object>) client)
-          .decoder(decoder)
-          .errorDecoder(errorDecoder)
-          .contract(contract)
-          .retryer(retryer)
-          .logger(logger)
-          .encoder(encoder)
-          .queryMapEncoder(queryMapEncoder)
-          .options(options)
-          .requestInterceptors(requestInterceptors)
-          .responseInterceptor(responseInterceptor)
-          .invocationHandlerFactory(invocationHandlerFactory)
-          .defaultContextSupplier((AsyncContextSupplier<Object>) defaultContextSupplier)
-          .methodInfoResolver(methodInfoResolver)
+          .logLevel(enrichedBuilder.logLevel)
+          .client((AsyncClient<Object>) enrichedBuilder.client)
+          .decoder(enrichedBuilder.decoder)
+          .errorDecoder(enrichedBuilder.errorDecoder)
+          .contract(enrichedBuilder.contract)
+          .retryer(enrichedBuilder.retryer)
+          .logger(enrichedBuilder.logger)
+          .encoder(enrichedBuilder.encoder)
+          .queryMapEncoder(enrichedBuilder.queryMapEncoder)
+          .options(enrichedBuilder.options)
+          .requestInterceptors(enrichedBuilder.requestInterceptors)
+          .responseInterceptor(enrichedBuilder.responseInterceptor)
+          .invocationHandlerFactory(enrichedBuilder.invocationHandlerFactory)
+          .defaultContextSupplier(
+              (AsyncContextSupplier<Object>) enrichedBuilder.defaultContextSupplier)
+          .methodInfoResolver(enrichedBuilder.methodInfoResolver)
           .build();
       return new CoroutineFeign<>(asyncFeign);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <maven-bundle-plugin.version>5.1.9</maven-bundle-plugin.version>
     <centralsync-maven-plugin.version>0.1.1</centralsync-maven-plugin.version>
     <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
-    <bom-generator.version>0.100.2</bom-generator.version>
+    <bom-generator.version>0.100.3</bom-generator.version>
     <bom.template.file.path>file://${project.basedir}/src/config/bom.xml</bom.template.file.path>
     <maven-scm-plugin.version>2.0.1</maven-scm-plugin.version>
     <maven-versions-plugin.version>2.16.0</maven-versions-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <main.basedir>${project.basedir}</main.basedir>
 
     <okhttp3.version>4.11.0</okhttp3.version>
-    <guava.version>32.1.0-jre</guava.version>
+    <guava.version>32.1.1-jre</guava.version>
     <googlehttpclient.version>1.43.3</googlehttpclient.version>
     <gson.version>2.10.1</gson.version>
     <slf4j.version>2.0.7</slf4j.version>

--- a/reactive/src/main/java/feign/reactive/ReactiveFeign.java
+++ b/reactive/src/main/java/feign/reactive/ReactiveFeign.java
@@ -42,13 +42,13 @@ abstract class ReactiveFeign {
      * @return a new Feign Instance.
      */
     @Override
-    public Feign build() {
+    public Feign internalBuild() {
       if (!(this.contract instanceof ReactiveDelegatingContract)) {
         super.contract(new ReactiveDelegatingContract(this.contract));
       } else {
         super.contract(this.contract);
       }
-      return super.build();
+      return super.internalBuild();
     }
 
     @Override

--- a/reactive/src/main/java/feign/reactive/ReactorFeign.java
+++ b/reactive/src/main/java/feign/reactive/ReactorFeign.java
@@ -14,13 +14,13 @@
 package feign.reactive;
 
 import feign.Feign;
-import reactor.core.scheduler.Scheduler;
-import reactor.core.scheduler.Schedulers;
+import feign.InvocationHandlerFactory;
+import feign.Target;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.util.Map;
-import feign.InvocationHandlerFactory;
-import feign.Target;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 
 public class ReactorFeign extends ReactiveFeign {
 
@@ -41,9 +41,9 @@ public class ReactorFeign extends ReactiveFeign {
     }
 
     @Override
-    public Feign build() {
+    public Feign internalBuild() {
       super.invocationHandlerFactory(new ReactorInvocationHandlerFactory(scheduler));
-      return super.build();
+      return super.internalBuild();
     }
 
     @Override

--- a/reactive/src/main/java/feign/reactive/RxJavaFeign.java
+++ b/reactive/src/main/java/feign/reactive/RxJavaFeign.java
@@ -13,14 +13,14 @@
  */
 package feign.reactive;
 
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-import java.util.Map;
 import feign.Feign;
 import feign.InvocationHandlerFactory;
 import feign.Target;
 import io.reactivex.Scheduler;
 import io.reactivex.schedulers.Schedulers;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.util.Map;
 
 public class RxJavaFeign extends ReactiveFeign {
 
@@ -33,9 +33,9 @@ public class RxJavaFeign extends ReactiveFeign {
     private Scheduler scheduler = Schedulers.trampoline();
 
     @Override
-    public Feign build() {
+    public Feign internalBuild() {
       super.invocationHandlerFactory(new RxJavaInvocationHandlerFactory(scheduler));
-      return super.build();
+      return super.internalBuild();
     }
 
     @Override


### PR DESCRIPTION
I have tried to resolve #1961: now when the builder makes a new *Feign it wraps own fields, on second call it wraps already wrapped fields. I replace the link to itself builder `thisB` and own fields by a clone and its fields.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Refactor:**
- Introduced a new method `internalBuild()` across various classes in the Feign library, improving code modularity and maintainability.
- Enhanced the `BaseBuilder` class with cloning capabilities to enrich builder objects, enhancing code consistency and logic.
- Updated test cases to reflect changes in the `BaseBuilder` class.

> Hopping through the code, making it neat 🐇,
> Refactoring here and there, isn't that sweet? 🍭
> With every change, we're on a roll,
> Making our codebase, beautifully whole. 🎉
<!-- end of auto-generated comment: release notes by coderabbit.ai -->