### PR TITLE
feat: Added decodeVoid feature

### DIFF
--- a/core/src/main/java/feign/BaseBuilder.java
+++ b/core/src/main/java/feign/BaseBuilder.java
@@ -43,6 +43,7 @@ public abstract class BaseBuilder<B extends BaseBuilder<B>> {
   protected Encoder encoder = new Encoder.Default();
   protected Decoder decoder = new Decoder.Default();
   protected boolean closeAfterDecode = true;
+  protected boolean decodeVoid = false;
   protected QueryMapEncoder queryMapEncoder = new FieldQueryMapEncoder();
   protected ErrorDecoder errorDecoder = new ErrorDecoder.Default();
   protected Options options = new Options();
@@ -103,6 +104,11 @@ public abstract class BaseBuilder<B extends BaseBuilder<B>> {
    */
   public B doNotCloseAfterDecode() {
     this.closeAfterDecode = false;
+    return thisB;
+  }
+
+  public B decodeVoid() {
+    this.decodeVoid = true;
     return thisB;
   }
 

--- a/core/src/main/java/feign/Feign.java
+++ b/core/src/main/java/feign/Feign.java
@@ -179,6 +179,11 @@ public abstract class Feign {
     }
 
     @Override
+    public Builder decodeVoid() {
+      return super.decodeVoid();
+    }
+
+    @Override
     public Builder exceptionPropagationPolicy(ExceptionPropagationPolicy propagationPolicy) {
       return super.exceptionPropagationPolicy(propagationPolicy);
     }
@@ -201,7 +206,7 @@ public abstract class Feign {
 
       final ResponseHandler responseHandler =
           new ResponseHandler(logLevel, logger, decoder, errorDecoder,
-              dismiss404, closeAfterDecode, responseInterceptor);
+              dismiss404, closeAfterDecode, decodeVoid, responseInterceptor);
       MethodHandler.Factory<Object> methodHandlerFactory =
           new SynchronousMethodHandler.Factory(client, retryer, requestInterceptors,
               responseHandler, logger, logLevel, propagationPolicy,

--- a/core/src/main/java/feign/ResponseHandler.java
+++ b/core/src/main/java/feign/ResponseHandler.java
@@ -37,10 +37,12 @@ public class ResponseHandler {
   private final boolean dismiss404;
   private final boolean closeAfterDecode;
 
+  private final boolean decodeVoid;
+
   private final ResponseInterceptor responseInterceptor;
 
   public ResponseHandler(Level logLevel, Logger logger, Decoder decoder,
-      ErrorDecoder errorDecoder, boolean dismiss404, boolean closeAfterDecode,
+      ErrorDecoder errorDecoder, boolean dismiss404, boolean closeAfterDecode, boolean decodeVoid,
       ResponseInterceptor responseInterceptor) {
     super();
     this.logLevel = logLevel;
@@ -50,6 +52,7 @@ public class ResponseHandler {
     this.dismiss404 = dismiss404;
     this.closeAfterDecode = closeAfterDecode;
     this.responseInterceptor = responseInterceptor;
+    this.decodeVoid = decodeVoid;
   }
 
   public Object handleResponse(String configKey,
@@ -113,7 +116,7 @@ public class ResponseHandler {
   }
 
   private Object decode(Response response, Type type) throws IOException {
-    if (isVoidType(type)) {
+    if (isVoidType(type) && !decodeVoid) {
       ensureClosed(response.body());
       return null;
     }


### PR DESCRIPTION
I added `decodeVoid()` feature, with which can be possible to change default behaviour of calling decoders for methods which has a void return type.

Currently, if method has void type, ResponseInterceptor or Decoder will not be called.

And this is good if don't working with REST-less API which everytime returns 200 OK, and that response has a code parameter, using that, for example, I need to detect response was successful or not.

And I don't need to return any data from the method, because if method fails I will get exception, and I can avoid warnings from static analyzer about "ignored return value", if I would be changed void to Object for bypass this limitation.

I had idea about check the response in the Client wrapper, but then I would need to decode a JSON twice time in some cases.


