### PR TITLE
Retryer: replace an instance of Date with an epoch millisecond

### DIFF
--- a/core/src/main/java/feign/FeignException.java
+++ b/core/src/main/java/feign/FeignException.java
@@ -276,7 +276,7 @@ public class FeignException extends RuntimeException {
         format("%s executing %s %s", cause.getMessage(), request.httpMethod(), request.url()),
         request.httpMethod(),
         cause,
-        null, request);
+        (Long) null, request);
   }
 
   public static class FeignClientException extends FeignException {

--- a/core/src/main/java/feign/FeignException.java
+++ b/core/src/main/java/feign/FeignException.java
@@ -271,12 +271,13 @@ public class FeignException extends RuntimeException {
   }
 
   static FeignException errorExecuting(Request request, IOException cause) {
+    final Long nonRetryable = null;
     return new RetryableException(
         -1,
         format("%s executing %s %s", cause.getMessage(), request.httpMethod(), request.url()),
         request.httpMethod(),
         cause,
-        (Long) null, request);
+        nonRetryable, request);
   }
 
   public static class FeignClientException extends FeignException {

--- a/core/src/main/java/feign/RetryableException.java
+++ b/core/src/main/java/feign/RetryableException.java
@@ -24,7 +24,7 @@ import java.util.Map;
  */
 public class RetryableException extends FeignException {
 
-  private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 2L;
 
   private final Long retryAfter;
   private final HttpMethod httpMethod;

--- a/core/src/main/java/feign/RetryableException.java
+++ b/core/src/main/java/feign/RetryableException.java
@@ -33,6 +33,14 @@ public class RetryableException extends FeignException {
    * @param retryAfter usually corresponds to the {@link feign.Util#RETRY_AFTER} header.
    */
   public RetryableException(int status, String message, HttpMethod httpMethod, Throwable cause,
+      Long retryAfter, Request request) {
+    super(status, message, request, cause);
+    this.httpMethod = httpMethod;
+    this.retryAfter = retryAfter;
+  }
+
+  @Deprecated
+  public RetryableException(int status, String message, HttpMethod httpMethod, Throwable cause,
       Date retryAfter, Request request) {
     super(status, message, request, cause);
     this.httpMethod = httpMethod;
@@ -42,6 +50,14 @@ public class RetryableException extends FeignException {
   /**
    * @param retryAfter usually corresponds to the {@link feign.Util#RETRY_AFTER} header.
    */
+  public RetryableException(int status, String message, HttpMethod httpMethod, Long retryAfter,
+      Request request) {
+    super(status, message, request);
+    this.httpMethod = httpMethod;
+    this.retryAfter = retryAfter;
+  }
+
+  @Deprecated
   public RetryableException(int status, String message, HttpMethod httpMethod, Date retryAfter,
       Request request) {
     super(status, message, request);
@@ -52,6 +68,15 @@ public class RetryableException extends FeignException {
   /**
    * @param retryAfter usually corresponds to the {@link feign.Util#RETRY_AFTER} header.
    */
+  public RetryableException(int status, String message, HttpMethod httpMethod, Long retryAfter,
+      Request request, byte[] responseBody,
+      Map<String, Collection<String>> responseHeaders) {
+    super(status, message, request, responseBody, responseHeaders);
+    this.httpMethod = httpMethod;
+    this.retryAfter = retryAfter;
+  }
+
+  @Deprecated
   public RetryableException(int status, String message, HttpMethod httpMethod, Date retryAfter,
       Request request, byte[] responseBody, Map<String, Collection<String>> responseHeaders) {
     super(status, message, request, responseBody, responseHeaders);
@@ -63,8 +88,8 @@ public class RetryableException extends FeignException {
    * Sometimes corresponds to the {@link feign.Util#RETRY_AFTER} header present in {@code 503}
    * status. Other times parsed from an application-specific response. Null if unknown.
    */
-  public Date retryAfter() {
-    return retryAfter != null ? new Date(retryAfter) : null;
+  public Long retryAfter() {
+    return retryAfter;
   }
 
   public HttpMethod method() {

--- a/core/src/main/java/feign/Retryer.java
+++ b/core/src/main/java/feign/Retryer.java
@@ -22,7 +22,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public interface Retryer extends Cloneable {
 
   /**
-   * if retry is permitted, return (possibly after sleeping). Otherwise propagate the exception.
+   * if retry is permitted, return (possibly after sleeping). Otherwise, propagate the exception.
    */
   void continueOrPropagate(RetryableException e);
 
@@ -59,7 +59,7 @@ public interface Retryer extends Cloneable {
 
       long interval;
       if (e.retryAfter() != null) {
-        interval = e.retryAfter().getTime() - currentTimeMillis();
+        interval = e.retryAfter() - currentTimeMillis();
         if (interval > maxPeriod) {
           interval = maxPeriod;
         }
@@ -79,7 +79,7 @@ public interface Retryer extends Cloneable {
     }
 
     /**
-     * Calculates the time interval to a retry attempt. <br>
+     * Calculates the time interval to a retry attempt.<br>
      * The interval increases exponentially with each attempt, at a rate of nextInterval *= 1.5
      * (where 1.5 is the backoff factor), to the maximum interval.
      *
@@ -87,7 +87,7 @@ public interface Retryer extends Cloneable {
      */
     long nextMaxInterval() {
       long interval = (long) (period * Math.pow(1.5, attempt - 1));
-      return interval > maxPeriod ? maxPeriod : interval;
+      return Math.min(interval, maxPeriod);
     }
 
     @Override

--- a/core/src/main/java/feign/codec/ErrorDecoder.java
+++ b/core/src/main/java/feign/codec/ErrorDecoder.java
@@ -16,16 +16,15 @@ package feign.codec;
 import static feign.FeignException.errorStatus;
 import static feign.Util.RETRY_AFTER;
 import static feign.Util.checkNotNull;
-import static java.util.Locale.US;
+import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import feign.FeignException;
 import feign.Response;
 import feign.RetryableException;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Collection;
-import java.util.Date;
 import java.util.Map;
 
 /**
@@ -103,7 +102,7 @@ public interface ErrorDecoder {
     public Exception decode(String methodKey, Response response) {
       FeignException exception = errorStatus(methodKey, response, maxBodyBytesLength,
           maxBodyCharsLength);
-      Date retryAfter = retryAfterDecoder.apply(firstOrNull(response.headers(), RETRY_AFTER));
+      Long retryAfter = retryAfterDecoder.apply(firstOrNull(response.headers(), RETRY_AFTER));
       if (retryAfter != null) {
         return new RetryableException(
             response.status(),
@@ -125,21 +124,19 @@ public interface ErrorDecoder {
   }
 
   /**
-   * Decodes a {@link feign.Util#RETRY_AFTER} header into an absolute date, if possible. <br>
+   * Decodes a {@link feign.Util#RETRY_AFTER} header into an epoch millisecond, if possible.<br>
    * See <a href="https://tools.ietf.org/html/rfc2616#section-14.37">Retry-After format</a>
    */
   static class RetryAfterDecoder {
 
-    static final DateFormat RFC822_FORMAT =
-        new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss 'GMT'", US);
-    private final DateFormat rfc822Format;
+    private final DateTimeFormatter dateTimeFormatter;
 
     RetryAfterDecoder() {
-      this(RFC822_FORMAT);
+      this(RFC_1123_DATE_TIME);
     }
 
-    RetryAfterDecoder(DateFormat rfc822Format) {
-      this.rfc822Format = checkNotNull(rfc822Format, "rfc822Format");
+    RetryAfterDecoder(DateTimeFormatter dateTimeFormatter) {
+      this.dateTimeFormatter = checkNotNull(dateTimeFormatter, "dateTimeFormatter");
     }
 
     protected long currentTimeMillis() {
@@ -147,26 +144,24 @@ public interface ErrorDecoder {
     }
 
     /**
-     * returns a date that corresponds to the first time a request can be retried.
+     * returns an epoch millisecond that corresponds to the first time a request can be retried.
      *
      * @param retryAfter String in
      *        <a href="https://tools.ietf.org/html/rfc2616#section-14.37" >Retry-After format</a>
      */
-    public Date apply(String retryAfter) {
+    public Long apply(String retryAfter) {
       if (retryAfter == null) {
         return null;
       }
       if (retryAfter.matches("^[0-9]+\\.?0*$")) {
         retryAfter = retryAfter.replaceAll("\\.0*$", "");
         long deltaMillis = SECONDS.toMillis(Long.parseLong(retryAfter));
-        return new Date(currentTimeMillis() + deltaMillis);
+        return currentTimeMillis() + deltaMillis;
       }
-      synchronized (rfc822Format) {
-        try {
-          return rfc822Format.parse(retryAfter);
-        } catch (ParseException ignored) {
-          return null;
-        }
+      try {
+        return ZonedDateTime.parse(retryAfter, dateTimeFormatter).toInstant().toEpochMilli();
+      } catch (NullPointerException | DateTimeParseException ignored) {
+        return null;
       }
     }
   }

--- a/core/src/test/java/feign/AsyncFeignTest.java
+++ b/core/src/test/java/feign/AsyncFeignTest.java
@@ -36,11 +36,13 @@ import feign.querymap.FieldQueryMapEncoder;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.net.URI;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -225,9 +227,9 @@ public class AsyncFeignTest {
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
 
-    CompletableFuture<?> cf = api.expand(new Date(1234l));
+    CompletableFuture<?> cf = api.expand(new TestClock(1234l) {});
 
-    assertThat(server.takeRequest()).hasPath("/?date=1234");
+    assertThat(server.takeRequest()).hasPath("/?clock=1234");
 
     checkCFCompletedSoon(cf);
   }
@@ -239,9 +241,10 @@ public class AsyncFeignTest {
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
 
-    CompletableFuture<?> cf = api.expandList(Arrays.asList(new Date(1234l), new Date(12345l)));
+    CompletableFuture<?> cf =
+        api.expandList(Arrays.asList(new TestClock(1234l), new TestClock(12345l)));
 
-    assertThat(server.takeRequest()).hasPath("/?date=1234&date=12345");
+    assertThat(server.takeRequest()).hasPath("/?clock=1234&clock=12345");
 
     checkCFCompletedSoon(cf);
   }
@@ -253,9 +256,9 @@ public class AsyncFeignTest {
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
 
-    CompletableFuture<?> cf = api.expandList(Arrays.asList(new Date(1234l), null));
+    CompletableFuture<?> cf = api.expandList(Arrays.asList(new TestClock(1234l), null));
 
-    assertThat(server.takeRequest()).hasPath("/?date=1234");
+    assertThat(server.takeRequest()).hasPath("/?clock=1234");
 
     checkCFCompletedSoon(cf);
   }
@@ -1021,16 +1024,17 @@ public class AsyncFeignTest {
     CompletableFuture<Response> queryParams(@Param("1") String one,
                                             @Param("2") Iterable<String> twos);
 
-    @RequestLine("POST /?date={date}")
-    CompletableFuture<Void> expand(@Param(value = "date", expander = DateToMillis.class) Date date);
+    @RequestLine("POST /?clock={clock}")
+    CompletableFuture<Void> expand(@Param(value = "clock",
+        expander = ClockToMillis.class) Clock clock);
 
-    @RequestLine("GET /?date={date}")
-    CompletableFuture<Void> expandList(@Param(value = "date",
-        expander = DateToMillis.class) List<Date> dates);
+    @RequestLine("GET /?clock={clock}")
+    CompletableFuture<Void> expandList(@Param(value = "clock",
+        expander = ClockToMillis.class) List<Clock> clocks);
 
-    @RequestLine("GET /?date={date}")
-    CompletableFuture<Void> expandArray(@Param(value = "date",
-        expander = DateToMillis.class) Date[] dates);
+    @RequestLine("GET /?clock={clock}")
+    CompletableFuture<Void> expandArray(@Param(value = "clock",
+        expander = ClockToMillis.class) Clock[] clocks);
 
     @RequestLine("GET /")
     CompletableFuture<Void> headerMap(@HeaderMap Map<String, Object> headerMap);
@@ -1061,11 +1065,11 @@ public class AsyncFeignTest {
     @RequestLine("GET /")
     CompletableFuture<Void> queryMapPropertyInheritence(@QueryMap ChildPojo object);
 
-    class DateToMillis implements Param.Expander {
+    class ClockToMillis implements Param.Expander {
 
       @Override
       public String expand(Object value) {
-        return String.valueOf(((Date) value).getTime());
+        return String.valueOf(((Clock) value).millis());
       }
     }
   }
@@ -1248,5 +1252,28 @@ public class AsyncFeignTest {
     CompletableFuture<?> x();
   }
 
+  class TestClock extends Clock {
+
+    private long millis;
+
+    public TestClock(long millis) {
+      this.millis = millis;
+    }
+
+    @Override
+    public ZoneId getZone() {
+      return null;
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+      return this;
+    }
+
+    @Override
+    public Instant instant() {
+      return Instant.ofEpochMilli(millis);
+    }
+  }
 
 }

--- a/core/src/test/java/feign/AsyncFeignTest.java
+++ b/core/src/test/java/feign/AsyncFeignTest.java
@@ -66,6 +66,7 @@ import org.junit.rules.ExpectedException;
 
 public class AsyncFeignTest {
 
+  private static final Long NON_RETRYABLE = null;
   @Rule
   public final ExpectedException thrown = ExpectedException.none();
   @Rule
@@ -503,8 +504,8 @@ public class AsyncFeignTest {
           public Object decode(Response response, Type type) throws IOException {
             String string = super.decode(response, type).toString();
             if ("retry!".equals(string)) {
-              throw new RetryableException(response.status(), string, HttpMethod.POST, (Long) null,
-                  response.request());
+              throw new RetryableException(response.status(), string, HttpMethod.POST,
+                  NON_RETRYABLE, response.request());
             }
             return string;
           }
@@ -582,7 +583,7 @@ public class AsyncFeignTest {
           @Override
           public Exception decode(String methodKey, Response response) {
             return new RetryableException(response.status(), "play it again sam!", HttpMethod.POST,
-                (Long) null, response.request());
+                NON_RETRYABLE, response.request());
           }
         }).target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
 
@@ -607,7 +608,7 @@ public class AsyncFeignTest {
           @Override
           public Exception decode(String methodKey, Response response) {
             return new RetryableException(response.status(), "play it again sam!", HttpMethod.POST,
-                new TestInterfaceException(message), (Long) null, response.request());
+                new TestInterfaceException(message), NON_RETRYABLE, response.request());
           }
         }).target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
 
@@ -629,8 +630,8 @@ public class AsyncFeignTest {
         .errorDecoder(new ErrorDecoder() {
           @Override
           public Exception decode(String methodKey, Response response) {
-            return new RetryableException(response.status(), message, HttpMethod.POST, (Long) null,
-                response.request());
+            return new RetryableException(response.status(), message, HttpMethod.POST,
+                NON_RETRYABLE, response.request());
           }
         }).target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
 

--- a/core/src/test/java/feign/AsyncFeignTest.java
+++ b/core/src/test/java/feign/AsyncFeignTest.java
@@ -1262,7 +1262,7 @@ public class AsyncFeignTest {
 
     @Override
     public ZoneId getZone() {
-      return null;
+      throw new UnsupportedOperationException("This operation is not supported.");
     }
 
     @Override

--- a/core/src/test/java/feign/AsyncFeignTest.java
+++ b/core/src/test/java/feign/AsyncFeignTest.java
@@ -16,7 +16,6 @@ package feign;
 import static feign.ExceptionPropagationPolicy.UNWRAP;
 import static feign.Util.UTF_8;
 import static feign.assertj.MockWebServerAssertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.hamcrest.CoreMatchers.isA;
 import static org.junit.Assert.assertEquals;
@@ -62,7 +61,6 @@ import okio.Buffer;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.rules.ExpectedException;
 
@@ -505,7 +503,7 @@ public class AsyncFeignTest {
           public Object decode(Response response, Type type) throws IOException {
             String string = super.decode(response, type).toString();
             if ("retry!".equals(string)) {
-              throw new RetryableException(response.status(), string, HttpMethod.POST, null,
+              throw new RetryableException(response.status(), string, HttpMethod.POST, (Long) null,
                   response.request());
             }
             return string;
@@ -584,7 +582,7 @@ public class AsyncFeignTest {
           @Override
           public Exception decode(String methodKey, Response response) {
             return new RetryableException(response.status(), "play it again sam!", HttpMethod.POST,
-                null, response.request());
+                (Long) null, response.request());
           }
         }).target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
 
@@ -609,7 +607,7 @@ public class AsyncFeignTest {
           @Override
           public Exception decode(String methodKey, Response response) {
             return new RetryableException(response.status(), "play it again sam!", HttpMethod.POST,
-                new TestInterfaceException(message), null, response.request());
+                new TestInterfaceException(message), (Long) null, response.request());
           }
         }).target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
 
@@ -631,7 +629,7 @@ public class AsyncFeignTest {
         .errorDecoder(new ErrorDecoder() {
           @Override
           public Exception decode(String methodKey, Response response) {
-            return new RetryableException(response.status(), message, HttpMethod.POST, null,
+            return new RetryableException(response.status(), message, HttpMethod.POST, (Long) null,
                 response.request());
           }
         }).target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());

--- a/core/src/test/java/feign/DefaultContractTest.java
+++ b/core/src/test/java/feign/DefaultContractTest.java
@@ -890,7 +890,7 @@ public class DefaultContractTest {
 
     @Override
     public ZoneId getZone() {
-      return null;
+      throw new UnsupportedOperationException("This operation is not supported.");
     }
 
     @Override

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -535,7 +535,7 @@ public class FeignTest {
           public Object decode(Response response, Type type) throws IOException {
             String string = super.decode(response, type).toString();
             if ("retry!".equals(string)) {
-              throw new RetryableException(response.status(), string, HttpMethod.POST, null,
+              throw new RetryableException(response.status(), string, HttpMethod.POST, (Long) null,
                   response.request());
             }
             return string;
@@ -616,7 +616,7 @@ public class FeignTest {
           @Override
           public Exception decode(String methodKey, Response response) {
             return new RetryableException(response.status(), "play it again sam!", HttpMethod.POST,
-                null, response.request());
+                (Long) null, response.request());
           }
         }).target(TestInterface.class, "http://localhost:" + server.getPort());
 
@@ -641,7 +641,7 @@ public class FeignTest {
           @Override
           public Exception decode(String methodKey, Response response) {
             return new RetryableException(response.status(), "play it again sam!", HttpMethod.POST,
-                new TestInterfaceException(message), null, response.request());
+                new TestInterfaceException(message), (Long) null, response.request());
           }
         }).target(TestInterface.class, "http://localhost:" + server.getPort());
 
@@ -663,7 +663,7 @@ public class FeignTest {
         .errorDecoder(new ErrorDecoder() {
           @Override
           public Exception decode(String methodKey, Response response) {
-            return new RetryableException(response.status(), message, HttpMethod.POST, null,
+            return new RetryableException(response.status(), message, HttpMethod.POST, (Long) null,
                 response.request());
           }
         }).target(TestInterface.class, "http://localhost:" + server.getPort());

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -1407,7 +1407,7 @@ public class FeignTest {
 
     @Override
     public ZoneId getZone() {
-      return null;
+      throw new UnsupportedOperationException("This operation is not supported.");
     }
 
     @Override

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -54,6 +54,7 @@ import static org.mockito.Mockito.*;
 @SuppressWarnings("deprecation")
 public class FeignTest {
 
+  private static final Long NON_RETRYABLE = null;
   @Rule
   public final ExpectedException thrown = ExpectedException.none();
   @Rule
@@ -535,8 +536,8 @@ public class FeignTest {
           public Object decode(Response response, Type type) throws IOException {
             String string = super.decode(response, type).toString();
             if ("retry!".equals(string)) {
-              throw new RetryableException(response.status(), string, HttpMethod.POST, (Long) null,
-                  response.request());
+              throw new RetryableException(response.status(), string, HttpMethod.POST,
+                  NON_RETRYABLE, response.request());
             }
             return string;
           }
@@ -616,7 +617,7 @@ public class FeignTest {
           @Override
           public Exception decode(String methodKey, Response response) {
             return new RetryableException(response.status(), "play it again sam!", HttpMethod.POST,
-                (Long) null, response.request());
+                NON_RETRYABLE, response.request());
           }
         }).target(TestInterface.class, "http://localhost:" + server.getPort());
 
@@ -641,7 +642,7 @@ public class FeignTest {
           @Override
           public Exception decode(String methodKey, Response response) {
             return new RetryableException(response.status(), "play it again sam!", HttpMethod.POST,
-                new TestInterfaceException(message), (Long) null, response.request());
+                new TestInterfaceException(message), NON_RETRYABLE, response.request());
           }
         }).target(TestInterface.class, "http://localhost:" + server.getPort());
 
@@ -663,8 +664,8 @@ public class FeignTest {
         .errorDecoder(new ErrorDecoder() {
           @Override
           public Exception decode(String methodKey, Response response) {
-            return new RetryableException(response.status(), message, HttpMethod.POST, (Long) null,
-                response.request());
+            return new RetryableException(response.status(), message, HttpMethod.POST,
+                NON_RETRYABLE, response.request());
           }
         }).target(TestInterface.class, "http://localhost:" + server.getPort());
 

--- a/core/src/test/java/feign/FeignUnderAsyncTest.java
+++ b/core/src/test/java/feign/FeignUnderAsyncTest.java
@@ -36,11 +36,13 @@ import org.junit.rules.ExpectedException;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.net.URI;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -201,10 +203,10 @@ public class FeignUnderAsyncTest {
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
-    api.expand(new Date(1234L));
+    api.expand(new TestClock(1234L));
 
     assertThat(server.takeRequest())
-        .hasPath("/?date=1234");
+        .hasPath("/?clock=1234");
   }
 
   @Test
@@ -213,10 +215,10 @@ public class FeignUnderAsyncTest {
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
-    api.expandList(Arrays.asList(new Date(1234L), new Date(12345L)));
+    api.expandList(Arrays.asList(new TestClock(1234L), new TestClock(12345L)));
 
     assertThat(server.takeRequest())
-        .hasPath("/?date=1234&date=12345");
+        .hasPath("/?clock=1234&clock=12345");
   }
 
   @Test
@@ -225,10 +227,10 @@ public class FeignUnderAsyncTest {
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
-    api.expandList(Arrays.asList(new Date(1234l), null));
+    api.expandList(Arrays.asList(new TestClock(1234l), null));
 
     assertThat(server.takeRequest())
-        .hasPath("/?date=1234");
+        .hasPath("/?clock=1234");
   }
 
   @Test
@@ -857,14 +859,14 @@ public class FeignUnderAsyncTest {
     @RequestLine("GET /?1={1}&2={2}")
     Response queryParams(@Param("1") String one, @Param("2") Iterable<String> twos);
 
-    @RequestLine("POST /?date={date}")
-    void expand(@Param(value = "date", expander = DateToMillis.class) Date date);
+    @RequestLine("POST /?clock={clock}")
+    void expand(@Param(value = "clock", expander = ClockToMillis.class) Clock clock);
 
-    @RequestLine("GET /?date={date}")
-    void expandList(@Param(value = "date", expander = DateToMillis.class) List<Date> dates);
+    @RequestLine("GET /?clock={clock}")
+    void expandList(@Param(value = "clock", expander = ClockToMillis.class) List<Clock> clocks);
 
-    @RequestLine("GET /?date={date}")
-    void expandArray(@Param(value = "date", expander = DateToMillis.class) Date[] dates);
+    @RequestLine("GET /?clock={clock}")
+    void expandArray(@Param(value = "clock", expander = ClockToMillis.class) Clock[] clocks);
 
     @RequestLine("GET /")
     void headerMap(@HeaderMap Map<String, Object> headerMap);
@@ -895,11 +897,11 @@ public class FeignUnderAsyncTest {
     @RequestLine("GET /")
     void queryMapPropertyInheritence(@QueryMap ChildPojo object);
 
-    class DateToMillis implements Param.Expander {
+    class ClockToMillis implements Param.Expander {
 
       @Override
       public String expand(Object value) {
-        return String.valueOf(((Date) value).getTime());
+        return String.valueOf(((Clock) value).millis());
       }
     }
   }
@@ -1014,4 +1016,29 @@ public class FeignUnderAsyncTest {
       return delegate.target(TestInterface.class, url);
     }
   }
+
+  class TestClock extends Clock {
+
+    private long millis;
+
+    public TestClock(long millis) {
+      this.millis = millis;
+    }
+
+    @Override
+    public ZoneId getZone() {
+      return null;
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+      return this;
+    }
+
+    @Override
+    public Instant instant() {
+      return Instant.ofEpochMilli(millis);
+    }
+  }
+
 }

--- a/core/src/test/java/feign/FeignUnderAsyncTest.java
+++ b/core/src/test/java/feign/FeignUnderAsyncTest.java
@@ -1027,7 +1027,7 @@ public class FeignUnderAsyncTest {
 
     @Override
     public ZoneId getZone() {
-      return null;
+      throw new UnsupportedOperationException("This operation is not supported.");
     }
 
     @Override

--- a/core/src/test/java/feign/RetryableExceptionTest.java
+++ b/core/src/test/java/feign/RetryableExceptionTest.java
@@ -32,7 +32,7 @@ public class RetryableExceptionTest {
 
     // when
     RetryableException retryableException =
-        new RetryableException(-1, null, null, new Date(5000), request, response, responseHeader);
+        new RetryableException(-1, null, null, 5000L, request, response, responseHeader);
 
     // then
     assertNotNull(retryableException);

--- a/core/src/test/java/feign/RetryableExceptionTest.java
+++ b/core/src/test/java/feign/RetryableExceptionTest.java
@@ -24,6 +24,7 @@ public class RetryableExceptionTest {
   @Test
   public void createRetryableExceptionWithResponseAndResponseHeader() {
     // given
+    Long retryAfter = 5000L;
     Request request =
         Request.create(Request.HttpMethod.GET, "/", Collections.emptyMap(), null, Util.UTF_8);
     byte[] response = "response".getBytes(StandardCharsets.UTF_8);
@@ -32,10 +33,11 @@ public class RetryableExceptionTest {
 
     // when
     RetryableException retryableException =
-        new RetryableException(-1, null, null, 5000L, request, response, responseHeader);
+        new RetryableException(-1, null, null, retryAfter, request, response, responseHeader);
 
     // then
     assertNotNull(retryableException);
+    assertEquals(retryAfter, retryableException.retryAfter());
     assertEquals(new String(response, UTF_8), retryableException.contentUTF8());
     assertTrue(retryableException.responseHeaders().containsKey("TEST_HEADER"));
     assertTrue(retryableException.responseHeaders().get("TEST_HEADER").contains("TEST_CONTENT"));

--- a/core/src/test/java/feign/RetryerTest.java
+++ b/core/src/test/java/feign/RetryerTest.java
@@ -32,7 +32,8 @@ public class RetryerTest {
 
   @Test
   public void only5TriesAllowedAndExponentialBackoff() {
-    RetryableException e = new RetryableException(-1, null, null, (Long) null, REQUEST);
+    final Long nonRetryable = null;
+    RetryableException e = new RetryableException(-1, null, null, nonRetryable, REQUEST);
     Default retryer = new Retryer.Default();
     assertEquals(1, retryer.attempt);
     assertEquals(0, retryer.sleptForMillis);

--- a/core/src/test/java/feign/RetryerTest.java
+++ b/core/src/test/java/feign/RetryerTest.java
@@ -18,7 +18,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import java.util.Collections;
-import java.util.Date;
 import feign.Retryer.Default;
 import static org.junit.Assert.assertEquals;
 
@@ -32,8 +31,8 @@ public class RetryerTest {
       .create(Request.HttpMethod.GET, "/", Collections.emptyMap(), null, Util.UTF_8);
 
   @Test
-  public void only5TriesAllowedAndExponentialBackoff() throws Exception {
-    RetryableException e = new RetryableException(-1, null, null, null, REQUEST);
+  public void only5TriesAllowedAndExponentialBackoff() {
+    RetryableException e = new RetryableException(-1, null, null, (Long) null, REQUEST);
     Default retryer = new Retryer.Default();
     assertEquals(1, retryer.attempt);
     assertEquals(0, retryer.sleptForMillis);
@@ -66,7 +65,7 @@ public class RetryerTest {
       }
     };
 
-    retryer.continueOrPropagate(new RetryableException(-1, null, null, new Date(5000), REQUEST));
+    retryer.continueOrPropagate(new RetryableException(-1, null, null, 5000L, REQUEST));
     assertEquals(2, retryer.attempt);
     assertEquals(1000, retryer.sleptForMillis);
   }
@@ -74,7 +73,7 @@ public class RetryerTest {
   @Test(expected = RetryableException.class)
   public void neverRetryAlwaysPropagates() {
     Retryer.NEVER_RETRY
-        .continueOrPropagate(new RetryableException(-1, null, null, new Date(5000), REQUEST));
+        .continueOrPropagate(new RetryableException(-1, null, null, 5000L, REQUEST));
   }
 
   @Test
@@ -83,8 +82,7 @@ public class RetryerTest {
 
     Thread.currentThread().interrupt();
     RetryableException expected =
-        new RetryableException(-1, null, null, new Date(System.currentTimeMillis() + 5000),
-            REQUEST);
+        new RetryableException(-1, null, null, System.currentTimeMillis() + 5000, REQUEST);
     try {
       retryer.continueOrPropagate(expected);
       Thread.interrupted(); // reset interrupted flag in case it wasn't

--- a/core/src/test/java/feign/UtilTest.java
+++ b/core/src/test/java/feign/UtilTest.java
@@ -51,7 +51,7 @@ public class UtilTest {
 
   @Test
   public void removesEvenNumbers() {
-    Integer[] values = new Integer[] {22, 23};
+    Integer[] values = {22, 23};
     assertThat(removeValues(values, number -> number % 2 == 0, Integer.class))
         .containsExactly(23);
   }
@@ -167,7 +167,7 @@ public class UtilTest {
     // Act
     final Object retval = Util.checkNotNull(reference, errorMessageTemplate, errorMessageArgs);
     // Assert result
-    assertEquals(new Integer(0), retval);
+    assertEquals(0, retval);
   }
 
   @Test

--- a/core/src/test/java/feign/codec/DefaultEncoderTest.java
+++ b/core/src/test/java/feign/codec/DefaultEncoderTest.java
@@ -16,8 +16,8 @@ package feign.codec;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import java.time.Clock;
 import java.util.Arrays;
-import java.util.Date;
 import feign.RequestTemplate;
 import static feign.Util.UTF_8;
 import static org.junit.Assert.assertEquals;
@@ -51,6 +51,6 @@ public class DefaultEncoderTest {
     thrown.expect(EncodeException.class);
     thrown.expectMessage("is not a type supported by this encoder.");
 
-    encoder.encode(new Date(), Date.class, new RequestTemplate());
+    encoder.encode(Clock.systemUTC(), Clock.class, new RequestTemplate());
   }
 }

--- a/core/src/test/java/feign/codec/RetryAfterDecoderTest.java
+++ b/core/src/test/java/feign/codec/RetryAfterDecoderTest.java
@@ -13,43 +13,50 @@
  */
 package feign.codec;
 
-import static feign.codec.ErrorDecoder.RetryAfterDecoder.RFC822_FORMAT;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
+import static org.junit.Assert.*;
 import feign.codec.ErrorDecoder.RetryAfterDecoder;
 import java.text.ParseException;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
 import org.junit.Test;
 
 public class RetryAfterDecoderTest {
 
-  private RetryAfterDecoder decoder = new RetryAfterDecoder(RFC822_FORMAT) {
+  private final RetryAfterDecoder decoder = new RetryAfterDecoder(RFC_1123_DATE_TIME) {
     protected long currentTimeMillis() {
-      try {
-        return RFC822_FORMAT.parse("Sat, 1 Jan 2000 00:00:00 GMT").getTime();
-      } catch (ParseException e) {
-        throw new RuntimeException(e);
-      }
+      return parseDateTime("Sat, 1 Jan 2000 00:00:00 GMT");
     }
   };
 
   @Test
-  public void malformDateFailsGracefully() {
-    assertFalse(decoder.apply("Fri, 31 Dec 1999 23:59:59 ZBW") != null);
+  public void malformedDateFailsGracefully() {
+    assertNull(decoder.apply("Fri, 31 Dec 1999 23:59:59 ZBW"));
   }
 
   @Test
   public void rfc822Parses() throws ParseException {
-    assertEquals(RFC822_FORMAT.parse("Fri, 31 Dec 1999 23:59:59 GMT"),
+    assertEquals(parseDateTime("Fri, 31 Dec 1999 23:59:59 GMT"),
         decoder.apply("Fri, 31 Dec 1999 23:59:59 GMT"));
   }
 
   @Test
   public void relativeSecondsParses() throws ParseException {
-    assertEquals(RFC822_FORMAT.parse("Sun, 2 Jan 2000 00:00:00 GMT"), decoder.apply("86400"));
+    assertEquals(parseDateTime("Sun, 2 Jan 2000 00:00:00 GMT"),
+        decoder.apply("86400"));
   }
 
   @Test
   public void relativeSecondsParseDecimalIntegers() throws ParseException {
-    assertEquals(RFC822_FORMAT.parse("Sun, 2 Jan 2000 00:00:00 GMT"), decoder.apply("86400.0"));
+    assertEquals(parseDateTime("Sun, 2 Jan 2000 00:00:00 GMT"),
+        decoder.apply("86400.0"));
+  }
+
+  private Long parseDateTime(String text) {
+    try {
+      return ZonedDateTime.parse(text, RFC_1123_DATE_TIME).toInstant().toEpochMilli();
+    } catch (NullPointerException | DateTimeParseException exception) {
+      throw new RuntimeException(exception);
+    }
   }
 }

--- a/hc5/src/test/java/feign/hc5/AsyncApacheHttp5ClientTest.java
+++ b/hc5/src/test/java/feign/hc5/AsyncApacheHttp5ClientTest.java
@@ -1074,7 +1074,7 @@ public class AsyncApacheHttp5ClientTest {
 
     @Override
     public ZoneId getZone() {
-      return null;
+      throw new UnsupportedOperationException("This operation is not supported.");
     }
 
     @Override

--- a/hystrix/src/test/java/feign/hystrix/HystrixBuilderTest.java
+++ b/hystrix/src/test/java/feign/hystrix/HystrixBuilderTest.java
@@ -86,7 +86,7 @@ public class HystrixBuilderTest {
     final HystrixCommand<Integer> command = api.intCommand();
 
     assertThat(command).isNotNull();
-    assertThat(command.execute()).isEqualTo(new Integer(1));
+    assertThat(command.execute()).isEqualTo(Integer.valueOf(1));
   }
 
   @Test
@@ -98,7 +98,7 @@ public class HystrixBuilderTest {
     final HystrixCommand<Integer> command = api.intCommand();
 
     assertThat(command).isNotNull();
-    assertThat(command.execute()).isEqualTo(new Integer(0));
+    assertThat(command.execute()).isEqualTo(Integer.valueOf(0));
   }
 
   @Test
@@ -250,7 +250,7 @@ public class HystrixBuilderTest {
     final TestSubscriber<Integer> testSubscriber = new TestSubscriber<Integer>();
     observable.subscribe(testSubscriber);
     testSubscriber.awaitTerminalEvent();
-    Assertions.assertThat(testSubscriber.getOnNextEvents().get(0)).isEqualTo(new Integer(1));
+    Assertions.assertThat(testSubscriber.getOnNextEvents().get(0)).isEqualTo(Integer.valueOf(1));
   }
 
   @Test
@@ -267,7 +267,7 @@ public class HystrixBuilderTest {
     final TestSubscriber<Integer> testSubscriber = new TestSubscriber<Integer>();
     observable.subscribe(testSubscriber);
     testSubscriber.awaitTerminalEvent();
-    Assertions.assertThat(testSubscriber.getOnNextEvents().get(0)).isEqualTo(new Integer(0));
+    Assertions.assertThat(testSubscriber.getOnNextEvents().get(0)).isEqualTo(Integer.valueOf(0));
   }
 
   @Test
@@ -373,7 +373,7 @@ public class HystrixBuilderTest {
     final TestSubscriber<Integer> testSubscriber = new TestSubscriber<Integer>();
     single.subscribe(testSubscriber);
     testSubscriber.awaitTerminalEvent();
-    Assertions.assertThat(testSubscriber.getOnNextEvents().get(0)).isEqualTo(new Integer(1));
+    Assertions.assertThat(testSubscriber.getOnNextEvents().get(0)).isEqualTo(Integer.valueOf(1));
   }
 
   @Test
@@ -390,7 +390,7 @@ public class HystrixBuilderTest {
     final TestSubscriber<Integer> testSubscriber = new TestSubscriber<Integer>();
     single.subscribe(testSubscriber);
     testSubscriber.awaitTerminalEvent();
-    Assertions.assertThat(testSubscriber.getOnNextEvents().get(0)).isEqualTo(new Integer(0));
+    Assertions.assertThat(testSubscriber.getOnNextEvents().get(0)).isEqualTo(Integer.valueOf(0));
   }
 
   @Test

--- a/java11/src/test/java/feign/http2client/test/Http2ClientAsyncTest.java
+++ b/java11/src/test/java/feign/http2client/test/Http2ClientAsyncTest.java
@@ -1075,12 +1075,12 @@ public class Http2ClientAsyncTest {
 
     @Override
     public ZoneId getZone() {
-      return null;
+      throw new UnsupportedOperationException("This operation is not supported.");
     }
 
     @Override
     public Clock withZone(ZoneId zone) {
-      return this;
+      throw new UnsupportedOperationException("This operation is not supported.");
     }
 
     @Override

--- a/java11/src/test/java/feign/http2client/test/Http2ClientAsyncTest.java
+++ b/java11/src/test/java/feign/http2client/test/Http2ClientAsyncTest.java
@@ -24,11 +24,13 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -223,9 +225,9 @@ public class Http2ClientAsyncTest {
     final TestInterfaceAsync api =
         newAsyncBuilder().target("http://localhost:" + server.getPort());
 
-    final CompletableFuture<?> cf = api.expand(new Date(1234l));
+    final CompletableFuture<?> cf = api.expand(new TestClock(1234l));
 
-    assertThat(server.takeRequest()).hasPath("/?date=1234");
+    assertThat(server.takeRequest()).hasPath("/?clock=1234");
 
     checkCFCompletedSoon(cf);
   }
@@ -238,9 +240,9 @@ public class Http2ClientAsyncTest {
         newAsyncBuilder().target("http://localhost:" + server.getPort());
 
     final CompletableFuture<?> cf =
-        api.expandList(Arrays.asList(new Date(1234l), new Date(12345l)));
+        api.expandList(Arrays.asList(new TestClock(1234l), new TestClock(12345l)));
 
-    assertThat(server.takeRequest()).hasPath("/?date=1234&date=12345");
+    assertThat(server.takeRequest()).hasPath("/?clock=1234&clock=12345");
 
     checkCFCompletedSoon(cf);
   }
@@ -252,9 +254,9 @@ public class Http2ClientAsyncTest {
     final TestInterfaceAsync api =
         newAsyncBuilder().target("http://localhost:" + server.getPort());
 
-    final CompletableFuture<?> cf = api.expandList(Arrays.asList(new Date(1234l), null));
+    final CompletableFuture<?> cf = api.expandList(Arrays.asList(new TestClock(1234l), null));
 
-    assertThat(server.takeRequest()).hasPath("/?date=1234");
+    assertThat(server.takeRequest()).hasPath("/?clock=1234");
 
     checkCFCompletedSoon(cf);
   }
@@ -865,16 +867,17 @@ public class Http2ClientAsyncTest {
     CompletableFuture<Response> queryParams(@Param("1") String one,
                                             @Param("2") Iterable<String> twos);
 
-    @RequestLine("POST /?date={date}")
-    CompletableFuture<Void> expand(@Param(value = "date", expander = DateToMillis.class) Date date);
+    @RequestLine("POST /?clock={clock}")
+    CompletableFuture<Void> expand(@Param(value = "clock",
+        expander = ClockToMillis.class) Clock clock);
 
-    @RequestLine("GET /?date={date}")
-    CompletableFuture<Void> expandList(@Param(value = "date",
-        expander = DateToMillis.class) List<Date> dates);
+    @RequestLine("GET /?clock={clock}")
+    CompletableFuture<Void> expandList(@Param(value = "clock",
+        expander = ClockToMillis.class) List<Clock> clocks);
 
-    @RequestLine("GET /?date={date}")
-    CompletableFuture<Void> expandArray(@Param(value = "date",
-        expander = DateToMillis.class) Date[] dates);
+    @RequestLine("GET /?clock={clock}")
+    CompletableFuture<Void> expandArray(@Param(value = "clock",
+        expander = ClockToMillis.class) Clock[] clocks);
 
     @RequestLine("GET /")
     CompletableFuture<Void> headerMap(@HeaderMap Map<String, Object> headerMap);
@@ -905,11 +908,11 @@ public class Http2ClientAsyncTest {
     @RequestLine("GET /")
     CompletableFuture<Void> queryMapPropertyInheritence(@QueryMap ChildPojo object);
 
-    class DateToMillis implements Param.Expander {
+    class ClockToMillis implements Param.Expander {
 
       @Override
       public String expand(Object value) {
-        return String.valueOf(((Date) value).getTime());
+        return String.valueOf(((Clock) value).millis());
       }
     }
   }
@@ -1062,4 +1065,29 @@ public class Http2ClientAsyncTest {
     @RequestLine("GET /")
     CompletableFuture<?> x();
   }
+
+  class TestClock extends Clock {
+
+    private long millis;
+
+    public TestClock(long millis) {
+      this.millis = millis;
+    }
+
+    @Override
+    public ZoneId getZone() {
+      return null;
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+      return this;
+    }
+
+    @Override
+    public Instant instant() {
+      return Instant.ofEpochMilli(millis);
+    }
+  }
+
 }

--- a/java11/src/test/java/feign/http2client/test/Http2ClientAsyncTest.java
+++ b/java11/src/test/java/feign/http2client/test/Http2ClientAsyncTest.java
@@ -14,7 +14,6 @@
 package feign.http2client.test;
 
 import static feign.assertj.MockWebServerAssertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.hamcrest.CoreMatchers.isA;
 import static org.junit.Assert.assertEquals;

--- a/jaxb-jakarta/src/test/java/feign/jaxb/examples/AWSSignatureVersion4.java
+++ b/jaxb-jakarta/src/test/java/feign/jaxb/examples/AWSSignatureVersion4.java
@@ -19,9 +19,7 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.net.URI;
 import java.security.MessageDigest;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.TimeZone;
+import java.time.Clock;
 import static feign.Util.UTF_8;
 
 // http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
@@ -29,10 +27,6 @@ public class AWSSignatureVersion4 {
 
   private static final String EMPTY_STRING_HASH =
       "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
-  private static final SimpleDateFormat iso8601 = new SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'");
-  static {
-    iso8601.setTimeZone(TimeZone.getTimeZone("GMT"));
-  }
   String region = "us-east-1";
   String service = "iam";
   String accessKey;
@@ -125,10 +119,7 @@ public class AWSSignatureVersion4 {
 
     String host = URI.create(input.url()).getHost();
 
-    String timestamp;
-    synchronized (iso8601) {
-      timestamp = iso8601.format(new Date());
-    }
+    String timestamp = Clock.systemUTC().instant().toString();
 
     String credentialScope =
         String.format("%s/%s/%s/%s", timestamp.substring(0, 8), region, service, "aws4_request");

--- a/jaxb/src/test/java/feign/jaxb/examples/AWSSignatureVersion4.java
+++ b/jaxb/src/test/java/feign/jaxb/examples/AWSSignatureVersion4.java
@@ -15,9 +15,7 @@ package feign.jaxb.examples;
 
 import java.net.URI;
 import java.security.MessageDigest;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.TimeZone;
+import java.time.Clock;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import feign.Request;
@@ -29,10 +27,6 @@ public class AWSSignatureVersion4 {
 
   private static final String EMPTY_STRING_HASH =
       "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
-  private static final SimpleDateFormat iso8601 = new SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'");
-  static {
-    iso8601.setTimeZone(TimeZone.getTimeZone("GMT"));
-  }
   String region = "us-east-1";
   String service = "iam";
   String accessKey;
@@ -125,10 +119,7 @@ public class AWSSignatureVersion4 {
 
     String host = URI.create(input.url()).getHost();
 
-    String timestamp;
-    synchronized (iso8601) {
-      timestamp = iso8601.format(new Date());
-    }
+    String timestamp = Clock.systemUTC().instant().toString();
 
     String credentialScope =
         String.format("%s/%s/%s/%s", timestamp.substring(0, 8), region, service, "aws4_request");

--- a/jaxrs2/src/main/java/feign/jaxrs2/JAXRSClient.java
+++ b/jaxrs2/src/main/java/feign/jaxrs2/JAXRSClient.java
@@ -86,7 +86,7 @@ public class JAXRSClient implements Client {
     }
 
     try {
-      return new Integer(headers.getFirst(header));
+      return Integer.valueOf(headers.getFirst(header));
     } catch (final NumberFormatException e) {
       // not a number or too big to fit Integer
       return null;

--- a/json/src/test/java/feign/json/JsonDecoderTest.java
+++ b/json/src/test/java/feign/json/JsonDecoderTest.java
@@ -26,8 +26,8 @@ import feign.Response;
 import feign.codec.DecodeException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 import java.util.Collections;
-import java.util.Date;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -147,8 +147,8 @@ public class JsonDecoderTest {
         .request(request)
         .build();
     Exception exception = assertThrows(DecodeException.class,
-        () -> new JsonDecoder().decode(response, Date.class));
-    assertEquals("class java.util.Date is not a type supported by this decoder.",
+        () -> new JsonDecoder().decode(response, Clock.class));
+    assertEquals("class java.time.Clock is not a type supported by this decoder.",
         exception.getMessage());
   }
 

--- a/json/src/test/java/feign/json/JsonEncoderTest.java
+++ b/json/src/test/java/feign/json/JsonEncoderTest.java
@@ -20,7 +20,7 @@ import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
-import java.util.Date;
+import java.time.Clock;
 import static feign.Util.UTF_8;
 import static org.junit.Assert.*;
 
@@ -64,8 +64,8 @@ public class JsonEncoderTest {
   @Test
   public void unknownTypeThrowsEncodeException() {
     Exception exception = assertThrows(EncodeException.class,
-        () -> new JsonEncoder().encode("qwerty", Date.class, new RequestTemplate()));
-    assertEquals("class java.util.Date is not a type supported by this encoder.",
+        () -> new JsonEncoder().encode("qwerty", Clock.class, new RequestTemplate()));
+    assertEquals("class java.time.Clock is not a type supported by this encoder.",
         exception.getMessage());
   }
 

--- a/okhttp/src/test/java/feign/okhttp/OkHttpClientAsyncTest.java
+++ b/okhttp/src/test/java/feign/okhttp/OkHttpClientAsyncTest.java
@@ -1039,7 +1039,7 @@ public class OkHttpClientAsyncTest {
 
     @Override
     public ZoneId getZone() {
-      return null;
+      throw new UnsupportedOperationException("This operation is not supported.");
     }
 
     @Override

--- a/okhttp/src/test/java/feign/okhttp/OkHttpClientAsyncTest.java
+++ b/okhttp/src/test/java/feign/okhttp/OkHttpClientAsyncTest.java
@@ -23,11 +23,13 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -221,9 +223,9 @@ public class OkHttpClientAsyncTest {
     final TestInterfaceAsync api =
         newAsyncBuilder().target("http://localhost:" + server.getPort());
 
-    final CompletableFuture<?> cf = api.expand(new Date(1234l));
+    final CompletableFuture<?> cf = api.expand(new TestClock(1234l));
 
-    assertThat(server.takeRequest()).hasPath("/?date=1234");
+    assertThat(server.takeRequest()).hasPath("/?clock=1234");
 
     checkCFCompletedSoon(cf);
   }
@@ -236,9 +238,9 @@ public class OkHttpClientAsyncTest {
         newAsyncBuilder().target("http://localhost:" + server.getPort());
 
     final CompletableFuture<?> cf =
-        api.expandList(Arrays.asList(new Date(1234l), new Date(12345l)));
+        api.expandList(Arrays.asList(new TestClock(1234l), new TestClock(12345l)));
 
-    assertThat(server.takeRequest()).hasPath("/?date=1234&date=12345");
+    assertThat(server.takeRequest()).hasPath("/?clock=1234&clock=12345");
 
     checkCFCompletedSoon(cf);
   }
@@ -250,9 +252,9 @@ public class OkHttpClientAsyncTest {
     final TestInterfaceAsync api =
         newAsyncBuilder().target("http://localhost:" + server.getPort());
 
-    final CompletableFuture<?> cf = api.expandList(Arrays.asList(new Date(1234l), null));
+    final CompletableFuture<?> cf = api.expandList(Arrays.asList(new TestClock(1234l), null));
 
-    assertThat(server.takeRequest()).hasPath("/?date=1234");
+    assertThat(server.takeRequest()).hasPath("/?clock=1234");
 
     checkCFCompletedSoon(cf);
   }
@@ -863,16 +865,17 @@ public class OkHttpClientAsyncTest {
     CompletableFuture<Response> queryParams(@Param("1") String one,
                                             @Param("2") Iterable<String> twos);
 
-    @RequestLine("POST /?date={date}")
-    CompletableFuture<Void> expand(@Param(value = "date", expander = DateToMillis.class) Date date);
+    @RequestLine("POST /?clock={clock}")
+    CompletableFuture<Void> expand(@Param(value = "clock",
+        expander = ClockToMillis.class) Clock clock);
 
-    @RequestLine("GET /?date={date}")
-    CompletableFuture<Void> expandList(@Param(value = "date",
-        expander = DateToMillis.class) List<Date> dates);
+    @RequestLine("GET /?clock={clock}")
+    CompletableFuture<Void> expandList(@Param(value = "clock",
+        expander = ClockToMillis.class) List<Clock> clocks);
 
-    @RequestLine("GET /?date={date}")
-    CompletableFuture<Void> expandArray(@Param(value = "date",
-        expander = DateToMillis.class) Date[] dates);
+    @RequestLine("GET /?clock={clock}")
+    CompletableFuture<Void> expandArray(@Param(value = "clock",
+        expander = ClockToMillis.class) Clock[] clocks);
 
     @RequestLine("GET /")
     CompletableFuture<Void> headerMap(@HeaderMap Map<String, Object> headerMap);
@@ -903,11 +906,11 @@ public class OkHttpClientAsyncTest {
     @RequestLine("GET /")
     CompletableFuture<Void> queryMapPropertyInheritence(@QueryMap ChildPojo object);
 
-    class DateToMillis implements Param.Expander {
+    class ClockToMillis implements Param.Expander {
 
       @Override
       public String expand(Object value) {
-        return String.valueOf(((Date) value).getTime());
+        return String.valueOf(((Clock) value).millis());
       }
     }
   }
@@ -1025,4 +1028,29 @@ public class OkHttpClientAsyncTest {
   static final class ExtendedCF<T> extends CompletableFuture<T> {
 
   }
+
+  class TestClock extends Clock {
+
+    private long millis;
+
+    public TestClock(long millis) {
+      this.millis = millis;
+    }
+
+    @Override
+    public ZoneId getZone() {
+      return null;
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+      return this;
+    }
+
+    @Override
+    public Instant instant() {
+      return Instant.ofEpochMilli(millis);
+    }
+  }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -637,6 +637,8 @@
             <exclude>NOTICE</exclude>
             <exclude>OSSMETADATA</exclude>
             <exclude>**/*.md</exclude>
+            <exclude>**/*.asciidoc</exclude>
+            <exclude>**/*.iuml</exclude>
             <exclude>bnd.bnd</exclude>
             <exclude>travis/**</exclude>
             <exclude>src/test/resources/**</exclude>

--- a/sax/src/test/java/feign/sax/examples/AWSSignatureVersion4.java
+++ b/sax/src/test/java/feign/sax/examples/AWSSignatureVersion4.java
@@ -15,9 +15,7 @@ package feign.sax.examples;
 
 import java.net.URI;
 import java.security.MessageDigest;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.TimeZone;
+import java.time.Clock;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import feign.Request;
@@ -29,10 +27,6 @@ public class AWSSignatureVersion4 {
 
   private static final String EMPTY_STRING_HASH =
       "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
-  private static final SimpleDateFormat iso8601 = new SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'");
-  static {
-    iso8601.setTimeZone(TimeZone.getTimeZone("GMT"));
-  }
   String region = "us-east-1";
   String service = "iam";
   String accessKey;
@@ -126,10 +120,7 @@ public class AWSSignatureVersion4 {
 
     String host = URI.create(input.url()).getHost();
 
-    String timestamp;
-    synchronized (iso8601) {
-      timestamp = iso8601.format(new Date());
-    }
+    String timestamp = Clock.systemUTC().instant().toString();
 
     String credentialScope =
         String.format("%s/%s/%s/%s", timestamp.substring(0, 8), region, service, "aws4_request");


### PR DESCRIPTION
Resolves #2154 

We do not use Date as date, every time we calculate epoch milliseconds. The Date class has issues with timezone.






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Replaced usage of `Date` with `Clock` in various classes and methods for better time handling.
- New Feature: Introduced a custom `TestClock` class for more flexible testing.
- Refactor: Updated `RetryableException` to use `Long` instead of `Date` for retry-after value, providing more flexibility.
- Refactor: Improved retry mechanism in `Retryer` using exponential backoff.
- Refactor: Replaced usage of `DateFormat` with `DateTimeFormatter` in `RetryAfterDecoder` for modern date/time handling.
- Test: Updated test cases to reflect changes in the main codebase.
- Chore: Updated build configuration to exclude certain file types from the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->