### PR TITLE
Add typed response

### DIFF
--- a/core/src/main/java/feign/InvocationContext.java
+++ b/core/src/main/java/feign/InvocationContext.java
@@ -77,15 +77,15 @@ public class InvocationContext {
         return null;
       }
 
-      try {
-        return decoder.decode(response, returnType);
-      } catch (final FeignException e) {
-        throw e;
-      } catch (final RuntimeException e) {
-        throw new DecodeException(response.status(), e.getMessage(), response.request(), e);
-      } catch (IOException e) {
-        throw errorReading(response.request(), response, e);
+      Class<?> rawType = Types.getRawType(returnType);
+      if (TypedResponse.class.isAssignableFrom(rawType)) {
+        Type bodyType = Types.resolveLastTypeParameter(returnType, TypedResponse.class);
+        return TypedResponse.builder(response)
+                .body(decode(response, bodyType))
+                .build();
       }
+
+      return decode(response, returnType);
     } finally {
       if (closeAfterDecode) {
         ensureClosed(response.body());
@@ -106,6 +106,18 @@ public class InvocationContext {
       return response.toBuilder().body(bodyData).build();
     } finally {
       ensureClosed(response.body());
+    }
+  }
+
+  private Object decode(Response response, Type returnType) {
+    try {
+      return decoder.decode(response, returnType);
+    } catch (final FeignException e) {
+      throw e;
+    } catch (final RuntimeException e) {
+      throw new DecodeException(response.status(), e.getMessage(), response.request(), e);
+    } catch (IOException e) {
+      throw errorReading(response.request(), response, e);
     }
   }
 

--- a/core/src/main/java/feign/Response.java
+++ b/core/src/main/java/feign/Response.java
@@ -215,7 +215,7 @@ public final class Response implements Closeable {
 
   @Override
   public String toString() {
-    StringBuilder builder = new StringBuilder("HTTP/1.1 ").append(status);
+    StringBuilder builder = new StringBuilder(protocolVersion.toString()).append(" ").append(status);
     if (reason != null)
       builder.append(' ').append(reason);
     builder.append('\n');

--- a/core/src/main/java/feign/TypedResponse.java
+++ b/core/src/main/java/feign/TypedResponse.java
@@ -161,7 +161,7 @@ public final class TypedResponse<T> {
 
   @Override
   public String toString() {
-    StringBuilder builder = new StringBuilder("HTTP/1.1 ").append(status);
+    StringBuilder builder = new StringBuilder(protocolVersion.toString()).append(" ").append(status);
     if (reason != null)
       builder.append(' ').append(reason);
     builder.append('\n');

--- a/core/src/main/java/feign/TypedResponse.java
+++ b/core/src/main/java/feign/TypedResponse.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2012-2023 The Feign Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package feign;
+
+import feign.Request.ProtocolVersion;
+
+import java.util.Collection;
+import java.util.Map;
+
+import static feign.Util.*;
+
+public final class TypedResponse<T> {
+
+  private final int status;
+  private final String reason;
+  private final Map<String, Collection<String>> headers;
+  private final T body;
+  private final Request request;
+  private final ProtocolVersion protocolVersion;
+
+  private TypedResponse(Builder<T> builder) {
+    checkState(builder.request != null, "original request is required");
+    this.status = builder.status;
+    this.request = builder.request;
+    this.reason = builder.reason; // nullable
+    this.headers = caseInsensitiveCopyOf(builder.headers);
+    this.body = builder.body;
+    this.protocolVersion = builder.protocolVersion;
+  }
+
+  public static <T> Builder<T> builder() {
+    return new Builder<T>();
+  }
+
+  public static <T> Builder<T> builder(Response source) {
+    return new Builder<T>(source);
+  }
+
+  public static final class Builder<T> {
+    int status;
+    String reason;
+    Map<String, Collection<String>> headers;
+    T body;
+    Request request;
+    private ProtocolVersion protocolVersion = ProtocolVersion.HTTP_1_1;
+
+    Builder() {}
+
+    Builder(Response source) {
+      this.status = source.status();
+      this.reason = source.reason();
+      this.headers = source.headers();
+      this.request = source.request();
+      this.protocolVersion = source.protocolVersion();
+    }
+
+    /** @see TypedResponse#status */
+    public Builder status(int status) {
+      this.status = status;
+      return this;
+    }
+
+    /** @see TypedResponse#reason */
+    public Builder reason(String reason) {
+      this.reason = reason;
+      return this;
+    }
+
+    /** @see TypedResponse#headers */
+    public Builder headers(Map<String, Collection<String>> headers) {
+      this.headers = headers;
+      return this;
+    }
+
+    /** @see TypedResponse#body */
+    public Builder body(T body) {
+      this.body = body;
+      return this;
+    }
+
+    /**
+     * @see TypedResponse#request
+     */
+    public Builder request(Request request) {
+      checkNotNull(request, "request is required");
+      this.request = request;
+      return this;
+    }
+
+    /**
+     * HTTP protocol version
+     */
+    public Builder protocolVersion(ProtocolVersion protocolVersion) {
+      this.protocolVersion = protocolVersion;
+      return this;
+    }
+
+    public TypedResponse build() {
+      return new TypedResponse<T>(this);
+    }
+  }
+
+  /**
+   * status code. ex {@code 200}
+   *
+   * See <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html" >rfc2616</a>
+   */
+  public int status() {
+    return status;
+  }
+
+  /**
+   * Nullable and not set when using http/2
+   *
+   * See https://github.com/http2/http2-spec/issues/202
+   */
+  public String reason() {
+    return reason;
+  }
+
+  /**
+   * Returns a case-insensitive mapping of header names to their values.
+   */
+  public Map<String, Collection<String>> headers() {
+    return headers;
+  }
+
+  /**
+   * if present, the response had a body
+   */
+  public T body() {
+    return body;
+  }
+
+  /**
+   * the request that generated this response
+   */
+  public Request request() {
+    return request;
+  }
+
+  /**
+   * the HTTP protocol version
+   *
+   * @return HTTP protocol version or empty if a client does not provide it
+   */
+  public ProtocolVersion protocolVersion() {
+    return protocolVersion;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder("HTTP/1.1 ").append(status);
+    if (reason != null)
+      builder.append(' ').append(reason);
+    builder.append('\n');
+    for (String field : headers.keySet()) {
+      for (String value : valuesOrEmpty(headers, field)) {
+        builder.append(field).append(": ").append(value).append('\n');
+      }
+    }
+    if (body != null)
+      builder.append('\n').append(body);
+    return builder.toString();
+  }
+
+}

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -89,6 +89,18 @@ public class FeignTest {
   }
 
   @Test
+  public void typedResponse() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
+
+    TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
+
+    TypedResponse response = api.getWithTypedResponse();
+
+    assertEquals(200, response.status());
+    assertEquals("foo", response.body());
+  }
+
+  @Test
   public void postTemplateParamsResolve() throws Exception {
     server.enqueue(new MockResponse().setBody("foo"));
 
@@ -1200,6 +1212,9 @@ public class FeignTest {
 
     @RequestLine("GET /")
     Response queryMapWithArrayValues(@QueryMap Map<String, String[]> twos);
+
+    @RequestLine("GET /")
+    TypedResponse<String> getWithTypedResponse();
 
     @RequestLine("POST /?clock={clock}")
     void expand(@Param(value = "clock", expander = ClockToMillis.class) Clock clock);

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -49,6 +49,7 @@ import static feign.ExceptionPropagationPolicy.UNWRAP;
 import static feign.Util.UTF_8;
 import static feign.assertj.MockWebServerAssertions.assertThat;
 import static java.util.Collections.emptyList;
+import static junit.framework.TestCase.assertNotNull;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.hamcrest.CoreMatchers.isA;
 import static org.junit.Assert.assertEquals;
@@ -98,6 +99,9 @@ public class FeignTest {
 
     assertEquals(200, response.status());
     assertEquals("foo", response.body());
+    assertEquals("HTTP/1.1", response.protocolVersion().toString());
+    assertNotNull(response.headers());
+    assertNotNull(response.request());
   }
 
   @Test


### PR DESCRIPTION
Issue: https://github.com/OpenFeign/feign/issues/1627
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- New Feature: Introduced `TypedResponse` class to handle different types of HTTP responses, enhancing the flexibility of the Feign library.
- Improvement: Updated the `toString()` method in the `Response` class for more accurate string representation of HTTP responses.
- Test: Added a new test method `typedResponse()` to validate the functionality of the new `TypedResponse` class.

These changes provide a more flexible and accurate way to handle and represent HTTP responses, improving the overall user experience with the Feign library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->