### PR TITLE
Fix code scanning alert no. 6: Cross-site scripting

### DIFF
--- a/feign-form/src/test/java/feign/form/Server.java
+++ b/feign-form/src/test/java/feign/form/Server.java
@@ -26,6 +26,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
 
 import java.io.IOException;
+import org.springframework.web.util.HtmlUtils;
 import java.util.Collection;
 import java.util.List;
 import lombok.val;
@@ -140,7 +141,8 @@ public class Server {
   @PostMapping(path = "/upload/byte_array", consumes = MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<String> uploadByteArray(@RequestPart("file") MultipartFile file) {
     val status = file != null ? OK : I_AM_A_TEAPOT;
-    return ResponseEntity.status(status).body(file.getOriginalFilename());
+    String safeFilename = HtmlUtils.htmlEscape(file.getOriginalFilename());
+    return ResponseEntity.status(status).body(safeFilename);
   }
 
   @PostMapping(path = "/upload/byte_array_parameter", consumes = MULTIPART_FORM_DATA_VALUE)


### PR DESCRIPTION
Fixes [https://github.com/OpenFeign/feign/security/code-scanning/6](https://github.com/OpenFeign/feign/security/code-scanning/6)

To fix the cross-site scripting vulnerability, we need to ensure that any user-controlled input is properly sanitized or encoded before being included in the HTTP response. In this case, we can use the `HtmlUtils.htmlEscape` method from the `org.springframework.web.util` package to escape the filename before including it in the response body. This will prevent any malicious scripts from being executed if the filename is rendered in a web page context.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
