### PR TITLE
Avoid ClassLoader leak from static default async executor (#3178)

### DIFF
--- a/core/src/main/java/feign/AsyncFeign.java
+++ b/core/src/main/java/feign/AsyncFeign.java
@@ -56,23 +56,28 @@ public final class AsyncFeign<C> {
     return builder();
   }
 
-  private static class LazyInitializedExecutorService {
-
-    private static final ExecutorService instance =
-        Executors.newCachedThreadPool(
-            r -> {
-              final Thread result = new Thread(r);
-              result.setDaemon(true);
-              return result;
-            });
+  /**
+   * Creates the default {@link ExecutorService} used when neither a custom {@link AsyncClient} nor
+   * a custom executor is provided. The executor is created per built client (instance scoped)
+   * rather than being held in a static singleton, so that it - together with its daemon threads -
+   * becomes eligible for garbage collection once the owning client is discarded. This avoids the
+   * {@code ClassLoader} leak that a static singleton causes on application redeployments inside
+   * servlet containers (see gh-3178).
+   */
+  private static ExecutorService defaultExecutorService() {
+    return Executors.newCachedThreadPool(
+        r -> {
+          final Thread result = new Thread(r);
+          result.setDaemon(true);
+          return result;
+        });
   }
 
   public static class AsyncBuilder<C> extends BaseBuilder<AsyncBuilder<C>, AsyncFeign<C>> {
 
     private AsyncContextSupplier<C> defaultContextSupplier = () -> null;
-    private AsyncClient<C> client =
-        new DefaultAsyncClient<>(
-            new DefaultClient(null, null), LazyInitializedExecutorService.instance);
+    private AsyncClient<C> client;
+    private ExecutorService executorService;
     private MethodInfoResolver methodInfoResolver = MethodInfo::new;
 
     @Deprecated
@@ -84,6 +89,28 @@ public final class AsyncFeign<C> {
     public AsyncBuilder<C> client(AsyncClient<C> client) {
       this.client = client;
       return this;
+    }
+
+    /**
+     * Sets the {@link ExecutorService} used by the default {@link AsyncClient} to run the
+     * (blocking) underlying client calls. When provided, the caller owns the executor's lifecycle
+     * and is responsible for shutting it down. This is the recommended way to avoid the {@code
+     * ClassLoader} leak described in gh-3178: supply a managed, shut-downable executor instead of
+     * relying on the built-in default. Ignored when a custom {@link #client(AsyncClient)} is
+     * supplied.
+     */
+    public AsyncBuilder<C> executorService(ExecutorService executorService) {
+      this.executorService = executorService;
+      return this;
+    }
+
+    private AsyncClient<C> resolveClient() {
+      if (client != null) {
+        return client;
+      }
+      final ExecutorService executor =
+          executorService != null ? executorService : defaultExecutorService();
+      return new DefaultAsyncClient<>(new DefaultClient(null, null), executor);
     }
 
     public AsyncBuilder<C> methodInfoResolver(MethodInfoResolver methodInfoResolver) {
@@ -206,6 +233,7 @@ public final class AsyncFeign<C> {
 
     @Override
     public AsyncFeign<C> internalBuild() {
+      final AsyncClient<C> client = resolveClient();
       AsyncResponseHandler responseHandler =
           (AsyncResponseHandler)
               Capability.enrich(

--- a/core/src/main/java/feign/BaseBuilder.java
+++ b/core/src/main/java/feign/BaseBuilder.java
@@ -362,6 +362,8 @@ public abstract class BaseBuilder<B extends BaseBuilder<B, T>, T> implements Clo
         .filter(field -> !Objects.equals(field.getName(), "requestInterceptors"))
         .filter(field -> !Objects.equals(field.getName(), "responseInterceptors"))
         .filter(field -> !Objects.equals(field.getName(), "methodInterceptors"))
+        // caller-owned lifecycle resources are not capability-enriched
+        .filter(field -> !Objects.equals(field.getName(), "executorService"))
         // skip primitive types
         .filter(field -> !field.getType().isPrimitive())
         // skip enumerations

--- a/core/src/test/java/feign/AsyncFeignTest.java
+++ b/core/src/test/java/feign/AsyncFeignTest.java
@@ -24,6 +24,10 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOf
 import static org.assertj.core.data.MapEntry.entry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -102,6 +106,39 @@ public class AsyncFeignTest {
         .hasBody(
             "{\"customer_name\": \"netflix\", \"user_name\": \"denominator\", \"password\":"
                 + " \"password\"}");
+  }
+
+  @Test
+  void usesProvidedExecutorService() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
+
+    ExecutorService executorService = spy(Executors.newCachedThreadPool());
+    try {
+      TestInterfaceAsync api =
+          AsyncFeign.<Void>builder()
+              .decoder(new DefaultDecoder())
+              .executorService(executorService)
+              .target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
+
+      String result = api.post().join();
+
+      assertThat(result).isEqualTo("foo");
+      verify(executorService, atLeastOnce()).submit(any(Runnable.class));
+    } finally {
+      executorService.shutdownNow();
+    }
+  }
+
+  @Test
+  void defaultExecutorServiceStillExecutesRequests() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
+
+    TestInterfaceAsync api =
+        AsyncFeign.<Void>builder()
+            .decoder(new DefaultDecoder())
+            .target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
+
+    assertThat(api.post().join()).isEqualTo("foo");
   }
 
   @Test


### PR DESCRIPTION
Fixes #3178

## Problem
`AsyncFeign` held its default `ExecutorService` in a private **static** singleton (`LazyInitializedExecutorService`) that is never shut down:

```java
private static class LazyInitializedExecutorService {
  private static final ExecutorService instance =
      Executors.newCachedThreadPool(r -> { Thread t = new Thread(r); t.setDaemon(true); return t; });
}
```

Inside a servlet container, marking the threads as daemon only lets the JVM exit — it does not help on redeploy. The static cached thread pool retains a strong reference to the initial application's `ContextClassLoader`, so each redeployment leaks the previous application's `ClassLoader` and its threads, eventually leading to a Metaspace `OutOfMemoryError`.

## Change
- Replace the static singleton with an **instance-scoped** default executor created per built client (`defaultExecutorService()`). Once the built client is discarded, the executor and its (daemon, idle-timing-out) threads become eligible for garbage collection, releasing the `ClassLoader`.
- Add `AsyncBuilder.executorService(ExecutorService)` so callers can supply and own a managed, shut-downable executor — the recommended way to control this lifecycle explicitly. It is ignored when a custom `client(AsyncClient)` is provided.

Default behavior is preserved for callers who don't configure anything: a cached daemon thread pool is still used; it is simply no longer a process-wide static singleton.

Note: `feign.kotlin.CoroutineFeign` contains the same static-singleton pattern. I kept this PR scoped to `AsyncFeign` (the reported class); happy to follow up on the Kotlin module if you'd like it addressed here too.

## Tests
Added to `core/src/test/java/feign/AsyncFeignTest.java`:
- `usesProvidedExecutorService` — builds an `AsyncFeign` with a spied `ExecutorService`, performs a request, and verifies the provided executor actually ran the work (`submit(...)` invoked).
- `defaultExecutorServiceStillExecutesRequests` — guards that the default (no executor configured) path still works end-to-end after removing the static singleton.

## Test evidence
`./mvnw -pl core -am test -Dtest=AsyncFeignTest` → `Tests run: 54, Failures: 0, Errors: 0, Skipped: 0`. Code format validated with `git-code-format:validate-code-format` (BUILD SUCCESS).

Verification done: confirmed no in-flight PR referencing #3178; reproduced the static-singleton pattern still present on `master` (`AsyncFeign.java`); maintainer invited a PR with automated tests on the issue; fix touches only `.java` files; build + targeted tests + format check pass locally on JDK 25.