### PR TITLE
feat: add streaming support for request bodies in `DefaultEncoder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Version 14.0
+
+* `DefaultEncoder` now supports streaming request bodies for `File`, `Path`, `InputStream`, and `Request.Body` types,
+  avoiding in-memory buffering. New `Request.PathBody` and `Request.InputStreamBody` implementations are provided for
+  these cases.
+
 ### Version 13.12
 
 * `UrlencodedFormContentProcessor` now honors `CollectionFormat` from `@RequestLine`/`RequestTemplate` for array and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 * `DefaultEncoder` now supports streaming request bodies for `File`, `Path`, `InputStream`, and `Request.Body` types,
   avoiding in-memory buffering. New `Request.PathBody` and `Request.InputStreamBody` implementations are provided for
-  these cases.
+  these cases. (https://github.com/OpenFeign/feign/pull/3396)
 
 ### Version 13.12
 
 * `UrlencodedFormContentProcessor` now honors `CollectionFormat` from `@RequestLine`/`RequestTemplate` for array and
-  collection values in `application/x-www-form-urlencoded` bodies.
+  collection values in `application/x-www-form-urlencoded` bodies. (https://github.com/OpenFeign/feign/pull/3286)
 
 ### Version 11.9
 

--- a/MIGRATION-v14.md
+++ b/MIGRATION-v14.md
@@ -19,7 +19,7 @@ The **breaking changes** primarily affect code that interacts directly with requ
 - Any code that directly reads `Request.body()`, `Request.length()`, `Request.charset()`, or `RequestTemplate.body()`/
   `RequestTemplate.requestBody()`
 
-### `DefaultEncoder` streaming support (non-breaking)
+### `DefaultEncoder` streaming support (non-breaking) (https://github.com/OpenFeign/feign/pull/3396)
 
 `DefaultEncoder` now additionally supports `File`, `Path`, `InputStream`, and `Request.Body` as request body types.
 This is an additive, non-breaking change. Existing `DefaultEncoder` users do not need to modify code; users can now opt

--- a/MIGRATION-v14.md
+++ b/MIGRATION-v14.md
@@ -1,8 +1,8 @@
 # Migration Guide — Feign v14 (Request Body Streaming)
 
-This guide covers the breaking changes introduced in #3360 and explains how to update your code.
+This guide covers the breaking changes introduced in https://github.com/OpenFeign/feign/pull/3360 and explains how to update your code.
 
-> **Target release:** `v14.rc.1`
+> **Target release:** `v14`
 
 ---
 
@@ -18,6 +18,12 @@ The **breaking changes** primarily affect code that interacts directly with requ
 - Custom `Client` implementations
 - Any code that directly reads `Request.body()`, `Request.length()`, `Request.charset()`, or `RequestTemplate.body()`/
   `RequestTemplate.requestBody()`
+
+### `DefaultEncoder` streaming support (non-breaking)
+
+`DefaultEncoder` now additionally supports `File`, `Path`, `InputStream`, and `Request.Body` as request body types.
+This is an additive, non-breaking change. Existing `DefaultEncoder` users do not need to modify code; users can now opt
+into streaming by passing these types.
 
 ---
 
@@ -406,7 +412,7 @@ public class FileBody implements Request.Body {
         try {
             return Files.size(path);
         } catch (IOException e) {
-            return super.contentLength(); // returns -1
+            return Request.Body.super.contentLength(); // returns -1
         }
     }
 }

--- a/api/src/main/java/feign/Request.java
+++ b/api/src/main/java/feign/Request.java
@@ -21,11 +21,14 @@ import static feign.Util.valuesOrEmpty;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.net.HttpURLConnection;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
@@ -345,6 +348,125 @@ public final class Request implements Serializable {
     }
   }
 
+  /** A {@link Body} implementation that reads content from a file specified by a {@link Path}. */
+  public static class PathBody implements Body {
+    private final Path path;
+
+    /**
+     * Creates a new {@link PathBody} instance with the specified file path.
+     *
+     * @param path the path to the file whose content will be used as the body of the request; must
+     *     not be {@code null}
+     */
+    public PathBody(Path path) {
+      this.path = Objects.requireNonNull(path, "path is required");
+    }
+
+    /**
+     * Writes the content of the file specified by the {@link Path} to the provided {@link
+     * OutputStream}.
+     *
+     * @param outputStream the output stream to which the body content should be written
+     * @throws IOException if an I/O error occurs while reading the file content or writing it to
+     *     the output stream
+     */
+    @Override
+    public void writeTo(OutputStream outputStream) throws IOException {
+      try (InputStream inputStream = Files.newInputStream(path)) {
+        Util.copy(inputStream, outputStream);
+      }
+    }
+
+    /**
+     * Returns the content length of the file specified by the {@link Path}, or {@code -1} if an I/O
+     * error occurs while determining the file size. This can be used by clients to set the {@code
+     * Content-Length} header.
+     *
+     * @return the content length of the file, or {@code -1} if an I/O error occurs while
+     *     determining the file size
+     */
+    @Override
+    public long contentLength() {
+      try {
+        return Files.size(path);
+      } catch (IOException e) {
+        return Body.super.contentLength();
+      }
+    }
+
+    /**
+     * Indicates that the body can be written multiple times, as the content is read from a file and
+     * can be re-read as needed. This is important for clients that may need to retry requests, as
+     * it allows the body to be re-sent without issues.
+     *
+     * @return {@code true} since the body can be written multiple times by re-reading the file
+     *     content
+     */
+    @Override
+    public boolean isRepeatable() {
+      return true;
+    }
+
+    /**
+     * Returns a string representation of the body content, which includes the file path and its
+     * size in bytes (or "unknown size" if the content length cannot be determined). This provides a
+     * human-readable description of the body content for debugging or logging purposes.
+     *
+     * @return a string representation of the body content, including the file path and its size in
+     *     bytes (or "unknown size" if the content length cannot be determined)
+     */
+    @Override
+    public String toString() {
+      long contentLength = contentLength();
+      String size = contentLength < 0 ? "unknown size" : contentLength + " bytes";
+
+      return "[Content of " + path + "(" + size + ")]";
+    }
+  }
+
+  /**
+   * A {@link Body} implementation that reads content from an {@link InputStream}. The content
+   * length is unknown, and the body is not repeatable.
+   */
+  public static class InputStreamBody implements Body {
+    private final InputStream inputStream;
+
+    /**
+     * Creates a new {@link InputStreamBody} instance with the specified input stream.
+     *
+     * @param inputStream the input stream from which the body content will be read; must not be
+     *     {@code null}
+     */
+    public InputStreamBody(InputStream inputStream) {
+      this.inputStream = Objects.requireNonNull(inputStream, "inputStream is required");
+    }
+
+    /**
+     * Writes the content read from the {@link InputStream} to the provided {@link OutputStream}.
+     * The content is read from the input stream and written to the output stream until the end of
+     * the stream is reached.
+     *
+     * @param outputStream the output stream to which the body content should be written
+     * @throws IOException if an I/O error occurs while reading from the input stream or writing to
+     *     the output stream
+     */
+    @Override
+    public void writeTo(OutputStream outputStream) throws IOException {
+      Util.copy(inputStream, outputStream);
+    }
+
+    /**
+     * Returns a string representation of the body content, which is a binary data of unknown size.
+     *
+     * @return a string representation of the body content, indicating that it is binary data of
+     *     unknown size
+     */
+    @Override
+    public String toString() {
+      return "[Binary data (unknown size)]";
+    }
+  }
+
   /**
    * Controls the per-request settings currently required to be implemented by all {@link Client
    * clients}
@@ -544,7 +666,7 @@ public final class Request implements Serializable {
 
     @Override
     public void writeTo(OutputStream outputStream) throws IOException {
-      Objects.requireNonNull(outputStream, "outputStream is required").write(content);
+      outputStream.write(content);
     }
 
     @Override

--- a/api/src/main/java/feign/Util.java
+++ b/api/src/main/java/feign/Util.java
@@ -266,7 +266,7 @@ public class Util {
   }
 
   /** Adapted from {@code com.google.common.io.ByteStreams.copy()}. */
-  private static long copy(InputStream from, OutputStream to) throws IOException {
+  public static long copy(InputStream from, OutputStream to) throws IOException {
     checkNotNull(from, "from");
     checkNotNull(to, "to");
     byte[] buf = new byte[BUF_SIZE];

--- a/api/src/main/java/feign/codec/Encoder.java
+++ b/api/src/main/java/feign/codec/Encoder.java
@@ -45,7 +45,7 @@ import java.lang.reflect.Type;
  *
  *   &#064;Override
  *   public void encode(Object object, Type bodyType, RequestTemplate template) {
- *     template.body(gson.toJson(object, bodyType));
+ *     template.body(Request.Body.of(gson.toJson(object, bodyType)));
  *   }
  * }
  * </pre>

--- a/core/src/main/java/feign/core/codec/DefaultEncoder.java
+++ b/core/src/main/java/feign/core/codec/DefaultEncoder.java
@@ -21,7 +21,10 @@ import feign.Request;
 import feign.RequestTemplate;
 import feign.codec.EncodeException;
 import feign.codec.Encoder;
+import java.io.File;
+import java.io.InputStream;
 import java.lang.reflect.Type;
+import java.nio.file.Path;
 
 public class DefaultEncoder implements Encoder {
 
@@ -31,6 +34,14 @@ public class DefaultEncoder implements Encoder {
       template.body(Request.Body.of(object.toString()));
     } else if (bodyType == byte[].class) {
       template.body(Request.Body.of((byte[]) object));
+    } else if (object instanceof File) {
+      template.body(new Request.PathBody(((File) object).toPath()));
+    } else if (object instanceof Path) {
+      template.body(new Request.PathBody((Path) object));
+    } else if (object instanceof InputStream) {
+      template.body(new Request.InputStreamBody((InputStream) object));
+    } else if (object instanceof Request.Body) {
+      template.body((Request.Body) object);
     } else if (object != null) {
       throw new EncodeException(
           format("%s is not a type supported by this encoder.", object.getClass()));

--- a/core/src/test/java/feign/FeignRequestBodyStreamingTest.java
+++ b/core/src/test/java/feign/FeignRequestBodyStreamingTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign;
+
+import static feign.assertj.MockWebServerAssertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class FeignRequestBodyStreamingTest {
+  private final MockWebServer mockWebServer = new MockWebServer();
+  private TestClient testClient;
+
+  @BeforeEach
+  void setup() throws IOException {
+    mockWebServer.enqueue(new MockResponse());
+    mockWebServer.start();
+    testClient = Feign.builder().target(TestClient.class, mockWebServer.url("/").toString());
+  }
+
+  @AfterEach
+  void tearDown() throws IOException {
+    mockWebServer.shutdown();
+  }
+
+  @Test
+  void shouldSendFile(@TempDir File tempDir) throws IOException, InterruptedException {
+    var file = new File(tempDir, "FeignRequestBodyStreamingTest_shouldSendFile.txt");
+    var expected = "File content";
+
+    Files.writeString(file.toPath(), expected);
+
+    testClient.post(file);
+
+    assertThat(mockWebServer.takeRequest()).hasBody(expected);
+  }
+
+  @Test
+  void shouldSendPath(@TempDir Path tempDir) throws IOException, InterruptedException {
+    var path = tempDir.resolve("FeignRequestBodyStreamingTest_shouldSendPath.txt");
+    var expected = "Path content";
+
+    Files.writeString(path, expected);
+
+    testClient.post(path);
+
+    assertThat(mockWebServer.takeRequest()).hasBody(expected);
+  }
+
+  @Test
+  void shouldSendInputStream() throws IOException, InterruptedException {
+    var expected = "InputStream content";
+
+    try (var inputStream = new ByteArrayInputStream(expected.getBytes(StandardCharsets.UTF_8))) {
+      testClient.post(inputStream);
+    }
+
+    assertThat(mockWebServer.takeRequest()).hasBody(expected);
+  }
+
+  @Test
+  void shouldSendRequestBody() throws InterruptedException {
+    var expected = "Request body content";
+
+    testClient.post(Request.Body.of(expected));
+
+    assertThat(mockWebServer.takeRequest()).hasBody(expected);
+  }
+
+  private interface TestClient {
+    @RequestLine("POST /")
+    void post(File body);
+
+    @RequestLine("POST /")
+    void post(Path body);
+
+    @RequestLine("POST /")
+    void post(InputStream body);
+
+    @RequestLine("POST /")
+    void post(Request.Body body);
+  }
+}

--- a/core/src/test/java/feign/core/codec/DefaultEncoderTest.java
+++ b/core/src/test/java/feign/core/codec/DefaultEncoderTest.java
@@ -17,16 +17,24 @@ package feign.core.codec;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import feign.Request;
 import feign.RequestTemplate;
 import feign.codec.EncodeException;
 import feign.codec.Encoder;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Clock;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class DefaultEncoderTest {
 
@@ -62,5 +70,66 @@ class DefaultEncoderTest {
             EncodeException.class,
             () -> encoder.encode(Clock.systemUTC(), Clock.class, new RequestTemplate()));
     assertThat(exception.getMessage()).contains("is not a type supported by this encoder.");
+  }
+
+  @Test
+  void shouldEncodeFile(@TempDir File tempDir) throws IOException {
+    var file = new File(tempDir, "DefaultEncoderTest_shouldEncodeFile.txt");
+    var template = new RequestTemplate();
+    var expected = "File content";
+
+    Files.writeString(file.toPath(), expected);
+
+    encoder.encode(file, File.class, template);
+
+    verifyBody(template, expected.length(), true, expected);
+  }
+
+  @Test
+  void shouldEncodePath(@TempDir Path tempDir) throws IOException {
+    var path = tempDir.resolve("DefaultEncoderTest_shouldEncodePath.txt");
+    var template = new RequestTemplate();
+    var expected = "Path content";
+
+    Files.writeString(path, expected);
+
+    encoder.encode(path, Path.class, template);
+
+    verifyBody(template, expected.length(), true, expected);
+  }
+
+  @Test
+  void shouldEncodeInputStream() throws IOException {
+    var template = new RequestTemplate();
+    var expected = "InputStream content";
+
+    try (var inputStream = new ByteArrayInputStream(expected.getBytes(StandardCharsets.UTF_8))) {
+      encoder.encode(inputStream, InputStream.class, template);
+    }
+
+    verifyBody(template, -1, false, expected);
+  }
+
+  @Test
+  void shouldEncodeRequestBody() {
+    var template = new RequestTemplate();
+    var expected = "Request body content";
+
+    encoder.encode(Request.Body.of(expected), Request.Body.class, template);
+
+    verifyBody(template, expected.length(), true, expected);
+  }
+
+  void verifyBody(
+      RequestTemplate template, long contentLength, boolean repeatable, String expected) {
+    var optionalBody = template.requestBody();
+    assertThat(optionalBody).isPresent();
+
+    var body = optionalBody.get();
+    assertEquals(contentLength, body.contentLength());
+    assertEquals(repeatable, body.isRepeatable());
+
+    var actual = assertDoesNotThrow(() -> body.writeToString(StandardCharsets.UTF_8));
+    assertEquals(expected, actual);
   }
 }


### PR DESCRIPTION
### Overview

A second PR in a series related to #2734 feature implementation.

`DefaultEncoder` previously accepted only `String` and `byte[]` body types, forcing callers to buffer file contents or stream data into a `byte[]` before encoding. This change extends `DefaultEncoder` with native support for `File`, `Path`, `InputStream`, and `Request.Body`, enabling streaming without in-memory buffering.

### What changed

**`DefaultEncoder`** — four new `instanceof` branches dispatch to the appropriate `Request.Body` implementation. `File` is normalized to `Path` before dispatch, so both go through `PathBody`.

**`Request.PathBody`** (new) — a `Body` backed by a filesystem path. Opens a fresh `InputStream` on each `writeTo()` call, so `isRepeatable()` returns `true` and retry-capable clients can re-send the body without special handling. `contentLength()` returns `Files.size(path)`, falling back to `-1` on I/O error, allowing clients to emit a `Content-Length` header when the file is accessible.

**`Request.InputStreamBody`** (new) — a `Body` backed by a caller-supplied `InputStream`. Because an `InputStream` can only be consumed once, `isRepeatable()` returns `false` (interface default) and `contentLength()` returns `-1` (interface default). Callers are responsible for stream lifecycle.

**`Util.copy()`** — visibility widened from `private` to `public` so that `PathBody` and `InputStreamBody` in `Request.java` (the `feign-api` module) can share the same buffered copy loop.

**`Encoder.java` Javadoc** — the example updated to use `Request.Body.of(...)` consistent with the v14 API.

**`MIGRATION-v14.md`** — adds a non-breaking change entry for the new `DefaultEncoder` types.

### Not changed

This is entirely additive. Existing `DefaultEncoder` behaviour for `String`, `byte[]`, and `null` is untouched. No interface changes.

### Tests

- `DefaultEncoderTest` — unit tests verify `contentLength`, `isRepeatable`, and round-trip body content for all four new types.
- `FeignRequestBodyStreamingTest` (new) — end-to-end integration tests against `MockWebServer` confirm the encoded body arrives over the wire correctly for `File`, `Path`, `InputStream`, and `Request.Body`.

---

Closes #220