### PR TITLE
Add japicmp-maven-plugin for API compatibility checks

### DIFF
--- a/apt-test-generator/pom.xml
+++ b/apt-test-generator/pom.xml
@@ -33,6 +33,7 @@
   <properties>
     <main.java.version>17</main.java.version>
     <moditect.skip>true</moditect.skip>
+    <japicmp.skip>true</japicmp.skip>
   </properties>
 
   <dependencies>
@@ -82,63 +83,7 @@
   </dependencies>
 
   <build>
-    <resources>
-      <resource>
-        <targetPath>docker</targetPath>
-        <filtering>true</filtering>
-        <!-- Replace maven properties in the docker file so we can get artifacts etc -->
-        <directory>${project.basedir}/docker</directory>
-      </resource>
-      <!-- need to manually specify the resources to copy because we have a manual setting above -->
-      <resource>
-        <directory>${basedir}/src/main/resources</directory>
-      </resource>
-      <resource>
-        <directory>src/main/java</directory>
-        <includes>
-          <include>**/*.java</include>
-        </includes>
-      </resource>
-    </resources>
-
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>${maven-shade-plugin.version}</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>feign.aptgenerator.github.GitHubFactoryExample</mainClass>
-                </transformer>
-              </transformers>
-              <createDependencyReducedPom>false</createDependencyReducedPom>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.skife.maven</groupId>
-        <artifactId>really-executable-jar-maven-plugin</artifactId>
-        <version>${really-executable-jar-maven-plugin.version}</version>
-        <configuration>
-          <programFile>github</programFile>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>really-executable-jar</goal>
-            </goals>
-            <phase>package</phase>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
@@ -148,40 +93,6 @@
               <goal>integration-test</goal>
               <goal>verify</goal>
             </goals>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <!-- used to create docker images -->
-        <groupId>com.spotify</groupId>
-        <artifactId>docker-maven-plugin</artifactId>
-        <version>${docker-maven-plugin.version}</version>
-        <configuration>
-          <!-- docker file copied here after maven replaces properties -->
-          <dockerDirectory>${project.build.directory}/classes/docker/</dockerDirectory>
-
-          <!-- Pull image before build, otherwise end up with image not found if it was never downloaded before -->
-          <pullOnBuild>true</pullOnBuild>
-
-          <serverId>docker-hub</serverId>
-          <registryUrl>https://index.docker.io/v1/</registryUrl>
-          <imageName>feign-apt-generator/test</imageName>
-          <resources>
-            <resource>
-              <targetPath>/</targetPath>
-              <directory>${project.build.directory}</directory>
-              <include>${project.artifactId}-${project.version}.jar</include>
-            </resource>
-          </resources>
-        </configuration>
-        <executions>
-          <!-- see definition of how this runs above -->
-          <execution>
-            <goals>
-              <goal>build</goal>
-            </goals>
-            <phase>post-integration-test</phase>
           </execution>
         </executions>
       </plugin>

--- a/core/src/main/java/feign/Client.java
+++ b/core/src/main/java/feign/Client.java
@@ -61,7 +61,7 @@ public interface Client {
   }
 
   /** Client that supports a {@link java.net.Proxy}. */
-  class Proxied extends DefaultClient {
+  class Proxied extends Default {
 
     public static final String PROXY_AUTHORIZATION = "Proxy-Authorization";
     private final Proxy proxy;

--- a/graphql/src/main/java/feign/graphql/GraphqlContract.java
+++ b/graphql/src/main/java/feign/graphql/GraphqlContract.java
@@ -16,11 +16,13 @@
 package feign.graphql;
 
 import feign.DefaultContract;
+import feign.Experimental;
 import feign.Request.HttpMethod;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
+@Experimental
 public class GraphqlContract extends DefaultContract {
 
   private static final Pattern OPERATION_FIELD_PATTERN =

--- a/graphql/src/main/java/feign/graphql/GraphqlDecoder.java
+++ b/graphql/src/main/java/feign/graphql/GraphqlDecoder.java
@@ -15,6 +15,7 @@
  */
 package feign.graphql;
 
+import feign.Experimental;
 import feign.Response;
 import feign.Util;
 import feign.codec.Decoder;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+@Experimental
 public class GraphqlDecoder implements Decoder {
 
   private final JsonDecoder jsonDecoder;

--- a/graphql/src/main/java/feign/graphql/GraphqlEncoder.java
+++ b/graphql/src/main/java/feign/graphql/GraphqlEncoder.java
@@ -15,6 +15,7 @@
  */
 package feign.graphql;
 
+import feign.Experimental;
 import feign.RequestInterceptor;
 import feign.RequestTemplate;
 import feign.codec.EncodeException;
@@ -23,6 +24,7 @@ import java.lang.reflect.Type;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+@Experimental
 public class GraphqlEncoder implements Encoder, RequestInterceptor {
 
   private final Encoder delegate;

--- a/graphql/src/main/java/feign/graphql/GraphqlErrorException.java
+++ b/graphql/src/main/java/feign/graphql/GraphqlErrorException.java
@@ -15,9 +15,11 @@
  */
 package feign.graphql;
 
+import feign.Experimental;
 import feign.FeignException;
 import feign.Request;
 
+@Experimental
 public class GraphqlErrorException extends FeignException {
 
   private final String operation;

--- a/graphql/src/main/java/feign/graphql/GraphqlQuery.java
+++ b/graphql/src/main/java/feign/graphql/GraphqlQuery.java
@@ -15,11 +15,13 @@
  */
 package feign.graphql;
 
+import feign.Experimental;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+@Experimental
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface GraphqlQuery {

--- a/graphql/src/main/java/feign/graphql/GraphqlSchema.java
+++ b/graphql/src/main/java/feign/graphql/GraphqlSchema.java
@@ -15,11 +15,13 @@
  */
 package feign.graphql;
 
+import feign.Experimental;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+@Experimental
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.TYPE)
 public @interface GraphqlSchema {

--- a/graphql/src/main/java/feign/graphql/Scalar.java
+++ b/graphql/src/main/java/feign/graphql/Scalar.java
@@ -15,11 +15,13 @@
  */
 package feign.graphql;
 
+import feign.Experimental;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+@Experimental
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface Scalar {

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,7 @@
     <rewrite-maven-plugin.version>6.30.0</rewrite-maven-plugin.version>
     <rewrite-testing-frameworks.version>3.28.0</rewrite-testing-frameworks.version>
     <rewrite-migrate-java.version>3.28.0</rewrite-migrate-java.version>
+    <japicmp-maven-plugin.version>0.25.4</japicmp-maven-plugin.version>
     <java18-signature.version>1.0</java18-signature.version>
 
     <!-- Third-party dependency versions -->
@@ -921,6 +922,38 @@
                 </requireNoRepositories>
               </rules>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.github.siom79.japicmp</groupId>
+        <artifactId>japicmp-maven-plugin</artifactId>
+        <version>${japicmp-maven-plugin.version}</version>
+        <configuration>
+          <parameter>
+            <ignoreMissingOldVersion>true</ignoreMissingOldVersion>
+            <onlyModified>true</onlyModified>
+            <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
+            <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
+            <breakBuildBasedOnSemanticVersioning>true</breakBuildBasedOnSemanticVersioning>
+            <ignoreMissingClasses>true</ignoreMissingClasses>
+            <excludeModules>
+              <excludeModule>feign-example-.*</excludeModule>
+              <excludeModule>feign-benchmark</excludeModule>
+            </excludeModules>
+            <excludes>
+              <exclude>@feign.Experimental</exclude>
+              <exclude>feign.graphql</exclude>
+            </excludes>
+            <accessModifier>public</accessModifier>
+          </parameter>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>cmp</goal>
+            </goals>
+            <phase>verify</phase>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
## Summary
- Add japicmp-maven-plugin to enforce binary and source compatibility against the latest released version
- Fix binary incompatibility in `Client.Proxied` (superclass changed from `Client.Default` to `DefaultClient`)
- Remove unnecessary shade, really-executable-jar, and docker plugins from `apt-test-generator` module
- Mark all graphql module classes as `@Experimental`

## Details

**japicmp configuration:**
- Breaks the build on binary/source incompatible modifications
- Enforces semantic versioning
- Excludes example modules, benchmark, `@feign.Experimental` annotated classes, and `feign.graphql` package
- Skipped for `apt-test-generator` (build tool, not a library)
- Already respected by `quickbuild` profile (`japicmp.skip=true`)

**Binary compatibility fix:**
- `Client.Proxied` now extends `Client.Default` again (instead of `DefaultClient` directly), preserving the class hierarchy from 13.9

**apt-test-generator cleanup:**
- Removed shade plugin, really-executable-jar plugin, docker plugin, and docker resource config (dead code — docker directory doesn't even exist)

**GraphQL module:**
- Added `@Experimental` to all public classes since the module's API is still evolving

## Test plan
- [x] `mvn verify -DskipTests` passes across all modules (except pre-existing `form` lombok issue)
- [x] `mvn test -pl core,graphql` passes