### PR TITLE
Using active metrics5 version

### DIFF
--- a/dropwizard-metrics5/pom.xml
+++ b/dropwizard-metrics5/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>io.dropwizard.metrics5</groupId>
       <artifactId>metrics-core</artifactId>
-      <version>5.0.0</version>
+      <version>5.0.0-rc20</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
For some reason, `5.0.0` was released in 2018 and it's untouched since

`5.0.0-rc20` is the actual latest release