### PR TITLE
Fix code scanning alert no. 7: Cross-site scripting

### DIFF
--- a/feign-form/pom.xml
+++ b/feign-form/pom.xml
@@ -31,6 +31,11 @@
   <name>Open Feign Forms Core</name>
   <dependencies>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <version>1.12.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>1.18.34</version>

--- a/feign-form/src/test/java/feign/form/Server.java
+++ b/feign-form/src/test/java/feign/form/Server.java
@@ -26,6 +26,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 
 import java.io.IOException;
+import org.apache.commons.text.StringEscapeUtils;
 import java.util.Collection;
 import java.util.List;
 import lombok.val;
@@ -160,7 +161,7 @@ public class Server {
   @PostMapping(path = "/upload/unknown_type", consumes = MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<String> uploadUnknownType(@RequestPart("file") MultipartFile file) {
     val status = file != null ? OK : I_AM_A_TEAPOT;
-    return ResponseEntity.status(status).body(file.getContentType());
+    return ResponseEntity.status(status).body(StringEscapeUtils.escapeHtml4(file.getContentType()));
   }
 
   @PostMapping(path = "/upload/form_data", consumes = MULTIPART_FORM_DATA_VALUE)


### PR DESCRIPTION
Fixes [https://github.com/OpenFeign/feign/security/code-scanning/7](https://github.com/OpenFeign/feign/security/code-scanning/7)

To fix the problem, we need to ensure that the user-provided content type is properly sanitized or encoded before being included in the response. The best way to fix this issue is to use a library that provides HTML encoding to prevent XSS attacks. In Java, the `StringEscapeUtils` class from the Apache Commons Text library can be used for this purpose.

- **General Fix:** Encode the user-provided content type before including it in the response body.
- **Detailed Fix:** Modify the `uploadUnknownType` method to encode the content type using `StringEscapeUtils.escapeHtml4`.
- **Files/Regions/Lines to Change:** Modify lines 161-164 in `feign-form/src/test/java/feign/form/Server.java`.
- **Needed Imports:** Add an import statement for `org.apache.commons.text.StringEscapeUtils`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
