### PR TITLE
Fix possible regex matching stack overflow

### DIFF
--- a/core/src/main/java/feign/template/Expressions.java
+++ b/core/src/main/java/feign/template/Expressions.java
@@ -22,6 +22,8 @@ import java.util.regex.Pattern;
 
 public final class Expressions {
 
+  private static final int MAX_EXPRESSION_LENGTH = 10000;
+
   private static final String PATH_STYLE_OPERATOR = ";";
   /**
    * Literals may be present and preceded the expression.
@@ -66,6 +68,12 @@ public final class Expressions {
     final String expression = stripBraces(value);
     if (expression == null || expression.isEmpty()) {
       throw new IllegalArgumentException("an expression is required.");
+    }
+
+    /* Check if the expression is too long */
+    if (expression.length() > MAX_EXPRESSION_LENGTH) {
+      throw new IllegalArgumentException(
+          "expression is too long. Max length: " + MAX_EXPRESSION_LENGTH);
     }
 
     /* create a new regular expression matcher for the expression */

--- a/core/src/test/java/feign/template/ExpressionsTest.java
+++ b/core/src/test/java/feign/template/ExpressionsTest.java
@@ -16,6 +16,7 @@ package feign.template;
 import org.junit.jupiter.api.Test;
 import java.util.Collections;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatObject;
 
 public class ExpressionsTest {
 
@@ -25,6 +26,17 @@ public class ExpressionsTest {
     assertThat(expression).isNotNull();
     String expanded = expression.expand(Collections.singletonMap("foo", "bar"), false);
     assertThat(expanded).isEqualToIgnoringCase("foo=bar");
+  }
+
+  @Test
+  public void malformedBodyTemplate() {
+    String bodyTemplate = "{" + "a".repeat(65536) + "}";
+
+    try {
+      BodyTemplate template = BodyTemplate.create(bodyTemplate);
+    } catch (Throwable e) {
+      assertThatObject(e).isNotInstanceOf(StackOverflowError.class);
+    }
   }
 
   @Test


### PR DESCRIPTION
This fixes a possible StackOverflowError in regex parsing of long expressions in core/src/main/java/feign/template/Expressions.java.

Java regex matchers are known to be recursive. When it handles some complicated structure like repetitive alternative paths `(a|b)*` on long string input, its recursive structure will fill up the stack fast. This will result in StackOverflowError. In Expressions.java, its `EXPRESSION_PATTERN` and `VARIABLE_LIST_PATTERN` do contain some complicated structure. Thus when a long enough string passed in for regex matching, it will fill up the stack and crash the JVM with a StackOverflowError. 

This PR reduces the possibility of the StackOverflowError by introducing a maximum length check for the expression string. Whenever the string is longer than the maximum length, the parser will not run and simply throw an IllegalArgumentException. This could avoid a long string regex matching with those complicated patterns resulting in StackOverflowException and crashing the JVM.

An additional unit test case has been added for testing the changed behaviour.

We found this bug using fuzzing by way of OSS-Fuzz, where we recently integrated Feign (https://github.com/google/oss-fuzz/pull/10684). OSS-Fuzz is a free service run by Google for fuzzing important open source software. If you'd like to know more about this then I'm happy to go into detail and also set up things so you can receive emails and detailed reports when bugs are found.