### PR TITLE
Refactoring: Move resolveLastTypeParameter from Util to Types

### DIFF
--- a/core/src/main/java/feign/Util.java
+++ b/core/src/main/java/feign/Util.java
@@ -215,33 +215,12 @@ public class Util {
   }
 
   /**
-   * Resolves the last type parameter of the parameterized {@code supertype}, based on the {@code
-   * genericContext}, into its upper bounds.
-   * <p/>
-   * Implementation copied from {@code
-   * retrofit.RestMethodInfo}.
-   *
-   * @param genericContext Ex. {@link java.lang.reflect.Field#getGenericType()}
-   * @param supertype Ex. {@code Decoder.class}
-   * @return in the example above, the type parameter of {@code Decoder}.
-   * @throws IllegalStateException if {@code supertype} cannot be resolved into a parameterized type
-   *         using {@code context}.
+   * Moved to {@code feign.Types.resolveLastTypeParameter}
    */
+  @Deprecated
   public static Type resolveLastTypeParameter(Type genericContext, Class<?> supertype)
       throws IllegalStateException {
-    Type resolvedSuperType =
-        Types.getSupertype(genericContext, Types.getRawType(genericContext), supertype);
-    checkState(resolvedSuperType instanceof ParameterizedType,
-        "could not resolve %s into a parameterized type %s",
-        genericContext, supertype);
-    Type[] types = ParameterizedType.class.cast(resolvedSuperType).getActualTypeArguments();
-    for (int i = 0; i < types.length; i++) {
-      Type type = types[i];
-      if (type instanceof WildcardType) {
-        types[i] = ((WildcardType) type).getUpperBounds()[0];
-      }
-    }
-    return types[types.length - 1];
+    return Types.resolveLastTypeParameter(genericContext, supertype);
   }
 
   /**


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Moved the `resolveLastTypeParameter` method from `feign.Util` to `feign.Types` for better organization and maintainability. This change improves the modularity of the codebase by grouping related functionalities together.
- Deprecation: Deprecated the `resolveLastTypeParameter` method in `feign.Util`. Future calls should use `feign.Types.resolveLastTypeParameter`.
- Documentation: Added JavaDoc comments for the `resolveLastTypeParameter` method in `feign.Types` to improve code readability and understanding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->