### PR TITLE
docs(feign): add detailed javadoc for RequestLine annotation parameters

### DIFF
--- a/core/src/main/java/feign/RequestLine.java
+++ b/core/src/main/java/feign/RequestLine.java
@@ -32,15 +32,14 @@ public @interface RequestLine {
 
   /**
    * The HTTP request line, including the method and an optional URI template.
-   * <p>
-   * The string must begin with a valid {@linkplain feign.Request.HttpMethod HTTP method name} (e.g.
-   * {@linkplain feign.Request.HttpMethod#GET GET}, {@linkplain feign.Request.HttpMethod#POST POST},
-   * {@linkplain feign.Request.HttpMethod#PUT PUT}), followed by a space and a URI template. If only
-   * the HTTP method is specified (e.g. {@code "DELETE"}), the request will use the base URL defined
-   * for the client.
    *
-   * <p>
-   * Example:
+   * <p>The string must begin with a valid {@linkplain feign.Request.HttpMethod HTTP method name}
+   * (e.g. {@linkplain feign.Request.HttpMethod#GET GET}, {@linkplain feign.Request.HttpMethod#POST
+   * POST}, {@linkplain feign.Request.HttpMethod#PUT PUT}), followed by a space and a URI template.
+   * If only the HTTP method is specified (e.g. {@code "DELETE"}), the request will use the base URL
+   * defined for the client.
+   *
+   * <p>Example:
    *
    * <pre>{@code @RequestLine("GET /repos/{owner}/{repo}")
    * Repo getRepo(@Param("owner") String owner, @Param("repo") String repo);
@@ -55,40 +54,37 @@ public @interface RequestLine {
    * Controls whether percent-encoded forward slashes ({@code %2F}) in expanded path variables are
    * decoded back to {@code '/'} before sending the request.
    *
-   * <p>
-   * When {@code true} (the default), any {@code %2F} sequences produced during URI template
+   * <p>When {@code true} (the default), any {@code %2F} sequences produced during URI template
    * expansion will be replaced with literal slashes, meaning that path variables containing slashes
    * will be interpreted as multiple path segments.
    *
-   * <p>
-   * When {@code false}, percent-encoded slashes ({@code %2F}) are preserved in the final URL. This
-   * is useful when a path variable intentionally includes a slash as part of its value (for
+   * <p>When {@code false}, percent-encoded slashes ({@code %2F}) are preserved in the final URL.
+   * This is useful when a path variable intentionally includes a slash as part of its value (for
    * example, an encoded identifier such as {@code "foo%2Fbar"}).
    *
-   * <p>
-   * Example:
+   * <p>Example:
    *
    * <pre>{@code @RequestLine(value = "GET /projects/{id}", decodeSlash = false)
    * Project getProject(@Param("id") String encodedId);
    * }</pre>
    *
    * @return {@code true} if encoded slashes should be decoded (default behavior); {@code false} to
-   *         preserve {@code %2F} sequences in the URL.
+   *     preserve {@code %2F} sequences in the URL.
    */
   boolean decodeSlash() default true;
 
   /**
    * Specifies how collections (e.g. {@link java.util.List List} or arrays) are serialized when
    * expanded into the URI template.
-   * <p>
-   * Determines whether values are represented as exploded parameters (repeated keys) or as a single
-   * comma-separated value, depending on the chosen {@link feign.CollectionFormat}.
    *
-   * <p>
-   * Example:
+   * <p>Determines whether values are represented as exploded parameters (repeated keys) or as a
+   * single comma-separated value, depending on the chosen {@link feign.CollectionFormat}.
+   *
+   * <p>Example:
+   *
    * <ul>
-   * <li>{@linkplain CollectionFormat#EXPLODED EXPLODED}: {@code /items?id=1&id=2&id=3}</li>
-   * <li>{@linkplain CollectionFormat#CSV CSV}: {@code /items?id=1,2,3}</li>
+   *   <li>{@linkplain CollectionFormat#EXPLODED EXPLODED}: {@code /items?id=1&id=2&id=3}
+   *   <li>{@linkplain CollectionFormat#CSV CSV}: {@code /items?id=1,2,3}
    * </ul>
    *
    * @return the collection serialization format to use when expanding templates.


### PR DESCRIPTION
I noticed that the `decodeSlash` parameter was not immediately clear _(at least to me)_, and the Javadoc did not provide any explanation. While the repository's README.md mentions it, it’s convenient to have this information available directly in the IDE

This PR adds detailed Javadoc for all three parameters of the `@RequestLine` annotation (`value`, `decodeSlash`, and `collectionFormat`), including examples and relevant links. All comments are formatted according to [Eclipse Java Google Style](https://raw.githubusercontent.com/google/styleguide/gh-pages/eclipse-java-google-style.xml)

> Sorry for not discussing it first in an issue, as HACKING.md suggests, I just believe this way it's a little more straightforward and the PR can immediately get rejected or modified if needed and integrated :)