### PR TITLE
Upgrade Spring versions to latest stable releases

### DIFF
--- a/form-spring/pom.xml
+++ b/form-spring/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
-      <version>6.1.21</version>
+      <version>6.2.11</version>
       <scope>compile</scope>
     </dependency>
 
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-openfeign</artifactId>
-      <version>4.1.4</version>
+      <version>4.3.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
     <moshi.version>1.15.2</moshi.version>
     <slf4j.version>2.0.17</slf4j.version>
     <json.version>20250517</json.version>
-    <springboot.version>3.3.5</springboot.version>
+    <springboot.version>3.5.6</springboot.version>
 
     <junit5.version>6.0.0</junit5.version>
     <jackson.version>2.19.2</jackson.version>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -31,7 +31,7 @@
 
   <properties>
     <main.java.version>17</main.java.version>
-    <spring.version>6.1.21</spring.version>
+    <spring.version>6.2.11</spring.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## Summary
Upgraded all Spring-related dependencies to their latest stable versions to ensure compatibility and access to latest features and security fixes.

## Changes
- **Spring Boot**: 3.3.5 → 3.5.6
- **Spring Framework 6**: 6.1.21 → 6.2.11  
- **Spring Cloud OpenFeign**: 4.1.4 → 4.3.0

## Files Modified
- `pom.xml` - Updated Spring Boot version property
- `spring/pom.xml` - Updated Spring Framework 6 version
- `form-spring/pom.xml` - Updated Spring Web and Spring Cloud OpenFeign versions

## Issue Fixed
The build was failing in `feign-form-spring` module due to `NoSuchMethodError` for `CollectionUtils.newLinkedHashSet(int)` which was removed in Spring Framework 6.2. This has been resolved by updating to compatible versions.

## Test Plan
- [x] Full build passes: `./mvnw clean install -Pdev -Dtoolchain.skip`
- [x] All 49 modules built successfully
- [x] All tests pass including previously failing `feign-form-spring` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)