### PR TITLE
Fix empty split bug

### DIFF
--- a/core/src/main/java/feign/template/Expressions.java
+++ b/core/src/main/java/feign/template/Expressions.java
@@ -80,8 +80,8 @@ public final class Expressions {
       /* we have a valid variable expression, extract the name from the first group */
       variableName = matcher.group(3).trim();
       if (variableName.contains(":")) {
-        /* split on the colon */
-        String[] parts = variableName.split(":");
+        /* split on the colon and ensure the size of parts array must be 2 */
+        String[] parts = variableName.split(":", 2);
         variableName = parts[0];
         variablePattern = parts[1];
       }


### PR DESCRIPTION
If the String.split(regex) method is called without providing the limit parameter, it has the same behaviour as String.split(regex, 0) which the limit is default to 0. As mentioned in the JDK javadoc, if the limit is set to 0, all trailing empty string in the split result will be discarded. For example, `"A::A".split(":")` will result in `["A", "", "A"]` correctly, but `A::".split(":")` will result in `["A"]` because the two trailing empty string is discarded. If the string only contains the split character, it will even result in empty array. For example, `"::".split(":") ` will result in `[]` because the 3 empty strings are discarded. Because of this reason, if the provided variableName contains only ":" characters, it will result in ArrayIndexOutOfBoundException in the next line. Also, if the provided variableName contains only 1 ":" characters and end with it. the parts[1] will also result in ArrayIndexOutOfBoundException. 

This PR fixes the possible ArrayIndexOutOfBoundException by adding the limit 2 to the split method call. With the limit set, it is guarantee to have a result String array with size equals to the limit, which should avoid the possible ArrayIndexOutOfBoundException. If the string contains undetermined number of ":" character, using the limit = -1 can guarantee all the trailing empty string are not discarded. The size of the result String array is guarantee to be the number of ":" character + 1.