### PR TITLE
bump commons-fileupload to fix CVE-2025-48976 (form-spring)

### DIFF
--- a/form-spring/pom.xml
+++ b/form-spring/pom.xml
@@ -32,6 +32,7 @@
 
   <properties>
     <main.java.version>17</main.java.version>
+    <moditect.skip>true</moditect.skip>
   </properties>
 
   <dependencies>
@@ -64,7 +65,7 @@
     <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
-      <version>1.5</version>
+      <version>1.6.0</version>
       <scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
fixes https://github.com/advisories/GHSA-vv7r-c36w-3prj

It does not seem like form-spring would be affected, but this would fix any of the dumb auditing tools that only look for the presence of libs