### PR TITLE
Only unwrap declared checked causes with UNWRAP

### DIFF
--- a/core/src/main/java/feign/SynchronousMethodHandler.java
+++ b/core/src/main/java/feign/SynchronousMethodHandler.java
@@ -76,10 +76,17 @@ final class SynchronousMethodHandler implements MethodHandler {
         } catch (RetryableException th) {
           Throwable cause = th.getCause();
           if (methodHandlerConfiguration.getPropagationPolicy() == UNWRAP && cause != null) {
-            throw cause;
-          } else {
-            throw th;
+            if (cause instanceof RuntimeException || cause instanceof Error) {
+              throw cause;
+            }
+            for (Class<?> exceptionType :
+                methodHandlerConfiguration.getMetadata().method().getExceptionTypes()) {
+              if (exceptionType.isAssignableFrom(cause.getClass())) {
+                throw cause;
+              }
+            }
           }
+          throw th;
         }
         if (methodHandlerConfiguration.getLogLevel() != Logger.Level.NONE) {
           methodHandlerConfiguration

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -50,6 +50,7 @@ import feign.querymap.BeanQueryMapEncoder;
 import feign.querymap.FieldQueryMapEncoder;
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.net.ProtocolException;
 import java.net.URI;
 import java.time.Clock;
 import java.time.Instant;
@@ -629,6 +630,60 @@ public class FeignTest {
           .isEqualTo("timeout reading POST http://localhost:" + server.getPort() + "/");
       assertThat(e.contentUTF8()).isEqualTo("");
     }
+  }
+
+  @Test
+  void doesNotUnwrapUndeclaredCheckedCauseWhenPropagationPolicyIsUnwrap() {
+    TestInterface api =
+        Feign.builder()
+            .exceptionPropagationPolicy(UNWRAP)
+            .retryer(new DefaultRetryer(1, 1, 1))
+            .client(
+                (_, _) -> {
+                  throw new ProtocolException("missing Location header for redirect");
+                })
+            .target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    RetryableException exception = assertThrows(RetryableException.class, () -> api.post());
+
+    assertThat(exception.getMessage()).contains("missing Location header for redirect");
+    assertThat(exception.getCause()).isInstanceOf(ProtocolException.class);
+  }
+
+  @Test
+  void unwrapDeclaredCheckedCauseWhenPropagationPolicyIsUnwrap() {
+    TestInterface api =
+        Feign.builder()
+            .exceptionPropagationPolicy(UNWRAP)
+            .retryer(new DefaultRetryer(1, 1, 1))
+            .client(
+                (_, _) -> {
+                  throw new ProtocolException("missing Location header for redirect");
+                })
+            .target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    ProtocolException exception =
+        assertThrows(ProtocolException.class, () -> api.postThrowsProtocolException());
+
+    assertThat(exception.getMessage()).contains("missing Location header for redirect");
+  }
+
+  @Test
+  void unwrapCheckedCauseAssignableToDeclaredTypeWhenPropagationPolicyIsUnwrap() {
+    TestInterface api =
+        Feign.builder()
+            .exceptionPropagationPolicy(UNWRAP)
+            .retryer(new DefaultRetryer(1, 1, 1))
+            .client(
+                (_, _) -> {
+                  throw new ProtocolException("missing Location header for redirect");
+                })
+            .target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    IOException exception = assertThrows(IOException.class, () -> api.postThrowsIOException());
+
+    assertThat(exception).isInstanceOf(ProtocolException.class);
+    assertThat(exception.getMessage()).contains("missing Location header for redirect");
   }
 
   @Test
@@ -1233,6 +1288,12 @@ public class FeignTest {
 
     @RequestLine("POST /")
     String post() throws TestInterfaceException;
+
+    @RequestLine("POST /")
+    String postThrowsProtocolException() throws ProtocolException;
+
+    @RequestLine("POST /")
+    String postThrowsIOException() throws IOException;
 
     @RequestLine("POST /")
     @Body(

--- a/httpclient/src/test/java/feign/httpclient/ApacheHttpClientTest.java
+++ b/httpclient/src/test/java/feign/httpclient/ApacheHttpClientTest.java
@@ -23,6 +23,8 @@ import feign.Feign;
 import feign.Feign.Builder;
 import feign.FeignException;
 import feign.Request.Options;
+import feign.RetryableException;
+import feign.Retryer;
 import feign.client.AbstractClientTest;
 import feign.jaxrs.JAXRSContract;
 import java.nio.charset.StandardCharsets;
@@ -32,6 +34,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
+import org.apache.http.ProtocolException;
+import org.apache.http.client.ClientProtocolException;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.junit.jupiter.api.Test;
 
@@ -41,6 +45,25 @@ public class ApacheHttpClientTest extends AbstractClientTest {
   @Override
   public Builder newBuilder() {
     return Feign.builder().client(new ApacheHttpClient());
+  }
+
+  @Test
+  void redirectWithoutLocationHeaderKeepsRetryableExceptionWhenPropagationPolicyIsUnwrap() {
+    JaxRsTestInterface api =
+        Feign.builder()
+            .contract(new JAXRSContract())
+            .exceptionPropagationPolicy(feign.ExceptionPropagationPolicy.UNWRAP)
+            .retryer(Retryer.NEVER_RETRY)
+            .client(new ApacheHttpClient(HttpClientBuilder.create().build()))
+            .target(JaxRsTestInterface.class, "http://localhost:" + server.getPort());
+
+    server.enqueue(new MockResponse().setResponseCode(303));
+
+    RetryableException exception =
+        assertThrows(RetryableException.class, () -> api.withoutBody("foo"));
+
+    assertThat(exception.getCause()).isInstanceOf(ClientProtocolException.class);
+    assertThat(exception.getCause()).hasCauseInstanceOf(ProtocolException.class);
   }
 
   @Test


### PR DESCRIPTION
## Summary

This updates `UNWRAP` propagation so that Feign only rethrows:

- `RuntimeException` and `Error`
- checked exceptions declared by the target method, including assignable supertypes

Undeclared checked causes now remain wrapped in `RetryableException`.

## Why

Previously, `UNWRAP` would rethrow any non-null cause from `RetryableException`.

That could rethrow checked exceptions that are not declared by the target method, which can lead to inconsistent exception propagation at the proxy boundary.

This keeps the fix at the core boundary instead of adding client-specific handling or synthesizing responses.

## Tests

Added coverage for:

- undeclared checked causes staying wrapped with `UNWRAP`
- declared checked causes being unwrapped with `UNWRAP`
- assignable checked causes being unwrapped with `UNWRAP`
- the Apache HttpClient redirect-without-Location case staying wrapped as `RetryableException`

Fixes #1487