### PR TITLE
Remove bcprov-jdk15on as it isn't used

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -69,11 +69,6 @@
       <artifactId>mockwebserver</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
-      <version>${bouncy.version}</version>
-    </dependency>
-    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
       <version>${netty.version}</version>
@@ -126,7 +121,13 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
       <artifactId>slf4j-nop</artifactId>
+      <version>${slf4j.version}</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,6 @@
     <googlehttpclient.version>1.43.3</googlehttpclient.version>
     <gson.version>2.10.1</gson.version>
     <slf4j.version>2.0.9</slf4j.version>
-    <bouncy.version>1.70</bouncy.version>
     <json.version>20230618</json.version>
 
     <junit.version>4.13.2</junit.version>
@@ -339,12 +338,6 @@
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client</artifactId>
         <version>${googlehttpclient.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.bouncycastle</groupId>
-        <artifactId>bcprov-jdk15on</artifactId>
-        <version>${bouncy.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
- There is an issue with `bcprov-jdk15on`. Of course we can increase its version to 1.76. But I checked: only the benchmark module depends on it and that module doesn't use any classes from BC.
- The benchmark module has the dependency issue: `rxnetty-common` depends on SLF4J 1.7.6 but now we use SLF4J 2.0* that is not binary compatible with previous branch.
    ```log
    [INFO] +- io.reactivex:rxnetty-common:jar:0.5.3:compile
    [INFO] |  \- org.slf4j:slf4j-api:jar:1.7.6:compile
    ```

This fix is not major on my opinion and can be added to any further version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

---
- Refactor: Removed the dependency on the Bouncy Castle library (`bcprov-jdk15on`). This change simplifies our dependencies and may affect some cryptographic features, depending on their usage in the project.
- New Feature: Added dependencies on `slf4j-api` and `slf4j-nop`, specifying the version of `slf4j`. This introduces a new logging framework to the project, improving the visibility and traceability of events within the application.
---
<!-- end of auto-generated comment: release notes by coderabbit.ai -->