### PR TITLE
Make GraphqlContract composable with any Contract

### DIFF
--- a/graphql/pom.xml
+++ b/graphql/pom.xml
@@ -58,5 +58,12 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>feign-spring</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/graphql/src/main/java/feign/graphql/GraphqlContract.java
+++ b/graphql/src/main/java/feign/graphql/GraphqlContract.java
@@ -15,35 +15,61 @@
  */
 package feign.graphql;
 
+import feign.Contract;
 import feign.DefaultContract;
+import feign.Experimental;
+import feign.MethodMetadata;
 import feign.Request.HttpMethod;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
-public class GraphqlContract extends DefaultContract {
+@Experimental
+public class GraphqlContract implements Contract {
 
   private static final Pattern OPERATION_FIELD_PATTERN =
       Pattern.compile("\\{\\s*(\\w+)\\s*[({]", Pattern.DOTALL);
 
   private static final Pattern VARIABLE_PATTERN = Pattern.compile("\\$\\s*(\\w+)\\s*:");
 
+  private final Contract delegate;
   private final Map<String, QueryMetadata> metadata = new ConcurrentHashMap<>();
 
   public GraphqlContract() {
-    super.registerMethodAnnotation(
-        GraphqlQuery.class,
-        (annotation, data) -> {
-          var query = annotation.value();
+    this.delegate = new GraphqlAwareDefaultContract(metadata);
+  }
 
-          if (data.template().method() == null) {
-            data.template().method(HttpMethod.POST);
-            data.template().uri("/");
-          }
+  public GraphqlContract(Contract delegate) {
+    this.delegate = delegate;
+  }
 
-          var variableName = extractFirstVariable(query);
-          metadata.put(data.configKey(), new QueryMetadata(query, variableName));
-        });
+  @Override
+  public List<MethodMetadata> parseAndValidateMetadata(Class<?> targetType) {
+    List<MethodMetadata> metadataList = delegate.parseAndValidateMetadata(targetType);
+    if (!(delegate instanceof GraphqlAwareDefaultContract)) {
+      for (MethodMetadata md : metadataList) {
+        processGraphqlQuery(md);
+      }
+    }
+    return metadataList;
+  }
+
+  private void processGraphqlQuery(MethodMetadata md) {
+    GraphqlQuery graphqlQuery = md.method().getAnnotation(GraphqlQuery.class);
+    if (graphqlQuery == null) {
+      return;
+    }
+
+    var query = graphqlQuery.value();
+
+    if (md.template().method() == null) {
+      md.template().method(HttpMethod.POST);
+      md.template().uri("/");
+    }
+
+    var variableName = extractFirstVariable(query);
+    metadata.put(md.configKey(), new QueryMetadata(query, variableName));
   }
 
   Map<String, QueryMetadata> queryMetadata() {
@@ -85,6 +111,25 @@ public class GraphqlContract extends DefaultContract {
       return m.group(1);
     }
     return null;
+  }
+
+  private static class GraphqlAwareDefaultContract extends DefaultContract {
+
+    GraphqlAwareDefaultContract(Map<String, QueryMetadata> metadata) {
+      registerMethodAnnotation(
+          GraphqlQuery.class,
+          (annotation, data) -> {
+            var query = annotation.value();
+
+            if (data.template().method() == null) {
+              data.template().method(HttpMethod.POST);
+              data.template().uri("/");
+            }
+
+            var variableName = GraphqlContract.extractFirstVariable(query);
+            metadata.put(data.configKey(), new QueryMetadata(query, variableName));
+          });
+    }
   }
 
   static class QueryMetadata {

--- a/graphql/src/test/java/feign/graphql/GraphqlSpringContractTest.java
+++ b/graphql/src/test/java/feign/graphql/GraphqlSpringContractTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.Feign;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import feign.spring.SpringContract;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+class GraphqlSpringContractTest {
+
+  private final ObjectMapper mapper =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  private MockWebServer server;
+
+  public static class User {
+    public String id;
+    public String name;
+    public String email;
+  }
+
+  interface SpringGraphqlApi {
+
+    @PostMapping(value = "/graphql", consumes = "application/json")
+    @GraphqlQuery("query getUser($id: String!) { getUser(id: $id) { id name email } }")
+    User getUser(String id);
+
+    @PostMapping(value = "/graphql", consumes = "application/json")
+    @GraphqlQuery("query getUser($id: String!) { getUser(id: $id) { id name email } }")
+    User getUserWithAuth(@RequestHeader("Authorization") String auth, String id);
+  }
+
+  @BeforeEach
+  void setUp() throws Exception {
+    server = new MockWebServer();
+    server.start();
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    server.shutdown();
+  }
+
+  private SpringGraphqlApi buildClient() {
+    var contract = new GraphqlContract(new SpringContract());
+    var graphqlEncoder = new GraphqlEncoder(new JacksonEncoder(mapper), contract);
+    return Feign.builder()
+        .contract(contract)
+        .encoder(graphqlEncoder)
+        .decoder(new GraphqlDecoder(new JacksonDecoder(mapper)))
+        .requestInterceptor(graphqlEncoder)
+        .target(SpringGraphqlApi.class, server.url("/").toString());
+  }
+
+  @Test
+  void queryWithSpringContract() throws Exception {
+    server.enqueue(
+        new MockResponse()
+            .setBody(
+                "{\"data\":{\"getUser\":{\"id\":\"1\",\"name\":\"Bob\",\"email\":\"bob@test.com\"}}}")
+            .addHeader("Content-Type", "application/json"));
+
+    var user = buildClient().getUser("1");
+
+    assertThat(user.id).isEqualTo("1");
+    assertThat(user.name).isEqualTo("Bob");
+
+    var recorded = server.takeRequest();
+    assertThat(recorded.getMethod()).isEqualTo("POST");
+    assertThat(recorded.getPath()).isEqualTo("/graphql");
+    var body = mapper.readTree(recorded.getBody().readUtf8());
+    assertThat(body.get("query").asText()).contains("getUser");
+    assertThat(body.get("variables").get("id").asText()).isEqualTo("1");
+  }
+
+  @Test
+  void authHeaderWithSpringContract() throws Exception {
+    server.enqueue(
+        new MockResponse()
+            .setBody(
+                "{\"data\":{\"getUser\":{\"id\":\"1\",\"name\":\"Bob\",\"email\":\"bob@test.com\"}}}")
+            .addHeader("Content-Type", "application/json"));
+
+    var user = buildClient().getUserWithAuth("Bearer mytoken", "1");
+
+    assertThat(user.id).isEqualTo("1");
+
+    var recorded = server.takeRequest();
+    assertThat(recorded.getHeader("Authorization")).isEqualTo("Bearer mytoken");
+  }
+}


### PR DESCRIPTION
## Summary
- Refactor `GraphqlContract` from extending `DefaultContract` to implementing `Contract` directly (decorator pattern)
- Add constructor that accepts any `Contract` implementation, enabling composition with Spring, JAX-RS, or custom contracts
- No-arg constructor maintains backward compatibility via internal `GraphqlAwareDefaultContract`

## Design

`GraphqlContract` now works as a decorator:

```java
// Default behavior (backward compatible) - uses Feign's @RequestLine, @Headers, @Param
var contract = new GraphqlContract();

// Compose with Spring MVC annotations
var contract = new GraphqlContract(new SpringContract());

// Compose with JAX-RS annotations
var contract = new GraphqlContract(new JAXRSContract());
```

When using a custom delegate contract, methods annotated with `@GraphqlQuery` must also use the delegate's HTTP method annotation (e.g., `@PostMapping` for Spring, `@POST` for JAX-RS). `@GraphqlQuery` adds GraphQL semantics (query metadata, variable extraction) on top of the delegate's HTTP configuration.

## Test plan
- [x] All existing `GraphqlClientTest` tests pass (backward compatible)
- [x] New `GraphqlSpringContractTest` verifies composition with `SpringContract`