### PR TITLE
FIX: inreliable JSON asserts in Java 11 project

### DIFF
--- a/java11/pom.xml
+++ b/java11/pom.xml
@@ -62,6 +62,11 @@
       <artifactId>gson</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/java11/src/test/java/feign/http2client/test/Http2ClientTest.java
+++ b/java11/src/test/java/feign/http2client/test/Http2ClientTest.java
@@ -33,7 +33,9 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
+import org.json.JSONException;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 /** Tests client-specific behavior, such as ensuring Content-Length is sent when specified. */
 public class Http2ClientTest extends AbstractClientTest {
@@ -148,19 +150,21 @@ public class Http2ClientTest extends AbstractClientTest {
   }
 
   @Test
-  void getWithRequestBody() {
+  void getWithRequestBody() throws JSONException {
     final TestInterface api =
         newBuilder().target(TestInterface.class, "https://nghttp2.org/httpbin/");
     String result = api.getWithBody();
-    assertThat(result).contains("\"data\": \"some request body\"");
+    String expected = "{ \"data\": \"some request body\" }";
+    JSONAssert.assertEquals(expected, result, false);
   }
 
   @Test
-  void deleteWithRequestBody() {
+  void deleteWithRequestBody() throws JSONException {
     final TestInterface api =
         newBuilder().target(TestInterface.class, "https://nghttp2.org/httpbin/");
     String result = api.deleteWithBody();
-    assertThat(result).contains("\"data\": \"some request body\"");
+    String expected = "{ \"data\": \"some request body\" }";
+    JSONAssert.assertEquals(expected, result, false);
   }
 
   @Override

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -47,7 +47,6 @@
     <dependency>
       <groupId>org.skyscreamer</groupId>
       <artifactId>jsonassert</artifactId>
-      <version>1.5.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,7 @@
     <assertj.version>3.27.3</assertj.version>
     <mockito.version>5.15.2</mockito.version>
     <fastjson2.version>2.0.56</fastjson2.version>
+    <jsonassert.version>1.5.3</jsonassert.version>
 
     <git-code-format-maven-plugin.version>5.3</git-code-format-maven-plugin.version>
     <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
@@ -474,6 +475,12 @@
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2</artifactId>
         <version>${fastjson2.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.skyscreamer</groupId>
+        <artifactId>jsonassert</artifactId>
+        <version>${jsonassert.version}</version>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
After update of some dependencies by dependabot, couple of unrelyable tests in the module Java 11 were broken, making the project unbuildable. Here is the fix.