### PR TITLE
Fix receive-pr workflow env

### DIFF
--- a/.github/workflows/receive-pr.yml
+++ b/.github/workflows/receive-pr.yml
@@ -43,7 +43,7 @@ jobs:
       # Execute recipes
       - name: Apply OpenRewrite recipes
         run: ./mvnw -Dtoolchain.skip=true -Dlicense.skip=true -DskipTests=true -P openrewrite clean install
-        secrets:
+        env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       # Capture the diff


### PR DESCRIPTION
In `receive-pr` workflow, change `secrets` to `env` to fix "Invalid workflow file" error