### PR TITLE
Add reason for decode404() deprecation

### DIFF
--- a/core/src/main/java/feign/BaseBuilder.java
+++ b/core/src/main/java/feign/BaseBuilder.java
@@ -164,7 +164,7 @@ public abstract class BaseBuilder<B extends BaseBuilder<B, T>, T> implements Clo
    * {@link #client(Client) client}.
    *
    * @since 8.12
-   * @deprecated
+   * @deprecated use {@link #dismiss404()} instead.
    */
   @Deprecated
   public B decode404() {


### PR DESCRIPTION
Issue: https://github.com/OpenFeign/feign/issues/2078
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: The `decode404()` method in our core service has been marked as deprecated. We recommend using the new `dismiss404()` method for handling 404 errors. This change is part of our ongoing efforts to improve the clarity and consistency of our codebase. Please note that while the `decode404()` method will continue to function for now, we plan to remove it in a future update. Transitioning to the `dismiss404()` method will ensure your workflows remain uninterrupted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->