### PR TITLE
Optimize moshi decoding

### DIFF
--- a/moshi/pom.xml
+++ b/moshi/pom.xml
@@ -43,12 +43,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-    </dependency>
-
-    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>feign-core</artifactId>
       <type>test-jar</type>

--- a/moshi/src/main/java/feign/moshi/MoshiDecoder.java
+++ b/moshi/src/main/java/feign/moshi/MoshiDecoder.java
@@ -13,19 +13,17 @@
  */
 package feign.moshi;
 
-import com.google.common.io.CharStreams;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.JsonDataException;
-import com.squareup.moshi.JsonEncodingException;
 import com.squareup.moshi.Moshi;
 import feign.Response;
 import feign.Util;
 import feign.codec.Decoder;
+import okio.BufferedSource;
+import okio.Okio;
+
 import java.io.IOException;
-import java.io.Reader;
 import java.lang.reflect.Type;
-import static feign.Util.UTF_8;
-import static feign.Util.ensureClosed;
 
 public class MoshiDecoder implements Decoder {
   private final Moshi moshi;
@@ -42,7 +40,6 @@ public class MoshiDecoder implements Decoder {
     this(MoshiFactory.create(adapters));
   }
 
-
   @Override
   public Object decode(Response response, Type type) throws IOException {
     JsonAdapter<Object> jsonAdapter = moshi.adapter(type);
@@ -52,23 +49,14 @@ public class MoshiDecoder implements Decoder {
     if (response.body() == null)
       return null;
 
-    Reader reader = response.body().asReader(UTF_8);
-
-    try {
-      return parseJson(jsonAdapter, reader);
+    try (BufferedSource source = Okio.buffer(Okio.source(response.body().asInputStream()))) {
+      return jsonAdapter.fromJson(source);
     } catch (JsonDataException e) {
       if (e.getCause() != null && e.getCause() instanceof IOException) {
         throw (IOException) e.getCause();
       }
       throw e;
-    } finally {
-      ensureClosed(reader);
     }
   }
 
-  private Object parseJson(JsonAdapter<Object> jsonAdapter, Reader reader) throws IOException {
-    String targetString = CharStreams.toString(reader);
-    return jsonAdapter.fromJson(targetString);
-  }
 }
-

--- a/moshi/src/main/java/feign/moshi/MoshiDecoder.java
+++ b/moshi/src/main/java/feign/moshi/MoshiDecoder.java
@@ -21,7 +21,6 @@ import feign.Util;
 import feign.codec.Decoder;
 import okio.BufferedSource;
 import okio.Okio;
-
 import java.io.IOException;
 import java.lang.reflect.Type;
 
@@ -50,6 +49,9 @@ public class MoshiDecoder implements Decoder {
       return null;
 
     try (BufferedSource source = Okio.buffer(Okio.source(response.body().asInputStream()))) {
+      if (source.exhausted()) {
+        return null; // empty body
+      }
       return jsonAdapter.fromJson(source);
     } catch (JsonDataException e) {
       if (e.getCause() != null && e.getCause() instanceof IOException) {


### PR DESCRIPTION
Follow-up to #2182

* Decode JSON more efficiently by leveraging InputStream rather than Reader so the full response body does not need to be written to an intermediate String
* Eagerly return null if the response body is empty (but not-null)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Simplified and optimized the `MoshiDecoder` in the Moshi library. The changes include removing unused imports, replacing the `Reader` with `BufferedSource` from Okio for improved performance, and directly parsing JSON using `jsonAdapter.fromJson()`. This refactor enhances the efficiency of the decoding process and simplifies the underlying code structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->