### PR TITLE
Do not decode URL encoding while setting up RequestTemplate

### DIFF
--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -518,7 +518,7 @@ public final class RequestTemplate implements Serializable {
       }
 
       /* strip the query string */
-      this.target = targetUri.getScheme() + "://" + targetUri.getAuthority() + targetUri.getPath();
+      this.target = targetUri.getScheme() + "://" + targetUri.getRawAuthority() + targetUri.getRawPath();
       if (targetUri.getFragment() != null) {
         this.fragment = "#" + targetUri.getFragment();
       }

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -515,6 +515,15 @@ public class RequestTemplateTest {
   }
 
   @Test
+  public void urlEncodingRemainsInPlace() {
+    RequestTemplate template = new RequestTemplate()
+        .method(HttpMethod.GET)
+        .target("https://exa%23mple.com/path%7Cpath");
+
+    assertThat(template.url()).isEqualTo("https://exa%23mple.com/path%7Cpath");
+  }
+
+  @Test
   public void slashShouldNotBeAppendedForMatrixParams() {
     RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)
         .uri("/path;key1=value1;key2=value2", true);


### PR DESCRIPTION
Fix #2227

Please find the reproduction scenario attached to the Issue above.