### PR TITLE
Add CI profile for optimized continuous integration builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
         run: ./mvnw -ntp -B org.apache.maven.plugins:maven-dependency-plugin:3.8.1:go-offline de.qaware.maven:go-offline-maven-plugin:1.2.8:resolve-dependencies -fn
 
       - name: Build
-        run: ./mvnw -ntp -B clean install
+        run: ./mvnw -ntp -B clean install -T1 -Pci
 
       - name: Verify formatting
         run: scripts/no-git-changes.sh

--- a/pom.xml
+++ b/pom.xml
@@ -1059,6 +1059,32 @@
     </profile>
 
     <profile>
+      <id>ci</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <redirectTestOutputToFile>false</redirectTestOutputToFile>
+              <forkCount>1</forkCount>
+              <reuseForks>false</reuseForks>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <redirectTestOutputToFile>false</redirectTestOutputToFile>
+              <forkCount>1</forkCount>
+              <reuseForks>false</reuseForks>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <id>openrewrite</id>
       <build>
         <plugins>


### PR DESCRIPTION
## Summary
Add a new Maven profile specifically designed for CI environments to improve build stability and test output visibility.

## Changes
- **New Maven profile `ci`**: Configures surefire and failsafe plugins for CI-optimized execution
- **Single-threaded test execution**: Uses `forkCount=1` and `reuseForks=false` to prevent resource contention
- **Enhanced test output**: Sets `redirectTestOutputToFile=false` for better log visibility in CI
- **GitHub Actions integration**: Updated workflow to use `-T1` (single-threaded builds) and `-Pci` profile

## Test plan
- [x] Verify CI profile can be activated locally: `mvn test -Pci`
- [x] Confirm GitHub Actions workflow uses new configuration
- [x] Test output should be visible directly in CI logs
- [x] Single-threaded execution should reduce timing-related test failures

🤖 Generated with [Claude Code](https://claude.ai/code)