### PR TITLE
fix: Response.protocolVersion may cause NPE

### DIFF
--- a/core/src/main/java/feign/Response.java
+++ b/core/src/main/java/feign/Response.java
@@ -51,6 +51,7 @@ public final class Response implements Closeable {
   }
 
   public static final class Builder {
+    private static final ProtocolVersion DEFAULT_PROTOCOL_VERSION = ProtocolVersion.HTTP_1_1;
     int status;
     String reason;
     Map<String, Collection<String>> headers;
@@ -125,7 +126,7 @@ public final class Response implements Closeable {
      * HTTP protocol version
      */
     public Builder protocolVersion(ProtocolVersion protocolVersion) {
-      this.protocolVersion = (protocolVersion != null) ? protocolVersion : ProtocolVersion.HTTP_1_1;
+      this.protocolVersion = (protocolVersion != null) ? protocolVersion : DEFAULT_PROTOCOL_VERSION;
       return this;
     }
 

--- a/core/src/main/java/feign/Response.java
+++ b/core/src/main/java/feign/Response.java
@@ -58,7 +58,7 @@ public final class Response implements Closeable {
     Body body;
     Request request;
     private RequestTemplate requestTemplate;
-    private ProtocolVersion protocolVersion = ProtocolVersion.HTTP_1_1;
+    private ProtocolVersion protocolVersion = DEFAULT_PROTOCOL_VERSION;
 
     Builder() {}
 

--- a/core/src/main/java/feign/Response.java
+++ b/core/src/main/java/feign/Response.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 The Feign Authors
+ * Copyright 2012-2024 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -125,7 +125,7 @@ public final class Response implements Closeable {
      * HTTP protocol version
      */
     public Builder protocolVersion(ProtocolVersion protocolVersion) {
-      this.protocolVersion = protocolVersion;
+      this.protocolVersion = (protocolVersion != null) ? protocolVersion : ProtocolVersion.HTTP_1_1;
       return this;
     }
 

--- a/core/src/test/java/feign/ResponseTest.java
+++ b/core/src/test/java/feign/ResponseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 The Feign Authors
+ * Copyright 2012-2024 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -109,5 +109,18 @@ class ResponseTest {
 
       assertThat(response.status()).isEqualTo(statusCode);
     });
+  }
+
+  @Test
+  void protocolVersionDefaultsToHttp1_1() {
+    Response response = Response.builder()
+        .status(200)
+        .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+        .protocolVersion(null)
+        .body(new byte[0])
+        .build();
+
+    assertThat(response.protocolVersion()).isEqualTo(Request.ProtocolVersion.HTTP_1_1);
+    assertThat(response.toString()).startsWith("HTTP/1.1 200");
   }
 }


### PR DESCRIPTION
Found and fixed an issue where `Response.protocolVersion` may have caused NullPointerExceptions. #2314 

I believe `Response builder` already defaults to `ProtocolVersion.HTTP_1_1`
and using it  when the `protocolVersion` argument is null.

I have other ideas:
- Create another enum value `UNKNOWN` based on `Logger.java` and use it when `protocolVersion` argument is null.
- Leave the current code as is and handle the NullPointerException when `Response` is used.

If you encounter any difficulties with this change, I'd appreciate some guidance or direction.

