### PR TITLE
Fix issuse #1721 Accept-Encoding header is added twice

### DIFF
--- a/core/src/main/java/feign/Client.java
+++ b/core/src/main/java/feign/Client.java
@@ -14,6 +14,7 @@
 package feign;
 
 import static feign.Util.CONTENT_ENCODING;
+import static feign.Util.ACCEPT_ENCODING;
 import static feign.Util.CONTENT_LENGTH;
 import static feign.Util.ENCODING_DEFLATE;
 import static feign.Util.ENCODING_GZIP;
@@ -186,6 +187,11 @@ public interface Client {
               contentLength = Integer.valueOf(value);
               connection.addRequestProperty(field, value);
             }
+          }
+          //Avoid add "Accept-encoding" twice or more when "compression" option is enabled
+          if (field.equals(ACCEPT_ENCODING)) {
+            connection.addRequestProperty(field, String.join(", ", request.headers().get(field)));
+            break;
           } else {
             connection.addRequestProperty(field, value);
           }

--- a/core/src/main/java/feign/Client.java
+++ b/core/src/main/java/feign/Client.java
@@ -188,7 +188,7 @@ public interface Client {
               connection.addRequestProperty(field, value);
             }
           }
-          //Avoid add "Accept-encoding" twice or more when "compression" option is enabled
+          // Avoid add "Accept-encoding" twice or more when "compression" option is enabled
           if (field.equals(ACCEPT_ENCODING)) {
             connection.addRequestProperty(field, String.join(", ", request.headers().get(field)));
             break;

--- a/core/src/main/java/feign/Util.java
+++ b/core/src/main/java/feign/Util.java
@@ -65,6 +65,10 @@ public class Util {
    */
   public static final String CONTENT_ENCODING = "Content-Encoding";
   /**
+   * The HTTP Accept-Encoding header field name.
+   */
+  public static final String ACCEPT_ENCODING = "Accept-Encoding";
+  /**
    * The HTTP Retry-After header field name.
    */
   public static final String RETRY_AFTER = "Retry-After";


### PR DESCRIPTION
Fix issuse #1721 "Accept-Encoding" header is added twice When feign.compression.response.enabled is set to true in configuration, feign adds "Accept-Encoding" header(s) when sending request. Currently, two header fields are added (Accept-Encoding: gzip and Accept-Encoding: deflate).
After fix, "Accept-Encoding" value is "gzip, deflate".