### PR TITLE
Add description for RetryableException

### DIFF
--- a/core/src/main/java/feign/RetryableException.java
+++ b/core/src/main/java/feign/RetryableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 The Feign Authors
+ * Copyright 2012-2024 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/core/src/main/java/feign/RetryableException.java
+++ b/core/src/main/java/feign/RetryableException.java
@@ -31,6 +31,7 @@ public class RetryableException extends FeignException {
 
   /**
    * @param retryAfter usually corresponds to the {@link feign.Util#RETRY_AFTER} header.
+   *                   If you don't want to retry, set null.
    */
   public RetryableException(int status, String message, HttpMethod httpMethod, Throwable cause,
       Long retryAfter, Request request) {
@@ -49,6 +50,7 @@ public class RetryableException extends FeignException {
 
   /**
    * @param retryAfter usually corresponds to the {@link feign.Util#RETRY_AFTER} header.
+   *                   If you don't want to retry, set null.
    */
   public RetryableException(int status, String message, HttpMethod httpMethod, Long retryAfter,
       Request request) {


### PR DESCRIPTION
Hi @velo ,

I've been using `RetryableException`, it's confusing because of last changes.

following issue: https://github.com/OpenFeign/feign/issues/2458

It's not intuitive to me that a Wrapper Long type doesn't retry on null when looking at the constructor.

existing constructors use null inside the constructor for special purposes.

The `overload resolution ambiguity` in the mentioned issue is beyond my control right now, but it would be nice to at least minimize confusion when using the new constructor.

thanks :)