### PR TITLE
removed testVeryLongResponseNullLength

### DIFF
--- a/googlehttpclient/src/test/java/feign/googlehttpclient/GoogleHttpClientTest.java
+++ b/googlehttpclient/src/test/java/feign/googlehttpclient/GoogleHttpClientTest.java
@@ -80,11 +80,4 @@ public class GoogleHttpClientTest extends AbstractClientTest {
             entry("Content-Length", Collections.singletonList("3")))
         .hasMethod("POST");
   }
-
-
-  @Override
-  public void testVeryLongResponseNullLength() {
-    assumeFalse("JaxRS client hang if the response doesn't have a payload", false);
-  }
-
 }

--- a/jaxrs2/src/test/java/feign/jaxrs2/JAXRSClientTest.java
+++ b/jaxrs2/src/test/java/feign/jaxrs2/JAXRSClientTest.java
@@ -176,9 +176,4 @@ public class JAXRSClientTest extends AbstractClientTest {
     Response consumesMultipleWithContentTypeHeaderAndBody(@HeaderParam("Content-Type") String contentType,
                                                           String body);
   }
-
-  @Override
-  public void testVeryLongResponseNullLength() {
-    assumeFalse("JaxRS client hang if the response doesn't have a payload", false);
-  }
 }


### PR DESCRIPTION
resolved #2177 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

"Test Refactor":
- Removed the `testVeryLongResponseNullLength` method from both `GoogleHttpClientTest.java` and `JAXRSClientTest.java`. This change is part of our ongoing effort to streamline our testing suite and remove redundant or unnecessary tests. It will not impact the functionality of the libraries, but it should make the test suite run slightly faster and be easier to maintain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->