### PR TITLE
Improve Documentation for feign-metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1123,6 +1123,10 @@ But, it's possible to add metric collection capabilities to any feign client.
 
 Metric Capabilities provide a first-class Metrics API that users can tap into to gain insight into the request/response lifecycle.
 
+> **A Note on Metrics modules**:
+>
+> All the metric-integrations are built in separate modules and not available in the `feign-core` module. You will need to add them to your dependencies.
+
 #### Dropwizard Metrics 4
 
 ```


### PR DESCRIPTION
**Problem**

From the current documentation it is not immediately  clear that additional dependencies are needed to make feign metrics work. This can lead to frustration.

**Solution**

Explicitly mention that additional dependencies are needed to make feign-metrics work.