### PR TITLE
Fix Slf4jLogger and JavaLogger returning unbuffered response when logging disabled

### DIFF
--- a/core/src/main/java/feign/Logger.java
+++ b/core/src/main/java/feign/Logger.java
@@ -230,10 +230,7 @@ public abstract class Logger {
     @Override
     protected Response logAndRebufferResponse(
         String configKey, Level logLevel, Response response, long elapsedTime) throws IOException {
-      if (logger.isLoggable(java.util.logging.Level.FINE)) {
-        return super.logAndRebufferResponse(configKey, logLevel, response, elapsedTime);
-      }
-      return response;
+      return super.logAndRebufferResponse(configKey, logLevel, response, elapsedTime);
     }
 
     @Override

--- a/core/src/test/java/feign/JavaLoggerTest.java
+++ b/core/src/test/java/feign/JavaLoggerTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign;
+
+import feign.Logger.JavaLogger;
+import feign.Request.HttpMethod;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.logging.Level;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class JavaLoggerTest {
+
+  private static final String CONFIG_KEY = "TestApi#testMethod()";
+  private java.util.logging.Logger julLogger;
+  private JavaLogger logger;
+
+  @BeforeEach
+  void setUp() {
+    julLogger = java.util.logging.Logger.getLogger(JavaLoggerTest.class.getName());
+    logger = new JavaLogger(JavaLoggerTest.class);
+  }
+
+  @Test
+  void rebuffersResponseBodyWhenJulLevelIsInfo() throws Exception {
+    // given
+    julLogger.setLevel(Level.INFO);
+    Response responseWithBody =
+        Response.builder()
+            .status(200)
+            .reason("OK")
+            .request(
+                Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .body("{\"error\":\"test\"}", Util.UTF_8)
+            .build();
+
+    // when
+    Response result =
+        logger.logAndRebufferResponse(
+            CONFIG_KEY, feign.Logger.Level.HEADERS, responseWithBody, 273);
+
+    // then
+    String body1 = Util.toString(result.body().asReader(Util.UTF_8));
+    String body2 = Util.toString(result.body().asReader(Util.UTF_8));
+    assert body1.equals("{\"error\":\"test\"}") : "First read should return body content";
+    assert body2.equals("{\"error\":\"test\"}") : "Second read should return same body content";
+  }
+
+  @Test
+  void rebuffersResponseBodyWhenJulLevelIsWarning() throws Exception {
+    // given
+    julLogger.setLevel(Level.WARNING);
+    Response responseWithBody =
+        Response.builder()
+            .status(500)
+            .reason("Internal Server Error")
+            .request(
+                Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .body("{\"message\":\"error details\"}", Util.UTF_8)
+            .build();
+
+    // when
+    Response result =
+        logger.logAndRebufferResponse(CONFIG_KEY, feign.Logger.Level.FULL, responseWithBody, 100);
+
+    // then
+    byte[] bodyBytes = Util.toByteArray(result.body().asInputStream());
+    assert new String(bodyBytes, Util.UTF_8).equals("{\"message\":\"error details\"}")
+        : "Body should be readable after rebuffering";
+  }
+
+  @Test
+  void responseBodyReadableMultipleTimesForErrorDecoder() throws Exception {
+    // given
+    julLogger.setLevel(Level.SEVERE);
+    String originalBody = "{\"errorCode\":\"E001\",\"message\":\"Validation failed\"}";
+    Response responseWithBody =
+        Response.builder()
+            .status(400)
+            .reason("Bad Request")
+            .request(
+                Request.create(
+                    HttpMethod.POST, "/api/submit", Collections.emptyMap(), null, Util.UTF_8))
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .body(originalBody, Util.UTF_8)
+            .build();
+
+    // when
+    Response result =
+        logger.logAndRebufferResponse(
+            CONFIG_KEY, feign.Logger.Level.HEADERS, responseWithBody, 150);
+
+    // then
+    String read1 = Util.toString(result.body().asReader(Util.UTF_8));
+    String read2 = Util.toString(result.body().asReader(Util.UTF_8));
+    String read3 = Util.toString(result.body().asReader(Util.UTF_8));
+    assert read1.equals(originalBody) : "First read should match original body";
+    assert read2.equals(originalBody) : "Second read should match original body";
+    assert read3.equals(originalBody) : "Third read should match original body";
+  }
+}

--- a/core/src/test/java/feign/LoggerRebufferTest.java
+++ b/core/src/test/java/feign/LoggerRebufferTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import feign.Request.HttpMethod;
+import java.util.Collection;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+public class LoggerRebufferTest {
+
+  private static final String CONFIG_KEY = "TestApi#testMethod()";
+
+  private static class TestLogger extends Logger {
+    @Override
+    protected void log(String configKey, String format, Object... args) {}
+  }
+
+  @Test
+  void headersLevelRebuffersResponseBody() throws Exception {
+    // given
+    TestLogger logger = new TestLogger();
+    String originalBody = "{\"status\":\"error\",\"message\":\"Not found\"}";
+    Response response =
+        Response.builder()
+            .status(404)
+            .reason("Not Found")
+            .request(
+                Request.create(
+                    HttpMethod.GET, "/api/resource", Collections.emptyMap(), null, Util.UTF_8))
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .body(originalBody, Util.UTF_8)
+            .build();
+
+    // when
+    Response result =
+        logger.logAndRebufferResponse(CONFIG_KEY, Logger.Level.HEADERS, response, 100);
+
+    // then
+    String read1 = Util.toString(result.body().asReader(Util.UTF_8));
+    String read2 = Util.toString(result.body().asReader(Util.UTF_8));
+    assertEquals(originalBody, read1, "First read should return original body");
+    assertEquals(originalBody, read2, "Second read should return same body (rebuffered)");
+  }
+
+  @Test
+  void basicLevelDoesNotRebufferResponseBody() throws Exception {
+    // given
+    TestLogger logger = new TestLogger();
+    String originalBody = "{\"status\":\"ok\"}";
+    Response response =
+        Response.builder()
+            .status(200)
+            .reason("OK")
+            .request(
+                Request.create(
+                    HttpMethod.GET, "/api/resource", Collections.emptyMap(), null, Util.UTF_8))
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .body(originalBody, Util.UTF_8)
+            .build();
+
+    // when
+    Response result = logger.logAndRebufferResponse(CONFIG_KEY, Logger.Level.BASIC, response, 100);
+
+    // then
+    String read1 = Util.toString(result.body().asReader(Util.UTF_8));
+    assertEquals(originalBody, read1, "First read should return original body");
+  }
+
+  @Test
+  void fullLevelRebuffersResponseBody() throws Exception {
+    // given
+    TestLogger logger = new TestLogger();
+    String originalBody = "{\"data\":{\"id\":123,\"name\":\"test\"}}";
+    Response response =
+        Response.builder()
+            .status(200)
+            .reason("OK")
+            .request(
+                Request.create(
+                    HttpMethod.POST, "/api/create", Collections.emptyMap(), null, Util.UTF_8))
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .body(originalBody, Util.UTF_8)
+            .build();
+
+    // when
+    Response result = logger.logAndRebufferResponse(CONFIG_KEY, Logger.Level.FULL, response, 50);
+
+    // then
+    String read1 = Util.toString(result.body().asReader(Util.UTF_8));
+    String read2 = Util.toString(result.body().asReader(Util.UTF_8));
+    String read3 = Util.toString(result.body().asReader(Util.UTF_8));
+    assertEquals(originalBody, read1, "First read should return original body");
+    assertEquals(originalBody, read2, "Second read should return same body");
+    assertEquals(originalBody, read3, "Third read should return same body");
+  }
+
+  @Test
+  void noneLevelDoesNotRebufferResponseBody() throws Exception {
+    // given
+    TestLogger logger = new TestLogger();
+    String originalBody = "{\"result\":\"success\"}";
+    Response response =
+        Response.builder()
+            .status(200)
+            .reason("OK")
+            .request(
+                Request.create(
+                    HttpMethod.GET, "/api/status", Collections.emptyMap(), null, Util.UTF_8))
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .body(originalBody, Util.UTF_8)
+            .build();
+
+    // When
+    Response result = logger.logAndRebufferResponse(CONFIG_KEY, Logger.Level.NONE, response, 100);
+
+    // then
+    String read1 = Util.toString(result.body().asReader(Util.UTF_8));
+    assertEquals(originalBody, read1, "Body should be readable");
+  }
+
+  @Test
+  void http204DoesNotRebufferEvenAtHeadersLevel() throws Exception {
+    // given
+    TestLogger logger = new TestLogger();
+    Response response =
+        Response.builder()
+            .status(204)
+            .reason("No Content")
+            .request(
+                Request.create(
+                    HttpMethod.DELETE, "/api/resource/1", Collections.emptyMap(), null, Util.UTF_8))
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .body("should be ignored", Util.UTF_8)
+            .build();
+
+    // when
+    Response result =
+        logger.logAndRebufferResponse(CONFIG_KEY, Logger.Level.HEADERS, response, 100);
+
+    // then
+    assertNotNull(result.body(), "Response body object should exist");
+  }
+
+  @Test
+  void http205DoesNotRebufferEvenAtHeadersLevel() throws Exception {
+    // given
+    TestLogger logger = new TestLogger();
+    Response response =
+        Response.builder()
+            .status(205)
+            .reason("Reset Content")
+            .request(
+                Request.create(
+                    HttpMethod.POST, "/api/form", Collections.emptyMap(), null, Util.UTF_8))
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .body("should be ignored", Util.UTF_8)
+            .build();
+
+    // when
+    Response result =
+        logger.logAndRebufferResponse(CONFIG_KEY, Logger.Level.HEADERS, response, 100);
+
+    // then
+    assertNotNull(result.body(), "Response body object should exist");
+  }
+
+  @Test
+  void nullBodyHandledCorrectlyAtHeadersLevel() throws Exception {
+    // given
+    TestLogger logger = new TestLogger();
+    Response response =
+        Response.builder()
+            .status(200)
+            .reason("OK")
+            .request(
+                Request.create(
+                    HttpMethod.HEAD, "/api/resource", Collections.emptyMap(), null, Util.UTF_8))
+            .headers(Collections.<String, Collection<String>>emptyMap())
+            .body((byte[]) null)
+            .build();
+
+    // when
+    Response result =
+        logger.logAndRebufferResponse(CONFIG_KEY, Logger.Level.HEADERS, response, 100);
+
+    // then
+    assertNull(result.body(), "Body should remain null");
+  }
+}

--- a/slf4j/src/main/java/feign/slf4j/Slf4jLogger.java
+++ b/slf4j/src/main/java/feign/slf4j/Slf4jLogger.java
@@ -56,10 +56,7 @@ public class Slf4jLogger extends feign.Logger {
   @Override
   protected Response logAndRebufferResponse(
       String configKey, Level logLevel, Response response, long elapsedTime) throws IOException {
-    if (logger.isDebugEnabled()) {
-      return super.logAndRebufferResponse(configKey, logLevel, response, elapsedTime);
-    }
-    return response;
+    return super.logAndRebufferResponse(configKey, logLevel, response, elapsedTime);
   }
 
   @Override


### PR DESCRIPTION
@velo 

### Problem

`Slf4jLogger` and `JavaLogger` currently behave differently depending on the logging level.

When the SLF4J level is set to `INFO` or higher (or `java.util.logging` is above `FINE`),  
`logAndRebufferResponse()` does not delegate to `super.logAndRebufferResponse()`.  
As a result, the response body is not rebuffered and remains a one-time `InputStream`.

This leads to several practical issues:

- `ErrorDecoder` implementations cannot reliably read the response body from error responses
- Calling `response.body().toString()` returns an instance reference (e.g. `feign@...`) instead of the actual content
- Application behavior varies across environments with different logging configurations

---

### Solution

Always delegate to `super.logAndRebufferResponse()`, regardless of the logger’s runtime level.

This ensures that response buffering follows Feign’s `Logger.Level` consistently and is no longer affected by SLF4J or JUL configuration differences.

---

### Result

- Response bodies are always rebuffered when `Logger.Level >= HEADERS`, regardless of SLF4J or JUL logging levels
- Consistent behavior is guaranteed across environments
- `ErrorDecoder` can reliably read response bodies

---

### Changes

- **`Slf4jLogger`**: Removed conditional logic in `logAndRebufferResponse()` and always delegate to `super`

---

### Behavioral Impact

**Memory usage**

- Response bodies are now buffered in memory when `Logger.Level` is `HEADERS` or `FULL`, even if the underlying SLF4J / JUL level is `INFO` or higher

---

All existing tests pass.

I’m happy to adjust this approach if there are alternative suggestions or concerns from the maintainers.

---

### Alternative Approach Considered

**Option: Lazy buffering with `LazyBufferedBody`**

As an alternative to eager buffering, we also considered introducing a `LazyBufferedBody` wrapper that would:

- Wrap non-repeatable streams when `Logger.Level >= HEADERS`
- Buffer the body into memory only on first access (for example, by an `ErrorDecoder`)
- Avoid allocating memory when the response body is never read

This approach could reduce memory usage in some cases, especially when response bodies are rarely accessed.

The current implementation is not meant to assert that eager rebuffering is the only or best solution.  
Rather, it serves as a concrete proposal to make the existing behavior consistent.

If maintainers prefer a different approach—such as lazy buffering—I’m happy to adjust the implementation based on that feedback.


Fixes #1336
