### PR TITLE
build(deps): update Jersey to 4.0.0 in jaxrs4 module

### DIFF
--- a/jaxrs4/pom.xml
+++ b/jaxrs4/pom.xml
@@ -31,7 +31,7 @@
 
   <properties>
     <main.java.version>17</main.java.version>
-    <jersey.version>4.0.0-M1</jersey.version>
+    <jersey.version>4.0.0</jersey.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Updates Jersey from 4.0.0-M1 (milestone) to 4.0.0 (stable release) in the jaxrs4 module only.

This PR correctly targets only the jaxrs4 module which uses Jakarta JAX-RS API 4.0.0. The other JAX-RS modules (jaxrs2 and jaxrs3) remain on their respective Jersey versions compatible with their JAX-RS API levels.

Closes #3104 (Dependabot's PR tried to update all modules which was incompatible)