### PR TITLE
Forward dismiss404 from CoroutineFeign builder to AsyncFeign

### DIFF
--- a/kotlin/src/main/java/feign/kotlin/CoroutineFeign.java
+++ b/kotlin/src/main/java/feign/kotlin/CoroutineFeign.java
@@ -163,25 +163,27 @@ public class CoroutineFeign<C> {
     @Override
     @SuppressWarnings("unchecked")
     public CoroutineFeign<C> internalBuild() {
-      AsyncFeign<C> asyncFeign =
-          (AsyncFeign<C>)
-              AsyncFeign.builder()
-                  .logLevel(logLevel)
-                  .client((AsyncClient<Object>) client)
-                  .decoder(decoder)
-                  .errorDecoder(errorDecoder)
-                  .contract(contract)
-                  .retryer(retryer)
-                  .logger(logger)
-                  .encoder(encoder)
-                  .queryMapEncoder(queryMapEncoder)
-                  .options(options)
-                  .requestInterceptors(requestInterceptors)
-                  .responseInterceptors(responseInterceptors)
-                  .invocationHandlerFactory(invocationHandlerFactory)
-                  .defaultContextSupplier((AsyncContextSupplier<Object>) defaultContextSupplier)
-                  .methodInfoResolver(methodInfoResolver)
-                  .build();
+      AsyncFeign.AsyncBuilder<Object> asyncBuilder =
+          AsyncFeign.builder()
+              .logLevel(logLevel)
+              .client((AsyncClient<Object>) client)
+              .decoder(decoder)
+              .errorDecoder(errorDecoder)
+              .contract(contract)
+              .retryer(retryer)
+              .logger(logger)
+              .encoder(encoder)
+              .queryMapEncoder(queryMapEncoder)
+              .options(options)
+              .requestInterceptors(requestInterceptors)
+              .responseInterceptors(responseInterceptors)
+              .invocationHandlerFactory(invocationHandlerFactory)
+              .defaultContextSupplier((AsyncContextSupplier<Object>) defaultContextSupplier)
+              .methodInfoResolver(methodInfoResolver);
+      if (dismiss404) {
+        asyncBuilder.dismiss404();
+      }
+      AsyncFeign<C> asyncFeign = (AsyncFeign<C>) asyncBuilder.build();
       return new CoroutineFeign<>(asyncFeign);
     }
   }

--- a/kotlin/src/test/kotlin/feign/kotlin/CoroutineFeignTest.kt
+++ b/kotlin/src/test/kotlin/feign/kotlin/CoroutineFeignTest.kt
@@ -34,6 +34,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import java.io.IOException
 import java.lang.reflect.Type
+import java.util.concurrent.atomic.AtomicBoolean
 
 class CoroutineFeignTest {
     @Test
@@ -103,6 +104,31 @@ class CoroutineFeignTest {
 
         // Assert
         assertThat(firstOrder).isEqualTo(Unit)
+    }
+
+    @Test
+    fun `sut should dismiss 404 responses when dismiss404 is configured on CoroutineBuilder`(): Unit = runBlocking {
+        // Arrange: server returns 404; a custom decoder records whether it was invoked
+        val server = MockWebServer()
+        server.enqueue(MockResponse().setResponseCode(404))
+
+        val decoderInvokedFor404 = AtomicBoolean(false)
+        val recordingDecoder = Decoder { response, _ ->
+            decoderInvokedFor404.set(response.status() == 404)
+            ""
+        }
+
+        val client = TestInterfaceAsyncBuilder()
+            .dismiss404()
+            .decoder(recordingDecoder)
+            .target("http://localhost:" + server.port)
+
+        // Act: must not throw FeignException; the decoder must be invoked for the 404
+        val result: String = client.findOrderThatReturningBasicType(orderId = 1)
+
+        // Assert
+        assertThat(decoderInvokedFor404.get()).isTrue()
+        assertThat(result).isEqualTo("")
     }
 
     @Test


### PR DESCRIPTION
`CoroutineFeign.CoroutineBuilder` inherits `dismiss404()` from `BaseBuilder`, but `internalBuild()` constructed a fresh `AsyncFeign.builder()` chain that never forwarded the flag. As a result, calling `.dismiss404()` on a coroutine builder silently had no effect — a 404 response still produced a `FeignException` instead of being routed through the decoder.

## Fix

Split the existing builder chain so the configured `dismiss404` value is applied to the underlying `AsyncBuilder` before `build()`:

```java
AsyncFeign.AsyncBuilder<Object> asyncBuilder =
    AsyncFeign.builder()
        .logLevel(logLevel)
        ...
        .methodInfoResolver(methodInfoResolver);
if (dismiss404) {
  asyncBuilder.dismiss404();
}
AsyncFeign<C> asyncFeign = (AsyncFeign<C>) asyncBuilder.build();
```

The conditional mirrors `BaseBuilder.dismiss404()` semantics (a one-way switch); preserving the default `false` behavior when the user doesn't opt in.

## Test

Adds `CoroutineFeignTest.\`sut should dismiss 404 responses when dismiss404 is configured on CoroutineBuilder\``, modeled on `AsyncFeignTest.decodingDoesNotSwallow404ErrorsInDismiss404Mode`. The test enqueues a 404, installs a recording `Decoder`, and asserts that:

1. The call does not throw a `FeignException`.
2. The decoder is invoked with `response.status() == 404`, proving the dismiss-404 path engaged.

Without the fix, the call would throw on the 404 before the decoder is ever called.

Fixes #2026