### PR TITLE
Fix code scanning alert no. 8: Cross-site scripting

### DIFF
--- a/feign-form/pom.xml
+++ b/feign-form/pom.xml
@@ -31,6 +31,11 @@
   <name>Open Feign Forms Core</name>
   <dependencies>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <version>1.12.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>1.18.34</version>

--- a/feign-form/src/test/java/feign/form/Server.java
+++ b/feign-form/src/test/java/feign/form/Server.java
@@ -28,6 +28,7 @@ import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import org.apache.commons.text.StringEscapeUtils;
 import lombok.val;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.http.HttpStatus;
@@ -166,8 +167,9 @@ public class Server {
   @PostMapping(path = "/upload/form_data", consumes = MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<String> uploadFormData(@RequestPart("file") MultipartFile file) {
     val status = file != null ? OK : I_AM_A_TEAPOT;
+    String sanitizedFilename = StringEscapeUtils.escapeHtml4(file.getOriginalFilename());
     return ResponseEntity.status(status)
-        .body(file.getOriginalFilename() + ':' + file.getContentType());
+        .body(sanitizedFilename + ':' + file.getContentType());
   }
 
   @PostMapping(path = "/submit/url", consumes = APPLICATION_FORM_URLENCODED_VALUE)


### PR DESCRIPTION
Fixes [https://github.com/OpenFeign/feign/security/code-scanning/8](https://github.com/OpenFeign/feign/security/code-scanning/8)

To fix the cross-site scripting vulnerability, we need to sanitize the user input before including it in the response. The best way to do this is to use a library that provides HTML escaping functionality to ensure that any potentially malicious characters in the filename are properly encoded.

We will:
1. Import the `StringEscapeUtils` class from the Apache Commons Text library.
2. Use the `escapeHtml4` method to sanitize the filename before appending it to the response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
