### PR TITLE
Remove Content-Type Header when request with empty body POST method

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,6 +815,12 @@ in a context-specific manner -- for example, thread-local storage can be used to
 header values depending on the invoking thread, which can be useful for things such as setting
 thread-specific trace identifiers for requests.
 
+#### Set zero Content-Length Header
+
+To specify `Content-Length: 0` header when making a request with empty body, system property `sun.net.http.allowRestrictedHeaders` should be set to `true`
+
+If not, the `Content-Length` header will not be added.
+
 ### Advanced usage
 
 #### Base Apis

--- a/core/src/main/java/feign/Client.java
+++ b/core/src/main/java/feign/Client.java
@@ -204,19 +204,14 @@ public interface Client {
         connection.addRequestProperty("Accept", "*/*");
       }
 
-      boolean hasEmptyBody = false;
       byte[] body = request.body();
-      if (body == null && request.httpMethod().isWithBody()) {
-        body = new byte[0];
-        hasEmptyBody = true;
-      }
 
       if (body != null) {
         /*
          * Ignore disableRequestBuffering flag if the empty body was set, to ensure that internal
          * retry logic applies to such requests.
          */
-        if (disableRequestBuffering && !hasEmptyBody) {
+        if (disableRequestBuffering) {
           if (contentLength != null) {
             connection.setFixedLengthStreamingMode(contentLength);
           } else {
@@ -239,6 +234,12 @@ public interface Client {
           }
         }
       }
+
+      if (body == null && request.httpMethod().isWithBody()) {
+        // To use this Header, set 'sun.net.http.allowRestrictedHeaders' property true.
+        connection.addRequestProperty("Content-Length", "0");
+      }
+
       return connection;
     }
 

--- a/core/src/test/java/feign/client/DefaultClientTest.java
+++ b/core/src/test/java/feign/client/DefaultClientTest.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.SocketPolicy;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 /** Tests client-specific behavior, such as ensuring Content-Length is sent when specified. */
 public class DefaultClientTest extends AbstractClientTest {
@@ -78,19 +79,41 @@ public class DefaultClientTest extends AbstractClientTest {
     assertThat(exception).hasCauseInstanceOf(ProtocolException.class);
   }
 
+  @Test
   @Override
   public void noResponseBodyForPost() throws Exception {
     super.noResponseBodyForPost();
     MockWebServerAssertions.assertThat(server.takeRequest())
         .hasMethod("POST")
+        .hasNoHeaderNamed("Content-Type");
+  }
+
+  @Test
+  @EnabledIfSystemProperty(named = "sun.net.http.allowRestrictedHeaders", matches = "true")
+  public void noRequestBodyForPostWithAllowRestrictedHeaders() throws Exception {
+    super.noResponseBodyForPost();
+    MockWebServerAssertions.assertThat(server.takeRequest())
+        .hasMethod("POST")
+        .hasNoHeaderNamed("Content-Type")
         .hasHeaders(entry("Content-Length", Collections.singletonList("0")));
   }
 
+  @Test
   @Override
   public void noResponseBodyForPut() throws Exception {
     super.noResponseBodyForPut();
     MockWebServerAssertions.assertThat(server.takeRequest())
         .hasMethod("PUT")
+        .hasNoHeaderNamed("Content-Type");
+  }
+
+  @Test
+  @EnabledIfSystemProperty(named = "sun.net.http.allowRestrictedHeaders", matches = "true")
+  public void noResponseBodyForPutWithAllowRestrictedHeaders() throws Exception {
+    super.noResponseBodyForPut();
+    MockWebServerAssertions.assertThat(server.takeRequest())
+        .hasMethod("PUT")
+        .hasNoHeaderNamed("Content-Type")
         .hasHeaders(entry("Content-Length", Collections.singletonList("0")));
   }
 


### PR DESCRIPTION
Hi.

I have looked [this issue](https://github.com/OpenFeign/feign/issues/2068) and got an idea to deal with.

In current code, convert null body to not null and it write to outputstream.

In that process, when writing empty string in outputstream,  unwanted **Content-Type** Header is added which is ''application/x-www-form-urlencoded".

So, I rearrange null body code to avoid unwanted header.

With this, **Content-Length** header is not set, so I added. But, this header is restricted header so **'sun.net.http.allowRestrictedHeaders'** system property should be true to add content-length header.

And this property should be set before client class loaded. I guess there is no suitable way to inject restricted header to connection.

Feel Free to comment this idea. thanks.