### PR TITLE
Fix expression pattern compilation on android

### DIFF
--- a/core/src/main/java/feign/template/Expressions.java
+++ b/core/src/main/java/feign/template/Expressions.java
@@ -41,7 +41,7 @@ public final class Expressions {
    * <a href="https://www.rfc-editor.org/rfc/rfc6570#section-2.2>RFC 6570 Expressions</a>
    */
   private static final Pattern EXPRESSION_PATTERN =
-      Pattern.compile("^(\\{([+#./;?&=,!@|]?)(.+)})$");
+      Pattern.compile("^(\\{([+#./;?&=,!@|]?)(.+)\\})$");
 
   // Partially From:
   // https://stackoverflow.com/questions/29494608/regex-for-uri-templates-rfc-6570-wanted -- I

--- a/core/src/main/java/feign/template/Expressions.java
+++ b/core/src/main/java/feign/template/Expressions.java
@@ -38,9 +38,9 @@ public final class Expressions {
    *
    * This is not a complete implementation of the rfc
    *
-   * <a href="https://www.rfc-editor.org/rfc/rfc6570#section-2.2>RFC 6570 Expressions</a>
+   * <a href="https://www.rfc-editor.org/rfc/rfc6570#section-2.2">RFC 6570 Expressions</a>
    */
-  private static final Pattern EXPRESSION_PATTERN =
+  static final Pattern EXPRESSION_PATTERN =
       Pattern.compile("^(\\{([+#./;?&=,!@|]?)(.+)\\})$");
 
   // Partially From:

--- a/core/src/test/java/feign/template/ExpressionsTest.java
+++ b/core/src/test/java/feign/template/ExpressionsTest.java
@@ -14,9 +14,7 @@
 package feign.template;
 
 import org.junit.jupiter.api.Test;
-
 import java.util.Collections;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ExpressionsTest {
@@ -35,5 +33,4 @@ public class ExpressionsTest {
     String pattern = Expressions.EXPRESSION_PATTERN.pattern();
     assertThat(pattern.contains("}")).isEqualTo(pattern.contains("\\}"));
   }
-
 }

--- a/core/src/test/java/feign/template/ExpressionsTest.java
+++ b/core/src/test/java/feign/template/ExpressionsTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package feign.template;
 
 import org.junit.jupiter.api.Test;

--- a/core/src/test/java/feign/template/ExpressionsTest.java
+++ b/core/src/test/java/feign/template/ExpressionsTest.java
@@ -1,0 +1,26 @@
+package feign.template;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExpressionsTest {
+
+  @Test
+  public void simpleExpression() {
+    Expression expression = Expressions.create("{foo}");
+    assertThat(expression).isNotNull();
+    String expanded = expression.expand(Collections.singletonMap("foo", "bar"), false);
+    assertThat(expanded).isEqualToIgnoringCase("foo=bar");
+  }
+
+  @Test
+  public void androidCompatibility() {
+    // To match close brace on Android, it must be escaped due to the simpler ICU regex engine
+    String pattern = Expressions.EXPRESSION_PATTERN.pattern();
+    assertThat(pattern.contains("}")).isEqualTo(pattern.contains("\\}"));
+  }
+
+}


### PR DESCRIPTION
The ICU regex engine used by Android requires `}` in `EXPRESSION_PATTERN` to be escaped.

Fixes `java.lang.NoClassDefFoundError: feign.template.Expressions` on Android (reported by @Awakened-Redstone)
