### PR TITLE
update restricted headers in jdk11 client implementation

### DIFF
--- a/java11/src/main/java/feign/http2client/Http2Client.java
+++ b/java11/src/main/java/feign/http2client/Http2Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 The Feign Authors
+ * Copyright 2012-2024 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/java11/src/main/java/feign/http2client/Http2Client.java
+++ b/java11/src/main/java/feign/http2client/Http2Client.java
@@ -203,8 +203,7 @@ public class Http2Client implements Client, AsyncClient<Object> {
   static {
     // A case insensitive TreeSet of strings.
     final TreeSet<String> treeSet = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-    treeSet.addAll(Set.of("connection", "content-length", "date", "expect", "from", "host",
-        "origin", "referer", "upgrade", "via", "warning"));
+    treeSet.addAll(Set.of("connection", "content-length", "expect", "host", "upgrade"));
     DISALLOWED_HEADERS_SET = Collections.unmodifiableSet(treeSet);
   }
 


### PR DESCRIPTION
Updates the list of restricted headers in jdk11 client implementation.

The current implementation still contains the original disallowed headers from ~6 years ago. Since then there were a few updates making the header restriction less strict. By default only `connection content-length expect host upgrade` headers are now restricted:
https://github.com/openjdk/jdk/blob/20cb6e786fbf6d924c509e28d6fded86d61a5f84/src/java.net.http/share/classes/jdk/internal/net/http/common/Utils.java#L178-L179

There is a test in the JDK showing that these headers are now available:
https://github.com/openjdk/jdk/blob/20cb6e786fbf6d924c509e28d6fded86d61a5f84/test/jdk/java/net/httpclient/RequestBuilderTest.java#L345-L358

However, users can allow them anyway setting the `jdk.httpclient.allowRestrictedHeaders` property in their net.properties, but I did not include that case into this PR.