### PR TITLE
feat(graphql-apt): honor @deprecated schema directive with class/method overrides

### DIFF
--- a/graphql-apt/src/main/java/feign/graphql/apt/GraphqlSchemaProcessor.java
+++ b/graphql-apt/src/main/java/feign/graphql/apt/GraphqlSchemaProcessor.java
@@ -419,6 +419,7 @@ public class GraphqlSchemaProcessor extends AbstractProcessor {
             rawAnnotations,
             annotation.useOptional(),
             annotation.useAliasForFieldNames(),
+            annotation.generateDeprecated(),
             classFieldAnnotations,
             nonNullFqns,
             nonNullRaw);
@@ -436,6 +437,7 @@ public class GraphqlSchemaProcessor extends AbstractProcessor {
         config.annotations(),
         config.useOptional(),
         config.useAliasForFieldNames(),
+        config.generateDeprecated(),
         config.fieldAnnotations(),
         config.nonNullAnnotations());
   }
@@ -455,6 +457,7 @@ public class GraphqlSchemaProcessor extends AbstractProcessor {
     var methodRaw = annotation.rawTypeAnnotations();
     var methodOptionalToggle = annotation.useOptional();
     var methodAliasToggle = annotation.useAliasForFieldNames();
+    var methodDeprecatedToggle = annotation.generateDeprecated();
 
     var useOptional =
         methodOptionalToggle == Toggle.INHERIT
@@ -464,6 +467,10 @@ public class GraphqlSchemaProcessor extends AbstractProcessor {
         methodAliasToggle == Toggle.INHERIT
             ? classConfig.useAliasForFieldNames()
             : methodAliasToggle == Toggle.TRUE;
+    var generateDeprecated =
+        methodDeprecatedToggle == Toggle.INHERIT
+            ? classConfig.generateDeprecated()
+            : methodDeprecatedToggle == Toggle.TRUE;
 
     var methodFieldAnnotations = extractFieldAnnotations(method);
     var fieldAnnotations =
@@ -479,6 +486,7 @@ public class GraphqlSchemaProcessor extends AbstractProcessor {
     if (!hasMethodAnnotations && !hasMethodNonNull) {
       if (useOptional == classConfig.useOptional()
           && useAliasForFieldNames == classConfig.useAliasForFieldNames()
+          && generateDeprecated == classConfig.generateDeprecated()
           && fieldAnnotations.equals(classConfig.fieldAnnotations())) {
         return classConfig;
       }
@@ -491,6 +499,7 @@ public class GraphqlSchemaProcessor extends AbstractProcessor {
           classConfig.annotations(),
           useOptional,
           useAliasForFieldNames,
+          generateDeprecated,
           fieldAnnotations,
           classConfig.nonNullAnnotations());
     }
@@ -503,6 +512,7 @@ public class GraphqlSchemaProcessor extends AbstractProcessor {
             methodRaw,
             useOptional,
             useAliasForFieldNames,
+            generateDeprecated,
             fieldAnnotations,
             nonNullFqns,
             nonNullRaw);
@@ -515,6 +525,7 @@ public class GraphqlSchemaProcessor extends AbstractProcessor {
           config.annotations(),
           useOptional,
           useAliasForFieldNames,
+          generateDeprecated,
           fieldAnnotations,
           resolvedNonNull);
     }

--- a/graphql-apt/src/main/java/feign/graphql/apt/TypeAnnotationConfig.java
+++ b/graphql-apt/src/main/java/feign/graphql/apt/TypeAnnotationConfig.java
@@ -28,48 +28,19 @@ record TypeAnnotationConfig(
     List<String> annotations,
     boolean useOptional,
     boolean useAliasForFieldNames,
+    boolean generateDeprecated,
     Map<String, FieldAnnotations> fieldAnnotations,
     List<String> nonNullAnnotations) {
 
   static final TypeAnnotationConfig EMPTY =
-      new TypeAnnotationConfig(Set.of(), List.of(), false, true, Map.of(), List.of());
-
-  static TypeAnnotationConfig resolve(
-      List<String> typeAnnotationFqns,
-      String[] rawTypeAnnotations,
-      boolean useOptional,
-      boolean useAliasForFieldNames) {
-    return resolve(
-        typeAnnotationFqns,
-        rawTypeAnnotations,
-        useOptional,
-        useAliasForFieldNames,
-        Map.of(),
-        List.of(),
-        new String[0]);
-  }
+      new TypeAnnotationConfig(Set.of(), List.of(), false, true, true, Map.of(), List.of());
 
   static TypeAnnotationConfig resolve(
       List<String> typeAnnotationFqns,
       String[] rawTypeAnnotations,
       boolean useOptional,
       boolean useAliasForFieldNames,
-      Map<String, FieldAnnotations> fieldAnnotations) {
-    return resolve(
-        typeAnnotationFqns,
-        rawTypeAnnotations,
-        useOptional,
-        useAliasForFieldNames,
-        fieldAnnotations,
-        List.of(),
-        new String[0]);
-  }
-
-  static TypeAnnotationConfig resolve(
-      List<String> typeAnnotationFqns,
-      String[] rawTypeAnnotations,
-      boolean useOptional,
-      boolean useAliasForFieldNames,
+      boolean generateDeprecated,
       Map<String, FieldAnnotations> fieldAnnotations,
       List<String> nonNullFqns,
       String[] nonNullRawAnnotations) {
@@ -88,6 +59,7 @@ record TypeAnnotationConfig(
         annotations,
         useOptional,
         useAliasForFieldNames,
+        generateDeprecated,
         fieldAnnotations,
         nonNullResolved);
   }

--- a/graphql-apt/src/main/java/feign/graphql/apt/TypeGenerator.java
+++ b/graphql-apt/src/main/java/feign/graphql/apt/TypeGenerator.java
@@ -20,6 +20,7 @@ import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
+import graphql.language.DirectivesContainer;
 import graphql.language.EnumTypeDefinition;
 import graphql.language.Field;
 import graphql.language.InputObjectTypeDefinition;
@@ -144,6 +145,10 @@ public class TypeGenerator {
       if (schemaDef == null) {
         continue;
       }
+      var deprecated = isDeprecated(schemaDef);
+      if (!annotationConfig.generateDeprecated() && deprecated) {
+        continue;
+      }
       var fieldName = responseKey(field);
 
       var fieldType = schemaDef.getType();
@@ -165,11 +170,11 @@ public class TypeGenerator {
         var nestedType =
             wrapType(fieldType, ClassName.get("", nestedClassName), annotationConfig.useOptional());
         var fieldNonNull = fieldType instanceof NonNullType;
-        fields.add(toRecordField(fieldName, nestedType, fieldNonNull));
+        fields.add(toRecordField(fieldName, nestedType, fieldNonNull, deprecated));
       } else {
         var javaType = typeMapper.map(fieldType, annotationConfig.useOptional());
         var fieldNonNull = fieldType instanceof NonNullType;
-        fields.add(toRecordField(fieldName, javaType, fieldNonNull));
+        fields.add(toRecordField(fieldName, javaType, fieldNonNull, deprecated));
         enqueueIfNonScalar(rawTypeName);
       }
     }
@@ -301,11 +306,15 @@ public class TypeGenerator {
     var fields = new ArrayList<RecordField>();
 
     for (var valueDef : inputDef.getInputValueDefinitions()) {
+      var deprecated = isDeprecated(valueDef);
+      if (!annotationConfig.generateDeprecated() && deprecated) {
+        continue;
+      }
       var fieldName = valueDef.getName();
       var fieldType = valueDef.getType();
       var javaType = typeMapper.map(fieldType, annotationConfig.useOptional());
       var fieldNonNull = fieldType instanceof NonNullType;
-      fields.add(toRecordField(fieldName, javaType, fieldNonNull));
+      fields.add(toRecordField(fieldName, javaType, fieldNonNull, deprecated));
 
       var rawTypeName = GraphqlTypeMapper.unwrapTypeName(fieldType);
       enqueueIfNonScalar(rawTypeName);
@@ -350,7 +359,17 @@ public class TypeGenerator {
     var enumBuilder = TypeSpec.enumBuilder(className).addModifiers(Modifier.PUBLIC);
 
     for (var value : enumDef.getEnumValueDefinitions()) {
-      enumBuilder.addEnumConstant(value.getName());
+      var deprecated = isDeprecated(value);
+      if (!annotationConfig.generateDeprecated() && deprecated) {
+        continue;
+      }
+      if (deprecated) {
+        enumBuilder.addEnumConstant(
+            value.getName(),
+            TypeSpec.anonymousClassBuilder("").addAnnotation(Deprecated.class).build());
+      } else {
+        enumBuilder.addEnumConstant(value.getName());
+      }
     }
 
     writeType(enumBuilder.build(), element);
@@ -366,11 +385,15 @@ public class TypeGenerator {
     var fields = new ArrayList<RecordField>();
 
     for (var fieldDef : objectDef.getFieldDefinitions()) {
+      var deprecated = isDeprecated(fieldDef);
+      if (!annotationConfig.generateDeprecated() && deprecated) {
+        continue;
+      }
       var fieldName = fieldDef.getName();
       var fieldType = fieldDef.getType();
       var javaType = typeMapper.map(fieldType, annotationConfig.useOptional());
       var fieldNonNull = fieldType instanceof NonNullType;
-      fields.add(toRecordField(fieldName, javaType, fieldNonNull));
+      fields.add(toRecordField(fieldName, javaType, fieldNonNull, deprecated));
 
       var rawTypeName = GraphqlTypeMapper.unwrapTypeName(fieldDef.getType());
       enqueueIfNonScalar(rawTypeName);
@@ -384,6 +407,15 @@ public class TypeGenerator {
     if (!typeMapper.isScalar(typeName) && !generatedTypes.contains(typeName)) {
       pendingTypes.add(typeName);
     }
+  }
+
+  private static boolean isDeprecated(DirectivesContainer<?> node) {
+    for (var directive : node.getDirectives()) {
+      if ("deprecated".equals(directive.getName())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private TypeName wrapType(Type<?> schemaType, TypeName innerType, boolean useOptional) {
@@ -434,11 +466,14 @@ public class TypeGenerator {
 
     var typeStr = fa != null && fa.typeOverride() != null ? fa.typeOverride() : f.typeString;
 
-    if (!hasNonNull && (fa == null || fa.annotations().isEmpty())) {
+    if (!hasNonNull && !f.deprecated && (fa == null || fa.annotations().isEmpty())) {
       return typeStr + " " + f.name;
     }
 
     var fieldAnns = new ArrayList<String>();
+    if (f.deprecated) {
+      fieldAnns.add("@Deprecated");
+    }
     if (hasNonNull) {
       fieldAnns.addAll(annotationConfig.nonNullAnnotations());
     }
@@ -448,9 +483,10 @@ public class TypeGenerator {
     return String.join(" ", fieldAnns) + " " + typeStr + " " + f.name;
   }
 
-  private RecordField toRecordField(String name, TypeName typeName, boolean nonNull) {
+  private RecordField toRecordField(
+      String name, TypeName typeName, boolean nonNull, boolean deprecated) {
     var typeString = typeNameToString(typeName);
-    return new RecordField(typeString, name, typeName, nonNull);
+    return new RecordField(typeString, name, typeName, nonNull, deprecated);
   }
 
   private String typeNameToString(TypeName typeName) {
@@ -544,5 +580,6 @@ public class TypeGenerator {
       List<RecordField> fields,
       List<ResultTypeDefinition> innerTypes) {}
 
-  record RecordField(String typeString, String name, TypeName typeName, boolean nonNull) {}
+  record RecordField(
+      String typeString, String name, TypeName typeName, boolean nonNull, boolean deprecated) {}
 }

--- a/graphql-apt/src/test/java/feign/graphql/apt/GraphqlSchemaProcessorTest.java
+++ b/graphql-apt/src/test/java/feign/graphql/apt/GraphqlSchemaProcessorTest.java
@@ -1913,4 +1913,256 @@ class GraphqlSchemaProcessorTest {
     plain.contains("Optional<Specs> specs");
     plain.contains("public record Specs(");
   }
+
+  @Test
+  void deprecatedFieldsIncludedByDefault() {
+    var source =
+        JavaFileObjects.forSourceString(
+            "test.DefaultDeprecatedApi",
+            """
+            package test;
+
+            import feign.graphql.GraphqlSchema;
+            import feign.graphql.GraphqlQuery;
+
+            @GraphqlSchema("deprecated-test-schema.graphql")
+            interface DefaultDeprecatedApi {
+              @GraphqlQuery(\"""
+                  { user(id: "1") { id name email emails status } }
+                  \""")
+              UserResult getUser();
+
+              @GraphqlQuery(\"""
+                  mutation createUser($input: CreateUserInput!) {
+                    createUser(input: $input) { id name }
+                  }\""")
+              CreateUserResult createUser(CreateUserInput input);
+            }
+            """);
+
+    var compilation = javac().withProcessors(new GraphqlSchemaProcessor()).compile(source);
+
+    assertThat(compilation).succeeded();
+    var userResult =
+        assertThat(compilation).generatedSourceFile("test.UserResult").contentsAsUtf8String();
+    userResult.contains("@Deprecated Optional<String> email,");
+
+    var createInput =
+        assertThat(compilation).generatedSourceFile("test.CreateUserInput").contentsAsUtf8String();
+    createInput.contains("@Deprecated Optional<String> email");
+
+    var status =
+        assertThat(compilation).generatedSourceFile("test.UserStatus").contentsAsUtf8String();
+    status.contains("@Deprecated\n  BANNED");
+  }
+
+  @Test
+  void deprecatedFieldsSkippedWhenDisabledAtClassLevel() {
+    var source =
+        JavaFileObjects.forSourceString(
+            "test.ClassDisabledDeprecatedApi",
+            """
+            package test;
+
+            import feign.graphql.GraphqlSchema;
+            import feign.graphql.GraphqlQuery;
+
+            @GraphqlSchema(value = "deprecated-test-schema.graphql", generateDeprecated = false)
+            interface ClassDisabledDeprecatedApi {
+              @GraphqlQuery(\"""
+                  { user(id: "1") { id name email emails status } }
+                  \""")
+              UserResult getUser();
+
+              @GraphqlQuery(\"""
+                  mutation createUser($input: CreateUserInput!) {
+                    createUser(input: $input) { id name }
+                  }\""")
+              CreateUserResult createUser(CreateUserInput input);
+            }
+            """);
+
+    var compilation = javac().withProcessors(new GraphqlSchemaProcessor()).compile(source);
+
+    assertThat(compilation).succeeded();
+    assertThat(compilation)
+        .generatedSourceFile("test.UserResult")
+        .contentsAsUtf8String()
+        .doesNotContain(" email,");
+    assertThat(compilation)
+        .generatedSourceFile("test.CreateUserInput")
+        .contentsAsUtf8String()
+        .doesNotContain(" email,");
+    assertThat(compilation)
+        .generatedSourceFile("test.UserStatus")
+        .contentsAsUtf8String()
+        .doesNotContain("BANNED");
+  }
+
+  @Test
+  void methodLevelToggleCanReEnableDeprecated() {
+    var source =
+        JavaFileObjects.forSourceString(
+            "test.MethodOverrideDeprecatedApi",
+            """
+            package test;
+
+            import feign.graphql.GraphqlSchema;
+            import feign.graphql.GraphqlQuery;
+            import feign.graphql.Toggle;
+
+            @GraphqlSchema(value = "deprecated-test-schema.graphql", generateDeprecated = false)
+            interface MethodOverrideDeprecatedApi {
+              @GraphqlQuery(value = \"""
+                  { user(id: "1") { id name email emails status } }
+                  \""", generateDeprecated = Toggle.TRUE)
+              WithDeprecatedResult getUserWithDeprecated();
+
+              @GraphqlQuery(\"""
+                  { user(id: "1") { id name email emails status } }
+                  \""")
+              WithoutDeprecatedResult getUserFiltered();
+            }
+            """);
+
+    var compilation = javac().withProcessors(new GraphqlSchemaProcessor()).compile(source);
+
+    assertThat(compilation).succeeded();
+    assertThat(compilation)
+        .generatedSourceFile("test.WithDeprecatedResult")
+        .contentsAsUtf8String()
+        .contains(" email,");
+    assertThat(compilation)
+        .generatedSourceFile("test.WithoutDeprecatedResult")
+        .contentsAsUtf8String()
+        .doesNotContain(" email,");
+  }
+
+  @Test
+  void deprecatedEnumValuesSkippedWhenDisabled() {
+    var source =
+        JavaFileObjects.forSourceString(
+            "test.EnumDeprecatedApi",
+            """
+            package test;
+
+            import feign.graphql.GraphqlSchema;
+            import feign.graphql.GraphqlQuery;
+
+            @GraphqlSchema(value = "deprecated-test-schema.graphql", generateDeprecated = false)
+            interface EnumDeprecatedApi {
+              @GraphqlQuery(\"""
+                  { user(id: "1") { id status } }
+                  \""")
+              UserResult getUser();
+            }
+            """);
+
+    var compilation = javac().withProcessors(new GraphqlSchemaProcessor()).compile(source);
+
+    assertThat(compilation).succeeded();
+    var status =
+        assertThat(compilation).generatedSourceFile("test.UserStatus").contentsAsUtf8String();
+    status.contains("ACTIVE");
+    status.contains("INACTIVE");
+    status.doesNotContain("BANNED");
+  }
+
+  @Test
+  void methodToggleReEnabledDeprecatedStillCarriesAnnotation() {
+    var source =
+        JavaFileObjects.forSourceString(
+            "test.ReEnabledDeprecatedApi",
+            """
+            package test;
+
+            import feign.graphql.GraphqlSchema;
+            import feign.graphql.GraphqlQuery;
+            import feign.graphql.Toggle;
+
+            @GraphqlSchema(value = "deprecated-test-schema.graphql", generateDeprecated = false)
+            interface ReEnabledDeprecatedApi {
+              @GraphqlQuery(value = \"""
+                  { user(id: "1") { id name email status } }
+                  \""", generateDeprecated = Toggle.TRUE)
+              ReEnabledResult getUser();
+            }
+            """);
+
+    var compilation = javac().withProcessors(new GraphqlSchemaProcessor()).compile(source);
+
+    assertThat(compilation).succeeded();
+    assertThat(compilation)
+        .generatedSourceFile("test.ReEnabledResult")
+        .contentsAsUtf8String()
+        .contains("@Deprecated Optional<String> email,");
+    assertThat(compilation)
+        .generatedSourceFile("test.UserStatus")
+        .contentsAsUtf8String()
+        .contains("@Deprecated\n  BANNED");
+  }
+
+  @Test
+  void deprecatedEnumValuesKeptByDefault() {
+    var source =
+        JavaFileObjects.forSourceString(
+            "test.EnumDefaultApi",
+            """
+            package test;
+
+            import feign.graphql.GraphqlSchema;
+            import feign.graphql.GraphqlQuery;
+
+            @GraphqlSchema("deprecated-test-schema.graphql")
+            interface EnumDefaultApi {
+              @GraphqlQuery(\"""
+                  { user(id: "1") { id status } }
+                  \""")
+              UserResult getUser();
+            }
+            """);
+
+    var compilation = javac().withProcessors(new GraphqlSchemaProcessor()).compile(source);
+
+    assertThat(compilation).succeeded();
+    var status =
+        assertThat(compilation).generatedSourceFile("test.UserStatus").contentsAsUtf8String();
+    status.contains("ACTIVE");
+    status.contains("INACTIVE");
+    status.contains("BANNED");
+  }
+
+  @Test
+  void methodLevelToggleCanDisableDeprecated() {
+    var source =
+        JavaFileObjects.forSourceString(
+            "test.MethodDisableDeprecatedApi",
+            """
+            package test;
+
+            import feign.graphql.GraphqlSchema;
+            import feign.graphql.GraphqlQuery;
+            import feign.graphql.Toggle;
+
+            @GraphqlSchema("deprecated-test-schema.graphql")
+            interface MethodDisableDeprecatedApi {
+              @GraphqlQuery(value = \"""
+                  { user(id: "1") { id name email emails status } }
+                  \""", generateDeprecated = Toggle.FALSE)
+              FilteredUserResult getUserFiltered();
+            }
+            """);
+
+    var compilation = javac().withProcessors(new GraphqlSchemaProcessor()).compile(source);
+
+    assertThat(compilation).succeeded();
+    assertThat(compilation)
+        .generatedSourceFile("test.FilteredUserResult")
+        .contentsAsUtf8String()
+        .doesNotContain(" email,");
+    assertThat(compilation)
+        .generatedSourceFile("test.UserStatus")
+        .contentsAsUtf8String()
+        .doesNotContain("BANNED");
+  }
 }

--- a/graphql-apt/src/test/resources/deprecated-test-schema.graphql
+++ b/graphql-apt/src/test/resources/deprecated-test-schema.graphql
@@ -1,0 +1,27 @@
+type Query {
+  user(id: ID!): User
+}
+
+type Mutation {
+  createUser(input: CreateUserInput!): User
+}
+
+type User {
+  id: ID!
+  name: String!
+  email: String @deprecated(reason: "use emails instead")
+  emails: [String]
+  status: UserStatus
+}
+
+input CreateUserInput {
+  name: String!
+  email: String @deprecated(reason: "use emails instead")
+  emails: [String]
+}
+
+enum UserStatus {
+  ACTIVE
+  INACTIVE
+  BANNED @deprecated(reason: "no longer used")
+}

--- a/graphql/src/main/java/feign/graphql/GraphqlQuery.java
+++ b/graphql/src/main/java/feign/graphql/GraphqlQuery.java
@@ -32,6 +32,8 @@ public @interface GraphqlQuery {
 
   Toggle useAliasForFieldNames() default Toggle.INHERIT;
 
+  Toggle generateDeprecated() default Toggle.INHERIT;
+
   Class<?>[] typeAnnotations() default {};
 
   String[] rawTypeAnnotations() default {};

--- a/graphql/src/main/java/feign/graphql/GraphqlSchema.java
+++ b/graphql/src/main/java/feign/graphql/GraphqlSchema.java
@@ -34,6 +34,8 @@ public @interface GraphqlSchema {
 
   boolean useAliasForFieldNames() default true;
 
+  boolean generateDeprecated() default true;
+
   Class<?>[] uses() default {};
 
   Class<?>[] typeAnnotations() default {};


### PR DESCRIPTION
## Summary
- Adds `generateDeprecated` to `@GraphqlSchema` (boolean, default `true`) and `@GraphqlQuery` (Toggle, default `INHERIT`) so code generation for GraphQL-deprecated fields/enum values can be disabled per class or overridden per method.
- When a deprecated element is emitted, the generated Java is annotated with `@Deprecated` so the deprecation propagates into downstream code.
- Covers result records (from query selections), input type records, full object type records, and enum constants.

## Test plan
- [x] `mvn -pl graphql,graphql-apt test` — 116 tests green
- [x] Default keeps deprecated fields and stamps `@Deprecated` on output
- [x] Class-level `generateDeprecated = false` skips deprecated fields, input fields, and enum values
- [x] Method-level `Toggle.TRUE` re-enables generation (and still stamps `@Deprecated`)
- [x] Method-level `Toggle.FALSE` disables for that method only