### PR TITLE
refactor(jackson): remove unused imports

### DIFF
--- a/jackson/src/main/java/feign/jackson/JacksonDecoder.java
+++ b/jackson/src/main/java/feign/jackson/JacksonDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2023 The Feign Authors
+ * Copyright 2012-2024 The Feign Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jackson/src/main/java/feign/jackson/JacksonDecoder.java
+++ b/jackson/src/main/java/feign/jackson/JacksonDecoder.java
@@ -17,8 +17,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.lang.reflect.Type;
-import java.nio.charset.Charset;
-import java.util.Collection;
 import java.util.Collections;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.Module;


### PR DESCRIPTION
## Description
* Remove unused imports

## How to review?
* Check in https://github.com/OpenFeign/feign/blob/master/jackson/src/main/java/feign/jackson/JacksonDecoder.java, that it's NOT used
  * `java.nio.charset.Charset`
  * `java.util.Collection` 