### PR TITLE
Add gzip and deflate compression support in Http2Client

### DIFF
--- a/core/src/test/java/feign/client/AbstractClientTest.java
+++ b/core/src/test/java/feign/client/AbstractClientTest.java
@@ -127,7 +127,7 @@ public abstract class AbstractClientTest {
   }
 
   @Test
-  void parsesErrorResponse() {
+  public void parsesErrorResponse() {
 
     server.enqueue(new MockResponse().setResponseCode(500).setBody("ARGHH"));
 
@@ -244,7 +244,7 @@ public abstract class AbstractClientTest {
   }
 
   @Test
-  void parsesResponseMissingLength() throws IOException {
+  public void parsesResponseMissingLength() throws IOException {
     server.enqueue(new MockResponse().setChunkedBody("foo", 1));
 
     TestInterface api =
@@ -332,7 +332,7 @@ public abstract class AbstractClientTest {
   }
 
   @Test
-  void defaultCollectionFormat() throws Exception {
+  public void defaultCollectionFormat() throws Exception {
     server.enqueue(new MockResponse().setBody("body"));
 
     TestInterface api =
@@ -349,7 +349,7 @@ public abstract class AbstractClientTest {
   }
 
   @Test
-  void headersWithNullParams() throws InterruptedException {
+  public void headersWithNullParams() throws InterruptedException {
     server.enqueue(new MockResponse().setBody("body"));
 
     TestInterface api =
@@ -367,7 +367,7 @@ public abstract class AbstractClientTest {
   }
 
   @Test
-  void headersWithNotEmptyParams() throws InterruptedException {
+  public void headersWithNotEmptyParams() throws InterruptedException {
     server.enqueue(new MockResponse().setBody("body"));
 
     TestInterface api =
@@ -385,7 +385,7 @@ public abstract class AbstractClientTest {
   }
 
   @Test
-  void alternativeCollectionFormat() throws Exception {
+  public void alternativeCollectionFormat() throws Exception {
     server.enqueue(new MockResponse().setBody("body"));
 
     TestInterface api =

--- a/java11/src/test/java/feign/http2client/test/Http2ClientTest.java
+++ b/java11/src/test/java/feign/http2client/test/Http2ClientTest.java
@@ -32,11 +32,9 @@ import java.io.IOException;
 import java.net.http.HttpTimeoutException;
 import java.util.concurrent.TimeUnit;
 import okhttp3.mockwebserver.MockResponse;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /** Tests client-specific behavior, such as ensuring Content-Length is sent when specified. */
-@Disabled
 public class Http2ClientTest extends AbstractClientTest {
 
   public interface TestInterface {

--- a/java11/src/test/java/feign/http2client/test/Http2ClientTest.java
+++ b/java11/src/test/java/feign/http2client/test/Http2ClientTest.java
@@ -15,23 +15,24 @@
  */
 package feign.http2client.test;
 
+import static feign.Util.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import feign.Body;
-import feign.Feign;
-import feign.FeignException;
-import feign.Headers;
-import feign.Request;
-import feign.RequestLine;
-import feign.Response;
-import feign.Retryer;
+import feign.*;
+import feign.assertj.MockWebServerAssertions;
 import feign.client.AbstractClientTest;
 import feign.http2client.Http2Client;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.http.HttpTimeoutException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.Test;
 
 /** Tests client-specific behavior, such as ensuring Content-Length is sent when specified. */
@@ -57,6 +58,24 @@ public class Http2ClientTest extends AbstractClientTest {
     @RequestLine("DELETE /anything")
     @Body("some request body")
     String deleteWithBody();
+
+    @RequestLine("POST /?foo=bar&foo=baz&qux=")
+    @Headers({"Foo: Bar", "Foo: Baz", "Qux: ", "Content-Type: text/plain"})
+    Response post(String body);
+
+    @RequestLine("GET /")
+    @Headers("Accept: text/plain")
+    String get();
+
+    @RequestLine("GET /?foo={multiFoo}")
+    Response get(@Param("multiFoo") List<String> multiFoo);
+
+    @Headers({"Authorization: {authorization}"})
+    @RequestLine("GET /")
+    Response getWithHeaders(@Param("authorization") String authorization);
+
+    @RequestLine(value = "GET /?foo={multiFoo}", collectionFormat = CollectionFormat.CSV)
+    Response getCSV(@Param("multiFoo") List<String> multiFoo);
   }
 
   @Override
@@ -142,6 +161,148 @@ public class Http2ClientTest extends AbstractClientTest {
         newBuilder().target(TestInterface.class, "https://nghttp2.org/httpbin/");
     String result = api.deleteWithBody();
     assertThat(result).contains("\"data\": \"some request body\"");
+  }
+
+  @Override
+  @Test
+  public void parsesResponseMissingLength() throws IOException {
+    server.enqueue(new MockResponse().setChunkedBody("foo", 1));
+
+    TestInterface api =
+        newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    Response response = api.post("testing");
+    assertThat(response.status()).isEqualTo(200);
+    // assertThat(response.reason()).isEqualTo("OK");
+    assertThat(response.body().length()).isNull();
+    assertThat(response.body().asInputStream())
+        .hasSameContentAs(new ByteArrayInputStream("foo".getBytes(UTF_8)));
+  }
+
+  @Override
+  @Test
+  public void parsesErrorResponse() {
+
+    server.enqueue(new MockResponse().setResponseCode(500).setBody("ARGHH"));
+
+    TestInterface api =
+        newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    Throwable exception = assertThrows(FeignException.class, () -> api.get());
+    assertThat(exception.getMessage())
+        .contains(
+            "[500] during [GET] to [http://localhost:"
+                + server.getPort()
+                + "/] [TestInterface#get()]: [ARGHH]");
+  }
+
+  @Override
+  @Test
+  public void defaultCollectionFormat() throws Exception {
+    server.enqueue(new MockResponse().setBody("body"));
+
+    TestInterface api =
+        newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    Response response = api.get(Arrays.asList("bar", "baz"));
+
+    assertThat(response.status()).isEqualTo(200);
+    // assertThat(response.reason()).isEqualTo("OK");
+
+    MockWebServerAssertions.assertThat(server.takeRequest())
+        .hasMethod("GET")
+        .hasPath("/?foo=bar&foo=baz");
+  }
+
+  @Override
+  @Test
+  public void headersWithNotEmptyParams() throws InterruptedException {
+    server.enqueue(new MockResponse().setBody("body"));
+
+    TestInterface api =
+        newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    Response response = api.getWithHeaders("token");
+
+    assertThat(response.status()).isEqualTo(200);
+    // assertThat(response.reason()).isEqualTo("OK");
+
+    MockWebServerAssertions.assertThat(server.takeRequest())
+        .hasMethod("GET")
+        .hasPath("/")
+        .hasHeaders(entry("authorization", Collections.singletonList("token")));
+  }
+
+  @Override
+  @Test
+  public void headersWithNullParams() throws InterruptedException {
+    server.enqueue(new MockResponse().setBody("body"));
+
+    TestInterface api =
+        newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    Response response = api.getWithHeaders(null);
+
+    assertThat(response.status()).isEqualTo(200);
+    // assertThat(response.reason()).isEqualTo("OK");
+
+    MockWebServerAssertions.assertThat(server.takeRequest())
+        .hasMethod("GET")
+        .hasPath("/")
+        .hasNoHeaderNamed("Authorization");
+  }
+
+  @Test
+  public void alternativeCollectionFormat() throws Exception {
+    server.enqueue(new MockResponse().setBody("body"));
+
+    TestInterface api =
+        newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    Response response = api.getCSV(Arrays.asList("bar", "baz"));
+
+    assertThat(response.status()).isEqualTo(200);
+    // assertThat(response.reason()).isEqualTo("OK");
+
+    // Some HTTP libraries percent-encode commas in query parameters and others
+    // don't.
+    MockWebServerAssertions.assertThat(server.takeRequest())
+        .hasMethod("GET")
+        .hasOneOfPath("/?foo=bar,baz", "/?foo=bar%2Cbaz");
+  }
+
+  @Override
+  @Test
+  public void parsesRequestAndResponse() throws IOException, InterruptedException {
+    server.enqueue(new MockResponse().setBody("foo").addHeader("Foo: Bar"));
+
+    TestInterface api =
+        newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    Response response = api.post("foo");
+
+    assertThat(response.status()).isEqualTo(200);
+    // assertThat(response.reason()).isEqualTo("OK");
+    assertThat(response.headers())
+        .hasEntrySatisfying(
+            "Content-Length",
+            value -> {
+              assertThat(value).contains("3");
+            })
+        .hasEntrySatisfying(
+            "Foo",
+            value -> {
+              assertThat(value).contains("Bar");
+            });
+    assertThat(response.body().asInputStream())
+        .hasSameContentAs(new ByteArrayInputStream("foo".getBytes(UTF_8)));
+
+    RecordedRequest recordedRequest = server.takeRequest();
+    assertThat(recordedRequest.getMethod()).isEqualToIgnoringCase("POST");
+    assertThat(recordedRequest.getHeader("Foo")).isEqualToIgnoringCase("Bar, Baz");
+    assertThat(recordedRequest.getHeader("Accept")).isEqualToIgnoringCase("*/*");
+    assertThat(recordedRequest.getHeader("Content-Length")).isEqualToIgnoringCase("3");
+    assertThat(recordedRequest.getBody().readUtf8()).isEqualToIgnoringCase("foo");
   }
 
   @Override

--- a/java11/src/test/java/feign/http2client/test/Http2ClientTest.java
+++ b/java11/src/test/java/feign/http2client/test/Http2ClientTest.java
@@ -115,12 +115,13 @@ public class Http2ClientTest extends AbstractClientTest {
 
   @Test
   void timeoutTest() {
-    server.enqueue(new MockResponse().setBody("foo").setBodyDelay(30, TimeUnit.SECONDS));
+    server.enqueue(new MockResponse().setBody("foo").setHeadersDelay(1, TimeUnit.SECONDS));
 
     final TestInterface api =
         newBuilder()
             .retryer(Retryer.NEVER_RETRY)
-            .options(new Request.Options(1, TimeUnit.SECONDS, 1, TimeUnit.SECONDS, true))
+            .options(
+                new Request.Options(500, TimeUnit.MILLISECONDS, 500, TimeUnit.MILLISECONDS, true))
             .target(TestInterface.class, server.url("/").toString());
 
     FeignException exception = assertThrows(FeignException.class, () -> api.timeout());


### PR DESCRIPTION
This PR has the following changes in order to add support for **gzip** and **deflate** compression.

- Enable Http2Client tests
- Fix Http2Client `timeoutTest`:
It seems that Java 11 HttpClient timeout stops when response headers are received. https://bugs.openjdk.org/browse/JDK-8208693
So to fix the test I adjust the mock accordingly.
- Override some `AbstractClientTests` as Http2Client does not expose reason phrase:
Java 11 [HttpClient](https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/HttpClient.html) does not expose reason phrase.
- Add gzip and deflate compression support in Http2Client