### PR TITLE
Polish static nested test classes

### DIFF
--- a/core/src/test/java/feign/EnumForNameTest.java
+++ b/core/src/test/java/feign/EnumForNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 The Feign Authors
+ * Copyright 2012-2024 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,15 +16,13 @@ package feign;
 import static feign.Util.enumForName;
 import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Arrays;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import feign.Request.ProtocolVersion;
 
 public class EnumForNameTest {
 
-  @Nested
-  public static class KnownEnumValues {
+  public static class KnownEnumValuesTest {
     public Object name;
     public ProtocolVersion expectedProtocolVersion;
 
@@ -54,8 +52,7 @@ public class EnumForNameTest {
 
   }
 
-  @Nested
-  public static class UnknownEnumValues {
+  public static class UnknownEnumValuesTest {
 
     public Object name;
 

--- a/core/src/test/java/feign/LoggerTest.java
+++ b/core/src/test/java/feign/LoggerTest.java
@@ -45,7 +45,6 @@ public class LoggerTest {
                  @Param("password") String password);
   }
 
-  @Nested
   public static class LogLevelEmitsTest extends LoggerTest {
 
     private Level logLevel;
@@ -98,8 +97,7 @@ public class LoggerTest {
     }
   }
 
-  @Nested
-  public static class ReasonPhraseOptional extends LoggerTest {
+  public static class ReasonPhraseOptionalTest extends LoggerTest {
 
     private Level logLevel;
 
@@ -128,7 +126,6 @@ public class LoggerTest {
     }
   }
 
-  @Nested
   public static class HttpProtocolVersionTest extends LoggerTest {
 
     private Level logLevel;
@@ -174,7 +171,6 @@ public class LoggerTest {
     }
   }
 
-  @Nested
   public static class ReadTimeoutEmitsTest extends LoggerTest {
 
     private Level logLevel;
@@ -231,7 +227,6 @@ public class LoggerTest {
     }
   }
 
-  @Nested
   public static class UnknownHostEmitsTest extends LoggerTest {
 
     private Level logLevel;
@@ -283,7 +278,6 @@ public class LoggerTest {
     }
   }
 
-  @Nested
   public static class FormatCharacterTest extends LoggerTest {
 
     private Level logLevel;
@@ -335,7 +329,6 @@ public class LoggerTest {
     }
   }
 
-  @Nested
   public static class RetryEmitsTest extends LoggerTest {
 
     private Level logLevel;

--- a/core/src/test/java/feign/MethodInfoTest.java
+++ b/core/src/test/java/feign/MethodInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 The Feign Authors
+ * Copyright 2012-2024 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -18,14 +18,12 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 
 
 public class MethodInfoTest {
 
-  @Nested
   static class AsyncClientTest {
     public interface AsyncClient {
       CompletableFuture<String> log();
@@ -39,7 +37,6 @@ public class MethodInfoTest {
     }
   }
 
-  @Nested
   static class GenericAsyncClientTest {
     public interface GenericAsyncClient<T> {
       T log();
@@ -56,7 +53,6 @@ public class MethodInfoTest {
     }
   }
 
-  @Nested
   static class SyncClientTest {
     public interface SyncClient {
       String log();
@@ -70,7 +66,6 @@ public class MethodInfoTest {
     }
   }
 
-  @Nested
   static class GenericSyncClientTest {
     public interface GenericSyncClient<T> {
       T log();

--- a/pom.xml
+++ b/pom.xml
@@ -480,7 +480,7 @@
             <trimStackTrace>false</trimStackTrace>
             <argLine>${jvm.options}</argLine>
             <excludes>
-              <exclude/>
+              <exclude></exclude>
             </excludes>
           </configuration>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -479,6 +479,9 @@
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
             <trimStackTrace>false</trimStackTrace>
             <argLine>${jvm.options}</argLine>
+            <excludes>
+              <exclude/>
+            </excludes>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
IDEA suggested to make some changes:

- Removed `@Nested` annotaion from inner static tests.
`@Nested` annotation is designed for nestsed **non-static** classes. From javadoc:
> @Nested is used to signal that the annotated class is a nested, non-static test class (i.e., an inner class) that can share setup and state with an instance of its enclosing class.

- Renamed some inner classes to have suffix Test.

- Changed exclude configuration in maven-surefire-plugin to execute static nested test classes.
By default plugin excludes all inner classes.
https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#excludes
https://github.com/junit-team/junit5/issues/1377#issuecomment-381964988