### PR TITLE
Re-enable Http2ClientReconnectTest - Need assistance from contributors

### DIFF
--- a/vertx/feign-vertx/src/test/java/feign/vertx/Http2ClientReconnectTest.java
+++ b/vertx/feign-vertx/src/test/java/feign/vertx/Http2ClientReconnectTest.java
@@ -25,11 +25,9 @@ import io.vertx.core.http.PoolOptions;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 
 @DisplayName("Tests of reconnection with HTTP 2")
-@Disabled("Temporarily disabled - requires assistance from contributors familiar with this test")
 class Http2ClientReconnectTest extends AbstractClientReconnectTest {
 
   @BeforeAll

--- a/vertx/feign-vertx4-test/src/test/java/feign/vertx/Http2ClientReconnectTest.java
+++ b/vertx/feign-vertx4-test/src/test/java/feign/vertx/Http2ClientReconnectTest.java
@@ -24,11 +24,9 @@ import io.vertx.core.http.HttpVersion;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 
 @DisplayName("Tests of reconnection with HTTP 2")
-@Disabled("Temporarily disabled - requires assistance from contributors familiar with this test")
 class Http2ClientReconnectTest extends AbstractClientReconnectTest {
 
   @BeforeAll


### PR DESCRIPTION
## Summary
This PR reverts the temporary disabling of `Http2ClientReconnectTest` in both `feign-vertx` and `feign-vertx4-test` modules. 

The test was temporarily disabled in commit 196f282 to prevent build failures, but it should be properly fixed rather than left disabled.

## Need for Assistance

@aklenin (Alexei KLENIN) - Could you please help investigate and fix the issues with the HTTP/2 reconnection tests? Based on the git history, you both have significant experience with this test code:

- Alexei implemented the original WebClient-based architecture in #2756
- Marvin has made several updates to the test infrastructure

## Test Failures
The `Http2ClientReconnectTest` is currently experiencing issues that cause build failures. The test extends `AbstractClientReconnectTest` and specifically tests HTTP/2 reconnection scenarios with:
- Vertx WebClient with HTTP/2 protocol
- Connection pool size limits
- Jackson encoder/decoder integration

## Action Items
- [ ] Investigate root cause of test failures
- [ ] Fix underlying issues with HTTP/2 reconnection logic
- [ ] Ensure tests pass consistently in CI
- [ ] Re-enable the tests

Any assistance in debugging and fixing these tests would be greatly appreciated\!

🤖 Generated with [Claude Code](https://claude.ai/code)