### PR TITLE
Flux type response should be corresponding to List

### DIFF
--- a/core/src/main/java/feign/Types.java
+++ b/core/src/main/java/feign/Types.java
@@ -357,6 +357,10 @@ public final class Types {
     return types[types.length - 1];
   }
 
+  public static ParameterizedType parameterize(Class<?> rawClass, Type... typeArguments) {
+    return new ParameterizedTypeImpl(rawClass.getEnclosingClass(), rawClass, typeArguments);
+  }
+
   static final class ParameterizedTypeImpl implements ParameterizedType {
 
     private final Type ownerType;

--- a/core/src/main/java/feign/Util.java
+++ b/core/src/main/java/feign/Util.java
@@ -215,33 +215,12 @@ public class Util {
   }
 
   /**
-   * Resolves the last type parameter of the parameterized {@code supertype}, based on the {@code
-   * genericContext}, into its upper bounds.
-   * <p/>
-   * Implementation copied from {@code
-   * retrofit.RestMethodInfo}.
-   *
-   * @param genericContext Ex. {@link java.lang.reflect.Field#getGenericType()}
-   * @param supertype Ex. {@code Decoder.class}
-   * @return in the example above, the type parameter of {@code Decoder}.
-   * @throws IllegalStateException if {@code supertype} cannot be resolved into a parameterized type
-   *         using {@code context}.
+   * Moved to {@code feign.Types.resolveLastTypeParameter}
    */
+  @Deprecated
   public static Type resolveLastTypeParameter(Type genericContext, Class<?> supertype)
       throws IllegalStateException {
-    Type resolvedSuperType =
-        Types.getSupertype(genericContext, Types.getRawType(genericContext), supertype);
-    checkState(resolvedSuperType instanceof ParameterizedType,
-        "could not resolve %s into a parameterized type %s",
-        genericContext, supertype);
-    Type[] types = ParameterizedType.class.cast(resolvedSuperType).getActualTypeArguments();
-    for (int i = 0; i < types.length; i++) {
-      Type type = types[i];
-      if (type instanceof WildcardType) {
-        types[i] = ((WildcardType) type).getUpperBounds()[0];
-      }
-    }
-    return types[types.length - 1];
+    return Types.resolveLastTypeParameter(genericContext, supertype);
   }
 
   /**

--- a/reactive/README.md
+++ b/reactive/README.md
@@ -35,7 +35,7 @@ public interface GitHubReactor {
 public class ExampleReactor {
   public static void main(String args[]) {
     GitHubReactor gitHub = ReactorFeign.builder() 
-      .decoder(new ReactiveDecoder(new JacksonDecoder()))     
+      .decoder(new ReactorDecoder(new JacksonDecoder()))     
       .target(GitHubReactor.class, "https://api.github.com");
     
     List<GitHubReactor.Contributor> contributorsFromFlux = gitHub.contributorsFlux("OpenFeign", "feign")
@@ -62,7 +62,8 @@ public interface GitHubReactiveX {
 
 public class ExampleRxJava2 {
   public static void main(String args[]) {
-    GitHubReactiveX gitHub = RxJavaFeign.builder()      
+    GitHubReactiveX gitHub = RxJavaFeign.builder() 
+      .decoder(new RxJavaDecoder(new JacksonDecoder()))     
       .target(GitHub.class, "https://api.github.com");
     
     List<Contributor> contributors = gitHub.contributors("OpenFeign", "feign")

--- a/reactive/src/main/java/feign/reactive/ReactiveDecoder.java
+++ b/reactive/src/main/java/feign/reactive/ReactiveDecoder.java
@@ -44,11 +44,11 @@ public class ReactiveDecoder implements Decoder {
             Type lastType = Types.resolveLastTypeParameter(type, Flux.class);
             Type listType = Types.parameterize(List.class, lastType);
             Object decoded = delegate.decode(response, listType);
-            if (decoded instanceof Iterable) {
+            try {
                 return Flux.fromIterable((Iterable) decoded);
-            } else {
-                String errorMessage = "Expected type Iterable, but was: " + decoded.getClass();
-                throw new DecodeException(response.status(), errorMessage, response.request());
+            } catch (ClassCastException e) {
+                String errorMessage = "Unable to cast decoded object to Iterable: " + e.getMessage();
+                throw new DecodeException(response.status(), errorMessage, response.request(), e);
             }
         }
 

--- a/reactive/src/main/java/feign/reactive/ReactiveDecoder.java
+++ b/reactive/src/main/java/feign/reactive/ReactiveDecoder.java
@@ -16,6 +16,7 @@ package feign.reactive;
 import feign.FeignException;
 import feign.Response;
 import feign.Types;
+import feign.codec.DecodeException;
 import feign.codec.Decoder;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -37,12 +38,18 @@ public class ReactiveDecoder implements Decoder {
         Class<?> rawType = Types.getRawType(type);
         if (rawType.isAssignableFrom(Mono.class)) {
             Type lastType = Types.resolveLastTypeParameter(type, Mono.class);
-            return Mono.just(delegate.decode(response, lastType));
+            return Mono.fromCallable(() -> delegate.decode(response, lastType));
         }
         if (rawType.isAssignableFrom(Flux.class)) {
             Type lastType = Types.resolveLastTypeParameter(type, Flux.class);
             Type listType = Types.parameterize(List.class, lastType);
-            return Flux.fromIterable((Iterable)delegate.decode(response, listType));
+            Object decoded = delegate.decode(response, listType);
+            if (decoded instanceof Iterable) {
+                return Flux.fromIterable((Iterable) decoded);
+            } else {
+                String errorMessage = "Expected type Iterable, but was: " + decoded.getClass();
+                throw new DecodeException(response.status(), errorMessage, response.request());
+            }
         }
 
         return delegate.decode(response, type);

--- a/reactive/src/main/java/feign/reactive/ReactiveDecoder.java
+++ b/reactive/src/main/java/feign/reactive/ReactiveDecoder.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.reactive;
+
+import feign.FeignException;
+import feign.Response;
+import feign.Types;
+import feign.codec.Decoder;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.List;
+
+public class ReactiveDecoder implements Decoder {
+
+    private final Decoder delegate;
+
+    public ReactiveDecoder(Decoder decoder) {
+        this.delegate = decoder;
+    }
+
+    @Override
+    public Object decode(Response response, Type type) throws IOException, FeignException {
+        Class<?> rawType = Types.getRawType(type);
+        if (rawType.isAssignableFrom(Mono.class)) {
+            Type lastType = Types.resolveLastTypeParameter(type, Mono.class);
+            return Mono.just(delegate.decode(response, lastType));
+        }
+        if (rawType.isAssignableFrom(Flux.class)) {
+            Type lastType = Types.resolveLastTypeParameter(type, Flux.class);
+            Type listType = Types.parameterize(List.class, lastType);
+            return Flux.fromIterable((Iterable)delegate.decode(response, listType));
+        }
+
+        return delegate.decode(response, type);
+    }
+}

--- a/reactive/src/main/java/feign/reactive/ReactiveDelegatingContract.java
+++ b/reactive/src/main/java/feign/reactive/ReactiveDelegatingContract.java
@@ -55,7 +55,7 @@ public class ReactiveDelegatingContract implements Contract {
           throw new IllegalArgumentException(
               "Streams are not supported when using Reactive Wrappers");
         }
-        metadata.returnType(actualTypes[0]);
+        metadata.returnType(type);
       }
     }
 

--- a/reactive/src/main/java/feign/reactive/ReactorDecoder.java
+++ b/reactive/src/main/java/feign/reactive/ReactorDecoder.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.reactive;
+
+import feign.FeignException;
+import feign.Response;
+import feign.Types;
+import feign.codec.Decoder;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.List;
+
+public class ReactorDecoder implements Decoder {
+
+    private final Decoder delegate;
+
+    public ReactorDecoder(Decoder decoder) {
+        this.delegate = decoder;
+    }
+
+    @Override
+    public Object decode(Response response, Type type) throws IOException, FeignException {
+        Class<?> rawType = Types.getRawType(type);
+        if (rawType.isAssignableFrom(Mono.class)) {
+            Type lastType = Types.resolveLastTypeParameter(type, Mono.class);
+            return delegate.decode(response, lastType);
+        }
+        if (rawType.isAssignableFrom(Flux.class)) {
+            Type lastType = Types.resolveLastTypeParameter(type, Flux.class);
+            Type listType = Types.parameterize(List.class, lastType);
+            return delegate.decode(response, listType);
+        }
+
+        return delegate.decode(response, type);
+    }
+}

--- a/reactive/src/main/java/feign/reactive/ReactorInvocationHandler.java
+++ b/reactive/src/main/java/feign/reactive/ReactorInvocationHandler.java
@@ -36,7 +36,7 @@ public class ReactorInvocationHandler extends ReactiveInvocationHandler {
   protected Publisher invoke(Method method, MethodHandler methodHandler, Object[] arguments) {
     Publisher<?> invocation = this.invokeMethod(methodHandler, arguments);
     if (Flux.class.isAssignableFrom(method.getReturnType())) {
-      return Flux.from(invocation).subscribeOn(scheduler);
+      return Flux.from(invocation).flatMapIterable(e -> (Iterable) e).subscribeOn(scheduler);
     } else if (Mono.class.isAssignableFrom(method.getReturnType())) {
       return Mono.from(invocation).subscribeOn(scheduler);
     }

--- a/reactive/src/test/java/feign/reactive/ReactiveFeignIntegrationTest.java
+++ b/reactive/src/test/java/feign/reactive/ReactiveFeignIntegrationTest.java
@@ -84,11 +84,11 @@ public class ReactiveFeignIntegrationTest {
   @Test
   public void testReactorTargetFull() throws Exception {
     this.webServer.enqueue(new MockResponse().setBody("1.0"));
-    this.webServer.enqueue(new MockResponse().setBody("{ \"username\": \"test\" }"));
+    this.webServer.enqueue(new MockResponse().setBody("[{ \"username\": \"test\" }]"));
 
     TestReactorService service = ReactorFeign.builder()
         .encoder(new JacksonEncoder())
-        .decoder(new JacksonDecoder())
+        .decoder(new ReactorDecoder(new JacksonDecoder()))
         .logger(new ConsoleLogger())
         .dismiss404()
         .options(new Options())
@@ -119,7 +119,7 @@ public class ReactiveFeignIntegrationTest {
 
     TestReactiveXService service = RxJavaFeign.builder()
         .encoder(new JacksonEncoder())
-        .decoder(new JacksonDecoder())
+        .decoder(new RxJavaDecoder(new JacksonDecoder()))
         .logger(new ConsoleLogger())
         .logLevel(Level.FULL)
         .target(TestReactiveXService.class, this.getServerUrl());
@@ -163,6 +163,7 @@ public class ReactiveFeignIntegrationTest {
     RequestInterceptor mockInterceptor = mock(RequestInterceptor.class);
     TestReactorService service = ReactorFeign.builder()
         .requestInterceptor(mockInterceptor)
+        .decoder(new ReactorDecoder(new Decoder.Default()))
         .target(TestReactorService.class, this.getServerUrl());
     StepVerifier.create(service.version())
         .expectNext("1.0")
@@ -178,6 +179,7 @@ public class ReactiveFeignIntegrationTest {
     RequestInterceptor mockInterceptor = mock(RequestInterceptor.class);
     TestReactorService service = ReactorFeign.builder()
         .requestInterceptors(Arrays.asList(mockInterceptor, mockInterceptor))
+        .decoder(new ReactorDecoder(new Decoder.Default()))
         .target(TestReactorService.class, this.getServerUrl());
     StepVerifier.create(service.version())
         .expectNext("1.0")
@@ -216,6 +218,7 @@ public class ReactiveFeignIntegrationTest {
     given(encoder.encode(any(Object.class))).willReturn(Collections.emptyMap());
     TestReactiveXService service = RxJavaFeign.builder()
         .queryMapEncoder(encoder)
+        .decoder(new RxJavaDecoder(new Decoder.Default()))
         .target(TestReactiveXService.class, this.getServerUrl());
     StepVerifier.create(service.search(new SearchQuery()))
         .expectNext("No Results Found")
@@ -254,6 +257,7 @@ public class ReactiveFeignIntegrationTest {
     when(spy.clone()).thenReturn(spy);
     TestReactorService service = ReactorFeign.builder()
         .retryer(spy)
+        .decoder(new ReactorDecoder(new Decoder.Default()))
         .target(TestReactorService.class, this.getServerUrl());
     StepVerifier.create(service.version())
         .expectNext("1.0")
@@ -275,6 +279,7 @@ public class ReactiveFeignIntegrationTest {
 
     TestReactorService service = ReactorFeign.builder()
         .client(client)
+        .decoder(new ReactorDecoder(new Decoder.Default()))
         .target(TestReactorService.class, this.getServerUrl());
     StepVerifier.create(service.version())
         .expectNext("1.0")
@@ -289,6 +294,7 @@ public class ReactiveFeignIntegrationTest {
 
     TestJaxRSReactorService service = ReactorFeign.builder()
         .contract(new JAXRSContract())
+        .decoder(new ReactorDecoder(new Decoder.Default()))
         .target(TestJaxRSReactorService.class, this.getServerUrl());
     StepVerifier.create(service.version())
         .expectNext("1.0")

--- a/reactive/src/test/java/feign/reactive/examples/ConsoleLogger.java
+++ b/reactive/src/test/java/feign/reactive/examples/ConsoleLogger.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.reactive.examples;
+
+import feign.Logger;
+
+public class ConsoleLogger extends Logger {
+    @Override
+    protected void log(String configKey, String format, Object... args) {
+        System.out.println(String.format(methodTag(configKey) + format, args));
+    }
+}

--- a/reactive/src/test/java/feign/reactive/examples/ReactorGitHubExample.java
+++ b/reactive/src/test/java/feign/reactive/examples/ReactorGitHubExample.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.reactive.examples;
+
+import feign.Logger;
+import feign.Param;
+import feign.RequestLine;
+import feign.jackson.JacksonDecoder;
+import feign.reactive.ReactorDecoder;
+import feign.reactive.ReactorFeign;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+/**
+ * adapted from {@code com.example.retrofit.GitHubClient}
+ */
+public class ReactorGitHubExample {
+
+  public static void main(String... args) {
+    GitHub github = ReactorFeign.builder()
+        .decoder(new ReactorDecoder(new JacksonDecoder()))
+        .logger(new ConsoleLogger())
+        .logLevel(Logger.Level.FULL)
+        .target(GitHub.class, "https://api.github.com");
+
+    System.out.println("Let's fetch and print a list of the contributors to this library (Using Flux).");
+    List<Contributor> contributorsFromFlux = github.contributorsFlux("OpenFeign", "feign")
+            .collectList()
+            .block();
+    for (Contributor contributor : contributorsFromFlux) {
+      System.out.println(contributor.login + " (" + contributor.contributions + ")");
+    }
+
+    System.out.println("Let's fetch and print a list of the contributors to this library (Using Mono).");
+    List<Contributor> contributorsFromMono = github.contributorsMono("OpenFeign", "feign")
+            .block();
+    for (Contributor contributor : contributorsFromMono) {
+      System.out.println(contributor.login + " (" + contributor.contributions + ")");
+    }
+  }
+
+  interface GitHub {
+    @RequestLine("GET /repos/{owner}/{repo}/contributors")
+    Flux<Contributor> contributorsFlux(@Param("owner") String owner, @Param("repo") String repo);
+
+    @RequestLine("GET /repos/{owner}/{repo}/contributors")
+    Mono<List<Contributor>> contributorsMono(@Param("owner") String owner, @Param("repo") String repo);
+  }
+
+  static class Contributor {
+
+    private String login;
+    private int contributions;
+
+    void setLogin(String login) {
+      this.login = login;
+    }
+
+    void setContributions(int contributions) {
+      this.contributions = contributions;
+    }
+  }
+}

--- a/reactive/src/test/java/feign/reactive/examples/RxJavaGitHubExample.java
+++ b/reactive/src/test/java/feign/reactive/examples/RxJavaGitHubExample.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign.reactive.examples;
+
+import feign.Logger;
+import feign.Param;
+import feign.RequestLine;
+import feign.jackson.JacksonDecoder;
+import feign.reactive.RxJavaDecoder;
+import feign.reactive.RxJavaFeign;
+import io.reactivex.Flowable;
+
+import java.util.List;
+
+/**
+ * adapted from {@code com.example.retrofit.GitHubClient}
+ */
+public class RxJavaGitHubExample {
+
+  public static void main(String... args) {
+    GitHub github = RxJavaFeign.builder()
+        .decoder(new RxJavaDecoder(new JacksonDecoder()))
+        .logger(new ConsoleLogger())
+        .logLevel(Logger.Level.FULL)
+        .target(GitHub.class, "https://api.github.com");
+
+    System.out.println("Let's fetch and print a list of the contributors to this library.");
+    List<Contributor> contributorsFromFlux = github.contributors("OpenFeign", "feign")
+            .blockingLast();
+    for (Contributor contributor : contributorsFromFlux) {
+      System.out.println(contributor.login + " (" + contributor.contributions + ")");
+    }
+
+  }
+
+  interface GitHub {
+    @RequestLine("GET /repos/{owner}/{repo}/contributors")
+    Flowable<List<Contributor>> contributors(@Param("owner") String owner, @Param("repo") String repo);
+  }
+
+  static class Contributor {
+
+    private String login;
+    private int contributions;
+
+    void setLogin(String login) {
+      this.login = login;
+    }
+
+    void setContributions(int contributions) {
+      this.contributions = contributions;
+    }
+  }
+}


### PR DESCRIPTION
Fixes: https://github.com/OpenFeign/feign/issues/1869




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced `ReactiveDecoder`, `ReactorDecoder`, and `RxJavaDecoder` classes to support reactive decoding capabilities for Feign clients, enhancing the ability to handle `Mono` and `Flux` types from the Reactor library and `Flowable` type from RxJava.
- Refactor: Improved modularity by moving the `resolveLastTypeParameter` method from `Util` class to `Types` class.
- Documentation: Updated `README.md` to reflect changes in the `GitHubReactor` interface and usage examples for Reactor and RxJava2.
- Test: Enhanced `ReactiveFeignIntegrationTest` to cover new features and changes, providing better test coverage.
- New Feature: Added `ConsoleLogger` for improved logging during testing.
- Documentation: Added `ReactorGitHubExample` and `RxJavaGitHubExample` classes to demonstrate the usage of Feign with Reactor and RxJava respectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->