### PR TITLE
Fix bug in string split

### DIFF
--- a/core/src/main/java/feign/template/Expressions.java
+++ b/core/src/main/java/feign/template/Expressions.java
@@ -80,8 +80,8 @@ public final class Expressions {
       /* we have a valid variable expression, extract the name from the first group */
       variableName = matcher.group(3).trim();
       if (variableName.contains(":")) {
-        /* split on the colon */
-        String[] parts = variableName.split(":");
+        /* split on the colon and ensure the size of parts array must be 2 */
+        String[] parts = variableName.split(":", 2);
         variableName = parts[0];
         variablePattern = parts[1];
       }

--- a/core/src/test/java/feign/template/ExpressionsTest.java
+++ b/core/src/test/java/feign/template/ExpressionsTest.java
@@ -16,6 +16,7 @@ package feign.template;
 import org.junit.jupiter.api.Test;
 import java.util.Collections;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatObject;
 
 public class ExpressionsTest {
 
@@ -25,6 +26,19 @@ public class ExpressionsTest {
     assertThat(expression).isNotNull();
     String expanded = expression.expand(Collections.singletonMap("foo", "bar"), false);
     assertThat(expanded).isEqualToIgnoringCase("foo=bar");
+  }
+
+  @Test
+  public void malformedExpression() {
+    String[] malformedStrings = {"{:}", "{str1:}", "{str1:{:}", "{str1:{str2:}"};
+
+    for (String malformed : malformedStrings) {
+      try {
+        Expressions.create(malformed);
+      } catch (Exception e) {
+        assertThatObject(e).isNotInstanceOf(ArrayIndexOutOfBoundsException.class);
+      }
+    }
   }
 
   @Test

--- a/core/src/test/java/feign/template/ExpressionsTest.java
+++ b/core/src/test/java/feign/template/ExpressionsTest.java
@@ -40,7 +40,7 @@ public class ExpressionsTest {
       }
     }
   }
-  
+
   @Test
   public void malformedBodyTemplate() {
     String bodyTemplate = "{" + "a".repeat(65536) + "}";


### PR DESCRIPTION
This fixes an ArrayIndexOutOfBoundException in core/src/main/java/feign/template/Expressions.java.

If the `String.split(regex)` method is called without providing the limit parameter, it has the same behaviour as `String.split(regex, 0)` in which the limit is default to 0. As mentioned in the JDK javadoc, if the limit is set to 0, all trailing empty string in the split result will be discarded. For example, `"A::A".split(":")` will result in `["A", "", "A"]` correctly, but `A::".split(":")` will result in `["A"]` because the two trailing empty strings are discarded. If the string only contains the split character, it will even result in an empty array. For example, `"::".split(":")`  will result in `[]` because the 3 empty strings are discarded. Because of this reason, if the provided variableName contains only `":"` characters, it will result in ArrayIndexOutOfBoundException in the next line. Also, if the provided variableName contains only 1 `":"` characters and end with it, parts[1] will also result in ArrayIndexOutOfBoundException.

This PR fixes the possible ArrayIndexOutOfBoundException by adding the limit 2 to the split method call. With the limit set, it is guaranteed to have a result String array with size equal to the limit if ":" split character does exist. This setting should avoid the possible ArrayIndexOutOfBoundException. If the string contains an undetermined number of ":" characters, using the limit = -1 can guarantee all the trailing empty strings are not discarded. The size of the resulting String array is guaranteed to be the number of ":" character + 1.

We found this bug using fuzzing by way of OSS-Fuzz, where we recently integrated Feign (https://github.com/google/oss-fuzz/pull/10684). OSS-Fuzz is a free service run by Google for fuzzing important open source software. If you'd like to know more about this then I'm happy to go in details and also set up things so you can receive emails and detailed reports when bugs are found.
