### PR TITLE
Add Moshi

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,17 @@ public class Example {
 For the lighter weight Jackson Jr, use `JacksonJrEncoder` and `JacksonJrDecoder` from
 the [Jackson Jr Module](./jackson-jr).
 
+#### Moshi
+[Moshi](./moshi) includes an encoder and decoder you can use with a JSON API.
+Add `MoshiEncoder` and/or `MoshiDecoder` to your `Feign.Builder` like so:
+
+```java
+GitHub github = Feign.builder()
+                     .encoder(new MoshiEncoder())
+                     .decoder(new MoshiDecoder())
+                     .target(GitHub.class, "https://api.github.com");
+```
+
 #### Sax
 [SaxDecoder](./sax) allows you to decode XML in a way that is compatible with normal JVM and also Android environments.
 

--- a/moshi/README.md
+++ b/moshi/README.md
@@ -1,0 +1,20 @@
+Moshi Codec
+===================
+
+This module adds support for encoding and decoding JSON via the Moshi library.
+
+Add `MoshiEncoder` and/or `MoshiDecoder` to your `Feign.Builder` like so:
+
+```java
+GitHub github = Feign.builder()
+                     .encoder(new MoshiEncoder())
+                     .decoder(new MoshiDecoder())
+                     .target(GitHub.class, "https://api.github.com");
+```
+
+### Map<String, Object> and Numbers
+The default constructors of `MoshiEncoder` and `MoshiDecoder` decoder numbers in
+`Map<String, Object>` as Integer type. This prevents reading `{"counter", "1"}`
+as `Map.of("counter", 1.0)`.
+
+To change this, please use constructors that accept a Moshi object.

--- a/moshi/README.md
+++ b/moshi/README.md
@@ -11,10 +11,3 @@ GitHub github = Feign.builder()
                      .decoder(new MoshiDecoder())
                      .target(GitHub.class, "https://api.github.com");
 ```
-
-### Map<String, Object> and Numbers
-The default constructors of `MoshiEncoder` and `MoshiDecoder` decoder numbers in
-`Map<String, Object>` as Integer type. This prevents reading `{"counter", "1"}`
-as `Map.of("counter", 1.0)`.
-
-To change this, please use constructors that accept a Moshi object.

--- a/moshi/pom.xml
+++ b/moshi/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2012-2023 The Feign Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.github.openfeign</groupId>
+    <artifactId>parent</artifactId>
+    <version>13.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>feign-moshi</artifactId>
+  <name>Feign Moshi</name>
+  <description>Feign Moshi</description>
+
+  <properties>
+    <main.basedir>${project.basedir}/..</main.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>feign-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup.moshi</groupId>
+      <artifactId>moshi</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>feign-core</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/moshi/src/main/java/feign/moshi/MoshiDecoder.java
+++ b/moshi/src/main/java/feign/moshi/MoshiDecoder.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.moshi;
+
+import com.google.common.io.CharStreams;
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonDataException;
+import com.squareup.moshi.JsonEncodingException;
+import com.squareup.moshi.Moshi;
+import feign.Response;
+import feign.Util;
+import feign.codec.Decoder;
+import java.io.IOException;
+import java.io.Reader;
+import java.lang.reflect.Type;
+import static feign.Util.UTF_8;
+import static feign.Util.ensureClosed;
+
+public class MoshiDecoder implements Decoder {
+  private final Moshi moshi;
+
+  public MoshiDecoder(Moshi moshi) {
+    this.moshi = moshi;
+  }
+
+  public MoshiDecoder() {
+    this.moshi = new Moshi.Builder().build();
+  }
+
+  public MoshiDecoder(Iterable<JsonAdapter<?>> adapters) {
+    this(MoshiFactory.create(adapters));
+  }
+
+
+  @Override
+  public Object decode(Response response, Type type) throws IOException {
+    JsonAdapter<Object> jsonAdapter = moshi.adapter(type);
+
+    if (response.status() == 404 || response.status() == 204)
+      return Util.emptyValueOf(type);
+    if (response.body() == null)
+      return null;
+
+    Reader reader = response.body().asReader(UTF_8);
+
+    try {
+      return parseJson(jsonAdapter, reader);
+    } catch (JsonDataException e) {
+      if (e.getCause() != null && e.getCause() instanceof IOException) {
+        throw (IOException) e.getCause();
+      }
+      throw e;
+    } finally {
+      ensureClosed(reader);
+    }
+  }
+
+  private Object parseJson(JsonAdapter<Object> jsonAdapter, Reader reader) throws IOException {
+    String targetString = CharStreams.toString(reader);
+    return jsonAdapter.fromJson(targetString);
+  }
+}
+

--- a/moshi/src/main/java/feign/moshi/MoshiEncoder.java
+++ b/moshi/src/main/java/feign/moshi/MoshiEncoder.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.moshi;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+import feign.RequestTemplate;
+import feign.codec.Encoder;
+import java.lang.reflect.Type;
+import java.util.Collections;
+
+public class MoshiEncoder implements Encoder {
+
+  private final Moshi moshi;
+
+  public MoshiEncoder() {
+    this.moshi = new Moshi.Builder().build();
+  }
+
+  public MoshiEncoder(Moshi moshi) {
+    this.moshi = moshi;
+  }
+
+  public MoshiEncoder(Iterable<JsonAdapter<?>> adapters) {
+    this(MoshiFactory.create(adapters));
+  }
+
+  @Override
+  public void encode(Object object, Type bodyType, RequestTemplate template) {
+    JsonAdapter<Object> jsonAdapter = moshi.adapter(bodyType).indent("  ");
+    template.body(jsonAdapter.toJson(object));
+  }
+}

--- a/moshi/src/main/java/feign/moshi/MoshiFactory.java
+++ b/moshi/src/main/java/feign/moshi/MoshiFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.moshi;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+
+public class MoshiFactory {
+  private MoshiFactory() {}
+
+  /**
+   * Registers JsonAdapter by implicit type. Adds one to read numbers in a {@code Map<String,
+   * Object>} as Integers.
+   */
+  static Moshi create(Iterable<JsonAdapter<?>> adapters) {
+    Moshi.Builder builder = new Moshi.Builder();
+
+    for (JsonAdapter<?> adapter : adapters) {
+      builder.add(adapter.getClass(), adapter);
+    }
+
+    return builder.build();
+  }
+}
+

--- a/moshi/src/test/java/feign/moshi/MoshiDecoderTest.java
+++ b/moshi/src/test/java/feign/moshi/MoshiDecoderTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.moshi;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+import feign.Request;
+import feign.Response;
+import feign.Util;
+import org.junit.Test;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import static feign.Util.UTF_8;
+import static feign.assertj.FeignAssertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class MoshiDecoderTest {
+
+  @Test
+  public void decodes() throws Exception {
+
+    class Zone extends LinkedHashMap<String, Object> {
+
+      Zone(String name) {
+        this(name, null);
+      }
+
+      Zone(String name, String id) {
+        put("name", name);
+        if (id != null) {
+          put("id", id);
+        }
+      }
+
+      private static final long serialVersionUID = 1L;
+    }
+
+    List<Zone> zones = new LinkedList<>();
+    zones.add(new Zone("denominator.io."));
+    zones.add(new Zone("denominator.io.", "ABCD"));
+
+    Response response = Response.builder()
+        .status(200)
+        .reason("OK")
+        .headers(Collections.emptyMap())
+        .request(Request.create(Request.HttpMethod.GET, "/api", Collections.emptyMap(), null,
+            Util.UTF_8))
+        .body(zonesJson, UTF_8)
+        .build();
+
+    assertEquals(zones,
+        new MoshiDecoder().decode(response, List.class));
+  }
+
+  private String zonesJson = ""//
+      + "[\n"//
+      + "  {\n"//
+      + "    \"name\": \"denominator.io.\"\n"//
+      + "  },\n"//
+      + "  {\n"//
+      + "    \"name\": \"denominator.io.\",\n"//
+      + "    \"id\": \"ABCD\"\n"//
+      + "  }\n"//
+      + "]\n";
+
+  private final String videoGamesJson = "{\n   " +
+      " \"hero\": {\n     " +
+      " \"enemy\": \"Bowser\",\n     " +
+      " \"name\": \"Luigi\"\n    " +
+      "},\n    " +
+      "\"name\": \"Super Mario\"\n  " +
+      "}";
+
+  @Test
+  public void nullBodyDecodesToNull() throws Exception {
+    Response response = Response.builder()
+        .status(204)
+        .reason("OK")
+        .headers(Collections.emptyMap())
+        .request(Request.create(Request.HttpMethod.GET, "/api", Collections.emptyMap(), null,
+            Util.UTF_8))
+        .build();
+    assertNull(new MoshiDecoder().decode(response, String.class));
+  }
+
+  @Test
+  public void emptyBodyDecodesToNull() throws Exception {
+    Response response = Response.builder()
+        .status(204)
+        .reason("OK")
+        .headers(Collections.emptyMap())
+        .request(Request.create(Request.HttpMethod.GET, "/api", Collections.emptyMap(), null,
+            Util.UTF_8))
+        .body(new byte[0])
+        .build();
+    assertNull(new MoshiDecoder().decode(response, String.class));
+  }
+
+
+  /** Enabled via {@link feign.Feign.Builder#dismiss404()} */
+  @Test
+  public void notFoundDecodesToEmpty() throws Exception {
+    Response response = Response.builder()
+        .status(404)
+        .reason("NOT FOUND")
+        .headers(Collections.emptyMap())
+        .request(Request.create(Request.HttpMethod.GET, "/api", Collections.emptyMap(), null,
+            Util.UTF_8))
+        .build();
+    assertThat((byte[]) new MoshiDecoder().decode(response, byte[].class)).isEmpty();
+  }
+
+  @Test
+  public void customDecoder() throws Exception {
+    final UpperZoneJSONAdapter upperZoneAdapter = new UpperZoneJSONAdapter();
+
+    MoshiDecoder decoder = new MoshiDecoder(Collections.singleton(upperZoneAdapter));
+
+    List<Zone> zones = new LinkedList<>();
+    zones.add(new Zone("DENOMINATOR.IO."));
+    zones.add(new Zone("DENOMINATOR.IO.", "ABCD"));
+
+    Response response =
+        Response.builder()
+            .status(200)
+            .reason("OK")
+            .headers(Collections.emptyMap())
+            .request(
+                Request.create(Request.HttpMethod.GET, "/api", Collections.emptyMap(), null,
+                    Util.UTF_8))
+            .body(zonesJson, UTF_8)
+            .build();
+
+    assertEquals(zones, decoder.decode(response, UpperZoneJSONAdapter.class));
+  }
+
+  @Test
+  public void customObjectDecoder() throws Exception {
+    final JsonAdapter<VideoGame> videoGameJsonAdapter =
+        new Moshi.Builder().build().adapter(VideoGame.class);
+
+    MoshiDecoder decoder = new MoshiDecoder(Collections.singleton(videoGameJsonAdapter));
+
+    VideoGame videoGame = new VideoGame("Super Mario", "Luigi", "Bowser");
+
+    Response response =
+        Response.builder()
+            .status(200)
+            .reason("OK")
+            .headers(Collections.emptyMap())
+            .request(
+                Request.create(Request.HttpMethod.GET, "/api", Collections.emptyMap(), null,
+                    Util.UTF_8))
+            .body(videoGamesJson, UTF_8)
+            .build();
+
+    VideoGame actual = (VideoGame) decoder.decode(response, videoGameJsonAdapter.getClass());
+
+    assertThat(actual)
+        .isEqualToComparingFieldByFieldRecursively(videoGame);
+  }
+}

--- a/moshi/src/test/java/feign/moshi/MoshiEncoderTest.java
+++ b/moshi/src/test/java/feign/moshi/MoshiEncoderTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.moshi;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+import feign.RequestTemplate;
+import org.junit.Test;
+import java.util.*;
+import static feign.assertj.FeignAssertions.assertThat;
+
+public class MoshiEncoderTest {
+
+  @Test
+  public void encodesMapObjectNumericalValuesAsInteger() {
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("foo", 1);
+
+    RequestTemplate template = new RequestTemplate();
+    new MoshiEncoder().encode(map, Map.class, template);
+
+    assertThat(template).hasBody("{\n" //
+        + "  \"foo\": 1\n" //
+        + "}");
+  }
+
+  @Test
+  public void encodesFormParams() {
+
+    Map<String, Object> form = new LinkedHashMap<>();
+    form.put("foo", 1);
+    form.put("bar", Arrays.asList(2, 3));
+
+    RequestTemplate template = new RequestTemplate();
+
+    new MoshiEncoder().encode(form, Map.class, template);
+
+    assertThat(template).hasBody("{\n" //
+        + "  \"foo\": 1,\n" //
+        + "  \"bar\": [\n" //
+        + "    2,\n" //
+        + "    3\n" //
+        + "  ]\n" //
+        + "}");
+  }
+
+  @Test
+  public void customEncoder() {
+    final UpperZoneJSONAdapter upperZoneAdapter = new UpperZoneJSONAdapter();
+
+    MoshiEncoder encoder = new MoshiEncoder(Collections.singleton(upperZoneAdapter));
+
+    List<Zone> zones = new LinkedList<>();
+    zones.add(new Zone("denominator.io."));
+    zones.add(new Zone("denominator.io.", "abcd"));
+
+    RequestTemplate template = new RequestTemplate();
+    encoder.encode(zones, UpperZoneJSONAdapter.class, template);
+
+    assertThat(template).hasBody("" //
+        + "[\n" //
+        + "  {\n" //
+        + "    \"name\": \"DENOMINATOR.IO.\"\n" //
+        + "  },\n" //
+        + "  {\n" //
+        + "    \"name\": \"DENOMINATOR.IO.\",\n" //
+        + "    \"id\": \"ABCD\"\n" //
+        + "  }\n" //
+        + "]");
+  }
+
+  @Test
+  public void customObjectEncoder() {
+    final JsonAdapter<VideoGame> videoGameJsonAdapter =
+        new Moshi.Builder().build().adapter(VideoGame.class);
+    MoshiEncoder encoder = new MoshiEncoder(Collections.singleton(videoGameJsonAdapter));
+
+    VideoGame videoGame = new VideoGame("Super Mario", "Luigi", "Bowser");
+
+    RequestTemplate template = new RequestTemplate();
+    encoder.encode(videoGame, videoGameJsonAdapter.getClass(), template);
+
+
+    assertThat(template)
+        .hasBody("{\n" +
+            "  \"hero\": {\n" +
+            "    \"enemy\": \"Bowser\",\n" +
+            "    \"name\": \"Luigi\"\n" +
+            "  },\n" +
+            "  \"name\": \"Super Mario\"\n" +
+            "}");
+  }
+}
+

--- a/moshi/src/test/java/feign/moshi/UpperZoneJSONAdapter.java
+++ b/moshi/src/test/java/feign/moshi/UpperZoneJSONAdapter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.moshi;
+
+import com.squareup.moshi.*;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.Map;
+
+class UpperZoneJSONAdapter extends JsonAdapter<LinkedList<Zone>> {
+
+  @ToJson
+  public void toJson(JsonWriter out, LinkedList<Zone> value) throws IOException {
+    out.beginArray();
+    for (Zone zone : value) {
+      out.beginObject();
+      for (Map.Entry<String, Object> entry : zone.entrySet()) {
+        out.name(entry.getKey()).value(entry.getValue().toString().toUpperCase());
+      }
+      out.endObject();
+    }
+    out.endArray();
+  }
+
+  @FromJson
+  public LinkedList<Zone> fromJson(JsonReader in) throws IOException {
+    LinkedList<Zone> zones = new LinkedList<>();
+    in.beginArray();
+    while (in.hasNext()) {
+      in.beginObject();
+      Zone zone = new Zone();
+      while (in.hasNext()) {
+        zone.put(in.nextName(), in.nextString().toUpperCase());
+      }
+      in.endObject();
+      zones.add(zone);
+    }
+    in.endArray();
+    return zones;
+  }
+}

--- a/moshi/src/test/java/feign/moshi/VideoGame.java
+++ b/moshi/src/test/java/feign/moshi/VideoGame.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.moshi;
+
+import com.squareup.moshi.Json;
+
+public class VideoGame {
+
+  @Json(name = "name")
+  public final String name;
+
+  @Json(name = "hero")
+  public final Hero hero;
+
+  public VideoGame(String name, String hero, String enemy) {
+    this.name = name;
+    this.hero = new Hero(hero, enemy);
+  }
+
+  static class Hero {
+    @Json(name = "name")
+    public final String name;
+
+    @Json(name = "enemy")
+    public final String enemyName;
+
+    Hero(String name, String enemyName) {
+      this.name = name;
+      this.enemyName = enemyName;
+    }
+  }
+
+
+}

--- a/moshi/src/test/java/feign/moshi/Zone.java
+++ b/moshi/src/test/java/feign/moshi/Zone.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.moshi;
+
+import java.util.LinkedHashMap;
+
+public class Zone extends LinkedHashMap<String, Object> {
+
+  Zone() {
+    // for reflective instantiation.
+  }
+
+  Zone(String name) {
+    this(name, null);
+  }
+
+  Zone(String name, String id) {
+    put("name", name);
+    if (id != null) {
+      put("id", id);
+    }
+  }
+
+  private static final long serialVersionUID = 1L;
+}
+

--- a/moshi/src/test/java/feign/moshi/examples/GithubExample.java
+++ b/moshi/src/test/java/feign/moshi/examples/GithubExample.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.moshi.examples;
+
+import feign.Feign;
+import feign.Param;
+import feign.RequestLine;
+import feign.moshi.MoshiDecoder;
+import feign.moshi.MoshiEncoder;
+import java.util.List;
+
+public class GithubExample {
+
+  public static void main(String... args) {
+    GitHub github = Feign.builder().encoder(new MoshiEncoder())
+        .decoder(new MoshiDecoder())
+        .target(GitHub.class, "https://api.github.com");
+
+    System.out.println("Let's fetch and print a list of the contributors to this library.");
+    List<Contributor> contributors = github.contributors("netflix", "feign");
+    for (Contributor contributor : contributors) {
+      System.out.println(contributor.login + " (" + contributor.contributions + ")");
+    }
+  }
+
+  interface GitHub {
+
+    @RequestLine("GET /repos/{owner}/{repo}/contributors")
+    List<Contributor> contributors(@Param("owner") String owner, @Param("repo") String repo);
+  }
+
+  static class Contributor {
+
+    String login;
+    int contributions;
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     <module>example-wikipedia</module>
     <module>example-wikipedia-with-springboot</module>
     <module>benchmark</module>
+    <module>moshi</module>
   </modules>
 
   <properties>
@@ -86,6 +87,7 @@
     <guava.version>32.1.2-jre</guava.version>
     <googlehttpclient.version>1.43.3</googlehttpclient.version>
     <gson.version>2.10.1</gson.version>
+    <moshi.version>1.15.0</moshi.version>
     <slf4j.version>2.0.9</slf4j.version>
     <json.version>20230618</json.version>
 
@@ -318,6 +320,12 @@
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>${gson.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.squareup.moshi</groupId>
+        <artifactId>moshi</artifactId>
+        <version>${moshi.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
- Add Moshi as a module to Feign 
- Create a MoshiEncoder and MoshiDecoder 
- Create tests for encoding and decoding, including an example using Github 

Hello,

This PR adds Moshi as a module in Feign. It comes with an implemented encode and decode method which uses Moshi as well as a constructor to add your own custom adapter. I wrote tests using two different ways one can create a JSONAdapter using Moshi. 

This is in response to an issue I opened on https://github.com/OpenFeign/feign/issues/2176.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added support for encoding and decoding JSON using the Moshi library in Feign clients. This includes new `MoshiEncoder` and `MoshiDecoder` classes that can be configured with a `Feign.Builder` instance.
- New Feature: Provided custom JSON adapter functionality through constructors in `MoshiEncoder` and `MoshiDecoder` that accept a collection of `JsonAdapter` instances.
- Test: Added comprehensive test coverage for the new Moshi encoder and decoder classes, including tests for custom encoders.
- Documentation: Updated README with instructions on how to use the new Moshi encoder and decoder in a Feign client.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->