### PR TITLE
Set graphql module to Java 17, apply var and clean up imports

### DIFF
--- a/graphql/pom.xml
+++ b/graphql/pom.xml
@@ -29,6 +29,10 @@
   <name>Feign GraphQL</name>
   <description>Feign GraphQL runtime support for declarative GraphQL clients</description>
 
+  <properties>
+    <main.java.version>17</main.java.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/graphql/src/main/java/feign/graphql/GraphqlContract.java
+++ b/graphql/src/main/java/feign/graphql/GraphqlContract.java
@@ -19,7 +19,6 @@ import feign.Contract;
 import feign.Request.HttpMethod;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class GraphqlContract extends Contract.Default {
@@ -35,14 +34,14 @@ public class GraphqlContract extends Contract.Default {
     super.registerMethodAnnotation(
         GraphqlQuery.class,
         (annotation, data) -> {
-          String query = annotation.value();
+          var query = annotation.value();
 
           if (data.template().method() == null) {
             data.template().method(HttpMethod.POST);
             data.template().uri("/");
           }
 
-          String variableName = extractFirstVariable(query);
+          var variableName = extractFirstVariable(query);
           metadata.put(data.configKey(), new QueryMetadata(query, variableName));
         });
   }
@@ -62,8 +61,8 @@ public class GraphqlContract extends Contract.Default {
         if (braceCount == 1) {
           inOperation = true;
         } else if (braceCount == 2 && inOperation) {
-          String prefix = query.substring(0, i).trim();
-          Matcher m = OPERATION_FIELD_PATTERN.matcher(prefix + "{");
+          var prefix = query.substring(0, i).trim();
+          var m = OPERATION_FIELD_PATTERN.matcher(prefix + "{");
           if (m.find()) {
             return m.group(1);
           }
@@ -73,7 +72,7 @@ public class GraphqlContract extends Contract.Default {
       }
     }
 
-    Matcher m = OPERATION_FIELD_PATTERN.matcher(query);
+    var m = OPERATION_FIELD_PATTERN.matcher(query);
     if (m.find()) {
       return m.group(1);
     }
@@ -81,7 +80,7 @@ public class GraphqlContract extends Contract.Default {
   }
 
   static String extractFirstVariable(String query) {
-    Matcher m = VARIABLE_PATTERN.matcher(query);
+    var m = VARIABLE_PATTERN.matcher(query);
     if (m.find()) {
       return m.group(1);
     }

--- a/graphql/src/main/java/feign/graphql/GraphqlDecoder.java
+++ b/graphql/src/main/java/feign/graphql/GraphqlDecoder.java
@@ -22,9 +22,7 @@ import feign.Util;
 import feign.codec.Decoder;
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.Reader;
 import java.lang.reflect.Type;
-import java.util.Iterator;
 
 public class GraphqlDecoder implements Decoder {
 
@@ -57,39 +55,39 @@ public class GraphqlDecoder implements Decoder {
       return null;
     }
 
-    Reader reader = response.body().asReader(response.charset());
+    var reader = response.body().asReader(response.charset());
     if (!reader.markSupported()) {
       reader = new BufferedReader(reader, 1);
     }
 
-    JsonNode root = mapper.readTree(reader);
+    var root = mapper.readTree(reader);
 
-    JsonNode errorsNode = root.path("errors");
+    var errorsNode = root.path("errors");
     if (!errorsNode.isMissingNode() && errorsNode.isArray() && !errorsNode.isEmpty()) {
-      String operationField = resolveOperationField(root, response);
+      var operationField = resolveOperationField(root, response);
       throw new GraphqlErrorException(
           response.status(), operationField, errorsNode.toString(), response.request());
     }
 
-    JsonNode dataNode = root.path("data");
+    var dataNode = root.path("data");
     if (dataNode.isMissingNode() || dataNode.isNull() || !dataNode.isObject()) {
       return Util.emptyValueOf(type);
     }
 
-    Iterator<String> fieldNames = dataNode.fieldNames();
+    var fieldNames = dataNode.fieldNames();
     if (!fieldNames.hasNext()) {
       return Util.emptyValueOf(type);
     }
 
-    String firstField = fieldNames.next();
-    JsonNode operationData = dataNode.get(firstField);
+    var firstField = fieldNames.next();
+    var operationData = dataNode.get(firstField);
     if (operationData == null || operationData.isNull()) {
       return Util.emptyValueOf(type);
     }
 
     if (delegate != null) {
-      byte[] dataBytes = mapper.writeValueAsBytes(operationData);
-      Response dataResponse =
+      var dataBytes = mapper.writeValueAsBytes(operationData);
+      var dataResponse =
           Response.builder()
               .status(response.status())
               .reason(response.reason())
@@ -104,9 +102,9 @@ public class GraphqlDecoder implements Decoder {
   }
 
   private String resolveOperationField(JsonNode root, Response response) {
-    JsonNode dataNode = root.path("data");
+    var dataNode = root.path("data");
     if (!dataNode.isMissingNode() && dataNode.isObject()) {
-      Iterator<String> names = dataNode.fieldNames();
+      var names = dataNode.fieldNames();
       if (names.hasNext()) {
         return names.next();
       }
@@ -114,8 +112,8 @@ public class GraphqlDecoder implements Decoder {
 
     if (response.request() != null && response.request().body() != null) {
       try {
-        JsonNode requestBody = mapper.readTree(response.request().body());
-        String query = requestBody.path("query").asText(null);
+        var requestBody = mapper.readTree(response.request().body());
+        var query = requestBody.path("query").asText(null);
         if (query != null) {
           return GraphqlContract.extractOperationField(query);
         }

--- a/graphql/src/main/java/feign/graphql/GraphqlEncoder.java
+++ b/graphql/src/main/java/feign/graphql/GraphqlEncoder.java
@@ -36,17 +36,17 @@ public class GraphqlEncoder implements Encoder, RequestInterceptor {
   @Override
   public void encode(Object object, Type bodyType, RequestTemplate template)
       throws EncodeException {
-    GraphqlContract.QueryMetadata meta = lookupMetadata(template);
+    var meta = lookupMetadata(template);
     if (meta == null) {
       delegate.encode(object, bodyType, template);
       return;
     }
 
-    Map<String, Object> graphqlBody = new LinkedHashMap<>();
+    var graphqlBody = new LinkedHashMap<String, Object>();
     graphqlBody.put("query", meta.query);
 
     if (object != null && meta.variableName != null) {
-      Map<String, Object> variables = new LinkedHashMap<>();
+      var variables = new LinkedHashMap<String, Object>();
       variables.put(meta.variableName, object);
       graphqlBody.put("variables", variables);
     }
@@ -60,12 +60,12 @@ public class GraphqlEncoder implements Encoder, RequestInterceptor {
       return;
     }
 
-    GraphqlContract.QueryMetadata meta = lookupMetadata(template);
+    var meta = lookupMetadata(template);
     if (meta == null) {
       return;
     }
 
-    Map<String, Object> graphqlBody = new LinkedHashMap<>();
+    var graphqlBody = new LinkedHashMap<String, Object>();
     graphqlBody.put("query", meta.query);
 
     delegate.encode(graphqlBody, MAP_STRING_WILDCARD, template);


### PR DESCRIPTION
## Summary
- Set `main.java.version` to 17 for the graphql module (aligns with graphql-apt which already requires Java 17)
- Apply `var` throughout main sources (GraphqlContract, GraphqlDecoder, GraphqlEncoder)
- Remove unused imports (`Matcher`, `Reader`, `Iterator`)

## Test plan
- [x] `mvn clean test -pl graphql` — all 27 tests pass