### PR TITLE
Preserve delegate content type for multipart parameters

### DIFF
--- a/form/src/main/java/feign/form/multipart/DelegateWriter.java
+++ b/form/src/main/java/feign/form/multipart/DelegateWriter.java
@@ -48,6 +48,18 @@ public class DelegateWriter extends AbstractWriter {
     delegate.encode(value, value.getClass(), fake);
     val bytes = fake.body();
     val string = new String(bytes, output.getCharset()).replaceAll("\n", "");
-    parameterWriter.write(output, key, string);
+    parameterWriter.writeWithContentType(output, key, string, contentType(fake));
+  }
+
+  private static String contentType(RequestTemplate template) {
+    val headers = template.headers().get("Content-Type");
+    if (headers != null) {
+      for (val header : headers) {
+        if (header != null && !header.isEmpty()) {
+          return header;
+        }
+      }
+    }
+    return null;
   }
 }

--- a/form/src/main/java/feign/form/multipart/SingleParameterWriter.java
+++ b/form/src/main/java/feign/form/multipart/SingleParameterWriter.java
@@ -34,14 +34,31 @@ public class SingleParameterWriter extends AbstractWriter {
 
   @Override
   protected void write(Output output, String key, Object value) throws EncodeException {
+    writeWithContentType(output, key, value, null);
+  }
+
+  /**
+   * Writes a single parameter using the given content type.
+   *
+   * @param output output writer.
+   * @param key name for piece of data.
+   * @param value piece of data.
+   * @param contentType the content type of the part. May be {@code null}, in which case {@code
+   *     text/plain} with the output charset is used.
+   * @throws EncodeException in case of write errors
+   */
+  protected void writeWithContentType(Output output, String key, Object value, String contentType)
+      throws EncodeException {
+    val contentTypeHeader =
+        contentType != null ? contentType : "text/plain; charset=" + output.getCharset().name();
     val string =
         new StringBuilder()
             .append("Content-Disposition: form-data; name=\"")
             .append(key)
             .append('"')
             .append(CRLF)
-            .append("Content-Type: text/plain; charset=")
-            .append(output.getCharset().name())
+            .append("Content-Type: ")
+            .append(contentTypeHeader)
             .append(CRLF)
             .append(CRLF)
             .append(value.toString())

--- a/form/src/test/java/feign/form/multipart/DelegateWriterTest.java
+++ b/form/src/test/java/feign/form/multipart/DelegateWriterTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.form.multipart;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import feign.codec.Encoder;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+class DelegateWriterTest {
+
+  private static final String BOUNDARY = "boundary";
+
+  private static final String KEY = "metadata";
+
+  @Test
+  void usesContentTypeFromDelegate() throws Exception {
+    Encoder delegate =
+        (object, bodyType, template) -> {
+          template.header("Content-Type", "application/json");
+          template.body("{\"hash\":\"somehash\"}");
+        };
+
+    assertThat(write(delegate))
+        .contains("Content-Type: application/json")
+        .doesNotContain("Content-Type: text/plain");
+  }
+
+  @Test
+  void fallsBackToTextPlainWhenDelegateSetsNoContentType() throws Exception {
+    Encoder delegate = (object, bodyType, template) -> template.body("plain");
+
+    assertThat(write(delegate)).contains("Content-Type: text/plain; charset=UTF-8");
+  }
+
+  private static String write(Encoder delegate) throws Exception {
+    DelegateWriter writer = new DelegateWriter(delegate);
+    try (Output output = new Output(StandardCharsets.UTF_8)) {
+      writer.write(output, BOUNDARY, KEY, new Object());
+      return new String(output.toByteArray(), StandardCharsets.UTF_8);
+    }
+  }
+}


### PR DESCRIPTION
Fixes #2813

## Problem
When a multipart request contains a POJO/JSON part, `DelegateWriter` encodes the value through the delegate `Encoder` (e.g. the Jackson encoder), which correctly sets `Content-Type: application/json` on the throwaway `RequestTemplate`. That header was then discarded, and `SingleParameterWriter` hard-coded `Content-Type: text/plain`. As a result, JSON parts were emitted as `text/plain` instead of `application/json` (see the report in #2813).

## Change
- `DelegateWriter` now reads the `Content-Type` produced by the delegate and forwards it to a new `SingleParameterWriter.writeWithContentType(output, key, value, contentType)` method.
- When the delegate sets no content type, the writer falls back to the previous `text/plain; charset=<charset>` behaviour, so plain single parameters are unaffected.
- The existing `write(output, key, value)` template method is preserved and simply delegates with a `null` content type.

## Tests
Added `feign.form.multipart.DelegateWriterTest`:
- `usesContentTypeFromDelegate` — asserts a delegate that sets `application/json` produces `Content-Type: application/json` (and not `text/plain`).
- `fallsBackToTextPlainWhenDelegateSetsNoContentType` — asserts the `text/plain; charset=UTF-8` fallback when the delegate sets no content type.

## Test evidence
Ran the `form` module test suite (and its upstream dependencies) locally:

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0 -- feign.form.multipart.DelegateWriterTest
... full feign-core + feign-form suites green ...
BUILD SUCCESS
```

Verification done: confirmed the hard-coded `text/plain` still present on `master` in `SingleParameterWriter#write`; confirmed no in-flight PR referencing the issue and no active self-claim (maintainer invited a PR with tests on 2026-05-27); fix touches only `.java` files; full `form` module test suite passes after the change.