### PR TITLE
Adding a constructor for the RetryableException to include a Response…

### DIFF
--- a/core/src/main/java/feign/RetryableException.java
+++ b/core/src/main/java/feign/RetryableException.java
@@ -14,7 +14,9 @@
 package feign;
 
 import feign.Request.HttpMethod;
+import java.util.Collection;
 import java.util.Date;
+import java.util.Map;
 
 /**
  * This exception is raised when the {@link Response} is deemed to be retryable, typically via an
@@ -43,6 +45,16 @@ public class RetryableException extends FeignException {
   public RetryableException(int status, String message, HttpMethod httpMethod, Date retryAfter,
       Request request) {
     super(status, message, request);
+    this.httpMethod = httpMethod;
+    this.retryAfter = retryAfter != null ? retryAfter.getTime() : null;
+  }
+
+  /**
+   * @param retryAfter usually corresponds to the {@link feign.Util#RETRY_AFTER} header.
+   */
+  public RetryableException(int status, String message, HttpMethod httpMethod, Date retryAfter,
+      Request request, byte[] responseBody, Map<String, Collection<String>> responseHeaders) {
+    super(status, message, request, responseBody, responseHeaders);
     this.httpMethod = httpMethod;
     this.retryAfter = retryAfter != null ? retryAfter.getTime() : null;
   }

--- a/core/src/test/java/feign/RetryableExceptionTest.java
+++ b/core/src/test/java/feign/RetryableExceptionTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign;
+
+import org.junit.Test;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import static feign.Util.UTF_8;
+import static org.junit.Assert.*;
+
+public class RetryableExceptionTest {
+
+  @Test
+  public void createRetryableExceptionWithResponseAndResponseHeader() {
+    // given
+    Request request = Request.create(Request.HttpMethod.GET, "/", Collections.emptyMap(), null, Util.UTF_8);
+    byte[] response = "response".getBytes(StandardCharsets.UTF_8);
+    Map<String, Collection<String>> responseHeader = new HashMap<>();
+    responseHeader.put("TEST_HEADER", Arrays.asList("TEST_CONTENT"));
+
+    // when
+    RetryableException retryableException =
+        new RetryableException(-1, null, null, new Date(5000), request, response, responseHeader);
+
+    // then
+    assertNotNull(retryableException);
+    assertEquals(new String(response, UTF_8), retryableException.contentUTF8());
+    assertTrue(retryableException.responseHeaders().containsKey("TEST_HEADER"));
+    assertTrue(retryableException.responseHeaders().get("TEST_HEADER").contains("TEST_CONTENT"));
+  }
+}

--- a/core/src/test/java/feign/RetryableExceptionTest.java
+++ b/core/src/test/java/feign/RetryableExceptionTest.java
@@ -24,7 +24,8 @@ public class RetryableExceptionTest {
   @Test
   public void createRetryableExceptionWithResponseAndResponseHeader() {
     // given
-    Request request = Request.create(Request.HttpMethod.GET, "/", Collections.emptyMap(), null, Util.UTF_8);
+    Request request =
+        Request.create(Request.HttpMethod.GET, "/", Collections.emptyMap(), null, Util.UTF_8);
     byte[] response = "response".getBytes(StandardCharsets.UTF_8);
     Map<String, Collection<String>> responseHeader = new HashMap<>();
     responseHeader.put("TEST_HEADER", Arrays.asList("TEST_CONTENT"));


### PR DESCRIPTION
I have a use case where I use a custom error decoder in a middleware Spring Boot application that processes the last RetryableException in an ExceptionHandler after the retries of a client call have run. But right now I can only access the response body and headers of a failed call with a workaround in the exception handler.
Therefore the extension of the constructor of the RetryableException so that the response body and header can be set in the FeignException and the possibility to access the content without a workaround.