### PR TITLE
Fix code scanning alert no. 12: Cross-site scripting

### DIFF
--- a/feign-form-spring/src/test/java/feign/form/feign/spring/Server.java
+++ b/feign-form-spring/src/test/java/feign/form/feign/spring/Server.java
@@ -22,6 +22,7 @@ import static org.springframework.http.MediaType.APPLICATION_OCTET_STREAM;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 
 import java.io.IOException;
+import org.springframework.web.util.HtmlUtils;
 import java.util.Map;
 import lombok.val;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -80,7 +81,7 @@ public class Server {
       @PathVariable("id") String id,
       @RequestBody Map<String, Object> map,
       @RequestParam String userName) {
-    return userName + ':' + id + ':' + map.size();
+    return HtmlUtils.htmlEscape(userName) + ':' + HtmlUtils.htmlEscape(id) + ':' + map.size();
   }
 
   @PostMapping(path = "/multipart/upload5", consumes = MULTIPART_FORM_DATA_VALUE)


### PR DESCRIPTION
Fixes [https://github.com/OpenFeign/feign/security/code-scanning/12](https://github.com/OpenFeign/feign/security/code-scanning/12)

To fix the cross-site scripting vulnerability, we need to ensure that any user input included in the response is properly sanitized or encoded. In this case, we can use the `HtmlUtils.htmlEscape` method from the `org.springframework.web.util` package to encode the user inputs before concatenating them into the response string. This will prevent any malicious scripts from being executed if the response is rendered in an HTML context.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
