### PR TITLE
Adds a client tag to the default micrometer observation

### DIFF
--- a/micrometer/src/main/java/feign/micrometer/DefaultFeignObservationConvention.java
+++ b/micrometer/src/main/java/feign/micrometer/DefaultFeignObservationConvention.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 The Feign Authors
+ * Copyright 2012-2024 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/micrometer/src/main/java/feign/micrometer/DefaultFeignObservationConvention.java
+++ b/micrometer/src/main/java/feign/micrometer/DefaultFeignObservationConvention.java
@@ -14,6 +14,7 @@
 package feign.micrometer;
 
 import feign.Request;
+import feign.RequestTemplate;
 import feign.Response;
 import io.micrometer.common.KeyValues;
 import io.micrometer.common.lang.Nullable;
@@ -21,8 +22,8 @@ import io.micrometer.common.lang.Nullable;
 /**
  * Default implementation of {@link FeignObservationConvention}.
  *
- * @since 12.1
  * @see FeignObservationConvention
+ * @since 12.1
  */
 public class DefaultFeignObservationConvention implements FeignObservationConvention {
 
@@ -34,7 +35,8 @@ public class DefaultFeignObservationConvention implements FeignObservationConven
 
   // There is no need to instantiate this class multiple times, but it may be extended,
   // hence protected visibility.
-  protected DefaultFeignObservationConvention() {}
+  protected DefaultFeignObservationConvention() {
+  }
 
   @Override
   public String getName() {
@@ -48,14 +50,16 @@ public class DefaultFeignObservationConvention implements FeignObservationConven
 
   @Override
   public KeyValues getLowCardinalityKeyValues(FeignContext context) {
-    String templatedUrl = context.getCarrier().requestTemplate().methodMetadata().template().url();
+    RequestTemplate requestTemplate = context.getCarrier().requestTemplate();
     return KeyValues.of(
         FeignObservationDocumentation.HttpClientTags.METHOD
             .withValue(getMethodString(context.getCarrier())),
         FeignObservationDocumentation.HttpClientTags.URI
-            .withValue(templatedUrl),
+            .withValue(requestTemplate.methodMetadata().template().url()),
         FeignObservationDocumentation.HttpClientTags.STATUS
-            .withValue(getStatusValue(context.getResponse())));
+            .withValue(getStatusValue(context.getResponse())),
+        FeignObservationDocumentation.HttpClientTags.CLIENT
+            .withValue(requestTemplate.feignTarget().type().getName()));
   }
 
   String getStatusValue(@Nullable Response response) {

--- a/micrometer/src/main/java/feign/micrometer/DefaultFeignObservationConvention.java
+++ b/micrometer/src/main/java/feign/micrometer/DefaultFeignObservationConvention.java
@@ -35,8 +35,7 @@ public class DefaultFeignObservationConvention implements FeignObservationConven
 
   // There is no need to instantiate this class multiple times, but it may be extended,
   // hence protected visibility.
-  protected DefaultFeignObservationConvention() {
-  }
+  protected DefaultFeignObservationConvention() {}
 
   @Override
   public String getName() {
@@ -58,7 +57,7 @@ public class DefaultFeignObservationConvention implements FeignObservationConven
             .withValue(requestTemplate.methodMetadata().template().url()),
         FeignObservationDocumentation.HttpClientTags.STATUS
             .withValue(getStatusValue(context.getResponse())),
-        FeignObservationDocumentation.HttpClientTags.CLIENT
+        FeignObservationDocumentation.HttpClientTags.CLIENT_NAME
             .withValue(requestTemplate.feignTarget().type().getName()));
   }
 

--- a/micrometer/src/main/java/feign/micrometer/FeignObservationDocumentation.java
+++ b/micrometer/src/main/java/feign/micrometer/FeignObservationDocumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 The Feign Authors
+ * Copyright 2012-2024 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/micrometer/src/main/java/feign/micrometer/FeignObservationDocumentation.java
+++ b/micrometer/src/main/java/feign/micrometer/FeignObservationDocumentation.java
@@ -20,7 +20,7 @@ import io.micrometer.observation.docs.ObservationDocumentation;
 
 /**
  * {@link ObservationDocumentation} for Feign.
- * 
+ *
  * @since 12.1
  */
 public enum FeignObservationDocumentation implements ObservationDocumentation {
@@ -36,6 +36,7 @@ public enum FeignObservationDocumentation implements ObservationDocumentation {
       return HttpClientTags.values();
     }
   };
+
 
   enum HttpClientTags implements KeyName {
 
@@ -73,6 +74,12 @@ public enum FeignObservationDocumentation implements ObservationDocumentation {
       @Override
       public String asString() {
         return "net.peer.port";
+      }
+    },
+    CLIENT {
+      @Override
+      public String asString() {
+        return "client";
       }
     }
 

--- a/micrometer/src/main/java/feign/micrometer/FeignObservationDocumentation.java
+++ b/micrometer/src/main/java/feign/micrometer/FeignObservationDocumentation.java
@@ -76,10 +76,10 @@ public enum FeignObservationDocumentation implements ObservationDocumentation {
         return "net.peer.port";
       }
     },
-    CLIENT {
+    CLIENT_NAME {
       @Override
       public String asString() {
-        return "client";
+        return "clientName";
       }
     }
 

--- a/micrometer/src/test/java/feign/micrometer/FeignHeaderInstrumentationTest.java
+++ b/micrometer/src/test/java/feign/micrometer/FeignHeaderInstrumentationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 The Feign Authors
+ * Copyright 2012-2024 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/micrometer/src/test/java/feign/micrometer/FeignHeaderInstrumentationTest.java
+++ b/micrometer/src/test/java/feign/micrometer/FeignHeaderInstrumentationTest.java
@@ -22,11 +22,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import feign.AsyncFeign;
@@ -35,6 +31,7 @@ import feign.Param;
 import feign.Request;
 import feign.RequestLine;
 import feign.Response;
+import io.micrometer.core.instrument.Meter.Id;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
@@ -43,10 +40,17 @@ import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.transport.RequestReplySenderContext;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 @WireMockTest
 class FeignHeaderInstrumentationTest {
+
+  static final String METER_NAME = "http.client.requests";
 
   MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
@@ -67,9 +71,11 @@ class FeignHeaderInstrumentationTest {
     testClient.templated("1", "2");
 
     verify(getRequestedFor(urlEqualTo("/customers/1/carts/2")).withHeader("foo", equalTo("bar")));
-    Timer timer = meterRegistry.get("http.client.requests").timer();
+    Timer timer = meterRegistry.get(METER_NAME).timer();
     assertThat(timer.count()).isEqualTo(1);
     assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isPositive();
+
+    assertTags();
   }
 
   @Test
@@ -82,9 +88,49 @@ class FeignHeaderInstrumentationTest {
     testClient.templated("1", "2").get();
 
     verify(getRequestedFor(urlEqualTo("/customers/1/carts/2")).withHeader("foo", equalTo("bar")));
-    Timer timer = meterRegistry.get("http.client.requests").timer();
+    Timer timer = meterRegistry.get(METER_NAME).timer();
     assertThat(timer.count()).isEqualTo(1);
     assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isPositive();
+
+    assertTags();
+  }
+
+  private void assertTags() {
+    Id requestsId = meterRegistry.get(METER_NAME).meter().getId();
+
+    assertMetricIdIncludesMethod(requestsId);
+    assertMetricIdIncludesURI(requestsId);
+    assertMetricIdIncludesStatus(requestsId);
+    assertsMetricIdIncludesClient(requestsId);
+  }
+
+  private void assertMetricIdIncludesMethod(Id metricId) {
+    String tag = metricId.getTag("http.method");
+    assertThat(tag).as("Expect all metric names to have tag 'http.method': " + metricId)
+        .isNotNull();
+    assertThat(tag).as("Expect method to be GET: " + metricId).isEqualTo("GET");
+  }
+
+  private void assertMetricIdIncludesURI(Id metricId) {
+    String tag = metricId.getTag("http.url");
+    assertThat(tag).as("Expect all metric names to have tag 'http.url': " + metricId).isNotNull();
+    assertThat(tag).as("Expect url to match path template: " + metricId)
+        .isEqualTo("/customers/{customerId}/carts/{cartId}");
+  }
+
+  private void assertMetricIdIncludesStatus(Id metricId) {
+    String tag = metricId.getTag("http.status_code");
+    assertThat(tag).as("Expect all metric names to have tag 'http.status_code': " + metricId)
+        .isNotNull();
+    assertThat(tag).as("Expect status to be 200: " + metricId).isEqualTo("200");
+  }
+
+  private void assertsMetricIdIncludesClient(Id metricId) {
+    String tag = metricId.getTag("client");
+    assertThat(tag).as("Expect all metric names to have tag 'client': " + metricId).isNotNull();
+    assertThat(tag).as("Expect class to be present: " + metricId)
+        .startsWith("feign.micrometer.FeignHeaderInstrumentationTest$");
+    assertThat(tag).endsWith("TestClient");
   }
 
   private TestClient clientInstrumentedWithObservations(String url) {
@@ -107,12 +153,14 @@ class FeignHeaderInstrumentationTest {
     String templated(@Param("customerId") String customerId, @Param("cartId") String cartId);
   }
 
+
   public interface AsyncTestClient {
 
     @RequestLine("GET /customers/{customerId}/carts/{cartId}")
     CompletableFuture<String> templated(@Param("customerId") String customerId,
                                         @Param("cartId") String cartId);
   }
+
 
   static class HeaderMutatingHandler
       implements ObservationHandler<RequestReplySenderContext<Request, Response>> {

--- a/micrometer/src/test/java/feign/micrometer/FeignHeaderInstrumentationTest.java
+++ b/micrometer/src/test/java/feign/micrometer/FeignHeaderInstrumentationTest.java
@@ -22,7 +22,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
-
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import feign.AsyncFeign;
@@ -101,7 +100,7 @@ class FeignHeaderInstrumentationTest {
     assertMetricIdIncludesMethod(requestsId);
     assertMetricIdIncludesURI(requestsId);
     assertMetricIdIncludesStatus(requestsId);
-    assertsMetricIdIncludesClient(requestsId);
+    assertsMetricIdIncludesClientName(requestsId);
   }
 
   private void assertMetricIdIncludesMethod(Id metricId) {
@@ -125,9 +124,9 @@ class FeignHeaderInstrumentationTest {
     assertThat(tag).as("Expect status to be 200: " + metricId).isEqualTo("200");
   }
 
-  private void assertsMetricIdIncludesClient(Id metricId) {
-    String tag = metricId.getTag("client");
-    assertThat(tag).as("Expect all metric names to have tag 'client': " + metricId).isNotNull();
+  private void assertsMetricIdIncludesClientName(Id metricId) {
+    String tag = metricId.getTag("clientName");
+    assertThat(tag).as("Expect all metric names to have tag 'clientName': " + metricId).isNotNull();
     assertThat(tag).as("Expect class to be present: " + metricId)
         .startsWith("feign.micrometer.FeignHeaderInstrumentationTest$");
     assertThat(tag).endsWith("TestClient");


### PR DESCRIPTION
Include a client tag on the default feign micrometer observation, so it's added to the `http.client.requests` meters, in the same way it's added to the `feign.*` meters.

This is useful for applications with more than one feign client, to avoid merging unrelated metrics, and improve observability of multiple downstreams which may have different latency etc

Opened to address #2332