### PR TITLE
Fix issuse #1721 "Accept-Encoding" header is added twice

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
-      <version>6.0.10</version>
+      <version>6.0.11</version>
       <scope>test</scope>
     </dependency>
 

--- a/core/src/main/java/feign/Client.java
+++ b/core/src/main/java/feign/Client.java
@@ -190,7 +190,7 @@ public interface Client {
           } 
           //Avoid add "Accept-encoding" twice or more when "compression" option is enabled
           if (field.equals(ACCEPT_ENCODING)) {
-            connection.addRequestProperty(field, String.join(", ",request.headers().get(field)));
+            connection.addRequestProperty(field, String.join(", ", request.headers().get(field)));
             break;
           } else {
             connection.addRequestProperty(field, value);

--- a/core/src/main/java/feign/Util.java
+++ b/core/src/main/java/feign/Util.java
@@ -65,6 +65,10 @@ public class Util {
    */
   public static final String CONTENT_ENCODING = "Content-Encoding";
   /**
+   * The HTTP Accept-Encoding header field name.
+   */
+  public static final String ACCEPT_ENCODING = "Accept-Encoding";
+  /**
    * The HTTP Retry-After header field name.
    */
   public static final String RETRY_AFTER = "Retry-After";


### PR DESCRIPTION
Fix issuse #1721 "Accept-Encoding" header is added twice When feign.compression.response.enabled is set to true in configuration, feign adds "Accept-Encoding" header(s) when sending request. Currently, two header fields are added (Accept-Encoding: gzip and Accept-Encoding: deflate).
After fix,  "Accept-Encoding" value is "gzip, deflate".