### PR TITLE
Publish feign-bom as a real module so it auto-deploys to Central

### DIFF
--- a/feign-bom/pom.xml
+++ b/feign-bom/pom.xml
@@ -1,0 +1,265 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- GENERATED FILE - do not edit by hand.
+       Regenerate with: mvn -Pquickbuild validate && cp target/classes/feign-bom/pom.xml feign-bom/pom.xml
+       Source of the dependency list: sundr-maven-plugin generate-bom (see root pom.xml).
+       Inherits the release profile (gpg + central-publishing) from feign-parent so it
+       publishes through the same path as every other module. -->
+
+  <parent>
+    <groupId>io.github.openfeign</groupId>
+    <artifactId>feign-parent</artifactId>
+    <version>13.13-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>feign-bom</artifactId>
+  <packaging>pom</packaging>
+  <name>Feign (Bill Of Materials)</name>
+  <description>Bill of material</description>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-core</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-gson</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-http-cache</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-jaxrs</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-httpclient</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-jaxrs2</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-hc5</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-hystrix</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-jackson</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-jackson3</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-jackson-jaxb</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-jackson-jr</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-jaxb</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-jaxb-jakarta</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-jaxrs3</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-jaxrs4</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-java11</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-jakarta</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-mock</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-json</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-okhttp</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-googlehttpclient</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-ribbon</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-sax</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-slf4j</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-spring</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-soap</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-soap-jakarta</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-reactive-wrappers</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-micrometer</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-dropwizard-metrics4</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-dropwizard-metrics5</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-kotlin</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-graphql</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-annotation-error-decoder</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-form</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-form-spring</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-moshi</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-fastjson2</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-validation</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-validation-jakarta</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-vertx</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-vertx4-test</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-vertx5-test</artifactId>
+        <version>13.13-SNAPSHOT</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,7 @@
     <module>validation</module>
     <module>validation-jakarta</module>
     <module>vertx</module>
+    <module>feign-bom</module>
   </modules>
 
   <scm>
@@ -894,11 +895,22 @@
                 <license.skip>true</license.skip>
               </properties>
 
+              <!-- sundr only generates the BOM pom; the committed feign-bom module
+                   (wired into <modules>) is what actually gets published, via the same
+                   central-publishing path as every other module. -->
+              <goals>
+                <excludes>
+                  <exclude>install</exclude>
+                  <exclude>deploy</exclude>
+                </excludes>
+              </goals>
+
               <modules>
                 <includes>
                   <include>io.github.openfeign:*</include>
                 </includes>
                 <excludes>
+                  <exclude>*:feign-bom</exclude>
                   <exclude>*:feign-example-*</exclude>
                   <exclude>*:feign-benchmark</exclude>
                 </excludes>

--- a/src/config/bom.xml
+++ b/src/config/bom.xml
@@ -1,70 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2012-2023 The Feign Authors
+    Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
 
-    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-    in compliance with the License. You may obtain a copy of the License at
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing, software distributed under the License
-    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-    or implied. See the License for the specific language governing permissions and limitations under
-    the License.
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>${model.groupId}</groupId>
+  <!-- GENERATED FILE - do not edit by hand.
+       Regenerate with: mvn -Pquickbuild validate && cp target/classes/feign-bom/pom.xml feign-bom/pom.xml
+       Source of the dependency list: sundr-maven-plugin generate-bom (see root pom.xml).
+       Inherits the release profile (gpg + central-publishing) from feign-parent so it
+       publishes through the same path as every other module. -->
+
+  <parent>
+    <groupId>io.github.openfeign</groupId>
+    <artifactId>feign-parent</artifactId>
+    <version>${model.version}</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
   <artifactId>${model.artifactId}</artifactId>
-  <version>${model.version}</version>
-  <name>${model.name}</name>
   <packaging>pom</packaging>
+  <name>${model.name}</name>
   <description>Bill of material</description>
-  #if ($model.url)
-
-  <url>${model.url}</url>#end
-  #if ($model.licenses && !$model.licenses.isEmpty())
-
-  <licenses>#foreach($l in $model.licenses)
-
-    <license>
-      <name>${l.name}</name>
-      <url>${l.url}</url>
-      <distribution>${l.distribution}</distribution>
-    </license>#end
-
-  </licenses>
-  #end
-
-  <scm>
-    <url>https://github.com/openfeign/feign</url>
-    <connection>scm:git:https://github.com/openfeign/feign.git</connection>
-    <developerConnection>scm:git:git@github.com:OpenFeign/feign.git</developerConnection>
-    <tag>HEAD</tag>
-  </scm>
-
-#if ($model.developers && !$model.developers.isEmpty())
-  <developers>#foreach($d in $model.developers)
-
-    <developer>
-      <id>${d.id}</id>
-      <name>${d.name}</name>#if($d.email)
-
-      <email>${d.email}</email>#end#if($d.url)
-
-      <url>${d.url}</url>#end#if($d.organization)
-
-      <organization>${d.organization}</organization>#end#if($d.organizationUrl)
-
-      <organizationUrl>${d.organizationUrl}</organizationUrl>#end
-
-    </developer>#end
-
-  </developers>
-#end
 
   <dependencyManagement>
     <dependencies>#foreach($d in $model.dependencyManagement.dependencies)


### PR DESCRIPTION
Replaces the sundr-generated `feign-bom` with a committed `feign-bom` module, mirroring the same change made on querydsl (OpenFeign/querydsl@4846482).

## What changed
- **New `feign-bom/pom.xml` module** — a real, committed module wired into `<modules>`. It inherits from `feign-parent`, so it publishes to Central through the exact same `central-publishing` + gpg path as every other module. Its `dependencyManagement` is identical to what sundr generated today, so there is no change to the published BOM contents.
- **`pom.xml`** — added `feign-bom` to `<modules>`; configured the sundr `generate-bom` to exclude `install`/`deploy` goals (so sundr only writes the pom template, the committed module is what publishes) and to exclude `*:feign-bom` from its own dependency list.
- **`src/config/bom.xml`** — the sundr template now emits the parent-based module form, so the committed file can be regenerated with:
  `mvn -Pquickbuild validate && cp target/classes/feign-bom/pom.xml feign-bom/pom.xml`

## Why
The generated BOM was attached/deployed by sundr out-of-band. Making it a first-class module means it goes through the normal release lifecycle (source/javadoc not needed for a pom, gpg signing, central publishing) consistently with the rest of the build.

## Validation
- `mvn -Pquickbuild validate` regenerates an output byte-identical to the committed module (verifying the dependency list and self-exclusion).
- Full-reactor `validate` and `feign-bom` `install`/`verify` pass; sortpom reports no changes on the committed file.