### PR TITLE
fix: remove static ExecutorService in AsyncFeign to prevent ClassLoader leak

### DIFF
--- a/core/src/main/java/feign/AsyncFeign.java
+++ b/core/src/main/java/feign/AsyncFeign.java
@@ -55,23 +55,18 @@ public final class AsyncFeign<C> {
     return builder();
   }
 
-  private static class LazyInitializedExecutorService {
-
-    private static final ExecutorService instance =
-        Executors.newCachedThreadPool(
-            r -> {
-              final Thread result = new Thread(r);
-              result.setDaemon(true);
-              return result;
-            });
-  }
-
   public static class AsyncBuilder<C> extends BaseBuilder<AsyncBuilder<C>, AsyncFeign<C>> {
 
     private AsyncContextSupplier<C> defaultContextSupplier = () -> null;
     private AsyncClient<C> client =
         new DefaultAsyncClient<>(
-            new DefaultClient(null, null), LazyInitializedExecutorService.instance);
+            new DefaultClient(null, null),
+            Executors.newCachedThreadPool(
+                r -> {
+                  final Thread result = new Thread(r);
+                  result.setDaemon(true);
+                  return result;
+                }));
     private MethodInfoResolver methodInfoResolver = MethodInfo::new;
 
     @Deprecated

--- a/core/src/test/java/feign/AsyncFeignTest.java
+++ b/core/src/test/java/feign/AsyncFeignTest.java
@@ -1377,4 +1377,23 @@ public class AsyncFeignTest {
   void afterEachTest() throws IOException {
     server.close();
   }
+
+  /**
+   * Verifies that {@link AsyncFeign} has no static singleton {@link ExecutorService}.
+   * A static executor retains a strong reference to the thread's ContextClassLoader,
+   * causing ClassLoader leaks on servlet container redeployment (Metaspace OOM).
+   *
+   * @see <a href="https://github.com/OpenFeign/feign/issues/3178">Issue #3178</a>
+   */
+  @Test
+  void asyncFeignHasNoStaticExecutorService() throws Exception {
+    boolean hasStaticExecutor =
+        java.util.Arrays.stream(AsyncFeign.class.getDeclaredClasses())
+            .flatMap(c -> java.util.Arrays.stream(c.getDeclaredFields()))
+            .anyMatch(
+                f ->
+                    java.lang.reflect.Modifier.isStatic(f.getModifiers())
+                        && ExecutorService.class.isAssignableFrom(f.getType()));
+    assertThat(hasStaticExecutor).isFalse();
+  }
 }


### PR DESCRIPTION
## Problem

`AsyncFeign` held a static singleton `ExecutorService` via `LazyInitializedExecutorService`:

```java
private static class LazyInitializedExecutorService {
  private static final ExecutorService instance =
      Executors.newCachedThreadPool(r -> {
        final Thread result = new Thread(r);
        result.setDaemon(true);
        return result;
      });
}
```

In servlet containers (Tomcat, Jetty, etc.), redeploying an application does not restart the JVM. The static thread pool holds a strong reference to the `ContextClassLoader` of the first deployment. On each redeployment:
- The old `ClassLoader` is never GC'd (retained by the static thread pool's threads)
- Thread count grows linearly
- Metaspace eventually exhausts → `OutOfMemoryError`

Setting threads as daemon only helps at JVM exit — it does not prevent ClassLoader leaks during hot-redeploy.

## Fix

Remove `LazyInitializedExecutorService` entirely. `AsyncBuilder.client` is now initialized with a fresh `Executors.newCachedThreadPool(...)` per builder instance. This means:
- Each `AsyncFeign.builder()` creates its own independent executor
- When the client is discarded, the executor becomes eligible for GC
- Users who need lifecycle control or sharing can supply their own via `.client(AsyncClient)`

## Testing

Added `asyncFeignHasNoStaticExecutorService()` to `AsyncFeignTest` — uses reflection to assert that no `static` field of type `ExecutorService` exists in any inner class of `AsyncFeign`.

Fixes #3178