### PR TITLE
Fix code scanning alert no. 13: Cross-site scripting

### DIFF
--- a/feign-form-spring/pom.xml
+++ b/feign-form-spring/pom.xml
@@ -36,6 +36,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <version>1.12.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>1.18.34</version>

--- a/feign-form-spring/src/test/java/feign/form/feign/spring/Server.java
+++ b/feign-form-spring/src/test/java/feign/form/feign/spring/Server.java
@@ -22,6 +22,7 @@ import static org.springframework.http.MediaType.APPLICATION_OCTET_STREAM;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 
 import java.io.IOException;
+import org.apache.commons.text.StringEscapeUtils;
 import java.util.Map;
 import lombok.val;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -99,7 +100,7 @@ public class Server {
     String result = "";
     if (popa1 != null && popa2 != null) {
       status = OK;
-      result = new String(popa1.getBytes()) + new String(popa2.getBytes());
+      result = StringEscapeUtils.escapeHtml4(new String(popa1.getBytes())) + StringEscapeUtils.escapeHtml4(new String(popa2.getBytes()));
     }
     return ResponseEntity.status(status).body(result);
   }


### PR DESCRIPTION
Fixes [https://github.com/OpenFeign/feign/security/code-scanning/13](https://github.com/OpenFeign/feign/security/code-scanning/13)

To fix the cross-site scripting vulnerability, we need to ensure that any user-provided data included in the HTTP response is properly sanitized or encoded. In this case, we can use a library like Apache Commons Text to escape the content of the files before including them in the response. This will prevent any malicious scripts from being executed in the user's browser.

1. Add the Apache Commons Text library to the project dependencies if it is not already included.
2. Import the necessary classes from the Apache Commons Text library.
3. Escape the content of the files using `StringEscapeUtils.escapeHtml4` before including them in the `result` variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
