### PR TITLE
build(deps): update Vert.x to 5.0.5 in vertx5-test module

### DIFF
--- a/vertx/feign-vertx5-test/pom.xml
+++ b/vertx/feign-vertx5-test/pom.xml
@@ -30,7 +30,7 @@
   <description>Tests with Vertx 5.x.</description>
 
   <properties>
-    <vertx.version>5.0.4</vertx.version>
+    <vertx.version>5.0.5</vertx.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Updates Vert.x from 5.0.4 to 5.0.5 in the feign-vertx5-test module only.

This PR correctly targets only the vertx5-test module which is specifically for testing with Vert.x 5.x. The vertx4-test module remains on Vert.x 4.x as intended.

Closes #3090 (Dependabot's PR tried to update both modules which was incompatible)