### PR TITLE
docs(readme): Added java syntax highlighting to metrics code snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1135,7 +1135,7 @@ Metric Capabilities provide a first-class Metrics API that users can tap into to
 
 #### Dropwizard Metrics 4
 
-```
+```java
 public class MyApp {
   public static void main(String[] args) {
     GitHub github = Feign.builder()
@@ -1150,7 +1150,7 @@ public class MyApp {
 
 #### Dropwizard Metrics 5
 
-```
+```java
 public class MyApp {
   public static void main(String[] args) {
     GitHub github = Feign.builder()
@@ -1165,7 +1165,7 @@ public class MyApp {
 
 #### Micrometer
 
-```
+```java
 public class MyApp {
   public static void main(String[] args) {
     GitHub github = Feign.builder()


### PR DESCRIPTION
Hey, I was reading the README's metrics documentation and noticed the code snippets were not consistent with the rest of the README. I figured I would make a drive by fix.

Thanks for the excellent library.