### PR TITLE
Allows adding literal header values to RequestTemplate

### DIFF
--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -729,6 +729,36 @@ public final class RequestTemplate implements Serializable {
   }
 
   /**
+   * @see RequestTemplate#headerLiteral(String, Iterable)
+   */
+  public RequestTemplate headerLiteral(String name, String... values) {
+    if (values == null) {
+      return appendHeader(name, Collections.emptyList(), true);
+    }
+
+    return headerLiteral(name, Arrays.asList(values));
+  }
+
+  /**
+   * Specify a Header, with the specified values. Values are treated as literals. Template
+   * expressions are not resolved.
+   *
+   * @param name of the header.
+   * @param values for this header.
+   * @return a RequestTemplate for chaining.
+   */
+  public RequestTemplate headerLiteral(String name, Iterable<String> values) {
+    if (name == null || name.isEmpty()) {
+      throw new IllegalArgumentException("name is required.");
+    }
+    if (values == null) {
+      values = Collections.emptyList();
+    }
+
+    return appendHeader(name, values, true);
+  }
+
+  /**
    * Clear on reader from {@link RequestTemplate}
    *
    * @param name of the header.

--- a/core/src/main/java/feign/RequestTemplate.java
+++ b/core/src/main/java/feign/RequestTemplate.java
@@ -733,7 +733,7 @@ public final class RequestTemplate implements Serializable {
    */
   public RequestTemplate headerLiteral(String name, String... values) {
     if (values == null) {
-      return appendHeader(name, Collections.emptyList(), true);
+      return headerLiteral(name, Collections.emptyList());
     }
 
     return headerLiteral(name, Arrays.asList(values));

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -247,6 +247,26 @@ public class RequestTemplateTest {
   }
 
   @Test
+  void templateWithEmptyJsonObjectLiteralHeader() {
+    String emptyJsonObject = "{}";
+    RequestTemplate template =
+        new RequestTemplate().method(HttpMethod.GET).headerLiteral("A-Header", emptyJsonObject);
+
+    template.resolve(new LinkedHashMap<>());
+    assertThat(template).hasHeaders(entry("A-Header", Collections.singletonList(emptyJsonObject)));
+  }
+
+  @Test
+  void templateWithTemplateExpressionLiteralHeader() {
+    String header = "{var}";
+    RequestTemplate template =
+        new RequestTemplate().method(HttpMethod.GET).headerLiteral("A-Header", header);
+
+    template = template.resolve(mapOf("var", "value"));
+    assertThat(template).hasHeaders(entry("A-Header", Collections.singletonList(header)));
+  }
+
+  @Test
   void resolveTemplateWithMixedRequestLineParams() {
     RequestTemplate template = new RequestTemplate().method(HttpMethod.GET)//
         .uri("/domains/{domainId}/records")//


### PR DESCRIPTION
This change adds a new method RequestTemplate#headerLiteral which allows adding headers which are not interpreted as Template expressions. This allows adding empty JSON objects to headers in RequestInterceptor implementations.

Fixes #2252, #1987