### PR TITLE
Enable Local Build Caching and Apply Optimizations

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -92,10 +92,14 @@ jobs:
         distribution: 'temurin'
         java-version: '21'
 
+    - name: Setup Develocity
+      uses: gradle/develocity-actions/setup-maven@v1.2
+      with:
+        add-pr-comment: false
+        develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+
     - name: Compile project
       run: ./mvnw -B -ntp clean package -Pquickbuild -Dtoolchain.skip=true
-      env:
-        DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/receive-pr.yml
+++ b/.github/workflows/receive-pr.yml
@@ -28,6 +28,11 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
+      - name: Setup Develocity
+        uses: gradle/develocity-actions/setup-maven@v1.2
+        with:
+          add-pr-comment: false
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       # Capture the PR number
       # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
@@ -43,8 +48,6 @@ jobs:
       # Execute recipes
       - name: Apply OpenRewrite recipes
         run: ./mvnw -Dtoolchain.skip=true -Dlicense.skip=true -DskipTests=true -P openrewrite clean install
-        env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       # Capture the diff
       - name: Create patch

--- a/.mvn/.develocity/develocity-workspace-id
+++ b/.mvn/.develocity/develocity-workspace-id
@@ -1,1 +1,0 @@
-h5io2ff2gzdbbjanvoljkzgzra

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -33,7 +33,7 @@
     </buildScan>
     <buildCache>
         <local>
-            <enabled>false</enabled>
+            <enabled>true</enabled>
         </local>
         <remote>
             <enabled>false</enabled>

--- a/pom.xml
+++ b/pom.xml
@@ -536,6 +536,22 @@
             <trimStackTrace>false</trimStackTrace>
           </configuration>
         </plugin>
+
+        <plugin>
+          <groupId>com.gradle</groupId>
+          <artifactId>develocity-maven-extension</artifactId>
+          <configuration>
+            <develocity>
+              <normalization>
+                <runtimeClassPath>
+                  <metaInf>
+                    <ignoreCompletely>true</ignoreCompletely>
+                  </metaInf>
+                </runtimeClassPath>
+              </normalization>
+            </develocity>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
 


### PR DESCRIPTION
Enable local build caching with Develocity, so that goals whose inputs have not changed do not need to be re-executed. This should help reduce local build times when making contributions to Feign (note that it is required to run the clean lifecycle phase - i.e. `./mvnw clean install` vs just `./mvnw install` - to store outputs to the build cache).

Resolve a cache miss by normalizing manifest files so that timestamps in them do not cause goals to be needlessly re-executed. This cache miss was discovered by executing the [Develocity Build Validation Scripts for Maven](https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/main/Maven.md) against the project.

Apply the [develocity-actions/setup-maven](https://github.com/gradle/develocity-actions?tab=readme-ov-file#setup-maven-action) action to help [surface Build Scan links](https://github.com/gradle/develocity-actions?tab=readme-ov-file#workflow-summary)