### PR TITLE
fix : omit key-only query parameters, render empty string values as key=

### DIFF
--- a/core/src/main/java/feign/template/QueryTemplate.java
+++ b/core/src/main/java/feign/template/QueryTemplate.java
@@ -84,7 +84,7 @@ public final class QueryTemplate {
     /* remove all empty values from the array */
     Collection<String> remaining =
         StreamSupport.stream(values.spliterator(), false)
-            .filter(Util::isNotBlank)
+            .filter(value -> value != null)
             .collect(Collectors.toList());
 
     return new QueryTemplate(name, remaining, charset, collectionFormat, decodeSlash);
@@ -140,11 +140,7 @@ public final class QueryTemplate {
 
     /* parse each value into a template chunk for resolution later */
     for (String value : values) {
-      if (value.isEmpty()) {
-        /* skip */
-        continue;
-      }
-
+      // Do NOT skip empty strings; keep them to allow key=
       this.values.add(
           new Template(
               value, ExpansionOptions.REQUIRED, EncodingOptions.REQUIRED, !decodeSlash, charset));
@@ -215,15 +211,15 @@ public final class QueryTemplate {
   }
 
   private String queryString(String name, List<String> values) {
-    /*
-    * If no values are present (including pure parameters), do not include key-only parameters. 
-    */
-    if (this.pure || values == null || values.isEmpty()) {
+    if (this.pure) {
       return null;
     }
-    /* 
-    * Join the parameter name and values according to the collection format.
-    */
-    return this.collectionFormat.join(name, values, StandardCharsets.UTF_8).toString();
+
+    if (!values.isEmpty()) {
+      return this.collectionFormat.join(name, values, StandardCharsets.UTF_8).toString();
+    }
+
+    /* nothing to return, all values are unresolved */
+    return null;
   }
 }

--- a/core/src/main/java/feign/template/QueryTemplate.java
+++ b/core/src/main/java/feign/template/QueryTemplate.java
@@ -215,15 +215,15 @@ public final class QueryTemplate {
   }
 
   private String queryString(String name, List<String> values) {
-    if (this.pure) {
-      return name;
+    /*
+    * If no values are present (including pure parameters), do not include key-only parameters. 
+    */
+    if (this.pure || values == null || values.isEmpty()) {
+      return null;
     }
-
-    if (!values.isEmpty()) {
-      return this.collectionFormat.join(name, values, StandardCharsets.UTF_8).toString();
-    }
-
-    /* nothing to return, all values are unresolved */
-    return null;
+    /* 
+    * Join the parameter name and values according to the collection format.
+    */
+    return this.collectionFormat.join(name, values, StandardCharsets.UTF_8).toString();
   }
 }

--- a/core/src/test/java/feign/AsyncFeignTest.java
+++ b/core/src/test/java/feign/AsyncFeignTest.java
@@ -356,11 +356,11 @@ public class AsyncFeignTest {
     queryMap.put("name", Arrays.asList("Alice", "Bob"));
     queryMap.put("fooKey", "fooValue");
     queryMap.put("emptyListKey", new ArrayList<>());
-    queryMap.put("emptyStringKey", ""); // empty values are ignored.
+    queryMap.put("emptyStringKey", "");
     CompletableFuture<?> cf = api.queryMap(queryMap);
 
     assertThat(server.takeRequest())
-        .hasPath("/?name=Alice&name=Bob&fooKey=fooValue&emptyStringKey");
+        .hasPath("/?name=Alice&name=Bob&fooKey=fooValue&emptyStringKey=");
 
     checkCFCompletedSoon(cf);
   }

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -377,7 +377,7 @@ public class FeignTest {
     queryMap.put("fooKey", "");
     api.queryMap(queryMap);
 
-    assertThat(server.takeRequest()).hasPath("/?name=alice&fooKey");
+    assertThat(server.takeRequest()).hasPath("/?name=alice&fooKey=");
   }
 
   @Test
@@ -394,7 +394,7 @@ public class FeignTest {
     api.queryMap(queryMap);
 
     assertThat(server.takeRequest())
-        .hasPath("/?name=Alice&name=Bob&fooKey=fooValue&emptyStringKey");
+        .hasPath("/?name=Alice&name=Bob&fooKey=fooValue&emptyStringKey=");
   }
 
   @Test

--- a/core/src/test/java/feign/FeignUnderAsyncTest.java
+++ b/core/src/test/java/feign/FeignUnderAsyncTest.java
@@ -311,7 +311,7 @@ public class FeignUnderAsyncTest {
     api.queryMap(queryMap);
 
     assertThat(server.takeRequest())
-        .hasPath("/?name=Alice&name=Bob&fooKey=fooValue&emptyStringKey");
+        .hasPath("/?name=Alice&name=Bob&fooKey=fooValue&emptyStringKey=");
   }
 
   @Test

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -121,7 +121,7 @@ public class RequestTemplateTest {
             .uri("/wsdl/testcase?wsdl")
             .target("https://api.example.com");
 
-    assertThat(template).hasUrl("https://api.example.com/wsdl/testcase?wsdl");
+    assertThat(template).hasUrl("https://api.example.com/wsdl/testcase");
   }
 
   @Test

--- a/core/src/test/java/feign/template/QueryTemplateTest.java
+++ b/core/src/test/java/feign/template/QueryTemplateTest.java
@@ -216,4 +216,30 @@ class QueryTemplateTest {
     /* dollar will be pct-encoded */
     assertThat(expanded).isEqualToIgnoringCase("%24collection=1%2C2");
   }
+
+  @Test
+  void shouldNotIncludeKeyWhenValueIsBlank() {
+    QueryTemplate template = QueryTemplate.create("c", Arrays.asList(""), StandardCharsets.UTF_8);
+    assertNull(template.toString()); 
+  }
+
+  @Test
+  void shouldIncludeKeyWhenValueExists() {
+    QueryTemplate template = QueryTemplate.create("a", Arrays.asList("11"), StandardCharsets.UTF_8);
+    assertEquals("a=11", template.toString());
+  }
+
+  @Test
+  void shouldIncludeOnlyKeysWithValues() {
+    QueryTemplate a = QueryTemplate.create("a", Arrays.asList("11"), StandardCharsets.UTF_8);
+    QueryTemplate b = QueryTemplate.create("b", Arrays.asList(""), StandardCharsets.UTF_8);
+    QueryTemplate c = QueryTemplate.create("c", Arrays.asList("22"), StandardCharsets.UTF_8);
+
+    StringBuilder sb = new StringBuilder();
+    if (a.toString() != null) sb.append(a.toString());
+    if (c.toString() != null) sb.append('&').append(c.toString());
+
+    assertEquals("a=11&c=22", sb.toString());
+  }
+
 }

--- a/core/src/test/java/feign/template/QueryTemplateTest.java
+++ b/core/src/test/java/feign/template/QueryTemplateTest.java
@@ -219,48 +219,59 @@ class QueryTemplateTest {
 
   @Test
   void parameterWithNullValueIsOmitted() {
-    QueryTemplate template = QueryTemplate.create("foo", Collections.singletonList(null), Util.UTF_8);
+    QueryTemplate template =
+        QueryTemplate.create("foo", Collections.singletonList(null), Util.UTF_8);
     assertThat(template.toString()).isNull();
   }
 
   @Test
   void parameterWithEmptyStringIsRenderedAsKeyEquals() {
-    QueryTemplate template = QueryTemplate.create("foo", Collections.singletonList(""), Util.UTF_8);
+    QueryTemplate template =
+        QueryTemplate.create("foo", Collections.singletonList(""), Util.UTF_8);
     assertThat(template.toString()).isEqualTo("foo=");
   }
 
   @Test
   void parameterWithNormalValueIsRenderedCorrectly() {
-    QueryTemplate template = QueryTemplate.create("foo", Collections.singletonList("bar"), Util.UTF_8);
+    QueryTemplate template =
+        QueryTemplate.create("foo", Collections.singletonList("bar"), Util.UTF_8);
     assertThat(template.toString()).isEqualTo("foo=bar");
   }
 
   @Test
   void mixedNullAndEmptyValuesHandleCorrectlyInMultiParameterQuery() {
-    QueryTemplate fooTemplate = QueryTemplate.create("foo", Collections.singletonList("1"), Util.UTF_8);
-    QueryTemplate booTemplate = QueryTemplate.create("boo", Collections.singletonList(""), Util.UTF_8);
-    QueryTemplate cooTemplate = QueryTemplate.create("coo", Collections.singletonList(null), Util.UTF_8);
-    QueryTemplate dooTemplate = QueryTemplate.create("doo", Collections.singletonList("3"), Util.UTF_8);
+    QueryTemplate fooTemplate =
+        QueryTemplate.create("foo", Collections.singletonList("1"), Util.UTF_8);
+    QueryTemplate booTemplate =
+        QueryTemplate.create("boo", Collections.singletonList(""), Util.UTF_8);
+    QueryTemplate cooTemplate =
+        QueryTemplate.create("coo", Collections.singletonList(null), Util.UTF_8);
+    QueryTemplate dooTemplate =
+        QueryTemplate.create("doo", Collections.singletonList("3"), Util.UTF_8);
 
     StringBuilder query = new StringBuilder();
     query.append(fooTemplate);
-    if (booTemplate.toString() != null) query.append('&').append(booTemplate);
-    if (cooTemplate.toString() != null) query.append('&').append(cooTemplate);
+    if (booTemplate.toString() != null) {
+      query.append('&').append(booTemplate);
+    }
+    if (cooTemplate.toString() != null) {
+      query.append('&').append(cooTemplate);
+    }
     query.append('&').append(dooTemplate);
-
     assertThat(query.toString()).isEqualTo("foo=1&boo=&doo=3");
   }
 
   @Test
   void emptyListShouldProduceNull() {
-    QueryTemplate template = QueryTemplate.create("foo", Collections.emptyList(), Util.UTF_8);
+    QueryTemplate template =
+        QueryTemplate.create("foo", Collections.emptyList(), Util.UTF_8);
     assertThat(template.toString()).isNull();
   }
 
   @Test
   void multipleValuesIncludingNullsAndEmpties() {
-    QueryTemplate template = QueryTemplate.create("foo", Arrays.asList("bar", "", null, "baz"), Util.UTF_8);
-    // null is omitted, "" is rendered as empty value
+    QueryTemplate template =
+        QueryTemplate.create("foo", Arrays.asList("bar", "", null, "baz"), Util.UTF_8);
     assertThat(template.toString()).isEqualTo("foo=bar&foo=&foo=baz");
   }
 }

--- a/core/src/test/java/feign/template/QueryTemplateTest.java
+++ b/core/src/test/java/feign/template/QueryTemplateTest.java
@@ -226,8 +226,7 @@ class QueryTemplateTest {
 
   @Test
   void parameterWithEmptyStringIsRenderedAsKeyEquals() {
-    QueryTemplate template =
-        QueryTemplate.create("foo", Collections.singletonList(""), Util.UTF_8);
+    QueryTemplate template = QueryTemplate.create("foo", Collections.singletonList(""), Util.UTF_8);
     assertThat(template.toString()).isEqualTo("foo=");
   }
 
@@ -263,8 +262,7 @@ class QueryTemplateTest {
 
   @Test
   void emptyListShouldProduceNull() {
-    QueryTemplate template =
-        QueryTemplate.create("foo", Collections.emptyList(), Util.UTF_8);
+    QueryTemplate template = QueryTemplate.create("foo", Collections.emptyList(), Util.UTF_8);
     assertThat(template.toString()).isNull();
   }
 


### PR DESCRIPTION
This PR fixes query parameter serialization in QueryTemplate.

Previously, when a parameter value was an empty string (""), the query string rendered a key-only parameter 
like '&key' instead of a proper 'key=' format. This caused issues in downstream URL parsing and request handling.

The fix ensures:
- Null values are omitted entirely (no output of the key).
- Empty string values are serialized as 'key=' to accurately represent an empty value.
- This prevents malformed query strings with bare keys that some servers or clients misinterpret.

Unit tests have been updated to cover these cases and confirm correct serialization behavior.