### PR TITLE
Add custom tags support to Metrics5Capability  Allows users to pass a…

### DIFF
--- a/dropwizard-metrics5/src/main/java/feign/metrics5/FeignMetricName.java
+++ b/dropwizard-metrics5/src/main/java/feign/metrics5/FeignMetricName.java
@@ -22,13 +22,22 @@ import io.dropwizard.metrics5.MetricRegistry;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.Map;
 
 final class FeignMetricName {
 
   private final Class<?> meteredComponent;
+  private final Map<String, String> customTags;
 
   public FeignMetricName(Class<?> meteredComponent) {
     this.meteredComponent = meteredComponent;
+    this.customTags = Collections.emptyMap();
+  }
+
+  public FeignMetricName(Class<?> meteredComponent, Map<String, String> customTags) {
+    this.meteredComponent = meteredComponent;
+    this.customTags = customTags;
   }
 
   public MetricName metricName(MethodMetadata methodMetadata, Target<?> target, String suffix) {
@@ -40,10 +49,16 @@ final class FeignMetricName {
   }
 
   public MetricName metricName(Class<?> targetType, Method method, String url) {
-    return MetricRegistry.name(meteredComponent)
-        .tagged("client", targetType.getName())
-        .tagged("method", method.getName())
-        .tagged("host", extractHost(url));
+    MetricName name =
+        MetricRegistry.name(meteredComponent)
+            .tagged("client", targetType.getName())
+            .tagged("method", method.getName())
+            .tagged("host", extractHost(url));
+
+    for (Map.Entry<String, String> entry : customTags.entrySet()) {
+      name = name.tagged(entry.getKey(), entry.getValue());
+    }
+    return name;
   }
 
   private String extractHost(final String targetUrl) {

--- a/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredAsyncClient.java
+++ b/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredAsyncClient.java
@@ -23,6 +23,7 @@ import feign.RequestTemplate;
 import feign.Response;
 import io.dropwizard.metrics5.MetricRegistry;
 import io.dropwizard.metrics5.Timer;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -36,6 +37,15 @@ public class MeteredAsyncClient extends BaseMeteredClient implements AsyncClient
       MetricRegistry metricRegistry,
       MetricSuppliers metricSuppliers) {
     super(metricRegistry, new FeignMetricName(AsyncClient.class), metricSuppliers);
+    this.asyncClient = asyncClient;
+  }
+
+  public MeteredAsyncClient(
+      AsyncClient<Object> asyncClient,
+      MetricRegistry metricRegistry,
+      MetricSuppliers metricSuppliers,
+      Map<String, String> customTags) {
+    super(metricRegistry, new FeignMetricName(AsyncClient.class, customTags), metricSuppliers);
     this.asyncClient = asyncClient;
   }
 

--- a/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredClient.java
+++ b/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredClient.java
@@ -24,6 +24,7 @@ import feign.Response;
 import io.dropwizard.metrics5.MetricRegistry;
 import io.dropwizard.metrics5.Timer;
 import java.io.IOException;
+import java.util.Map;
 
 /** Warp feign {@link Client} with metrics. */
 public class MeteredClient extends BaseMeteredClient implements Client {
@@ -33,7 +34,15 @@ public class MeteredClient extends BaseMeteredClient implements Client {
   public MeteredClient(
       Client client, MetricRegistry metricRegistry, MetricSuppliers metricSuppliers) {
     super(metricRegistry, new FeignMetricName(Client.class), metricSuppliers);
+    this.client = client;
+  }
 
+  public MeteredClient(
+      Client client,
+      MetricRegistry metricRegistry,
+      MetricSuppliers metricSuppliers,
+      Map<String, String> customTags) {
+    super(metricRegistry, new FeignMetricName(Client.class, customTags), metricSuppliers);
     this.client = client;
   }
 

--- a/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredDecoder.java
+++ b/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredDecoder.java
@@ -25,6 +25,7 @@ import io.dropwizard.metrics5.MetricRegistry;
 import io.dropwizard.metrics5.Timer.Context;
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.util.Map;
 
 /** Warp feign {@link Decoder} with metrics. */
 public class MeteredDecoder implements Decoder {
@@ -40,6 +41,17 @@ public class MeteredDecoder implements Decoder {
     this.metricRegistry = metricRegistry;
     this.metricSuppliers = metricSuppliers;
     this.metricName = new FeignMetricName(Decoder.class);
+  }
+
+  public MeteredDecoder(
+      Decoder decoder,
+      MetricRegistry metricRegistry,
+      MetricSuppliers metricSuppliers,
+      Map<String, String> customTags) {
+    this.decoder = decoder;
+    this.metricRegistry = metricRegistry;
+    this.metricSuppliers = metricSuppliers;
+    this.metricName = new FeignMetricName(Decoder.class, customTags);
   }
 
   @Override

--- a/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredEncoder.java
+++ b/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredEncoder.java
@@ -21,6 +21,7 @@ import feign.codec.Encoder;
 import io.dropwizard.metrics5.MetricRegistry;
 import io.dropwizard.metrics5.Timer.Context;
 import java.lang.reflect.Type;
+import java.util.Map;
 
 /** Warp feign {@link Encoder} with metrics. */
 public class MeteredEncoder implements Encoder {
@@ -36,6 +37,17 @@ public class MeteredEncoder implements Encoder {
     this.metricRegistry = metricRegistry;
     this.metricSuppliers = metricSuppliers;
     this.metricName = new FeignMetricName(Encoder.class);
+  }
+
+  public MeteredEncoder(
+      Encoder encoder,
+      MetricRegistry metricRegistry,
+      MetricSuppliers metricSuppliers,
+      Map<String, String> customTags) {
+    this.encoder = encoder;
+    this.metricRegistry = metricRegistry;
+    this.metricSuppliers = metricSuppliers;
+    this.metricName = new FeignMetricName(Encoder.class, customTags);
   }
 
   @Override

--- a/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredInvocationHandleFactory.java
+++ b/dropwizard-metrics5/src/main/java/feign/metrics5/MeteredInvocationHandleFactory.java
@@ -57,6 +57,17 @@ public class MeteredInvocationHandleFactory implements InvocationHandlerFactory 
     this.metricName = new FeignMetricName(Feign.class);
   }
 
+  public MeteredInvocationHandleFactory(
+      InvocationHandlerFactory invocationHandler,
+      MetricRegistry metricRegistry,
+      MetricSuppliers metricSuppliers,
+      Map<String, String> customTags) {
+    this.invocationHandler = invocationHandler;
+    this.metricRegistry = metricRegistry;
+    this.metricSuppliers = metricSuppliers;
+    this.metricName = new FeignMetricName(Feign.class, customTags);
+  }
+
   @Override
   public InvocationHandler create(Target target, Map<Method, MethodHandler> dispatch) {
     final Class clientClass = target.type();

--- a/dropwizard-metrics5/src/main/java/feign/metrics5/Metrics5Capability.java
+++ b/dropwizard-metrics5/src/main/java/feign/metrics5/Metrics5Capability.java
@@ -23,11 +23,14 @@ import feign.codec.Decoder;
 import feign.codec.Encoder;
 import io.dropwizard.metrics5.MetricRegistry;
 import io.dropwizard.metrics5.SharedMetricRegistries;
+import java.util.Collections;
+import java.util.Map;
 
 public class Metrics5Capability implements Capability {
 
   private final MetricRegistry metricRegistry;
   private final MetricSuppliers metricSuppliers;
+  private final Map<String, String> customTags;
 
   public Metrics5Capability() {
     this(SharedMetricRegistries.getOrCreate("feign"), new MetricSuppliers());
@@ -40,31 +43,41 @@ public class Metrics5Capability implements Capability {
   public Metrics5Capability(MetricRegistry metricRegistry, MetricSuppliers metricSuppliers) {
     this.metricRegistry = metricRegistry;
     this.metricSuppliers = metricSuppliers;
+    this.customTags = Collections.emptyMap();
+  }
+
+  public Metrics5Capability(
+      MetricRegistry metricRegistry,
+      MetricSuppliers metricSuppliers,
+      Map<String, String> customTags) {
+    this.metricRegistry = metricRegistry;
+    this.metricSuppliers = metricSuppliers;
+    this.customTags = customTags;
   }
 
   @Override
   public Client enrich(Client client) {
-    return new MeteredClient(client, metricRegistry, metricSuppliers);
+    return new MeteredClient(client, metricRegistry, metricSuppliers, customTags);
   }
 
   @Override
   public AsyncClient<Object> enrich(AsyncClient<Object> client) {
-    return new MeteredAsyncClient(client, metricRegistry, metricSuppliers);
+    return new MeteredAsyncClient(client, metricRegistry, metricSuppliers, customTags);
   }
 
   @Override
   public Encoder enrich(Encoder encoder) {
-    return new MeteredEncoder(encoder, metricRegistry, metricSuppliers);
+    return new MeteredEncoder(encoder, metricRegistry, metricSuppliers, customTags);
   }
 
   @Override
   public Decoder enrich(Decoder decoder) {
-    return new MeteredDecoder(decoder, metricRegistry, metricSuppliers);
+    return new MeteredDecoder(decoder, metricRegistry, metricSuppliers, customTags);
   }
 
   @Override
   public InvocationHandlerFactory enrich(InvocationHandlerFactory invocationHandlerFactory) {
     return new MeteredInvocationHandleFactory(
-        invocationHandlerFactory, metricRegistry, metricSuppliers);
+        invocationHandlerFactory, metricRegistry, metricSuppliers, customTags);
   }
 }

--- a/dropwizard-metrics5/src/test/java/feign/metrics5/Metrics5CapabilityTest.java
+++ b/dropwizard-metrics5/src/test/java/feign/metrics5/Metrics5CapabilityTest.java
@@ -15,9 +15,16 @@
  */
 package feign.metrics5;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import feign.Capability;
+import feign.Feign;
 import feign.Util;
 import feign.micrometer.AbstractMetricsTestBase;
+import feign.micrometer.AbstractMetricsTestBase.SimpleSource;
+import feign.mock.HttpMethod;
+import feign.mock.MockClient;
+import feign.mock.MockTarget;
 import io.dropwizard.metrics5.Metered;
 import io.dropwizard.metrics5.Metric;
 import io.dropwizard.metrics5.MetricName;
@@ -25,6 +32,7 @@ import io.dropwizard.metrics5.MetricRegistry;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Map.Entry;
+import org.junit.jupiter.api.Test;
 
 public class Metrics5CapabilityTest
     extends AbstractMetricsTestBase<MetricRegistry, MetricName, Metric> {
@@ -119,5 +127,24 @@ public class Metrics5CapabilityTest
   @Override
   protected long getMetricCounter(Metric metric) {
     return ((Metered) metric).getCount();
+  }
+
+  @Test
+  void customTagsAreAppliedToMetrics() {
+    SimpleSource source =
+        Feign.builder()
+            .client(new MockClient().ok(HttpMethod.GET, "/get", "1234567890abcde"))
+            .addCapability(
+                new Metrics5Capability(
+                    metricsRegistry, new MetricSuppliers(), Map.of("env", "prod")))
+            .target(new MockTarget<>(SimpleSource.class));
+
+    source.get("0x3456789");
+
+    boolean hasCustomTag =
+        metricsRegistry.getMetrics().keySet().stream()
+            .anyMatch(name -> "prod".equals(name.getTags().get("env")));
+
+    assertTrue(hasCustomTag);
   }
 }


### PR DESCRIPTION
… Map<String, String> of custom tags when building

  Metrics5Capability. Tags are applied to all metrics registered by Feign.
  Fixes #2306