### PR TITLE
Fixed NullPointerException bug

### DIFF
--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 The Feign Authors
+ * Copyright 2012-2024 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -703,6 +703,10 @@ public final class RequestTemplate implements Serializable {
    * @see RequestTemplate#header(String, Iterable)
    */
   public RequestTemplate header(String name, String... values) {
+    if (values == null) {
+      return appendHeader(name, new Collections.emptyList())
+    }
+
     return header(name, Arrays.asList(values));
   }
 


### PR DESCRIPTION
`RequestTemplate.header(name, values)` method has two overloaded implementations.
In the case where `values` has type `Iterable<String>`, `values` is guarded against `null`.
This does not happen when `values` has type `String...`, which is fixed by this commit.

Concrete testcase:
```java
import feign.RequestTemplate;

public class Test{
	public static void main(String args[]) throws Exception {
		RequestTemplate rt = new RequestTemplate();
		String[] values = null;
		String name = "";
		rt.header(name, values); // NPE
	}
}
```
Result:
```console
Exception in thread "main" java.lang.NullPointerException
        at java.base/java.util.Objects.requireNonNull(Objects.java:233)
        at java.base/java.util.Arrays$ArrayList.<init>(Arrays.java:4238)
        at java.base/java.util.Arrays.asList(Arrays.java:4223)
        at feign.RequestTemplate.header(RequestTemplate.java:706)
        at Test.main(Test.java:8)
```