### PR TITLE
Fix flaky vertx http2NoConnectionLeak test by using h2c prior knowledge

### DIFF
--- a/vertx/feign-vertx/src/test/java/feign/vertx/ConnectionsLeakTests.java
+++ b/vertx/feign-vertx/src/test/java/feign/vertx/ConnectionsLeakTests.java
@@ -95,7 +95,14 @@ class ConnectionsLeakTests {
     int poolSize = 1;
     int nbRequests = 100;
 
-    WebClientOptions options = new WebClientOptions().setProtocolVersion(HttpVersion.HTTP_2);
+    // Use h2c with prior knowledge instead of the default HTTP/1.1 upgrade: during the upgrade
+    // handshake the connection is still HTTP/1.1, so the pool applies http1MaxSize (5) rather than
+    // http2MaxSize (1) and can open several connections under load before the first upgrades to
+    // HTTP/2 - which made this test flaky on CI.
+    WebClientOptions options =
+        new WebClientOptions()
+            .setProtocolVersion(HttpVersion.HTTP_2)
+            .setHttp2ClearTextUpgrade(false);
     PoolOptions poolOptions = new PoolOptions().setHttp2MaxSize(1);
     WebClient webClient = WebClient.create(vertx, options, poolOptions);
 

--- a/vertx/feign-vertx4-test/src/test/java/feign/vertx/ConnectionsLeakTests.java
+++ b/vertx/feign-vertx4-test/src/test/java/feign/vertx/ConnectionsLeakTests.java
@@ -98,8 +98,15 @@ class ConnectionsLeakTests {
     int poolSize = 1;
     int nbRequests = 100;
 
+    // Use h2c with prior knowledge instead of the default HTTP/1.1 upgrade: during the upgrade
+    // handshake the connection is still HTTP/1.1, so the pool applies the HTTP/1.1 max pool size
+    // rather than the HTTP/2 one and can open several connections under load before the first
+    // upgrades to HTTP/2 - which made this test flaky on CI.
     WebClientOptions options =
-        new WebClientOptions().setProtocolVersion(HttpVersion.HTTP_2).setHttp2MaxPoolSize(1);
+        new WebClientOptions()
+            .setProtocolVersion(HttpVersion.HTTP_2)
+            .setHttp2MaxPoolSize(1)
+            .setHttp2ClearTextUpgrade(false);
     WebClient webClient = WebClient.create(vertx, options);
 
     HelloServiceAPI client =


### PR DESCRIPTION
`feign.vertx.ConnectionsLeakTests.http2NoConnectionLeak` has been flaky on CI (e.g. failed on #3384), asserting `Expected size: 1 but was: 2` open server connections.

## Root cause
The test fires 100 concurrent requests over an HTTP/2 pool capped at one connection (`PoolOptions.setHttp2MaxSize(1)`) and asserts the server saw exactly one connection.

By default vertx negotiates cleartext HTTP/2 via an **HTTP/1.1 Upgrade** (`HttpClientOptions.DEFAULT_HTTP2_CLEAR_TEXT_UPGRADE = true`). During that handshake the connection is still HTTP/1.1, so the pool applies `http1MaxSize` (default **5**) instead of `http2MaxSize` (**1**). Under CI load the upgrade window is wide enough that a second connection is opened before the first finishes upgrading to HTTP/2, so the server records 2 connections. (`DEFAULT_MAX_CONCURRENT_STREAMS` is effectively unlimited, so stream multiplexing is not the issue.) It surfaced after the recent vertx 5.1.0 bump because the full `pr-build` suite only runs on PRs.

## Fix
Connect with h2c **prior knowledge** (`setHttp2ClearTextUpgrade(false)`): the connection is HTTP/2 from the first byte, so `http2MaxSize(1)` deterministically caps it at one connection and the 100 requests multiplex over it. Applied to both the `feign-vertx` test (run against vertx 5.x via `feign-vertx5-test`) and the `feign-vertx4-test` copy.

## Validation
`ConnectionsLeakTests` (both HTTP/1.1 and HTTP/2) passes locally under vertx 5.1.0 (5/5 runs) and vertx 4.5.27.