### PR TITLE
Java 11 HTTP client incorrectly reports 'invalid URI' exception message when cause is thread interruption

### DIFF
--- a/java11/src/main/java/feign/http2client/Http2Client.java
+++ b/java11/src/main/java/feign/http2client/Http2Client.java
@@ -99,7 +99,7 @@ public class Http2Client implements Client, AsyncClient<Object> {
       httpResponse = clientForRequest.send(httpRequest, BodyHandlers.ofByteArray());
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new IOException("Invalid uri " + request.url(), e);
+      throw new IOException(e);
     }
 
     return toFeignResponse(request, httpResponse);


### PR DESCRIPTION
Fixes https://github.com/OpenFeign/feign/issues/2188

Java 11 HTTP client incorrectly reports 'invalid URI' exception message when cause is thread interruption.
Example stacktrace:
```
Caused by: java.io.IOException: Invalid uri https://yourdomainhere.com/api/example?foo=bar
 	at feign.http2client.Http2Client.execute(Http2Client.java:102) ~[feign-java11-12.5.jar!/:?]
 	at feign.SynchronousMethodHandler.executeAndDecode(SynchronousMethodHandler.java:100) ~[feign-core-12.5.jar!/:?]
 	at feign.SynchronousMethodHandler.invoke(SynchronousMethodHandler.java:70) ~[feign-core-12.5.jar!/:?]
 	at feign.ReflectiveFeign$FeignInvocationHandler.invoke(ReflectiveFeign.java:96) ~[feign-core-12.5.jar!/:?]
 	... 9 more
 Caused by: java.lang.InterruptedException
 	at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:386) ~[?:?]
 	at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2073) ~[?:?]
 	at jdk.internal.net.http.HttpClientImpl.send(HttpClientImpl.java:553) ~[java.net.http:?]
 	at jdk.internal.net.http.HttpClientFacade.send(HttpClientFacade.java:123) ~[java.net.http:?]
 	at feign.http2client.Http2Client.execute(Http2Client.java:99) ~[feign-java11-12.5.jar!/:?]
 	at feign.SynchronousMethodHandler.executeAndDecode(SynchronousMethodHandler.java:100) ~[feign-core-12.5.jar!/:?]
 	at feign.SynchronousMethodHandler.invoke(SynchronousMethodHandler.java:70) ~[feign-core-12.5.jar!/:?]
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Simplified the exception handling in `Http2Client.java`. The `execute` method now throws the original `InterruptedException` without appending the URL. This change enhances the readability of error messages and focuses on the core issue, making it easier for developers to debug issues related to network interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->