### PR TITLE
fix: Response.charset does not support RFC 7231 compliant Content-Type headers using quotation marks as application/json; charset="utf-8"

### DIFF
--- a/core/src/main/java/feign/Response.java
+++ b/core/src/main/java/feign/Response.java
@@ -158,8 +158,8 @@ public final class Response implements Closeable {
 
   /**
    * Nullable and not set when using http/2
-   *
-   * See https://github.com/http2/http2-spec/issues/202
+   * See <a href="https://github.com/http2/http2-spec/issues/202">...</a>
+   * See <a href="https://github.com/http2/http2-spec/issues/202">...</a>
    */
   public String reason() {
     return reason;
@@ -195,6 +195,11 @@ public final class Response implements Closeable {
     return protocolVersion;
   }
 
+  /**
+   * Returns a charset object based on the requests content type. Defaults to UTF-8
+   * See <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.3">rfc7231 - Accept-Charset</a>
+   * See <a href="https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.1.1">rfc7231 - Media Type</a>
+   */
   public Charset charset() {
 
     Collection<String> contentTypeHeaders = headers().get("Content-Type");
@@ -205,7 +210,8 @@ public final class Response implements Closeable {
         if (contentTypeParmeters.length > 1) {
           String[] charsetParts = contentTypeParmeters[1].split("=");
           if (charsetParts.length == 2 && "charset".equalsIgnoreCase(charsetParts[0].trim())) {
-            return Charset.forName(charsetParts[1]);
+            String charsetString = charsetParts[1].replaceAll("\"", "");
+            return Charset.forName(charsetString);
           }
         }
       }
@@ -314,7 +320,7 @@ public final class Response implements Closeable {
     }
 
     @Override
-    public Reader asReader(Charset charset) throws IOException {
+    public Reader asReader(Charset charset) {
       checkNotNull(charset, "charset should not be null");
       return new InputStreamReader(inputStream, charset);
     }
@@ -360,24 +366,24 @@ public final class Response implements Closeable {
     }
 
     @Override
-    public InputStream asInputStream() throws IOException {
+    public InputStream asInputStream() {
       return new ByteArrayInputStream(data);
     }
 
     @SuppressWarnings("deprecation")
     @Override
-    public Reader asReader() throws IOException {
+    public Reader asReader() {
       return new InputStreamReader(asInputStream(), UTF_8);
     }
 
     @Override
-    public Reader asReader(Charset charset) throws IOException {
+    public Reader asReader(Charset charset) {
       checkNotNull(charset, "charset should not be null");
       return new InputStreamReader(asInputStream(), charset);
     }
 
     @Override
-    public void close() throws IOException {}
+    public void close() {}
 
   }
 

--- a/core/src/test/java/feign/ResponseTest.java
+++ b/core/src/test/java/feign/ResponseTest.java
@@ -14,6 +14,8 @@
 package feign;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -57,6 +59,20 @@ class ResponseTest {
         }).hasEntrySatisfying("Content-Type", value -> {
           assertThat(value).contains("application/json");
         });
+  }
+
+  @Test
+  void charsetSupportsMediaTypesWithQuotedCharset() {
+    Map<String, Collection<String>> headersMap = new LinkedHashMap<>();
+    List<String> valueList = Collections.singletonList("application/json; charset=\"utf-8\"");
+    headersMap.put("Content-Type", valueList);
+    Response response = Response.builder()
+            .status(200)
+            .headers(headersMap)
+            .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+            .body(new byte[0])
+            .build();
+    assertThat(response.charset()).isEqualTo(Util.UTF_8);
   }
 
   @Test


### PR DESCRIPTION
Hi,

when migrating from rest template to feign i noticed that the feign Response object does not determine the charset in an RFC compliant way. As this charset() method is used e.g. by the JacksonDecoder class decoding an response with an RFC compliant Content-Type header like `application/json; charset="utf-8"` will fail.

See also:
https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.1.1

> For example, the following
>    examples are all equivalent, but the first is preferred for
>    consistency:
> 
>      text/html;charset=utf-8
>      text/html;charset=UTF-8
>      Text/HTML;Charset="utf-8"
>      text/html; charset="utf-8"