### PR TITLE
Add custom tags to MicrometerCapability

### DIFF
--- a/micrometer/src/main/java/feign/micrometer/MicrometerCapability.java
+++ b/micrometer/src/main/java/feign/micrometer/MicrometerCapability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 The Feign Authors
+ * Copyright 2012-2024 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/micrometer/src/main/java/feign/micrometer/MicrometerCapability.java
+++ b/micrometer/src/main/java/feign/micrometer/MicrometerCapability.java
@@ -22,8 +22,13 @@ import feign.codec.Encoder;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class MicrometerCapability implements Capability {
 
@@ -35,6 +40,17 @@ public class MicrometerCapability implements Capability {
   }
 
   public MicrometerCapability(MeterRegistry meterRegistry) {
+    this.meterRegistry = meterRegistry;
+  }
+
+  public MicrometerCapability(MeterRegistry meterRegistry, List<Tag> tagsList) {
+    meterRegistry.config().commonTags(tagsList);
+    this.meterRegistry = meterRegistry;
+  }
+
+  public MicrometerCapability(MeterRegistry meterRegistry, Map<String, String> tagsMap) {
+    List<Tag> tagsList = mapTags(tagsMap);
+    meterRegistry.config().commonTags(tagsList);
     this.meterRegistry = meterRegistry;
   }
 
@@ -61,5 +77,11 @@ public class MicrometerCapability implements Capability {
   @Override
   public InvocationHandlerFactory enrich(InvocationHandlerFactory invocationHandlerFactory) {
     return new MeteredInvocationHandleFactory(invocationHandlerFactory, meterRegistry);
+  }
+
+  private List<Tag> mapTags(Map<String, String> tags) {
+    return tags.keySet().stream()
+            .map(tagKey -> Tag.of(tagKey, tags.get(tagKey)))
+            .collect(Collectors.toList());
   }
 }


### PR DESCRIPTION
This pull request adds new constructors to `MicrometerCapability`, so the clients are now able to add custom tags to `MeterRegistry` from the builder level.

Two new constructors were added. The first one can take a `List<Tags>`:
```
public MicrometerCapability(MeterRegistry meterRegistry, List<Tag> tagsList)
```

The second one can take a `Map<String, String>` of Keys and Values:
```
public MicrometerCapability(MeterRegistry meterRegistry, Map<String, String> tagsMap)
```
---
Closes #1456 