### PR TITLE
feat: raise minimum Java version to 11 and apply OpenRewrite best practices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,8 @@ release.properties
 pom.xml.releaseBackup
 .mvn/.develocity/develocity-workspace-id
 .sdkmanrc
+
+# AI assistant tooling
+.antigravitycli/
+.claude/
+.understand-anything/

--- a/annotation-error-decoder/pom.xml
+++ b/annotation-error-decoder/pom.xml
@@ -44,7 +44,7 @@
 
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>mockwebserver</artifactId>
+      <artifactId>mockwebserver3</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -45,7 +45,7 @@
 
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>mockwebserver</artifactId>
+      <artifactId>mockwebserver3</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/api/src/main/java/feign/stream/StreamDecoder.java
+++ b/api/src/main/java/feign/stream/StreamDecoder.java
@@ -67,7 +67,7 @@ public final class StreamDecoder implements Decoder {
   @Override
   public Object decode(Response response, Type type) throws IOException, FeignException {
     if (!isStream(type)) {
-      if (!delegateDecoder.isPresent()) {
+      if (delegateDecoder.isEmpty()) {
         throw new IllegalArgumentException(
             "StreamDecoder supports types other than stream. "
                 + "When type is not stream, the delegate decoder needs to be setting.");

--- a/api/src/test/java/feign/EmptyTargetTest.java
+++ b/api/src/test/java/feign/EmptyTargetTest.java
@@ -16,7 +16,7 @@
 package feign;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import feign.Request.HttpMethod;
 import feign.Target.EmptyTarget;
@@ -33,24 +33,25 @@ class EmptyTargetTest {
 
   @Test
   void toString_withoutName() {
-    assertThat(EmptyTarget.create(UriInterface.class).toString())
-        .isEqualTo("EmptyTarget(type=UriInterface)");
+    assertThat(EmptyTarget.create(UriInterface.class))
+        .hasToString("EmptyTarget(type=UriInterface)");
   }
 
   @Test
   void toString_withName() {
-    assertThat(EmptyTarget.create(UriInterface.class, "manager-access").toString())
-        .isEqualTo("EmptyTarget(type=UriInterface, name=manager-access)");
+    assertThat(EmptyTarget.create(UriInterface.class, "manager-access"))
+        .hasToString("EmptyTarget(type=UriInterface, name=manager-access)");
   }
 
   @Test
   void mustApplyToAbsoluteUrl() {
     UnsupportedOperationException exception =
-        assertThrows(
-            UnsupportedOperationException.class,
-            () ->
-                EmptyTarget.create(UriInterface.class)
-                    .apply(new RequestTemplate().method(HttpMethod.GET).uri("/relative")));
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+            .isThrownBy(
+                () ->
+                    EmptyTarget.create(UriInterface.class)
+                        .apply(new RequestTemplate().method(HttpMethod.GET).uri("/relative")))
+            .actual();
     assertThat(exception.getMessage())
         .isEqualTo("Request with non-absolute URL not supported with empty target");
   }

--- a/api/src/test/java/feign/EnumForNameTest.java
+++ b/api/src/test/java/feign/EnumForNameTest.java
@@ -20,12 +20,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import feign.Request.ProtocolVersion;
 import java.util.Arrays;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 public class EnumForNameTest {
 
-  public static class KnownEnumValuesTest {
+  @Nested
+  public class KnownEnumValuesTest {
     public Object name;
     public ProtocolVersion expectedProtocolVersion;
 
@@ -56,7 +58,8 @@ public class EnumForNameTest {
     }
   }
 
-  public static class UnknownEnumValuesTest {
+  @Nested
+  public class UnknownEnumValuesTest {
 
     public Object name;
 

--- a/api/src/test/java/feign/FeignExceptionTest.java
+++ b/api/src/test/java/feign/FeignExceptionTest.java
@@ -16,7 +16,7 @@
 package feign;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -255,40 +255,41 @@ class FeignExceptionTest {
 
   @Test
   void nullRequestShouldThrowNPEwThrowable() {
-    assertThrows(
-        NullPointerException.class, () -> new Derived(404, "message", null, new Throwable()));
+    assertThatThrownBy(() -> new Derived(404, "message", null, new Throwable()))
+        .isInstanceOf(NullPointerException.class);
   }
 
   @Test
   void nullRequestShouldThrowNPEwThrowableAndBytes() {
-    assertThrows(
-        NullPointerException.class,
-        () ->
-            new Derived(
-                404,
-                "message",
-                null,
-                new Throwable(),
-                "content".getBytes(StandardCharsets.UTF_8),
-                Collections.emptyMap()));
+    assertThatThrownBy(
+            () ->
+                new Derived(
+                    404,
+                    "message",
+                    null,
+                    new Throwable(),
+                    "content".getBytes(StandardCharsets.UTF_8),
+                    Collections.emptyMap()))
+        .isInstanceOf(NullPointerException.class);
   }
 
   @Test
   void nullRequestShouldThrowNPE() {
-    assertThrows(NullPointerException.class, () -> new Derived(404, "message", null));
+    assertThatThrownBy(() -> new Derived(404, "message", null))
+        .isInstanceOf(NullPointerException.class);
   }
 
   @Test
   void nullRequestShouldThrowNPEwBytes() {
-    assertThrows(
-        NullPointerException.class,
-        () ->
-            new Derived(
-                404,
-                "message",
-                null,
-                "content".getBytes(StandardCharsets.UTF_8),
-                Collections.emptyMap()));
+    assertThatThrownBy(
+            () ->
+                new Derived(
+                    404,
+                    "message",
+                    null,
+                    "content".getBytes(StandardCharsets.UTF_8),
+                    Collections.emptyMap()))
+        .isInstanceOf(NullPointerException.class);
   }
 
   static class Derived extends FeignException {

--- a/api/src/test/java/feign/JavaLoggerTest.java
+++ b/api/src/test/java/feign/JavaLoggerTest.java
@@ -23,7 +23,7 @@ import java.util.logging.Level;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class JavaLoggerTest {
+class JavaLoggerTest {
 
   private static final String CONFIG_KEY = "TestApi#testMethod()";
   private java.util.logging.Logger julLogger;

--- a/api/src/test/java/feign/LoggerMethodsTest.java
+++ b/api/src/test/java/feign/LoggerMethodsTest.java
@@ -21,11 +21,10 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 import feign.Logger.Level;
-import java.io.IOException;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
-public class LoggerMethodsTest {
+class LoggerMethodsTest {
 
   Logger logger =
       new Logger() {
@@ -34,7 +33,7 @@ public class LoggerMethodsTest {
       };
 
   @Test
-  void responseIsClosedAfterRebuffer() throws IOException {
+  void responseIsClosedAfterRebuffer() throws Exception {
     Request request =
         Request.create(Request.HttpMethod.GET, "/api", Collections.emptyMap(), null, null);
     Response response =

--- a/api/src/test/java/feign/LoggerRebufferTest.java
+++ b/api/src/test/java/feign/LoggerRebufferTest.java
@@ -15,16 +15,14 @@
  */
 package feign;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import feign.Request.HttpMethod;
 import java.util.Collection;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
-public class LoggerRebufferTest {
+class LoggerRebufferTest {
 
   private static final String CONFIG_KEY = "TestApi#testMethod()";
 
@@ -55,8 +53,10 @@ public class LoggerRebufferTest {
     // then
     String read1 = Util.toString(result.body().asReader(Util.UTF_8));
     String read2 = Util.toString(result.body().asReader(Util.UTF_8));
-    assertEquals(originalBody, read1, "First read should return original body");
-    assertEquals(originalBody, read2, "Second read should return same body (rebuffered)");
+    assertThat(read1).as("First read should return original body").isEqualTo(originalBody);
+    assertThat(read2)
+        .as("Second read should return same body (rebuffered)")
+        .isEqualTo(originalBody);
   }
 
   @Test
@@ -79,7 +79,7 @@ public class LoggerRebufferTest {
 
     // then
     String read1 = Util.toString(result.body().asReader(Util.UTF_8));
-    assertEquals(originalBody, read1, "First read should return original body");
+    assertThat(read1).as("First read should return original body").isEqualTo(originalBody);
   }
 
   @Test
@@ -104,9 +104,9 @@ public class LoggerRebufferTest {
     String read1 = Util.toString(result.body().asReader(Util.UTF_8));
     String read2 = Util.toString(result.body().asReader(Util.UTF_8));
     String read3 = Util.toString(result.body().asReader(Util.UTF_8));
-    assertEquals(originalBody, read1, "First read should return original body");
-    assertEquals(originalBody, read2, "Second read should return same body");
-    assertEquals(originalBody, read3, "Third read should return same body");
+    assertThat(read1).as("First read should return original body").isEqualTo(originalBody);
+    assertThat(read2).as("Second read should return same body").isEqualTo(originalBody);
+    assertThat(read3).as("Third read should return same body").isEqualTo(originalBody);
   }
 
   @Test
@@ -129,7 +129,7 @@ public class LoggerRebufferTest {
 
     // then
     String read1 = Util.toString(result.body().asReader(Util.UTF_8));
-    assertEquals(originalBody, read1, "Body should be readable");
+    assertThat(read1).as("Body should be readable").isEqualTo(originalBody);
   }
 
   @Test
@@ -152,7 +152,7 @@ public class LoggerRebufferTest {
         logger.logAndRebufferResponse(CONFIG_KEY, Logger.Level.HEADERS, response, 100);
 
     // then
-    assertNotNull(result.body(), "Response body object should exist");
+    assertThat(result.body()).as("Response body object should exist").isNotNull();
   }
 
   @Test
@@ -174,7 +174,7 @@ public class LoggerRebufferTest {
         logger.logAndRebufferResponse(CONFIG_KEY, Logger.Level.HEADERS, response, 100);
 
     // then
-    assertNotNull(result.body(), "Response body object should exist");
+    assertThat(result.body()).as("Response body object should exist").isNotNull();
   }
 
   @Test
@@ -197,6 +197,6 @@ public class LoggerRebufferTest {
         logger.logAndRebufferResponse(CONFIG_KEY, Logger.Level.HEADERS, response, 100);
 
     // then
-    assertNull(result.body(), "Body should remain null");
+    assertThat(result.body()).as("Body should remain null").isNull();
   }
 }

--- a/api/src/test/java/feign/MethodInfoTest.java
+++ b/api/src/test/java/feign/MethodInfoTest.java
@@ -21,11 +21,13 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class MethodInfoTest {
 
-  static class AsyncClientTest {
+  @Nested
+  class AsyncClientTest {
     public interface AsyncClient {
       CompletableFuture<String> log();
     }
@@ -38,7 +40,8 @@ public class MethodInfoTest {
     }
   }
 
-  static class GenericAsyncClientTest {
+  @Nested
+  class GenericAsyncClientTest {
     public interface GenericAsyncClient<T> {
       T log();
     }
@@ -53,7 +56,8 @@ public class MethodInfoTest {
     }
   }
 
-  static class SyncClientTest {
+  @Nested
+  class SyncClientTest {
     public interface SyncClient {
       String log();
     }
@@ -66,7 +70,8 @@ public class MethodInfoTest {
     }
   }
 
-  static class GenericSyncClientTest {
+  @Nested
+  class GenericSyncClientTest {
     public interface GenericSyncClient<T> {
       T log();
     }

--- a/api/src/test/java/feign/RequestTemplateTest.java
+++ b/api/src/test/java/feign/RequestTemplateTest.java
@@ -17,8 +17,8 @@ package feign;
 
 import static feign.assertj.FeignAssertions.assertThat;
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.data.MapEntry.entry;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import feign.Request.HttpMethod;
 import feign.template.UriUtils;
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class RequestTemplateTest {
@@ -451,9 +452,9 @@ public class RequestTemplateTest {
   @Test
   void uriStuffedIntoMethod() {
     Throwable exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> new RequestTemplate().method("/path?queryParam={queryParam}"));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> new RequestTemplate().method("/path?queryParam={queryParam}"))
+            .actual();
     assertThat(exception.getMessage())
         .contains("Invalid HTTP Method: /path?queryParam={queryParam}");
   }
@@ -511,19 +512,19 @@ public class RequestTemplateTest {
     RequestTemplate template = new RequestTemplate().header("key1", "valid");
 
     assertThat(template.headers()).hasSize(1);
-    assertThat(template.headers().keySet()).containsExactly("key1");
+    Assertions.assertThat(template.headers()).containsOnlyKeys("key1");
     assertThat(template.headers().get("key1")).containsExactly("valid");
 
     template.headers().put("key2", Collections.singletonList("other value"));
     // nothing should change
     assertThat(template.headers()).hasSize(1);
-    assertThat(template.headers().keySet()).containsExactly("key1");
+    Assertions.assertThat(template.headers()).containsOnlyKeys("key1");
     assertThat(template.headers().get("key1")).containsExactly("valid");
 
     template.headers().get("key1").add("value2");
     // nothing should change either
     assertThat(template.headers()).hasSize(1);
-    assertThat(template.headers().keySet()).containsExactly("key1");
+    Assertions.assertThat(template.headers()).containsOnlyKeys("key1");
     assertThat(template.headers().get("key1")).containsExactly("valid");
   }
 

--- a/api/src/test/java/feign/ResponseTest.java
+++ b/api/src/test/java/feign/ResponseTest.java
@@ -114,7 +114,7 @@ class ResponseTest {
             .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, null))
             .body(new byte[0])
             .build();
-    assertThat(response.headers()).isNotNull().isEmpty();
+    assertThat(response.headers()).isEmpty();
   }
 
   @Test

--- a/api/src/test/java/feign/TypesResolveReturnTypeTest.java
+++ b/api/src/test/java/feign/TypesResolveReturnTypeTest.java
@@ -53,7 +53,7 @@ public class TypesResolveReturnTypeTest {
   @Test
   void simple() {
     Method[] methods = Simple.class.getMethods();
-    assertThat(methods.length).isEqualTo(1);
+    assertThat(methods.length).isOne();
     Type resolved = Types.resolve(Simple.class, Simple.class, methods[0].getGenericReturnType());
     assertThat(resolved).isEqualTo(String.class);
     // included for completeness sake only
@@ -64,7 +64,7 @@ public class TypesResolveReturnTypeTest {
   @Test
   void concreteSimple() {
     Method[] methods = ConcreteSimple.class.getMethods();
-    assertThat(methods.length).isEqualTo(1);
+    assertThat(methods.length).isOne();
     Type resolved =
         Types.resolve(
             ConcreteSimple.class, ConcreteSimple.class, methods[0].getGenericReturnType());
@@ -77,7 +77,7 @@ public class TypesResolveReturnTypeTest {
   @Test
   void overridingConcreteSimple() {
     Method[] methods = OverridingConcreteSimple.class.getMethods();
-    assertThat(methods.length).isEqualTo(1);
+    assertThat(methods.length).isOne();
     Type resolved =
         Types.resolve(
             OverridingConcreteSimple.class,
@@ -103,7 +103,7 @@ public class TypesResolveReturnTypeTest {
   @Test
   void simplePrimitive() {
     Method[] methods = SimplePrimitive.class.getMethods();
-    assertThat(methods.length).isEqualTo(1);
+    assertThat(methods.length).isOne();
     Type resolved =
         Types.resolve(
             SimplePrimitive.class, SimplePrimitive.class, methods[0].getGenericReturnType());
@@ -116,7 +116,7 @@ public class TypesResolveReturnTypeTest {
   @Test
   void concreteSimplePrimitive() {
     Method[] methods = ConcreteSimplePrimitive.class.getMethods();
-    assertThat(methods.length).isEqualTo(1);
+    assertThat(methods.length).isOne();
     Type resolved =
         Types.resolve(
             ConcreteSimplePrimitive.class,
@@ -131,7 +131,7 @@ public class TypesResolveReturnTypeTest {
   @Test
   void overridingConcreteSimplePrimitive() {
     Method[] methods = OverridingConcreteSimplePrimitive.class.getMethods();
-    assertThat(methods.length).isEqualTo(1);
+    assertThat(methods.length).isOne();
     Type resolved =
         Types.resolve(
             OverridingConcreteSimplePrimitive.class,
@@ -157,7 +157,7 @@ public class TypesResolveReturnTypeTest {
   @Test
   void generic() {
     Method[] methods = Generic.class.getMethods();
-    assertThat(methods.length).isEqualTo(1);
+    assertThat(methods.length).isOne();
     Type resolved =
         Types.resolve(
             Generic.class, Generic.class, Generic.class.getMethods()[0].getGenericReturnType());
@@ -169,7 +169,7 @@ public class TypesResolveReturnTypeTest {
   @Test
   void concreteSimpleClassGenericSecondLevel() {
     Method[] methods = ConcreteSimpleClassGenericSecondLevel.class.getMethods();
-    assertThat(methods.length).isEqualTo(1);
+    assertThat(methods.length).isOne();
     Type resolved =
         Types.resolve(
             ConcreteSimpleClassGenericSecondLevel.class,
@@ -350,8 +350,7 @@ public class TypesResolveReturnTypeTest {
             methods[1].getGenericReturnType());
     assertThat(resolved2).isEqualTo(Object.class);
     Type resolvedType = Types.resolveReturnType(resolved, resolved2);
-    assertThat(resolvedType).isEqualTo(resolved);
-    assertThat(resolvedType).isNotEqualTo(resolved2);
+    assertThat(resolvedType).isEqualTo(resolved).isNotEqualTo(resolved2);
   }
 
   interface MultipleInheritedGeneric<T> extends Generic<T>, SecondGeneric<T> {}
@@ -373,8 +372,7 @@ public class TypesResolveReturnTypeTest {
             methods[1].getGenericReturnType());
     assertThat(resolved2 instanceof TypeVariable).isTrue();
     Type resolvedType = Types.resolveReturnType(resolved, resolved2);
-    assertThat(resolvedType).isEqualTo(resolved2);
-    assertThat(resolvedType).isEqualTo(resolved);
+    assertThat(resolvedType).isEqualTo(resolved2).isEqualTo(resolved);
   }
 
   interface SecondLevelSimpleClassGeneric<T extends Number> extends Generic<T> {}
@@ -390,7 +388,7 @@ public class TypesResolveReturnTypeTest {
   @Test
   void secondLevelSimpleClassGeneric() {
     Method[] methods = SecondLevelSimpleClassGeneric.class.getMethods();
-    assertThat(methods.length).isEqualTo(1);
+    assertThat(methods.length).isOne();
     Type resolved =
         Types.resolve(
             SecondLevelSimpleClassGeneric.class,
@@ -404,7 +402,7 @@ public class TypesResolveReturnTypeTest {
   @Test
   void concreteSimpleClassGenericThirdLevel() {
     Method[] methods = ConcreteSimpleClassGenericThirdLevel.class.getMethods();
-    assertThat(methods.length).isEqualTo(1);
+    assertThat(methods.length).isOne();
     Type resolved =
         Types.resolve(
             ConcreteSimpleClassGenericThirdLevel.class,
@@ -482,7 +480,7 @@ public class TypesResolveReturnTypeTest {
   @Test
   void secondLevelCollectionGeneric() {
     Method[] methods = SecondLevelCollectionGeneric.class.getMethods();
-    assertThat(methods.length).isEqualTo(1);
+    assertThat(methods.length).isOne();
     Type resolved =
         Types.resolve(
             SecondLevelCollectionGeneric.class,
@@ -496,7 +494,7 @@ public class TypesResolveReturnTypeTest {
   @Test
   void thirdLevelCollectionGeneric() {
     Method[] methods = ThirdLevelCollectionGeneric.class.getMethods();
-    assertThat(methods.length).isEqualTo(1);
+    assertThat(methods.length).isOne();
     Type resolved =
         Types.resolve(
             ThirdLevelCollectionGeneric.class,
@@ -510,7 +508,7 @@ public class TypesResolveReturnTypeTest {
   @Test
   void concreteCollectionGenericFourthLevel() {
     Method[] methods = ConcreteCollectionGenericFourthLevel.class.getMethods();
-    assertThat(methods.length).isEqualTo(1);
+    assertThat(methods.length).isOne();
     Type resolved =
         Types.resolve(
             ConcreteCollectionGenericFourthLevel.class,
@@ -564,7 +562,7 @@ public class TypesResolveReturnTypeTest {
   @Test
   void genericFourthLevelCollectionGeneric() {
     Method[] methods = GenericFourthLevelCollectionGeneric.class.getMethods();
-    assertThat(methods.length).isEqualTo(1);
+    assertThat(methods.length).isOne();
     Type resolved =
         Types.resolve(
             GenericFourthLevelCollectionGeneric.class,
@@ -578,7 +576,7 @@ public class TypesResolveReturnTypeTest {
   @Test
   void concreteGenericCollectionGenericFifthLevel() {
     Method[] methods = ConcreteGenericCollectionGenericFifthLevel.class.getMethods();
-    assertThat(methods.length).isEqualTo(1);
+    assertThat(methods.length).isOne();
     Type resolved =
         Types.resolve(
             ConcreteGenericCollectionGenericFifthLevel.class,

--- a/api/src/test/java/feign/UtilTest.java
+++ b/api/src/test/java/feign/UtilTest.java
@@ -21,8 +21,6 @@ import static feign.Util.removeValues;
 import static feign.Util.resolveLastTypeParameter;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import feign.codec.Decoder;
 import java.io.Reader;
@@ -58,7 +56,7 @@ class UtilTest {
     assertThat(Util.emptyValueOf(Boolean.class)).isEqualTo(false);
     assertThat((byte[]) Util.emptyValueOf(byte[].class)).isEmpty();
     assertThat(Util.emptyValueOf(Collection.class)).isEqualTo(Collections.emptyList());
-    assertThat(((Iterator<?>) Util.emptyValueOf(Iterator.class)).hasNext()).isFalse();
+    assertThat(((Iterator<?>) Util.emptyValueOf(Iterator.class))).isExhausted();
     assertThat(Util.emptyValueOf(List.class)).isEqualTo(Collections.emptyList());
     assertThat(Util.emptyValueOf(Map.class)).isEqualTo(Collections.emptyMap());
     assertThat(Util.emptyValueOf(Set.class)).isEqualTo(Collections.emptySet());
@@ -94,7 +92,7 @@ class UtilTest {
         LastTypeParameter.class.getDeclaredField("PARAMETERIZED_LIST_STRING").getGenericType();
     Type listStringType = LastTypeParameter.class.getDeclaredField("LIST_STRING").getGenericType();
     Type last = resolveLastTypeParameter(context, Parameterized.class);
-    assertEquals(last, listStringType);
+    assertThat(listStringType).isEqualTo(last);
   }
 
   @Test
@@ -143,8 +141,7 @@ class UtilTest {
 
   @Test
   void checkArgumentInputFalseNotNullNullOutputIllegalArgumentException() {
-    assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(
+    assertThatThrownBy(
             () -> {
               // Arrange
               final boolean expression = false;
@@ -152,14 +149,14 @@ class UtilTest {
               final Object[] errorMessageArgs = null;
               Util.checkArgument(expression, errorMessageTemplate, errorMessageArgs);
               // Method is not expected to return due to exception thrown
-            });
+            })
+        .isInstanceOf(IllegalArgumentException.class);
     // Method is not expected to return due to exception thrown
   }
 
   @Test
   void checkNotNullInputNullNotNullNullOutputNullPointerException() {
-    assertThatExceptionOfType(NullPointerException.class)
-        .isThrownBy(
+    assertThatThrownBy(
             () -> {
               // Arrange
               final Object reference = null;
@@ -167,7 +164,8 @@ class UtilTest {
               final Object[] errorMessageArgs = null;
               Util.checkNotNull(reference, errorMessageTemplate, errorMessageArgs);
               // Method is not expected to return due to exception thrown
-            });
+            })
+        .isInstanceOf(NullPointerException.class);
     // Method is not expected to return due to exception thrown
   }
 
@@ -185,8 +183,7 @@ class UtilTest {
 
   @Test
   void checkStateInputFalseNotNullNullOutputIllegalStateException() {
-    assertThatExceptionOfType(IllegalStateException.class)
-        .isThrownBy(
+    assertThatThrownBy(
             () -> {
               // Arrange
               final boolean expression = false;
@@ -194,7 +191,8 @@ class UtilTest {
               final Object[] errorMessageArgs = null;
               Util.checkState(expression, errorMessageTemplate, errorMessageArgs);
               // Method is not expected to return due to exception thrown
-            });
+            })
+        .isInstanceOf(IllegalStateException.class);
     // Method is not expected to return due to exception thrown
   }
 
@@ -225,7 +223,7 @@ class UtilTest {
     // Act
     final boolean retval = Util.isBlank(value);
     // Assert result
-    assertThat(retval).isEqualTo(false);
+    assertThat(retval).isFalse();
   }
 
   @Test
@@ -235,7 +233,7 @@ class UtilTest {
     // Act
     final boolean retval = Util.isBlank(value);
     // Assert result
-    assertThat(retval).isEqualTo(true);
+    assertThat(retval).isTrue();
   }
 
   @Test
@@ -245,7 +243,7 @@ class UtilTest {
     // Act
     final boolean retval = Util.isNotBlank(value);
     // Assert result
-    assertThat(retval).isEqualTo(false);
+    assertThat(retval).isFalse();
   }
 
   @Test
@@ -255,7 +253,7 @@ class UtilTest {
     // Act
     final boolean retval = Util.isNotBlank(value);
     // Assert result
-    assertThat(retval).isEqualTo(true);
+    assertThat(retval).isTrue();
   }
 
   @Test
@@ -312,7 +310,7 @@ class UtilTest {
     // Act
     Map<String, Collection<String>> actualMap = caseInsensitiveCopyOf(null);
     // Assert result
-    assertThat(actualMap).isNotNull().isEmpty();
+    assertThat(actualMap).isEmpty();
   }
 
   interface LastTypeParameter {

--- a/api/src/test/java/feign/assertj/MockWebServerAssertions.java
+++ b/api/src/test/java/feign/assertj/MockWebServerAssertions.java
@@ -15,7 +15,7 @@
  */
 package feign.assertj;
 
-import okhttp3.mockwebserver.RecordedRequest;
+import mockwebserver3.RecordedRequest;
 import org.assertj.core.api.Assertions;
 
 public class MockWebServerAssertions extends Assertions {

--- a/api/src/test/java/feign/assertj/RecordedRequestAssert.java
+++ b/api/src/test/java/feign/assertj/RecordedRequestAssert.java
@@ -30,8 +30,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
+import mockwebserver3.RecordedRequest;
 import okhttp3.Headers;
-import okhttp3.mockwebserver.RecordedRequest;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.data.MapEntry;
 import org.assertj.core.internal.ByteArrays;
@@ -59,7 +59,7 @@ public final class RecordedRequestAssert
 
   public RecordedRequestAssert hasPath(String expected) {
     isNotNull();
-    objects.assertEqual(info, actual.getPath(), expected);
+    objects.assertEqual(info, actual.getTarget(), expected);
     return this;
   }
 
@@ -78,27 +78,27 @@ public final class RecordedRequestAssert
   }
 
   private Collection<String> getQueryParams() {
-    String path = actual.getPath();
+    String path = actual.getTarget();
     int queryStart = path.indexOf("?") + 1;
-    String[] queryParams = actual.getPath().substring(queryStart).split("&");
+    String[] queryParams = actual.getTarget().substring(queryStart).split("&");
     return Arrays.asList(queryParams);
   }
 
   public RecordedRequestAssert hasOneOfPath(String... expected) {
     isNotNull();
-    objects.assertIsIn(info, actual.getPath(), expected);
+    objects.assertIsIn(info, actual.getTarget(), expected);
     return this;
   }
 
   public RecordedRequestAssert hasBody(String utf8Expected) {
     isNotNull();
-    objects.assertEqual(info, actual.getBody().readUtf8(), utf8Expected);
+    objects.assertEqual(info, actual.getBody().utf8(), utf8Expected);
     return this;
   }
 
   public RecordedRequestAssert hasGzippedBody(byte[] expectedUncompressed) {
     isNotNull();
-    byte[] compressedBody = actual.getBody().readByteArray();
+    byte[] compressedBody = actual.getBody().toByteArray();
     byte[] uncompressedBody;
     try {
       uncompressedBody =
@@ -112,7 +112,7 @@ public final class RecordedRequestAssert
 
   public RecordedRequestAssert hasDeflatedBody(byte[] expectedUncompressed) {
     isNotNull();
-    byte[] compressedBody = actual.getBody().readByteArray();
+    byte[] compressedBody = actual.getBody().toByteArray();
     byte[] uncompressedBody;
     try {
       uncompressedBody =
@@ -126,7 +126,7 @@ public final class RecordedRequestAssert
 
   public RecordedRequestAssert hasBody(byte[] expected) {
     isNotNull();
-    arrays.assertContains(info, actual.getBody().readByteArray(), expected);
+    arrays.assertContains(info, actual.getBody().toByteArray(), expected);
     return this;
   }
 

--- a/api/src/test/java/feign/assertj/RequestTemplateAssert.java
+++ b/api/src/test/java/feign/assertj/RequestTemplateAssert.java
@@ -62,7 +62,7 @@ public final class RequestTemplateAssert
       failWithMessage("\nExpecting bodyTemplate to be null, but was:<%s>", actual.bodyTemplate());
     }
     Optional<Request.Body> requestBody = actual.requestBody();
-    if (!requestBody.isPresent()) {
+    if (requestBody.isEmpty()) {
       failWithMessage("\nExpecting body to be <%s>, but was empty", utf8Expected);
       return this;
     }
@@ -80,7 +80,7 @@ public final class RequestTemplateAssert
       failWithMessage("\nExpecting bodyTemplate to be null, but was:<%s>", actual.bodyTemplate());
     }
     Optional<Request.Body> requestBody = actual.requestBody();
-    if (!requestBody.isPresent()) {
+    if (requestBody.isEmpty()) {
       failWithMessage("\nExpecting body to be present, but was empty");
       return this;
     }
@@ -129,7 +129,7 @@ public final class RequestTemplateAssert
         failWithMessage(
             "\nExpecting requestBody.data to be null, but was:<%s>",
             actual.requestBody().get().writeToString(UTF_8));
-      } catch (IOException e) {
+      } catch (IOException _) {
         failWithMessage("\nExpecting requestBody to be null, but was present");
       }
     }

--- a/api/src/test/java/feign/template/HeaderTemplateTest.java
+++ b/api/src/test/java/feign/template/HeaderTemplateTest.java
@@ -16,7 +16,7 @@
 package feign.template;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,25 +28,27 @@ class HeaderTemplateTest {
   @Test
   void it_should_throw_exception_when_name_is_null() {
     IllegalArgumentException exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> HeaderTemplate.create(null, Collections.singletonList("test")));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> HeaderTemplate.create(null, Collections.singletonList("test")))
+            .actual();
     assertThat(exception.getMessage()).isEqualTo("name is required.");
   }
 
   @Test
   void it_should_throw_exception_when_name_is_empty() {
     IllegalArgumentException exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> HeaderTemplate.create("", Collections.singletonList("test")));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> HeaderTemplate.create("", Collections.singletonList("test")))
+            .actual();
     assertThat(exception.getMessage()).isEqualTo("name is required.");
   }
 
   @Test
   void it_should_throw_exception_when_value_is_null() {
     IllegalArgumentException exception =
-        assertThrows(IllegalArgumentException.class, () -> HeaderTemplate.create("test", null));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> HeaderTemplate.create("test", null))
+            .actual();
     assertThat(exception.getMessage()).isEqualTo("values are required");
   }
 
@@ -83,12 +85,12 @@ class HeaderTemplateTest {
     HeaderTemplate headerTemplateWithFirstOrdering =
         HeaderTemplate.create("hello", Arrays.asList("test 1", "test 2"));
     assertThat(new ArrayList<>(headerTemplateWithFirstOrdering.getValues()))
-        .isEqualTo(Arrays.asList("test 1", "test 2"));
+        .containsExactlyElementsOf(Arrays.asList("test 1", "test 2"));
 
     HeaderTemplate headerTemplateWithSecondOrdering =
         HeaderTemplate.create("hello", Arrays.asList("test 2", "test 1"));
     assertThat(new ArrayList<>(headerTemplateWithSecondOrdering.getValues()))
-        .isEqualTo(Arrays.asList("test 2", "test 1"));
+        .containsExactlyElementsOf(Arrays.asList("test 2", "test 1"));
   }
 
   @Test
@@ -102,14 +104,14 @@ class HeaderTemplateTest {
             HeaderTemplate.create("hello", Collections.emptyList()),
             Arrays.asList("test 1", "test 2"));
     assertThat(new ArrayList<>(headerTemplateWithFirstOrdering.getValues()))
-        .isEqualTo(Arrays.asList("test 1", "test 2"));
+        .containsExactlyElementsOf(Arrays.asList("test 1", "test 2"));
 
     HeaderTemplate headerTemplateWithSecondOrdering =
         HeaderTemplate.append(
             HeaderTemplate.create("hello", Collections.emptyList()),
             Arrays.asList("test 2", "test 1"));
     assertThat(new ArrayList<>(headerTemplateWithSecondOrdering.getValues()))
-        .isEqualTo(Arrays.asList("test 2", "test 1"));
+        .containsExactlyElementsOf(Arrays.asList("test 2", "test 1"));
   }
 
   @Test

--- a/api/src/test/java/feign/template/UriTemplateTest.java
+++ b/api/src/test/java/feign/template/UriTemplateTest.java
@@ -16,7 +16,7 @@
 package feign.template;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import feign.Util;
 import java.net.URI;
@@ -38,7 +38,8 @@ class UriTemplateTest {
 
   @Test
   void nullTemplate() {
-    assertThrows(IllegalArgumentException.class, () -> UriTemplate.create(null, Util.UTF_8));
+    assertThatThrownBy(() -> UriTemplate.create(null, Util.UTF_8))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -154,7 +155,8 @@ class UriTemplateTest {
     variables.put("bar", "stuff");
 
     /* the foo variable must be a number and no more than four, this should fail */
-    assertThrows(IllegalArgumentException.class, () -> uriTemplate.expand(variables));
+    assertThatThrownBy(() -> uriTemplate.expand(variables))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -187,7 +189,8 @@ class UriTemplateTest {
   @Test
   void rejectEmptyExpressions() {
     String template = "https://www.example.com/{}/things";
-    assertThrows(IllegalArgumentException.class, () -> UriTemplate.create(template, Util.UTF_8));
+    assertThatThrownBy(() -> UriTemplate.create(template, Util.UTF_8))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -244,8 +247,8 @@ class UriTemplateTest {
 
   @Test
   void substituteNullMap() {
-    assertThrows(
-        IllegalArgumentException.class, () -> UriTemplate.create("stuff", Util.UTF_8).expand(null));
+    assertThatThrownBy(() -> UriTemplate.create("stuff", Util.UTF_8).expand(null))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test

--- a/api/src/test/java/feign/template/UriUtilsTest.java
+++ b/api/src/test/java/feign/template/UriUtilsTest.java
@@ -45,7 +45,7 @@ class UriUtilsTest {
 
   @ParameterizedTest
   @MethodSource("provideValuesToEncode")
-  void testVariousEncodingScenarios(String input, String expected) {
+  void variousEncodingScenarios(String input, String expected) {
     assertThat(UriUtils.encode(input, UTF_8)).isEqualTo(expected);
   }
 

--- a/apt-test-generator/pom.xml
+++ b/apt-test-generator/pom.xml
@@ -86,6 +86,12 @@
       <version>${auto-service-annotations.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <version>1.3.5</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -66,7 +66,7 @@
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>mockwebserver</artifactId>
+      <artifactId>mockwebserver3</artifactId>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -55,7 +55,7 @@
 
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>mockwebserver</artifactId>
+      <artifactId>mockwebserver3</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -159,7 +159,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>--illegal-access=deny</argLine>
+              <argLine>--illegal-access=deny --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED -Dnet.bytebuddy.experimental=true</argLine>
             </configuration>
           </plugin>
         </plugins>

--- a/core/src/main/java/feign/core/DefaultClient.java
+++ b/core/src/main/java/feign/core/DefaultClient.java
@@ -227,7 +227,7 @@ public class DefaultClient implements Client {
       }
     }
 
-    if (!body.isPresent() && request.httpMethod().isWithBody()) {
+    if (body.isEmpty() && request.httpMethod().isWithBody()) {
       // To use this Header, set 'sun.net.http.allowRestrictedHeaders' property true.
       connection.addRequestProperty("Content-Length", "0");
     }

--- a/core/src/test/java/feign/AlwaysEncodeBodyContractTest.java
+++ b/core/src/test/java/feign/AlwaysEncodeBodyContractTest.java
@@ -17,7 +17,6 @@ package feign;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import feign.codec.EncodeException;
 import feign.codec.Encoder;
@@ -89,7 +88,11 @@ class AlwaysEncodeBodyContractTest {
     }
 
     private byte[] bodyAsBytes(Request.Body body) {
-      return assertDoesNotThrow(body::writeToByteArray);
+      try {
+        return body.writeToByteArray();
+      } catch (IOException e) {
+        throw new AssertionError("Failed to write body", e);
+      }
     }
   }
 
@@ -113,7 +116,7 @@ class AlwaysEncodeBodyContractTest {
             .encoder(new AllParametersSampleEncoder())
             .client(new SampleClient())
             .target(SampleTargetNoParameters.class, "http://localhost");
-    assertThat(sampleClient2.concatenate()).isEqualTo("");
+    assertThat(sampleClient2.concatenate()).isEmpty();
 
     SampleTargetOneParameter sampleClient3 =
         Feign.builder()

--- a/core/src/test/java/feign/AsyncFeignTest.java
+++ b/core/src/test/java/feign/AsyncFeignTest.java
@@ -18,11 +18,8 @@ package feign;
 import static feign.ExceptionPropagationPolicy.UNWRAP;
 import static feign.Util.UTF_8;
 import static feign.assertj.MockWebServerAssertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.data.MapEntry.entry;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -65,10 +62,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import okio.Buffer;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -79,7 +78,7 @@ public class AsyncFeignTest {
 
   @Test
   void iterableQueryParams() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
@@ -91,7 +90,7 @@ public class AsyncFeignTest {
 
   @Test
   void postTemplateParamsResolve() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
@@ -106,7 +105,7 @@ public class AsyncFeignTest {
 
   @Test
   void postFormParams() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
@@ -122,7 +121,7 @@ public class AsyncFeignTest {
 
   @Test
   void postBodyParam() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
@@ -142,7 +141,7 @@ public class AsyncFeignTest {
    */
   @Test
   void bodyTypeCorrespondsWithParameterType() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final AtomicReference<Type> encodedType = new AtomicReference<>();
     TestInterfaceAsync api =
@@ -167,7 +166,7 @@ public class AsyncFeignTest {
 
   @Test
   void postGZIPEncodedBodyParam() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
@@ -183,7 +182,7 @@ public class AsyncFeignTest {
 
   @Test
   void postDeflateEncodedBodyParam() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
@@ -199,7 +198,7 @@ public class AsyncFeignTest {
 
   @Test
   void singleInterceptor() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder()
@@ -216,7 +215,7 @@ public class AsyncFeignTest {
 
   @Test
   void multipleInterceptor() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder()
@@ -236,7 +235,7 @@ public class AsyncFeignTest {
 
   @Test
   void customExpander() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
@@ -250,7 +249,7 @@ public class AsyncFeignTest {
 
   @Test
   void customExpanderListParam() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
@@ -265,7 +264,7 @@ public class AsyncFeignTest {
 
   @Test
   void customExpanderNullParam() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
@@ -279,7 +278,7 @@ public class AsyncFeignTest {
 
   @Test
   void headerMap() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
@@ -299,7 +298,7 @@ public class AsyncFeignTest {
 
   @Test
   void headerMapWithHeaderAnnotations() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
@@ -314,7 +313,7 @@ public class AsyncFeignTest {
             entry("Content-Encoding", Arrays.asList("deflate")),
             entry("Custom-Header", Arrays.asList("fooValue")));
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     headerMap.put("Content-Encoding", "overrideFromMap");
 
     CompletableFuture<?> cf = api.headerMapWithHeaderAnnotations(headerMap);
@@ -333,7 +332,7 @@ public class AsyncFeignTest {
 
   @Test
   void queryMap() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
@@ -350,7 +349,7 @@ public class AsyncFeignTest {
 
   @Test
   void queryMapIterableValuesExpanded() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
@@ -373,21 +372,21 @@ public class AsyncFeignTest {
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     Map<String, Object> queryMap = new LinkedHashMap<>();
     queryMap.put("fooKey", "fooValue");
     api.queryMapWithQueryParams("alice", queryMap);
     // query map should be expanded after built-in parameters
     assertThat(server.takeRequest()).hasPath("/?name=alice&fooKey=fooValue");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("name", "bob");
     api.queryMapWithQueryParams("alice", queryMap);
     // queries are additive
     assertThat(server.takeRequest()).hasPath("/?name=alice&name=bob");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("name", null);
     api.queryMapWithQueryParams("alice", queryMap);
@@ -400,25 +399,25 @@ public class AsyncFeignTest {
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     Map<String, Object> queryMap = new LinkedHashMap<>();
     queryMap.put("name", "{alice");
     api.queryMap(queryMap);
     assertThat(server.takeRequest()).hasPath("/?name=%7Balice");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("{name", "alice");
     api.queryMap(queryMap);
     assertThat(server.takeRequest()).hasPath("/?%7Bname=alice");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("name", "%7Balice");
     api.queryMapEncoded(queryMap);
     assertThat(server.takeRequest()).hasPath("/?name=%7Balice");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("%7Bname", "%7Balice");
     api.queryMapEncoded(queryMap);
@@ -432,7 +431,7 @@ public class AsyncFeignTest {
 
     CustomPojo customPojo = new CustomPojo("Name", 3);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     CompletableFuture<?> cf = api.queryMapPojo(customPojo);
     assertThat(server.takeRequest()).hasQueryParams(Arrays.asList("name=Name", "number=3"));
     checkCFCompletedSoon(cf);
@@ -445,7 +444,7 @@ public class AsyncFeignTest {
 
     CustomPojo customPojo = new CustomPojo("Name", null);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     CompletableFuture<?> cf = api.queryMapPojo(customPojo);
     assertThat(server.takeRequest()).hasPath("/?name=Name");
 
@@ -459,7 +458,7 @@ public class AsyncFeignTest {
 
     CustomPojo customPojo = new CustomPojo(null, null);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     api.queryMapPojo(customPojo);
     assertThat(server.takeRequest()).hasPath("/");
   }
@@ -494,20 +493,23 @@ public class AsyncFeignTest {
 
   @Test
   void canOverrideErrorDecoder() throws Throwable {
-    server.enqueue(new MockResponse().setResponseCode(400).setBody("foo"));
+    server.enqueue(new MockResponse.Builder().code(400).body("foo").build());
 
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder()
             .errorDecoder(new IllegalArgumentExceptionOn400())
             .target("http://localhost:" + server.getPort());
 
-    Throwable exception = assertThrows(IllegalArgumentException.class, () -> unwrap(api.post()));
+    Throwable exception =
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> unwrap(api.post()))
+            .actual();
     assertThat(exception.getMessage()).contains("bad zone name");
   }
 
   @Test
   void overrideTypeSpecificDecoder() throws Throwable {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder()
@@ -520,8 +522,8 @@ public class AsyncFeignTest {
   /** when you must parse a 2xx status to determine if the operation succeeded or not. */
   @Test
   void retryableExceptionInDecoder() throws Exception {
-    server.enqueue(new MockResponse().setBody("retry!"));
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("retry!").build());
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder()
@@ -549,7 +551,7 @@ public class AsyncFeignTest {
 
   @Test
   void doesntRetryAfterResponseIsSent() throws Throwable {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder()
@@ -561,13 +563,14 @@ public class AsyncFeignTest {
 
     CompletableFuture<?> cf = api.post();
     server.takeRequest();
-    Throwable exception = assertThrows(FeignException.class, () -> unwrap(cf));
+    Throwable exception =
+        assertThatExceptionOfType(FeignException.class).isThrownBy(() -> unwrap(cf)).actual();
     assertThat(exception.getMessage()).contains("timeout reading POST http://");
   }
 
   @Test
   void throwsFeignExceptionIncludingBody() throws Throwable {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     TestInterfaceAsync api =
         AsyncFeign.builder()
@@ -592,7 +595,7 @@ public class AsyncFeignTest {
 
   @Test
   void throwsFeignExceptionWithoutBody() {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     TestInterfaceAsync api =
         AsyncFeign.builder()
@@ -607,16 +610,16 @@ public class AsyncFeignTest {
     } catch (FeignException e) {
       assertThat(e.getMessage())
           .isEqualTo("timeout reading POST http://localhost:" + server.getPort() + "/");
-      assertThat(e.contentUTF8()).isEqualTo("");
+      assertThat(e.contentUTF8()).isEmpty();
     }
   }
 
   @Test
   void ensureRetryerClonesItself() throws Throwable {
-    server.enqueue(new MockResponse().setResponseCode(503).setBody("foo 1"));
-    server.enqueue(new MockResponse().setResponseCode(200).setBody("foo 2"));
-    server.enqueue(new MockResponse().setResponseCode(503).setBody("foo 3"));
-    server.enqueue(new MockResponse().setResponseCode(200).setBody("foo 4"));
+    server.enqueue(new MockResponse.Builder().code(503).body("foo 1").build());
+    server.enqueue(new MockResponse.Builder().code(200).body("foo 2").build());
+    server.enqueue(new MockResponse.Builder().code(503).body("foo 3").build());
+    server.enqueue(new MockResponse.Builder().code(200).body("foo 4").build());
 
     MockRetryer retryer = new MockRetryer();
 
@@ -640,8 +643,8 @@ public class AsyncFeignTest {
 
   @Test
   void throwsOriginalExceptionAfterFailedRetries() throws Throwable {
-    server.enqueue(new MockResponse().setResponseCode(503).setBody("foo 1"));
-    server.enqueue(new MockResponse().setResponseCode(503).setBody("foo 2"));
+    server.enqueue(new MockResponse.Builder().code(503).body("foo 1").build());
+    server.enqueue(new MockResponse.Builder().code(503).body("foo 2").build());
 
     final String message = "the innerest";
 
@@ -660,14 +663,17 @@ public class AsyncFeignTest {
                         response.request()))
             .target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
 
-    Throwable exception = assertThrows(TestInterfaceException.class, () -> unwrap(api.post()));
+    Throwable exception =
+        assertThatExceptionOfType(TestInterfaceException.class)
+            .isThrownBy(() -> unwrap(api.post()))
+            .actual();
     assertThat(exception.getMessage()).contains(message);
   }
 
   @Test
   void throwsRetryableExceptionIfNoUnderlyingCause() throws Throwable {
-    server.enqueue(new MockResponse().setResponseCode(503).setBody("foo 1"));
-    server.enqueue(new MockResponse().setResponseCode(503).setBody("foo 2"));
+    server.enqueue(new MockResponse.Builder().code(503).body("foo 1").build());
+    server.enqueue(new MockResponse.Builder().code(503).body("foo 2").build());
 
     String message = "play it again sam!";
 
@@ -685,7 +691,10 @@ public class AsyncFeignTest {
                         response.request()))
             .target(TestInterfaceAsync.class, "http://localhost:" + server.getPort());
 
-    Throwable exception = assertThrows(RetryableException.class, () -> unwrap(api.post()));
+    Throwable exception =
+        assertThatExceptionOfType(RetryableException.class)
+            .isThrownBy(() -> unwrap(api.post()))
+            .actual();
     assertThat(exception.getMessage()).contains(message);
   }
 
@@ -794,7 +803,7 @@ public class AsyncFeignTest {
 
   @Test
   void okIfDecodeRootCauseHasNoMessage() throws Throwable {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder()
@@ -804,33 +813,35 @@ public class AsyncFeignTest {
                 })
             .target("http://localhost:" + server.getPort());
 
-    assertThrows(DecodeException.class, () -> unwrap(api.post()));
+    assertThatThrownBy(() -> unwrap(api.post())).isInstanceOf(DecodeException.class);
   }
 
   @Test
   void decodingExceptionGetWrappedInDismiss404Mode() throws Throwable {
-    server.enqueue(new MockResponse().setResponseCode(404));
+    server.enqueue(new MockResponse.Builder().code(404).build());
 
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder()
             .dismiss404()
             .decoder(
                 (response, _) -> {
-                  assertEquals(404, response.status());
+                  Assertions.assertThat(response.status()).isEqualTo(404);
                   throw new NoSuchElementException();
                 })
             .target("http://localhost:" + server.getPort());
 
-    DecodeException exception = assertThrows(DecodeException.class, () -> unwrap(api.post()));
+    DecodeException exception =
+        assertThatExceptionOfType(DecodeException.class)
+            .isThrownBy(() -> unwrap(api.post()))
+            .actual();
     assertThat(exception).hasCauseInstanceOf(NoSuchElementException.class);
   }
 
   @Test
   void decodingDoesNotSwallow404ErrorsInDismiss404Mode() throws Throwable {
-    assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(
+    assertThatThrownBy(
             () -> {
-              server.enqueue(new MockResponse().setResponseCode(404));
+              server.enqueue(new MockResponse.Builder().code(404).build());
 
               TestInterfaceAsync api =
                   new TestInterfaceAsyncBuilder()
@@ -841,12 +852,13 @@ public class AsyncFeignTest {
               CompletableFuture<Void> cf = api.queryMap(Collections.<String, Object>emptyMap());
               server.takeRequest();
               unwrap(cf);
-            });
+            })
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void okIfEncodeRootCauseHasNoMessage() throws Throwable {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder()
@@ -856,7 +868,8 @@ public class AsyncFeignTest {
                 })
             .target("http://localhost:" + server.getPort());
 
-    assertThrows(EncodeException.class, () -> unwrap(api.body(Arrays.asList("foo"))));
+    assertThatThrownBy(() -> unwrap(api.body(Arrays.asList("foo"))))
+        .isInstanceOf(EncodeException.class);
   }
 
   @Test
@@ -886,16 +899,14 @@ public class AsyncFeignTest {
 
     assertThat(t1).isNotEqualTo(i1);
 
-    assertThat(t1.hashCode()).isEqualTo(i1.hashCode());
-
-    assertThat(t1.toString()).isEqualTo(i1.toString());
+    Assertions.assertThat(t1).hasSameHashCodeAs(i1).hasToString(i1.toString());
   }
 
   @SuppressWarnings("resource")
   @Test
   void decodeLogicSupportsByteArray() throws Throwable {
     byte[] expectedResponse = {12, 34, 56};
-    server.enqueue(new MockResponse().setBody(new Buffer().write(expectedResponse)));
+    server.enqueue(new MockResponse.Builder().body(new Buffer().write(expectedResponse)).build());
 
     OtherTestInterfaceAsync api =
         AsyncFeign.builder()
@@ -907,7 +918,7 @@ public class AsyncFeignTest {
   @Test
   void encodeLogicSupportsByteArray() throws Exception {
     byte[] expectedRequest = {12, 34, 56};
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     OtherTestInterfaceAsync api =
         AsyncFeign.builder()
@@ -922,7 +933,7 @@ public class AsyncFeignTest {
 
   @Test
   void encodedQueryParam() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
@@ -945,7 +956,7 @@ public class AsyncFeignTest {
   }
 
   @Test
-  void responseMapperIsAppliedBeforeDelegate() throws IOException {
+  void responseMapperIsAppliedBeforeDelegate() throws Exception {
     ResponseMappingDecoder decoder =
         new ResponseMappingDecoder(upperCaseResponseMapper(), new StringDecoder());
     String output = (String) decoder.decode(responseWithText("response"), String.class);
@@ -977,7 +988,7 @@ public class AsyncFeignTest {
 
   @Test
   void mapAndDecodeExecutesMapFunction() throws Throwable {
-    server.enqueue(new MockResponse().setBody("response!"));
+    server.enqueue(new MockResponse.Builder().body("response!").build());
 
     TestInterfaceAsync api =
         AsyncFeign.builder()
@@ -999,7 +1010,7 @@ public class AsyncFeignTest {
     propertyPojo.setName("Name");
     propertyPojo.setNumber(1);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     CompletableFuture<?> cf = api.queryMapPropertyPojo(propertyPojo);
     assertThat(server.takeRequest()).hasQueryParams(Arrays.asList("name=Name", "number=1"));
     checkCFCompletedSoon(cf);
@@ -1017,7 +1028,7 @@ public class AsyncFeignTest {
     childPojo.setParentProtectedProperty("second");
     childPojo.setParentPublicProperty("third");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     CompletableFuture<?> cf = api.queryMapPropertyInheritence(childPojo);
     assertThat(server.takeRequest())
         .hasQueryParams(
@@ -1038,7 +1049,7 @@ public class AsyncFeignTest {
     propertyPojo.setName(null);
     propertyPojo.setNumber(1);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     CompletableFuture<?> cf = api.queryMapPropertyPojo(propertyPojo);
 
     assertThat(server.takeRequest()).hasQueryParams("number=1");
@@ -1055,7 +1066,7 @@ public class AsyncFeignTest {
 
     PropertyPojo.ChildPojoClass propertyPojo = new PropertyPojo.ChildPojoClass();
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     CompletableFuture<?> cf = api.queryMapPropertyPojo(propertyPojo);
     assertThat(server.takeRequest()).hasQueryParams("/");
 
@@ -1274,47 +1285,32 @@ public class AsyncFeignTest {
 
   @Test
   void nonInterface() {
-    assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(
-            () -> {
-              AsyncFeign.builder().target(NonInterface.class, "http://localhost");
-            });
+    assertThatThrownBy(() -> AsyncFeign.builder().target(NonInterface.class, "http://localhost"))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void extendedCFReturnType() {
-    assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(
-            () -> {
-              AsyncFeign.builder().target(ExtendedCFApi.class, "http://localhost");
-            });
+    assertThatThrownBy(() -> AsyncFeign.builder().target(ExtendedCFApi.class, "http://localhost"))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void lowerWildReturnType() {
-    assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(
-            () -> {
-              AsyncFeign.builder().target(LowerWildApi.class, "http://localhost");
-            });
+    assertThatThrownBy(() -> AsyncFeign.builder().target(LowerWildApi.class, "http://localhost"))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void upperWildReturnType() {
-    assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(
-            () -> {
-              AsyncFeign.builder().target(UpperWildApi.class, "http://localhost");
-            });
+    assertThatThrownBy(() -> AsyncFeign.builder().target(UpperWildApi.class, "http://localhost"))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void rWildReturnType() {
-    assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(
-            () -> {
-              AsyncFeign.builder().target(WildApi.class, "http://localhost");
-            });
+    assertThatThrownBy(() -> AsyncFeign.builder().target(WildApi.class, "http://localhost"))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   static final class ExtendedCF<T> extends CompletableFuture<T> {}
@@ -1371,6 +1367,11 @@ public class AsyncFeignTest {
     public Instant instant() {
       return Instant.ofEpochMilli(millis);
     }
+  }
+
+  @BeforeEach
+  void setUp() throws IOException {
+    server.start();
   }
 
   @AfterEach

--- a/core/src/test/java/feign/BaseApiTest.java
+++ b/core/src/test/java/feign/BaseApiTest.java
@@ -21,9 +21,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
 import java.util.List;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class BaseApiTest {
@@ -58,8 +59,8 @@ public class BaseApiTest {
   interface MyApi extends BaseApi<String, Long> {}
 
   @Test
-  void resolvesParameterizedResult() throws InterruptedException {
-    server.enqueue(new MockResponse().setBody("foo"));
+  void resolvesParameterizedResult() throws Exception {
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     String baseUrl = server.url("/default").toString();
 
@@ -76,8 +77,8 @@ public class BaseApiTest {
   }
 
   @Test
-  void resolvesBodyParameter() throws InterruptedException {
-    server.enqueue(new MockResponse().setBody("foo"));
+  void resolvesBodyParameter() throws Exception {
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     String baseUrl = server.url("/default").toString();
 
@@ -92,6 +93,11 @@ public class BaseApiTest {
             })
         .target(MyApi.class, baseUrl)
         .getAll(new Keys<>());
+  }
+
+  @BeforeEach
+  void setUp() throws IOException {
+    server.start();
   }
 
   @AfterEach

--- a/core/src/test/java/feign/BaseBuilderTest.java
+++ b/core/src/test/java/feign/BaseBuilderTest.java
@@ -16,7 +16,6 @@
 package feign;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.mockito.Mockito.RETURNS_MOCKS;
 
 import java.lang.reflect.Field;
@@ -27,8 +26,7 @@ import org.mockito.Mockito;
 class BaseBuilderTest {
 
   @Test
-  void checkEnrichTouchesAllAsyncBuilderFields()
-      throws IllegalArgumentException, IllegalAccessException {
+  void checkEnrichTouchesAllAsyncBuilderFields() throws Exception {
     test(
         AsyncFeign.builder().requestInterceptor(_ -> {}).responseInterceptor((ic, c) -> c.next(ic)),
         12);
@@ -52,13 +50,12 @@ class BaseBuilderTest {
       assertThat(Mockito.mockingDetails(mockedValue).isMock())
           .as("Field was not enriched " + field)
           .isTrue();
-      assertNotSame(builder, enriched);
+      assertThat(enriched).isNotSameAs(builder);
     }
   }
 
   @Test
-  void checkEnrichTouchesAllBuilderFields()
-      throws IllegalArgumentException, IllegalAccessException {
+  void checkEnrichTouchesAllBuilderFields() throws Exception {
     test(
         Feign.builder().requestInterceptor(_ -> {}).responseInterceptor((ic, c) -> c.next(ic)), 10);
   }

--- a/core/src/test/java/feign/ContractWithRuntimeInjectionTest.java
+++ b/core/src/test/java/feign/ContractWithRuntimeInjectionTest.java
@@ -22,9 +22,10 @@ import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.ApplicationContext;
@@ -61,8 +62,8 @@ public class ContractWithRuntimeInjectionTest {
   }
 
   @Test
-  void baseCaseExpanderNewInstance() throws InterruptedException {
-    server.enqueue(new MockResponse());
+  void baseCaseExpanderNewInstance() throws Exception {
+    server.enqueue(new MockResponse.Builder().build());
 
     String baseUrl = server.url("/default").toString();
 
@@ -111,8 +112,8 @@ public class ContractWithRuntimeInjectionTest {
   }
 
   @Test
-  void contractWithRuntimeInjection() throws InterruptedException {
-    server.enqueue(new MockResponse());
+  void contractWithRuntimeInjection() throws Exception {
+    server.enqueue(new MockResponse.Builder().build());
 
     String baseUrl = server.url("/default").toString();
     ApplicationContext context = new AnnotationConfigApplicationContext(FeignConfiguration.class);
@@ -123,6 +124,11 @@ public class ContractWithRuntimeInjectionTest {
         .get("FOO");
 
     assertThat(server.takeRequest()).hasPath("/default/path?query=foo");
+  }
+
+  @BeforeEach
+  void setUp() throws IOException {
+    server.start();
   }
 
   @AfterEach

--- a/core/src/test/java/feign/FeignBuilderTest.java
+++ b/core/src/test/java/feign/FeignBuilderTest.java
@@ -16,6 +16,7 @@
 package feign;
 
 import static feign.assertj.MockWebServerAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
@@ -39,10 +40,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import org.assertj.core.api.Assertions;
 import org.assertj.core.data.MapEntry;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class FeignBuilderTest {
@@ -51,7 +54,7 @@ public class FeignBuilderTest {
 
   @Test
   void defaults() throws Exception {
-    server.enqueue(new MockResponse().setBody("response data"));
+    server.enqueue(new MockResponse.Builder().body("response data").build());
 
     String url = "http://localhost:" + server.getPort();
     TestInterface api = Feign.builder().target(TestInterface.class, url);
@@ -65,18 +68,18 @@ public class FeignBuilderTest {
   /** Shows exception handling isn't required to coerce 404 to null or empty */
   @Test
   void dismiss404() {
-    server.enqueue(new MockResponse().setResponseCode(404));
-    server.enqueue(new MockResponse().setResponseCode(404));
-    server.enqueue(new MockResponse().setResponseCode(404));
-    server.enqueue(new MockResponse().setResponseCode(404));
-    server.enqueue(new MockResponse().setResponseCode(404));
-    server.enqueue(new MockResponse().setResponseCode(400));
+    server.enqueue(new MockResponse.Builder().code(404).build());
+    server.enqueue(new MockResponse.Builder().code(404).build());
+    server.enqueue(new MockResponse.Builder().code(404).build());
+    server.enqueue(new MockResponse.Builder().code(404).build());
+    server.enqueue(new MockResponse.Builder().code(404).build());
+    server.enqueue(new MockResponse.Builder().code(400).build());
 
     String url = "http://localhost:" + server.getPort();
     TestInterface api = Feign.builder().dismiss404().target(TestInterface.class, url);
 
     assertThat(api.getQueues("/")).isEmpty(); // empty, not null!
-    assertThat(api.decodedLazyPost().hasNext()).isFalse(); // empty, not null!
+    Assertions.assertThat(api.decodedLazyPost()).isExhausted(); // empty, not null!
     assertThat(api.optionalContent()).isEmpty(); // empty, not null!
     assertThat(api.streamPost()).isEmpty(); // empty, not null!
     assertThat(api.decodedPost()).isNull(); // null, not empty!
@@ -92,18 +95,18 @@ public class FeignBuilderTest {
   /** Shows exception handling isn't required to coerce 204 to null or empty */
   @Test
   void decode204() {
-    server.enqueue(new MockResponse().setResponseCode(204));
-    server.enqueue(new MockResponse().setResponseCode(204));
-    server.enqueue(new MockResponse().setResponseCode(204));
-    server.enqueue(new MockResponse().setResponseCode(204));
-    server.enqueue(new MockResponse().setResponseCode(204));
-    server.enqueue(new MockResponse().setResponseCode(400));
+    server.enqueue(new MockResponse.Builder().code(204).build());
+    server.enqueue(new MockResponse.Builder().code(204).build());
+    server.enqueue(new MockResponse.Builder().code(204).build());
+    server.enqueue(new MockResponse.Builder().code(204).build());
+    server.enqueue(new MockResponse.Builder().code(204).build());
+    server.enqueue(new MockResponse.Builder().code(400).build());
 
     String url = "http://localhost:" + server.getPort();
     TestInterface api = Feign.builder().target(TestInterface.class, url);
 
     assertThat(api.getQueues("/")).isEmpty(); // empty, not null!
-    assertThat(api.decodedLazyPost().hasNext()).isFalse(); // empty, not null!
+    Assertions.assertThat(api.decodedLazyPost()).isExhausted(); // empty, not null!
     assertThat(api.optionalContent()).isEmpty(); // empty, not null!
     assertThat(api.streamPost()).isEmpty(); // empty, not null!
     assertThat(api.decodedPost()).isNull(); // null, not empty!
@@ -118,7 +121,7 @@ public class FeignBuilderTest {
 
   @Test
   void noFollowRedirect() {
-    server.enqueue(new MockResponse().setResponseCode(302).addHeader("Location", "/"));
+    server.enqueue(new MockResponse.Builder().code(302).addHeader("Location", "/").build());
 
     String url = "http://localhost:" + server.getPort();
     TestInterface noFollowApi =
@@ -136,8 +139,8 @@ public class FeignBuilderTest {
               assertThat(value).contains("/");
             });
 
-    server.enqueue(new MockResponse().setResponseCode(302).addHeader("Location", "/"));
-    server.enqueue(new MockResponse().setResponseCode(200));
+    server.enqueue(new MockResponse.Builder().code(302).addHeader("Location", "/").build());
+    server.enqueue(new MockResponse.Builder().code(200).build());
     TestInterface defaultApi =
         Feign.builder()
             .options(
@@ -148,7 +151,7 @@ public class FeignBuilderTest {
 
   @Test
   void urlPathConcatUrlTrailingSlash() throws Exception {
-    server.enqueue(new MockResponse().setBody("response data"));
+    server.enqueue(new MockResponse.Builder().body("response data").build());
 
     String url = "http://localhost:" + server.getPort() + "/";
     TestInterface api = Feign.builder().target(TestInterface.class, url);
@@ -159,7 +162,7 @@ public class FeignBuilderTest {
 
   @Test
   void urlPathConcatNoPathOnRequestLine() throws Exception {
-    server.enqueue(new MockResponse().setBody("response data"));
+    server.enqueue(new MockResponse.Builder().body("response data").build());
 
     String url = "http://localhost:" + server.getPort() + "/";
     TestInterface api = Feign.builder().target(TestInterface.class, url);
@@ -170,7 +173,7 @@ public class FeignBuilderTest {
 
   @Test
   void httpNotFoundError() {
-    server.enqueue(new MockResponse().setResponseCode(404));
+    server.enqueue(new MockResponse.Builder().code(404).build());
 
     String url = "http://localhost:" + server.getPort() + "/";
     TestInterface api = Feign.builder().target(TestInterface.class, url);
@@ -185,7 +188,7 @@ public class FeignBuilderTest {
 
   @Test
   void urlPathConcatNoInitialSlashOnPath() throws Exception {
-    server.enqueue(new MockResponse().setBody("response data"));
+    server.enqueue(new MockResponse.Builder().body("response data").build());
 
     String url = "http://localhost:" + server.getPort() + "/";
     TestInterface api = Feign.builder().target(TestInterface.class, url);
@@ -196,7 +199,7 @@ public class FeignBuilderTest {
 
   @Test
   void urlPathConcatNoInitialSlashOnPathNoTrailingSlashOnUrl() throws Exception {
-    server.enqueue(new MockResponse().setBody("response data"));
+    server.enqueue(new MockResponse.Builder().body("response data").build());
 
     String url = "http://localhost:" + server.getPort();
     TestInterface api = Feign.builder().target(TestInterface.class, url);
@@ -207,7 +210,7 @@ public class FeignBuilderTest {
 
   @Test
   void overrideEncoder() throws Exception {
-    server.enqueue(new MockResponse().setBody("response data"));
+    server.enqueue(new MockResponse.Builder().body("response data").build());
 
     String url = "http://localhost:" + server.getPort();
     Encoder encoder = (object, _, template) -> template.body(Request.Body.of(object.toString()));
@@ -220,7 +223,7 @@ public class FeignBuilderTest {
 
   @Test
   void overrideDecoder() {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     String url = "http://localhost:" + server.getPort();
     Decoder decoder = (_, _) -> "fail";
@@ -228,12 +231,12 @@ public class FeignBuilderTest {
     TestInterface api = Feign.builder().decoder(decoder).target(TestInterface.class, url);
     assertThat(api.decodedPost()).isEqualTo("fail");
 
-    assertThat(server.getRequestCount()).isEqualTo(1);
+    assertThat(server.getRequestCount()).isOne();
   }
 
   @Test
   void overrideQueryMapEncoder() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     String url = "http://localhost:" + server.getPort();
     QueryMapEncoder customMapEncoder =
@@ -249,12 +252,12 @@ public class FeignBuilderTest {
     api.queryMapEncoded("ignored");
 
     assertThat(server.takeRequest()).hasQueryParams(Arrays.asList("key1=value1", "key2=value2"));
-    assertThat(server.getRequestCount()).isEqualTo(1);
+    assertThat(server.getRequestCount()).isOne();
   }
 
   @Test
   void provideRequestInterceptors() throws Exception {
-    server.enqueue(new MockResponse().setBody("response data"));
+    server.enqueue(new MockResponse.Builder().body("response data").build());
 
     String url = "http://localhost:" + server.getPort();
     RequestInterceptor requestInterceptor =
@@ -272,7 +275,7 @@ public class FeignBuilderTest {
 
   @Test
   void provideInvocationHandlerFactory() throws Exception {
-    server.enqueue(new MockResponse().setBody("response data"));
+    server.enqueue(new MockResponse.Builder().body("response data").build());
 
     String url = "http://localhost:" + server.getPort();
 
@@ -294,14 +297,14 @@ public class FeignBuilderTest {
         Feign.builder().invocationHandlerFactory(factory).target(TestInterface.class, url);
     Response response = api.codecPost("request data");
     assertThat(Util.toString(response.body().asReader(Util.UTF_8))).isEqualTo("response data");
-    assertThat(callCount.get()).isEqualTo(1);
+    assertThat(callCount.get()).isOne();
 
     assertThat(server.takeRequest()).hasBody("request data");
   }
 
   @Test
   void slashIsEncodedInPathParams() throws Exception {
-    server.enqueue(new MockResponse().setBody("response data"));
+    server.enqueue(new MockResponse.Builder().body("response data").build());
 
     String url = "http://localhost:" + server.getPort();
 
@@ -318,12 +321,12 @@ public class FeignBuilderTest {
     TestInterface api = Feign.builder().target(TestInterface.class, url);
     String result = api.independentDefaultMethod();
 
-    assertThat(result.equals("default result")).isTrue();
+    Assertions.assertThat(result).isEqualTo("default result");
   }
 
   @Test
   void defaultCallingProxiedMethod() throws Exception {
-    server.enqueue(new MockResponse().setBody("response data"));
+    server.enqueue(new MockResponse.Builder().body("response data").build());
 
     String url = "http://localhost:" + server.getPort();
     TestInterface api = Feign.builder().target(TestInterface.class, url);
@@ -344,7 +347,7 @@ public class FeignBuilderTest {
    */
   @Test
   void doNotCloseAfterDecode() {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     String url = "http://localhost:" + server.getPort();
     Decoder decoder =
@@ -375,11 +378,11 @@ public class FeignBuilderTest {
         Feign.builder().decoder(decoder).doNotCloseAfterDecode().target(TestInterface.class, url);
     Iterator<String> iterator = api.decodedLazyPost();
 
-    assertThat(iterator.hasNext()).isTrue();
+    Assertions.assertThat(iterator).hasNext();
     assertThat(iterator.next()).isEqualTo("success!");
-    assertThat(iterator.hasNext()).isFalse();
+    Assertions.assertThat(iterator).isExhausted();
 
-    assertThat(server.getRequestCount()).isEqualTo(1);
+    assertThat(server.getRequestCount()).isOne();
   }
 
   /**
@@ -388,7 +391,7 @@ public class FeignBuilderTest {
    */
   @Test
   void doNotCloseAfterDecodeDecoderFailure() {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     String url = "http://localhost:" + server.getPort();
     Decoder angryDecoder =
@@ -452,11 +455,7 @@ public class FeignBuilderTest {
             .decoder(angryDecoder)
             .doNotCloseAfterDecode()
             .target(TestInterface.class, url);
-    try {
-      api.decodedLazyPost();
-      fail("Expected an exception");
-    } catch (FeignException _) {
-    }
+    assertThatThrownBy(() -> api.decodedLazyPost()).isInstanceOf(FeignException.class);
     assertThat(closed.get()).as("Responses must be closed when the decoder fails").isTrue();
   }
 
@@ -501,6 +500,11 @@ public class FeignBuilderTest {
     default Response defaultMethodPassthrough() {
       return getNoPath();
     }
+  }
+
+  @BeforeEach
+  void setUp() throws IOException {
+    server.start();
   }
 
   @AfterEach

--- a/core/src/test/java/feign/FeignRequestBodyStreamingTest.java
+++ b/core/src/test/java/feign/FeignRequestBodyStreamingTest.java
@@ -24,8 +24,8 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,14 +37,14 @@ public class FeignRequestBodyStreamingTest {
 
   @BeforeEach
   void setup() throws IOException {
-    mockWebServer.enqueue(new MockResponse());
+    mockWebServer.enqueue(new MockResponse.Builder().build());
     mockWebServer.start();
     testClient = Feign.builder().target(TestClient.class, mockWebServer.url("/").toString());
   }
 
   @AfterEach
   void tearDown() throws IOException {
-    mockWebServer.shutdown();
+    mockWebServer.close();
   }
 
   @Test

--- a/core/src/test/java/feign/FeignTest.java
+++ b/core/src/test/java/feign/FeignTest.java
@@ -19,12 +19,8 @@ import static feign.ExceptionPropagationPolicy.UNWRAP;
 import static feign.Util.UTF_8;
 import static feign.assertj.MockWebServerAssertions.assertThat;
 import static java.util.Collections.emptyList;
-import static org.assertj.core.api.Assertions.fail;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.data.MapEntry.entry;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -65,13 +61,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicReference;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.SocketPolicy;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import mockwebserver3.SocketEffect;
 import okio.Buffer;
+import org.assertj.core.api.Assertions;
 import org.assertj.core.data.MapEntry;
 import org.assertj.core.util.Maps;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 
@@ -83,7 +81,7 @@ public class FeignTest {
 
   @Test
   void iterableQueryParams() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -94,7 +92,7 @@ public class FeignTest {
 
   @Test
   void arrayQueryMapParams() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -105,7 +103,7 @@ public class FeignTest {
 
   @Test
   void typedResponse() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -113,14 +111,14 @@ public class FeignTest {
 
     assertThat(response.status()).isEqualTo(200);
     assertThat(response.body()).isEqualTo("foo");
-    assertThat(response.protocolVersion().toString()).isEqualTo("HTTP/1.1");
-    assertNotNull(response.headers());
-    assertNotNull(response.request());
+    Assertions.assertThat(response.protocolVersion()).hasToString("HTTP/1.1");
+    Assertions.assertThat(response.headers()).isNotNull();
+    assertThat(response.request()).isNotNull();
   }
 
   @Test
   void postTemplateParamsResolve() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -134,7 +132,7 @@ public class FeignTest {
 
   @Test
   void postFormParams() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -147,7 +145,7 @@ public class FeignTest {
 
   @Test
   void postBodyParam() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -164,7 +162,7 @@ public class FeignTest {
    */
   @Test
   void bodyTypeCorrespondsWithParameterType() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final AtomicReference<Type> encodedType = new AtomicReference<>();
     TestInterface api =
@@ -187,7 +185,7 @@ public class FeignTest {
 
   @Test
   void postGZIPEncodedBodyParam() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -200,7 +198,7 @@ public class FeignTest {
 
   @Test
   void postDeflateEncodedBodyParam() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -213,7 +211,7 @@ public class FeignTest {
 
   @Test
   void singleInterceptor() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterface api =
         new TestInterfaceBuilder()
@@ -228,7 +226,7 @@ public class FeignTest {
 
   @Test
   void multipleInterceptor() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterface api =
         new TestInterfaceBuilder()
@@ -246,7 +244,7 @@ public class FeignTest {
 
   @Test
   void customExpander() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -257,7 +255,7 @@ public class FeignTest {
 
   @Test
   void customExpanderListParam() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -268,7 +266,7 @@ public class FeignTest {
 
   @Test
   void customExpanderNullParam() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -279,7 +277,7 @@ public class FeignTest {
 
   @Test
   void headerMap() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -296,7 +294,7 @@ public class FeignTest {
 
   @Test
   void HeaderMapUserObject() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -313,7 +311,7 @@ public class FeignTest {
 
   @Test
   void headerMapWithHeaderAnnotations() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -327,7 +325,7 @@ public class FeignTest {
             entry("Content-Encoding", Collections.singletonList("deflate")),
             entry("Custom-Header", Collections.singletonList("fooValue")));
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     headerMap.put("Content-Encoding", "overrideFromMap");
 
     api.headerMapWithHeaderAnnotations(headerMap);
@@ -344,7 +342,7 @@ public class FeignTest {
 
   @Test
   void queryMap() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -358,7 +356,7 @@ public class FeignTest {
 
   @Test
   void queryMapWithNull() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -372,7 +370,7 @@ public class FeignTest {
 
   @Test
   void queryMapWithEmpty() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -386,7 +384,7 @@ public class FeignTest {
 
   @Test
   void queryMapIterableValuesExpanded() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -405,21 +403,21 @@ public class FeignTest {
   void queryMapWithQueryParams() throws Exception {
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     Map<String, Object> queryMap = new LinkedHashMap<>();
     queryMap.put("fooKey", "fooValue");
     api.queryMapWithQueryParams("alice", queryMap);
     // query map should be expanded after built-in parameters
     assertThat(server.takeRequest()).hasPath("/?name=alice&fooKey=fooValue");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("name", "bob");
     api.queryMapWithQueryParams("alice", queryMap);
     // queries are additive
     assertThat(server.takeRequest()).hasPath("/?name=alice&name=bob");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("name", null);
     api.queryMapWithQueryParams("alice", queryMap);
@@ -431,25 +429,25 @@ public class FeignTest {
   void queryMapValueStartingWithBrace() throws Exception {
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     Map<String, Object> queryMap = new LinkedHashMap<>();
     queryMap.put("name", "{alice");
     api.queryMap(queryMap);
     assertThat(server.takeRequest()).hasPath("/?name=%7Balice");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("{name", "alice");
     api.queryMap(queryMap);
     assertThat(server.takeRequest()).hasPath("/?%7Bname=alice");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("name", "%7Balice");
     api.queryMap(queryMap);
     assertThat(server.takeRequest()).hasPath("/?name=%7Balice");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("%7Bname", "%7Balice");
     api.queryMap(queryMap);
@@ -462,7 +460,7 @@ public class FeignTest {
 
     CustomPojo customPojo = new CustomPojo("Name", 3);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     api.queryMapPojo(customPojo);
     assertThat(server.takeRequest()).hasQueryParams(Arrays.asList("name=Name", "number=3"));
   }
@@ -473,7 +471,7 @@ public class FeignTest {
 
     CustomPojo customPojo = new CustomPojo("Name", null);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     api.queryMapPojo(customPojo);
     assertThat(server.takeRequest()).hasPath("/?name=Name");
   }
@@ -484,7 +482,7 @@ public class FeignTest {
 
     CustomPojo customPojo = new CustomPojo(null, null);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     api.queryMapPojo(customPojo);
     assertThat(server.takeRequest()).hasPath("/");
   }
@@ -509,21 +507,25 @@ public class FeignTest {
 
   @Test
   void canOverrideErrorDecoder() throws Exception {
-    server.enqueue(new MockResponse().setResponseCode(400).setBody("foo"));
+    server.enqueue(new MockResponse.Builder().code(400).body("foo").build());
 
     TestInterface api =
         new TestInterfaceBuilder()
             .errorDecoder(new IllegalArgumentExceptionOn400())
             .target("http://localhost:" + server.getPort());
 
-    Throwable exception = assertThrows(IllegalArgumentException.class, () -> api.post());
+    Throwable exception =
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> api.post())
+            .actual();
     assertThat(exception.getMessage()).contains("bad zone name");
   }
 
   @Test
   void retriesLostConnectionBeforeRead() throws Exception {
-    server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(
+        new MockResponse.Builder().onRequestStart(new SocketEffect.CloseSocket()).build());
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -534,7 +536,7 @@ public class FeignTest {
 
   @Test
   void overrideTypeSpecificDecoder() throws Exception {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     TestInterface api =
         new TestInterfaceBuilder()
@@ -547,8 +549,8 @@ public class FeignTest {
   /** when you must parse a 2xx status to determine if the operation succeeded or not. */
   @Test
   void retryableExceptionInDecoder() throws Exception {
-    server.enqueue(new MockResponse().setBody("retry!"));
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("retry!").build());
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     TestInterface api =
         new TestInterfaceBuilder()
@@ -576,7 +578,7 @@ public class FeignTest {
 
   @Test
   void doesntRetryAfterResponseIsSent() throws Exception {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     TestInterface api =
         new TestInterfaceBuilder()
@@ -586,13 +588,14 @@ public class FeignTest {
                 })
             .target("http://localhost:" + server.getPort());
 
-    Throwable exception = assertThrows(FeignException.class, () -> api.post());
+    Throwable exception =
+        assertThatExceptionOfType(FeignException.class).isThrownBy(() -> api.post()).actual();
     assertThat(exception.getMessage()).contains("timeout reading POST http://");
   }
 
   @Test
   void throwsFeignExceptionIncludingBody() {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     TestInterface api =
         Feign.builder()
@@ -613,7 +616,7 @@ public class FeignTest {
 
   @Test
   void throwsFeignExceptionWithoutBody() {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     TestInterface api =
         Feign.builder()
@@ -628,7 +631,7 @@ public class FeignTest {
     } catch (FeignException e) {
       assertThat(e.getMessage())
           .isEqualTo("timeout reading POST http://localhost:" + server.getPort() + "/");
-      assertThat(e.contentUTF8()).isEqualTo("");
+      assertThat(e.contentUTF8()).isEmpty();
     }
   }
 
@@ -644,7 +647,8 @@ public class FeignTest {
                 })
             .target(TestInterface.class, "http://localhost:" + server.getPort());
 
-    RetryableException exception = assertThrows(RetryableException.class, () -> api.post());
+    RetryableException exception =
+        assertThatExceptionOfType(RetryableException.class).isThrownBy(() -> api.post()).actual();
 
     assertThat(exception.getMessage()).contains("missing Location header for redirect");
     assertThat(exception.getCause()).isInstanceOf(ProtocolException.class);
@@ -663,7 +667,9 @@ public class FeignTest {
             .target(TestInterface.class, "http://localhost:" + server.getPort());
 
     ProtocolException exception =
-        assertThrows(ProtocolException.class, () -> api.postThrowsProtocolException());
+        assertThatExceptionOfType(ProtocolException.class)
+            .isThrownBy(() -> api.postThrowsProtocolException())
+            .actual();
 
     assertThat(exception.getMessage()).contains("missing Location header for redirect");
   }
@@ -680,7 +686,10 @@ public class FeignTest {
                 })
             .target(TestInterface.class, "http://localhost:" + server.getPort());
 
-    IOException exception = assertThrows(IOException.class, () -> api.postThrowsIOException());
+    IOException exception =
+        assertThatExceptionOfType(IOException.class)
+            .isThrownBy(() -> api.postThrowsIOException())
+            .actual();
 
     assertThat(exception).isInstanceOf(ProtocolException.class);
     assertThat(exception.getMessage()).contains("missing Location header for redirect");
@@ -688,10 +697,10 @@ public class FeignTest {
 
   @Test
   void ensureRetryerClonesItself() throws Exception {
-    server.enqueue(new MockResponse().setResponseCode(503).setBody("foo 1"));
-    server.enqueue(new MockResponse().setResponseCode(200).setBody("foo 2"));
-    server.enqueue(new MockResponse().setResponseCode(503).setBody("foo 3"));
-    server.enqueue(new MockResponse().setResponseCode(200).setBody("foo 4"));
+    server.enqueue(new MockResponse.Builder().code(503).body("foo 1").build());
+    server.enqueue(new MockResponse.Builder().code(200).body("foo 2").build());
+    server.enqueue(new MockResponse.Builder().code(503).body("foo 3").build());
+    server.enqueue(new MockResponse.Builder().code(200).body("foo 4").build());
 
     MockRetryer retryer = new MockRetryer();
 
@@ -715,8 +724,8 @@ public class FeignTest {
 
   @Test
   void throwsOriginalExceptionAfterFailedRetries() throws Exception {
-    server.enqueue(new MockResponse().setResponseCode(503).setBody("foo 1"));
-    server.enqueue(new MockResponse().setResponseCode(503).setBody("foo 2"));
+    server.enqueue(new MockResponse.Builder().code(503).body("foo 1").build());
+    server.enqueue(new MockResponse.Builder().code(503).body("foo 2").build());
 
     final String message = "the innerest";
 
@@ -734,14 +743,17 @@ public class FeignTest {
                         NON_RETRYABLE,
                         response.request()))
             .target(TestInterface.class, "http://localhost:" + server.getPort());
-    TestInterfaceException exception = assertThrows(TestInterfaceException.class, () -> api.post());
+    TestInterfaceException exception =
+        assertThatExceptionOfType(TestInterfaceException.class)
+            .isThrownBy(() -> api.post())
+            .actual();
     assertThat(exception.getMessage()).contains(message);
   }
 
   @Test
   void throwsRetryableExceptionIfNoUnderlyingCause() throws Exception {
-    server.enqueue(new MockResponse().setResponseCode(503).setBody("foo 1"));
-    server.enqueue(new MockResponse().setResponseCode(503).setBody("foo 2"));
+    server.enqueue(new MockResponse.Builder().code(503).body("foo 1").build());
+    server.enqueue(new MockResponse.Builder().code(503).body("foo 2").build());
 
     String message = "play it again sam!";
 
@@ -759,7 +771,8 @@ public class FeignTest {
                         response.request()))
             .target(TestInterface.class, "http://localhost:" + server.getPort());
 
-    RetryableException exception = assertThrows(RetryableException.class, () -> api.post());
+    RetryableException exception =
+        assertThatExceptionOfType(RetryableException.class).isThrownBy(() -> api.post()).actual();
     assertThat(exception.getMessage()).contains(message);
   }
 
@@ -811,7 +824,7 @@ public class FeignTest {
 
   @Test
   void okIfDecodeRootCauseHasNoMessage() throws Exception {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     TestInterface api =
         new TestInterfaceBuilder()
@@ -821,32 +834,32 @@ public class FeignTest {
                 })
             .target("http://localhost:" + server.getPort());
 
-    assertThrows(DecodeException.class, () -> api.post());
+    assertThatThrownBy(() -> api.post()).isInstanceOf(DecodeException.class);
   }
 
   @Test
   void decodingExceptionGetWrappedInDismiss404Mode() throws Exception {
-    server.enqueue(new MockResponse().setResponseCode(404));
+    server.enqueue(new MockResponse.Builder().code(404).build());
 
     TestInterface api =
         new TestInterfaceBuilder()
             .dismiss404()
             .decoder(
                 (response, _) -> {
-                  assertEquals(404, response.status());
+                  Assertions.assertThat(response.status()).isEqualTo(404);
                   throw new NoSuchElementException();
                 })
             .target("http://localhost:" + server.getPort());
-    DecodeException exception = assertThrows(DecodeException.class, () -> api.post());
+    DecodeException exception =
+        assertThatExceptionOfType(DecodeException.class).isThrownBy(() -> api.post()).actual();
     assertThat(exception).hasCauseInstanceOf(NoSuchElementException.class);
   }
 
   @Test
   void decodingDoesNotSwallow404ErrorsInDismiss404Mode() throws Exception {
-    assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(
+    assertThatThrownBy(
             () -> {
-              server.enqueue(new MockResponse().setResponseCode(404));
+              server.enqueue(new MockResponse.Builder().code(404).build());
 
               TestInterface api =
                   new TestInterfaceBuilder()
@@ -854,12 +867,13 @@ public class FeignTest {
                       .errorDecoder(new IllegalArgumentExceptionOn404())
                       .target("http://localhost:" + server.getPort());
               api.queryMap(Collections.<String, Object>emptyMap());
-            });
+            })
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void okIfEncodeRootCauseHasNoMessage() throws Exception {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     TestInterface api =
         new TestInterfaceBuilder()
@@ -869,7 +883,7 @@ public class FeignTest {
                 })
             .target("http://localhost:" + server.getPort());
 
-    assertThrows(EncodeException.class, () -> api.body(Arrays.asList("foo")));
+    assertThatThrownBy(() -> api.body(Arrays.asList("foo"))).isInstanceOf(EncodeException.class);
   }
 
   @Test
@@ -897,15 +911,13 @@ public class FeignTest {
 
     assertThat(t1).isNotEqualTo(i1);
 
-    assertThat(t1.hashCode()).isEqualTo(i1.hashCode());
-
-    assertThat(t1.toString()).isEqualTo(i1.toString());
+    Assertions.assertThat(t1).hasSameHashCodeAs(i1).hasToString(i1.toString());
   }
 
   @Test
   void decodeLogicSupportsByteArray() throws Exception {
     byte[] expectedResponse = {12, 34, 56};
-    server.enqueue(new MockResponse().setBody(new Buffer().write(expectedResponse)));
+    server.enqueue(new MockResponse.Builder().body(new Buffer().write(expectedResponse)).build());
 
     OtherTestInterface api =
         Feign.builder().target(OtherTestInterface.class, "http://localhost:" + server.getPort());
@@ -916,7 +928,7 @@ public class FeignTest {
   @Test
   void encodeLogicSupportsByteArray() throws Exception {
     byte[] expectedRequest = {12, 34, 56};
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     OtherTestInterface api =
         Feign.builder().target(OtherTestInterface.class, "http://localhost:" + server.getPort());
@@ -928,7 +940,7 @@ public class FeignTest {
 
   @Test
   void encodedQueryParam() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -938,7 +950,7 @@ public class FeignTest {
   }
 
   @Test
-  void responseMapperIsAppliedBeforeDelegate() throws IOException {
+  void responseMapperIsAppliedBeforeDelegate() throws Exception {
     ResponseMappingDecoder decoder =
         new ResponseMappingDecoder(upperCaseResponseMapper(), new StringDecoder());
     String output = (String) decoder.decode(responseWithText("response"), String.class);
@@ -969,7 +981,7 @@ public class FeignTest {
 
   @Test
   void mapAndDecodeExecutesMapFunction() throws Exception {
-    server.enqueue(new MockResponse().setBody("response!"));
+    server.enqueue(new MockResponse.Builder().body("response!").build());
 
     TestInterface api =
         new Feign.Builder()
@@ -991,7 +1003,7 @@ public class FeignTest {
     propertyPojo.setName("Name");
     propertyPojo.setNumber(1);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     api.queryMapPropertyPojo(propertyPojo);
     assertThat(server.takeRequest()).hasQueryParams(Arrays.asList("name=Name", "number=1"));
   }
@@ -1009,7 +1021,7 @@ public class FeignTest {
     childPojo.setParentPublicProperty("third");
     childPojo.setParentPrivatePropertyAlteredByGetter("fourth");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     api.queryMapPropertyInheritence(childPojo);
     assertThat(server.takeRequest())
         .hasQueryParams(
@@ -1033,7 +1045,7 @@ public class FeignTest {
     childPojo.setParentPublicProperty("third");
     childPojo.setParentPrivatePropertyAlteredByGetter("fourth");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     api.queryMapPropertyInheritenceWithBeanMapEncoder(childPojo);
     assertThat(server.takeRequest())
         .hasQueryParams(
@@ -1054,7 +1066,7 @@ public class FeignTest {
     propertyPojo.setName(null);
     propertyPojo.setNumber(1);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     api.queryMapPropertyPojo(propertyPojo);
     assertThat(server.takeRequest()).hasQueryParams("number=1");
   }
@@ -1068,7 +1080,7 @@ public class FeignTest {
 
     PropertyPojo.ChildPojoClass propertyPojo = new PropertyPojo.ChildPojoClass();
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     api.queryMapPropertyPojo(propertyPojo);
     assertThat(server.takeRequest()).hasQueryParams("/");
   }
@@ -1077,7 +1089,7 @@ public class FeignTest {
   void matrixParametersAreSupported() throws Exception {
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     List<String> owners = new ArrayList<>();
     owners.add("Mark");
@@ -1091,7 +1103,7 @@ public class FeignTest {
   void matrixParametersAlsoSupportMaps() throws Exception {
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     Map<String, Object> properties = new LinkedHashMap<>();
     properties.put("account", "a");
     properties.put("name", "n");
@@ -1104,7 +1116,7 @@ public class FeignTest {
   void supportComplexHeaders() throws Exception {
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     /* demonstrate that a complex header, like a JSON document, is supported */
     String complex = "{ \"object\": \"value\", \"second\": \"string\" }";
 
@@ -1117,7 +1129,7 @@ public class FeignTest {
   @Test
   void decodeVoid() throws Exception {
     Decoder mockDecoder = mock(Decoder.class);
-    server.enqueue(new MockResponse().setResponseCode(200).setBody("OK"));
+    server.enqueue(new MockResponse.Builder().code(200).body("OK").build());
 
     TestInterface api =
         new TestInterfaceBuilder()
@@ -1132,7 +1144,7 @@ public class FeignTest {
   @Test
   void redirectionInterceptorString() throws Exception {
     String location = "https://redirect.example.com";
-    server.enqueue(new MockResponse().setResponseCode(302).setHeader("Location", location));
+    server.enqueue(new MockResponse.Builder().code(302).setHeader("Location", location).build());
 
     TestInterface api =
         new TestInterfaceBuilder()
@@ -1149,7 +1161,7 @@ public class FeignTest {
     String location = "https://redirect.example.com";
     Collection<String> locations = Collections.singleton("https://redirect.example.com");
 
-    server.enqueue(new MockResponse().setResponseCode(302).setHeader("Location", location));
+    server.enqueue(new MockResponse.Builder().code(302).setHeader("Location", location).build());
 
     TestInterface api =
         new TestInterfaceBuilder()
@@ -1157,7 +1169,8 @@ public class FeignTest {
             .target("http://localhost:" + server.getPort());
 
     Collection<String> response = api.collection();
-    assertThat(response.size())
+    Assertions.assertThat(response)
+        .size()
         .as("RedirectionInterceptor did not extract the location header")
         .isEqualTo(locations.size());
     assertThat(response.contains(location))
@@ -1168,7 +1181,7 @@ public class FeignTest {
   @Test
   void responseInterceptor400Error() throws Exception {
     String body = "BACK OFF!!";
-    server.enqueue(new MockResponse().setResponseCode(429).setBody(body));
+    server.enqueue(new MockResponse.Builder().code(429).body(body).build());
 
     TestInterface api =
         new TestInterfaceBuilder()
@@ -1182,7 +1195,7 @@ public class FeignTest {
   @Test
   void responseInterceptor500Error() throws Exception {
     String body = "One moment, please.";
-    server.enqueue(new MockResponse().setResponseCode(503).setBody(body));
+    server.enqueue(new MockResponse.Builder().code(503).body(body).build());
 
     TestInterface api =
         new TestInterfaceBuilder()
@@ -1196,10 +1209,10 @@ public class FeignTest {
   @Test
   void responseInterceptorChain() throws Exception {
     String location = "https://redirect.example.com";
-    server.enqueue(new MockResponse().setResponseCode(302).setHeader("Location", location));
+    server.enqueue(new MockResponse.Builder().code(302).setHeader("Location", location).build());
 
     String body = "One moment, please.";
-    server.enqueue(new MockResponse().setResponseCode(503).setBody(body));
+    server.enqueue(new MockResponse.Builder().code(503).body(body).build());
 
     TestInterface api =
         new TestInterfaceBuilder()
@@ -1218,10 +1231,10 @@ public class FeignTest {
   @Test
   void responseInterceptorChainList() throws Exception {
     String location = "https://redirect.example.com";
-    server.enqueue(new MockResponse().setResponseCode(302).setHeader("Location", location));
+    server.enqueue(new MockResponse.Builder().code(302).setHeader("Location", location).build());
 
     String body = "One moment, please.";
-    server.enqueue(new MockResponse().setResponseCode(503).setBody(body));
+    server.enqueue(new MockResponse.Builder().code(503).body(body).build());
 
     TestInterface api =
         new TestInterfaceBuilder()
@@ -1241,13 +1254,14 @@ public class FeignTest {
     String location = "https://redirect.example.com";
     String redirectBody = "Not the location";
     server.enqueue(
-        new MockResponse()
-            .setResponseCode(302)
+        new MockResponse.Builder()
+            .code(302)
             .setHeader("Location", location)
-            .setBody(redirectBody));
+            .body(redirectBody)
+            .build());
 
     String body = "One moment, please.";
-    server.enqueue(new MockResponse().setResponseCode(503).setBody(body));
+    server.enqueue(new MockResponse.Builder().code(503).body(body).build());
 
     // ErrorInterceptor WILL extract the body of redirects, so we re-order our
     // interceptors to
@@ -1585,6 +1599,11 @@ public class FeignTest {
     public Instant instant() {
       return Instant.ofEpochMilli(millis);
     }
+  }
+
+  @BeforeEach
+  void setUp() throws IOException {
+    server.start();
   }
 
   @AfterEach

--- a/core/src/test/java/feign/FeignUnderAsyncTest.java
+++ b/core/src/test/java/feign/FeignUnderAsyncTest.java
@@ -17,10 +17,9 @@ package feign;
 
 import static feign.Util.UTF_8;
 import static feign.assertj.MockWebServerAssertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.data.MapEntry.entry;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -56,11 +55,13 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.SocketPolicy;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import mockwebserver3.SocketEffect;
 import okio.Buffer;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation")
@@ -69,7 +70,7 @@ public class FeignUnderAsyncTest {
 
   @Test
   void iterableQueryParams() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -80,7 +81,7 @@ public class FeignUnderAsyncTest {
 
   @Test
   void postTemplateParamsResolve() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -94,7 +95,7 @@ public class FeignUnderAsyncTest {
 
   @Test
   void postFormParams() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -107,7 +108,7 @@ public class FeignUnderAsyncTest {
 
   @Test
   void postBodyParam() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -124,7 +125,7 @@ public class FeignUnderAsyncTest {
    */
   @Test
   void bodyTypeCorrespondsWithParameterType() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final AtomicReference<Type> encodedType = new AtomicReference<>();
     TestInterface api =
@@ -147,7 +148,7 @@ public class FeignUnderAsyncTest {
 
   @Test
   void postGZIPEncodedBodyParam() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -160,7 +161,7 @@ public class FeignUnderAsyncTest {
 
   @Test
   void postDeflateEncodedBodyParam() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -173,7 +174,7 @@ public class FeignUnderAsyncTest {
 
   @Test
   void singleInterceptor() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterface api =
         new TestInterfaceBuilder()
@@ -188,7 +189,7 @@ public class FeignUnderAsyncTest {
 
   @Test
   void multipleInterceptor() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterface api =
         new TestInterfaceBuilder()
@@ -206,7 +207,7 @@ public class FeignUnderAsyncTest {
 
   @Test
   void customExpander() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -217,7 +218,7 @@ public class FeignUnderAsyncTest {
 
   @Test
   void customExpanderListParam() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -228,7 +229,7 @@ public class FeignUnderAsyncTest {
 
   @Test
   void customExpanderNullParam() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -239,7 +240,7 @@ public class FeignUnderAsyncTest {
 
   @Test
   void headerMap() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -256,7 +257,7 @@ public class FeignUnderAsyncTest {
 
   @Test
   void headerMapWithHeaderAnnotations() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -270,7 +271,7 @@ public class FeignUnderAsyncTest {
             entry("Content-Encoding", Collections.singletonList("deflate")),
             entry("Custom-Header", Collections.singletonList("fooValue")));
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     headerMap.put("Content-Encoding", "overrideFromMap");
 
     api.headerMapWithHeaderAnnotations(headerMap);
@@ -287,7 +288,7 @@ public class FeignUnderAsyncTest {
 
   @Test
   void queryMap() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -301,7 +302,7 @@ public class FeignUnderAsyncTest {
 
   @Test
   void queryMapIterableValuesExpanded() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -320,21 +321,21 @@ public class FeignUnderAsyncTest {
   void queryMapWithQueryParams() throws Exception {
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     Map<String, Object> queryMap = new LinkedHashMap<>();
     queryMap.put("fooKey", "fooValue");
     api.queryMapWithQueryParams("alice", queryMap);
     // query map should be expanded after built-in parameters
     assertThat(server.takeRequest()).hasPath("/?name=alice&fooKey=fooValue");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("name", "bob");
     api.queryMapWithQueryParams("alice", queryMap);
     // queries are additive
     assertThat(server.takeRequest()).hasPath("/?name=alice&name=bob");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("name", null);
     api.queryMapWithQueryParams("alice", queryMap);
@@ -346,25 +347,25 @@ public class FeignUnderAsyncTest {
   void queryMapValueStartingWithBrace() throws Exception {
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     Map<String, Object> queryMap = new LinkedHashMap<>();
     queryMap.put("name", "{alice");
     api.queryMap(queryMap);
     assertThat(server.takeRequest()).hasPath("/?name=%7Balice");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("{name", "alice");
     api.queryMap(queryMap);
     assertThat(server.takeRequest()).hasPath("/?%7Bname=alice");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("name", "%7Balice");
     api.queryMapEncoded(queryMap);
     assertThat(server.takeRequest()).hasPath("/?name=%7Balice");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("%7Bname", "%7Balice");
     api.queryMapEncoded(queryMap);
@@ -377,7 +378,7 @@ public class FeignUnderAsyncTest {
 
     CustomPojo customPojo = new CustomPojo("Name", 3);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     api.queryMapPojo(customPojo);
     assertThat(server.takeRequest()).hasQueryParams(Arrays.asList("name=Name", "number=3"));
   }
@@ -388,7 +389,7 @@ public class FeignUnderAsyncTest {
 
     CustomPojo customPojo = new CustomPojo("Name", null);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     api.queryMapPojo(customPojo);
     assertThat(server.takeRequest()).hasPath("/?name=Name");
   }
@@ -399,7 +400,7 @@ public class FeignUnderAsyncTest {
 
     CustomPojo customPojo = new CustomPojo(null, null);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     api.queryMapPojo(customPojo);
     assertThat(server.takeRequest()).hasPath("/");
   }
@@ -424,21 +425,25 @@ public class FeignUnderAsyncTest {
 
   @Test
   void canOverrideErrorDecoder() throws Exception {
-    server.enqueue(new MockResponse().setResponseCode(400).setBody("foo"));
+    server.enqueue(new MockResponse.Builder().code(400).body("foo").build());
 
     TestInterface api =
         new TestInterfaceBuilder()
             .errorDecoder(new IllegalArgumentExceptionOn400())
             .target("http://localhost:" + server.getPort());
 
-    Throwable exception = assertThrows(IllegalArgumentException.class, () -> api.post());
+    Throwable exception =
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> api.post())
+            .actual();
     assertThat(exception.getMessage()).contains("bad zone name");
   }
 
   @Test
   void retriesLostConnectionBeforeRead() throws Exception {
-    server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(
+        new MockResponse.Builder().onRequestStart(new SocketEffect.CloseSocket()).build());
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -449,7 +454,7 @@ public class FeignUnderAsyncTest {
 
   @Test
   void overrideTypeSpecificDecoder() throws Exception {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     TestInterface api =
         new TestInterfaceBuilder()
@@ -461,7 +466,7 @@ public class FeignUnderAsyncTest {
 
   @Test
   void doesntRetryAfterResponseIsSent() throws Exception {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     TestInterface api =
         new TestInterfaceBuilder()
@@ -471,13 +476,14 @@ public class FeignUnderAsyncTest {
                 })
             .target("http://localhost:" + server.getPort());
 
-    Throwable exception = assertThrows(FeignException.class, () -> api.post());
+    Throwable exception =
+        assertThatExceptionOfType(FeignException.class).isThrownBy(() -> api.post()).actual();
     assertThat(exception.getMessage()).contains("timeout reading POST http://");
   }
 
   @Test
   void throwsFeignExceptionIncludingBody() {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     TestInterface api =
         AsyncFeign.builder()
@@ -498,7 +504,7 @@ public class FeignUnderAsyncTest {
 
   @Test
   void throwsFeignExceptionWithoutBody() {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     TestInterface api =
         AsyncFeign.builder()
@@ -513,7 +519,7 @@ public class FeignUnderAsyncTest {
     } catch (FeignException e) {
       assertThat(e.getMessage())
           .isEqualTo("timeout reading POST http://localhost:" + server.getPort() + "/");
-      assertThat(e.contentUTF8()).isEqualTo("");
+      assertThat(e.contentUTF8()).isEmpty();
     }
   }
 
@@ -568,7 +574,7 @@ public class FeignUnderAsyncTest {
 
   @Test
   void okIfDecodeRootCauseHasNoMessage() throws Exception {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     TestInterface api =
         new TestInterfaceBuilder()
@@ -578,32 +584,32 @@ public class FeignUnderAsyncTest {
                 })
             .target("http://localhost:" + server.getPort());
 
-    assertThrows(DecodeException.class, () -> api.post());
+    assertThatThrownBy(() -> api.post()).isInstanceOf(DecodeException.class);
   }
 
   @Test
   void decodingExceptionGetWrappedInDismiss404Mode() throws Exception {
-    server.enqueue(new MockResponse().setResponseCode(404));
+    server.enqueue(new MockResponse.Builder().code(404).build());
 
     TestInterface api =
         new TestInterfaceBuilder()
             .dismiss404()
             .decoder(
                 (response, _) -> {
-                  assertEquals(404, response.status());
+                  Assertions.assertThat(response.status()).isEqualTo(404);
                   throw new NoSuchElementException();
                 })
             .target("http://localhost:" + server.getPort());
-    DecodeException exception = assertThrows(DecodeException.class, () -> api.post());
+    DecodeException exception =
+        assertThatExceptionOfType(DecodeException.class).isThrownBy(() -> api.post()).actual();
     assertThat(exception).hasCauseInstanceOf(NoSuchElementException.class);
   }
 
   @Test
   void decodingDoesNotSwallow404ErrorsInDismiss404Mode() throws Exception {
-    assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(
+    assertThatThrownBy(
             () -> {
-              server.enqueue(new MockResponse().setResponseCode(404));
+              server.enqueue(new MockResponse.Builder().code(404).build());
 
               TestInterface api =
                   new TestInterfaceBuilder()
@@ -611,12 +617,13 @@ public class FeignUnderAsyncTest {
                       .errorDecoder(new IllegalArgumentExceptionOn404())
                       .target("http://localhost:" + server.getPort());
               api.queryMap(Collections.<String, Object>emptyMap());
-            });
+            })
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void okIfEncodeRootCauseHasNoMessage() throws Exception {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     TestInterface api =
         new TestInterfaceBuilder()
@@ -626,7 +633,7 @@ public class FeignUnderAsyncTest {
                 })
             .target("http://localhost:" + server.getPort());
 
-    assertThrows(EncodeException.class, () -> api.body(Arrays.asList("foo")));
+    assertThatThrownBy(() -> api.body(Arrays.asList("foo"))).isInstanceOf(EncodeException.class);
   }
 
   @Test
@@ -654,15 +661,13 @@ public class FeignUnderAsyncTest {
 
     assertThat(t1).isNotEqualTo(i1);
 
-    assertThat(t1.hashCode()).isEqualTo(i1.hashCode());
-
-    assertThat(t1.toString()).isEqualTo(i1.toString());
+    Assertions.assertThat(t1).hasSameHashCodeAs(i1).hasToString(i1.toString());
   }
 
   @Test
   void decodeLogicSupportsByteArray() throws Exception {
     byte[] expectedResponse = {12, 34, 56};
-    server.enqueue(new MockResponse().setBody(new Buffer().write(expectedResponse)));
+    server.enqueue(new MockResponse.Builder().body(new Buffer().write(expectedResponse)).build());
 
     OtherTestInterface api =
         AsyncFeign.builder()
@@ -674,7 +679,7 @@ public class FeignUnderAsyncTest {
   @Test
   void encodeLogicSupportsByteArray() throws Exception {
     byte[] expectedRequest = {12, 34, 56};
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     OtherTestInterface api =
         AsyncFeign.builder()
@@ -687,7 +692,7 @@ public class FeignUnderAsyncTest {
 
   @Test
   void encodedQueryParam() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterface api = new TestInterfaceBuilder().target("http://localhost:" + server.getPort());
 
@@ -697,7 +702,7 @@ public class FeignUnderAsyncTest {
   }
 
   @Test
-  void responseMapperIsAppliedBeforeDelegate() throws IOException {
+  void responseMapperIsAppliedBeforeDelegate() throws Exception {
     ResponseMappingDecoder decoder =
         new ResponseMappingDecoder(upperCaseResponseMapper(), new StringDecoder());
     String output = (String) decoder.decode(responseWithText("response"), String.class);
@@ -728,7 +733,7 @@ public class FeignUnderAsyncTest {
 
   @Test
   void mapAndDecodeExecutesMapFunction() throws Exception {
-    server.enqueue(new MockResponse().setBody("response!"));
+    server.enqueue(new MockResponse.Builder().body("response!").build());
 
     TestInterface api =
         AsyncFeign.builder()
@@ -750,7 +755,7 @@ public class FeignUnderAsyncTest {
     propertyPojo.setName("Name");
     propertyPojo.setNumber(1);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     api.queryMapPropertyPojo(propertyPojo);
     assertThat(server.takeRequest()).hasQueryParams(Arrays.asList("name=Name", "number=1"));
   }
@@ -767,7 +772,7 @@ public class FeignUnderAsyncTest {
     childPojo.setParentProtectedProperty("second");
     childPojo.setParentPublicProperty("third");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     api.queryMapPropertyInheritence(childPojo);
     assertThat(server.takeRequest())
         .hasQueryParams(
@@ -787,7 +792,7 @@ public class FeignUnderAsyncTest {
     propertyPojo.setName(null);
     propertyPojo.setNumber(1);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     api.queryMapPropertyPojo(propertyPojo);
     assertThat(server.takeRequest()).hasQueryParams("number=1");
   }
@@ -801,7 +806,7 @@ public class FeignUnderAsyncTest {
 
     PropertyPojo.ChildPojoClass propertyPojo = new PropertyPojo.ChildPojoClass();
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     api.queryMapPropertyPojo(propertyPojo);
     assertThat(server.takeRequest()).hasQueryParams("/");
   }
@@ -1026,6 +1031,11 @@ public class FeignUnderAsyncTest {
     public Instant instant() {
       return Instant.ofEpochMilli(millis);
     }
+  }
+
+  @BeforeEach
+  void setUp() throws IOException {
+    server.start();
   }
 
   @AfterEach

--- a/core/src/test/java/feign/LoggerTest.java
+++ b/core/src/test/java/feign/LoggerTest.java
@@ -17,7 +17,7 @@ package feign;
 
 import static feign.Util.enumForName;
 import static java.util.Objects.nonNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import feign.Logger.Level;
 import feign.Request.ProtocolVersion;
@@ -29,14 +29,27 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 public class LoggerTest {
   public final MockWebServer server = new MockWebServer();
   public final RecordingLogger logger = new RecordingLogger();
+
+  @BeforeEach
+  void setUp() throws IOException {
+    server.start();
+  }
+
+  @AfterEach
+  void tearDown() throws IOException {
+    server.close();
+  }
 
   interface SendsStuff {
 
@@ -51,7 +64,8 @@ public class LoggerTest {
         @Param("password") String password);
   }
 
-  public static class LogLevelEmitsTest extends LoggerTest {
+  @Nested
+  public class LogLevelEmitsTest {
 
     private Level logLevel;
 
@@ -104,7 +118,8 @@ public class LoggerTest {
     @ParameterizedTest
     void levelEmits(Level logLevel, List<String> expectedMessages) {
       initLogLevelEmitsTest(logLevel, expectedMessages);
-      server.enqueue(new MockResponse().setHeader("Y-Powered-By", "Mock").setBody("foo"));
+      server.enqueue(
+          new MockResponse.Builder().setHeader("Y-Powered-By", "Mock").body("foo").build());
 
       SendsStuff api =
           Feign.builder()
@@ -116,7 +131,8 @@ public class LoggerTest {
     }
   }
 
-  public static class ReasonPhraseOptionalTest extends LoggerTest {
+  @Nested
+  public class ReasonPhraseOptionalTest {
 
     private Level logLevel;
 
@@ -141,7 +157,7 @@ public class LoggerTest {
     @ParameterizedTest
     void reasonPhraseOptional(Level logLevel, List<String> expectedMessages) {
       initReasonPhraseOptional(logLevel, expectedMessages);
-      server.enqueue(new MockResponse().setStatus("HTTP/1.1 " + 200));
+      server.enqueue(new MockResponse.Builder().status("HTTP/1.1 " + 200).build());
 
       SendsStuff api =
           Feign.builder()
@@ -153,7 +169,8 @@ public class LoggerTest {
     }
   }
 
-  public static class HttpProtocolVersionTest extends LoggerTest {
+  @Nested
+  public class HttpProtocolVersionTest {
 
     private Level logLevel;
     private String protocolVersionName;
@@ -204,7 +221,7 @@ public class LoggerTest {
     void httpProtocolVersion(
         Level logLevel, String protocolVersionName, List<String> expectedMessages) {
       initHttpProtocolVersionTest(logLevel, protocolVersionName, expectedMessages);
-      server.enqueue(new MockResponse().setStatus("HTTP/1.1 " + 200));
+      server.enqueue(new MockResponse.Builder().status("HTTP/1.1 " + 200).build());
 
       SendsStuff api =
           Feign.builder()
@@ -217,7 +234,8 @@ public class LoggerTest {
     }
   }
 
-  public static class ReadTimeoutEmitsTest extends LoggerTest {
+  @Nested
+  public class ReadTimeoutEmitsTest {
 
     private Level logLevel;
 
@@ -269,7 +287,8 @@ public class LoggerTest {
     @ParameterizedTest
     void levelEmitsOnReadTimeout(Level logLevel, List<String> expectedMessages) {
       initReadTimeoutEmitsTest(logLevel, expectedMessages);
-      server.enqueue(new MockResponse().throttleBody(1, 1, TimeUnit.SECONDS).setBody("foo"));
+      server.enqueue(
+          new MockResponse.Builder().throttleBody(1, 1, TimeUnit.SECONDS).body("foo").build());
 
       SendsStuff api =
           Feign.builder()
@@ -292,11 +311,13 @@ public class LoggerTest {
                   })
               .target(SendsStuff.class, "http://localhost:" + server.getPort());
 
-      assertThrows(FeignException.class, () -> api.login("netflix", "denominator", "password"));
+      assertThatThrownBy(() -> api.login("netflix", "denominator", "password"))
+          .isInstanceOf(FeignException.class);
     }
   }
 
-  public static class UnknownHostEmitsTest extends LoggerTest {
+  @Nested
+  public class UnknownHostEmitsTest {
 
     private Level logLevel;
 
@@ -366,11 +387,13 @@ public class LoggerTest {
                   })
               .target(SendsStuff.class, "http://non-exist.invalid");
 
-      assertThrows(FeignException.class, () -> api.login("netflix", "denominator", "password"));
+      assertThatThrownBy(() -> api.login("netflix", "denominator", "password"))
+          .isInstanceOf(FeignException.class);
     }
   }
 
-  public static class FormatCharacterTest extends LoggerTest {
+  @Nested
+  public class FormatCharacterTest {
 
     private Level logLevel;
 
@@ -440,11 +463,13 @@ public class LoggerTest {
                   })
               .target(SendsStuff.class, "http://non-exist.invalid");
 
-      assertThrows(FeignException.class, () -> api.login("netflix", "denominator", "password"));
+      assertThatThrownBy(() -> api.login("netflix", "denominator", "password"))
+          .isInstanceOf(FeignException.class);
     }
   }
 
-  public static class RetryEmitsTest extends LoggerTest {
+  @Nested
+  public class RetryEmitsTest {
 
     private Level logLevel;
 
@@ -501,7 +526,8 @@ public class LoggerTest {
                   })
               .target(SendsStuff.class, "http://non-exist.invalid");
 
-      assertThrows(FeignException.class, () -> api.login("netflix", "denominator", "password"));
+      assertThatThrownBy(() -> api.login("netflix", "denominator", "password"))
+          .isInstanceOf(FeignException.class);
     }
   }
 

--- a/core/src/test/java/feign/MethodMetadataPresenceTest.java
+++ b/core/src/test/java/feign/MethodMetadataPresenceTest.java
@@ -17,16 +17,16 @@ package feign;
 
 import static feign.assertj.MockWebServerAssertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import feign.FeignBuilderTest.TestInterface;
 import feign.core.DefaultClient;
 import feign.core.codec.DefaultDecoder;
 import feign.core.codec.DefaultEncoder;
 import java.io.IOException;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class MethodMetadataPresenceTest {
@@ -35,16 +35,16 @@ public class MethodMetadataPresenceTest {
 
   @Test
   void client() throws Exception {
-    server.enqueue(new MockResponse().setBody("response data"));
+    server.enqueue(new MockResponse.Builder().body("response data").build());
 
     final String url = "http://localhost:" + server.getPort();
     final TestInterface api =
         Feign.builder()
             .client(
                 (request, options) -> {
-                  assertNotNull(request.requestTemplate());
-                  assertNotNull(request.requestTemplate().methodMetadata());
-                  assertNotNull(request.requestTemplate().feignTarget());
+                  assertThat(request.requestTemplate()).isNotNull();
+                  assertThat(request.requestTemplate().methodMetadata()).isNotNull();
+                  assertThat(request.requestTemplate().feignTarget()).isNotNull();
                   return new DefaultClient(null, null).execute(request, options);
                 })
             .target(TestInterface.class, url);
@@ -57,16 +57,16 @@ public class MethodMetadataPresenceTest {
 
   @Test
   void encoder() throws Exception {
-    server.enqueue(new MockResponse().setBody("response data"));
+    server.enqueue(new MockResponse.Builder().body("response data").build());
 
     final String url = "http://localhost:" + server.getPort();
     final TestInterface api =
         Feign.builder()
             .encoder(
                 (object, bodyType, template) -> {
-                  assertNotNull(template);
-                  assertNotNull(template.methodMetadata());
-                  assertNotNull(template.feignTarget());
+                  assertThat(template).isNotNull();
+                  assertThat(template.methodMetadata()).isNotNull();
+                  assertThat(template.feignTarget()).isNotNull();
                   new DefaultEncoder().encode(object, bodyType, template);
                 })
             .target(TestInterface.class, url);
@@ -79,7 +79,7 @@ public class MethodMetadataPresenceTest {
 
   @Test
   void decoder() throws Exception {
-    server.enqueue(new MockResponse().setBody("response data"));
+    server.enqueue(new MockResponse.Builder().body("response data").build());
 
     final String url = "http://localhost:" + server.getPort();
     final TestInterface api =
@@ -87,9 +87,9 @@ public class MethodMetadataPresenceTest {
             .decoder(
                 (response, type) -> {
                   final RequestTemplate template = response.request().requestTemplate();
-                  assertNotNull(template);
-                  assertNotNull(template.methodMetadata());
-                  assertNotNull(template.feignTarget());
+                  assertThat(template).isNotNull();
+                  assertThat(template.methodMetadata()).isNotNull();
+                  assertThat(template.feignTarget()).isNotNull();
                   return new DefaultDecoder().decode(response, type);
                 })
             .target(TestInterface.class, url);
@@ -98,6 +98,11 @@ public class MethodMetadataPresenceTest {
     assertThat(Util.toString(response.body().asReader(Util.UTF_8))).isEqualTo("response data");
 
     assertThat(server.takeRequest()).hasBody("request data");
+  }
+
+  @BeforeEach
+  void setUp() throws IOException {
+    server.start();
   }
 
   @AfterEach

--- a/core/src/test/java/feign/OptionsTest.java
+++ b/core/src/test/java/feign/OptionsTest.java
@@ -16,14 +16,15 @@
 package feign;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -50,23 +51,28 @@ class OptionsTest {
   }
 
   @Test
-  void socketTimeoutTest() {
+  void socketTimeoutTest() throws IOException {
     final MockWebServer server = new MockWebServer();
-    server.enqueue(new MockResponse().setBody("foo").setBodyDelay(3, TimeUnit.SECONDS));
+
+    server.start();
+    server.enqueue(new MockResponse.Builder().body("foo").bodyDelay(3, TimeUnit.SECONDS).build());
 
     final OptionsInterface api =
         Feign.builder()
             .options(new Request.Options(1000, 1000))
             .target(OptionsInterface.class, server.url("/").toString());
 
-    FeignException exception = assertThrows(FeignException.class, () -> api.get());
+    FeignException exception =
+        assertThatExceptionOfType(FeignException.class).isThrownBy(() -> api.get()).actual();
     assertThat(exception).hasCauseInstanceOf(SocketTimeoutException.class);
   }
 
   @Test
-  void normalResponseTest() {
+  void normalResponseTest() throws IOException {
     final MockWebServer server = new MockWebServer();
-    server.enqueue(new MockResponse().setBody("foo").setBodyDelay(3, TimeUnit.SECONDS));
+
+    server.start();
+    server.enqueue(new MockResponse.Builder().body("foo").bodyDelay(3, TimeUnit.SECONDS).build());
 
     final OptionsInterface api =
         Feign.builder()
@@ -77,9 +83,11 @@ class OptionsTest {
   }
 
   @Test
-  void normalResponseForChildOptionsTest() {
+  void normalResponseForChildOptionsTest() throws IOException {
     final MockWebServer server = new MockWebServer();
-    server.enqueue(new MockResponse().setBody("foo").setBodyDelay(3, TimeUnit.SECONDS));
+
+    server.start();
+    server.enqueue(new MockResponse.Builder().body("foo").bodyDelay(3, TimeUnit.SECONDS).build());
 
     final OptionsInterface api =
         Feign.builder()
@@ -92,7 +100,9 @@ class OptionsTest {
   @Test
   void socketTimeoutWithMethodOptionsTest() throws Exception {
     final MockWebServer server = new MockWebServer();
-    server.enqueue(new MockResponse().setBody("foo").setBodyDelay(2, TimeUnit.SECONDS));
+
+    server.start();
+    server.enqueue(new MockResponse.Builder().body("foo").bodyDelay(2, TimeUnit.SECONDS).build());
     Request.Options options = new Request.Options(1000, 3000);
     final OptionsInterface api =
         Feign.builder().options(options).target(OptionsInterface.class, server.url("/").toString());
@@ -112,14 +122,17 @@ class OptionsTest {
     thread.join();
 
     Exception exception = exceptionAtomicReference.get();
-    assertThat(exception).isInstanceOf(FeignException.class);
-    assertThat(exception).hasCauseInstanceOf(SocketTimeoutException.class);
+    assertThat(exception)
+        .isInstanceOf(FeignException.class)
+        .hasCauseInstanceOf(SocketTimeoutException.class);
   }
 
   @Test
   void normalResponseWithMethodOptionsTest() throws Exception {
     final MockWebServer server = new MockWebServer();
-    server.enqueue(new MockResponse().setBody("foo").setBodyDelay(2, TimeUnit.SECONDS));
+
+    server.start();
+    server.enqueue(new MockResponse.Builder().body("foo").bodyDelay(2, TimeUnit.SECONDS).build());
     Request.Options options = new Request.Options(1000, 1000);
     final OptionsInterface api =
         Feign.builder().options(options).target(OptionsInterface.class, server.url("/").toString());

--- a/core/src/test/java/feign/TargetTest.java
+++ b/core/src/test/java/feign/TargetTest.java
@@ -20,9 +20,10 @@ import static feign.assertj.MockWebServerAssertions.assertThat;
 import feign.Target.HardCodedTarget;
 import java.io.IOException;
 import java.net.URI;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation")
@@ -37,8 +38,8 @@ public class TargetTest {
   }
 
   @Test
-  void baseCaseQueryParamsArePercentEncoded() throws InterruptedException {
-    server.enqueue(new MockResponse());
+  void baseCaseQueryParamsArePercentEncoded() throws Exception {
+    server.enqueue(new MockResponse.Builder().build());
 
     String baseUrl = server.url("/default").toString();
 
@@ -52,8 +53,8 @@ public class TargetTest {
    * percent encoding. Here's how.
    */
   @Test
-  void targetCanCreateCustomRequest() throws InterruptedException {
-    server.enqueue(new MockResponse());
+  void targetCanCreateCustomRequest() throws Exception {
+    server.enqueue(new MockResponse.Builder().build());
 
     String baseUrl = server.url("/default").toString();
     Target<TestQuery> custom =
@@ -83,8 +84,8 @@ public class TargetTest {
   }
 
   @Test
-  void emptyTarget() throws InterruptedException {
-    server.enqueue(new MockResponse());
+  void emptyTarget() throws Exception {
+    server.enqueue(new MockResponse.Builder().build());
 
     UriTarget uriTarget = Feign.builder().target(Target.EmptyTarget.create(UriTarget.class));
 
@@ -97,8 +98,8 @@ public class TargetTest {
   }
 
   @Test
-  void hardCodedTargetWithURI() throws InterruptedException {
-    server.enqueue(new MockResponse());
+  void hardCodedTargetWithURI() throws Exception {
+    server.enqueue(new MockResponse.Builder().build());
 
     String host = server.getHostName();
     int port = server.getPort();
@@ -109,6 +110,11 @@ public class TargetTest {
     uriTarget.get(URI.create("http://" + host + ":" + port + "/path?query=param"));
 
     assertThat(server.takeRequest()).hasPath("/path?query=param").hasQueryParams("query=param");
+  }
+
+  @BeforeEach
+  void setUp() throws IOException {
+    server.start();
   }
 
   @AfterEach

--- a/core/src/test/java/feign/assertj/MockWebServerAssertions.java
+++ b/core/src/test/java/feign/assertj/MockWebServerAssertions.java
@@ -15,7 +15,7 @@
  */
 package feign.assertj;
 
-import okhttp3.mockwebserver.RecordedRequest;
+import mockwebserver3.RecordedRequest;
 import org.assertj.core.api.Assertions;
 
 public class MockWebServerAssertions extends Assertions {

--- a/core/src/test/java/feign/assertj/RecordedRequestAssert.java
+++ b/core/src/test/java/feign/assertj/RecordedRequestAssert.java
@@ -30,8 +30,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
+import mockwebserver3.RecordedRequest;
 import okhttp3.Headers;
-import okhttp3.mockwebserver.RecordedRequest;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.data.MapEntry;
 import org.assertj.core.internal.ByteArrays;
@@ -59,7 +59,7 @@ public final class RecordedRequestAssert
 
   public RecordedRequestAssert hasPath(String expected) {
     isNotNull();
-    objects.assertEqual(info, actual.getPath(), expected);
+    objects.assertEqual(info, actual.getTarget(), expected);
     return this;
   }
 
@@ -78,27 +78,27 @@ public final class RecordedRequestAssert
   }
 
   private Collection<String> getQueryParams() {
-    String path = actual.getPath();
+    String path = actual.getTarget();
     int queryStart = path.indexOf("?") + 1;
-    String[] queryParams = actual.getPath().substring(queryStart).split("&");
+    String[] queryParams = actual.getTarget().substring(queryStart).split("&");
     return Arrays.asList(queryParams);
   }
 
   public RecordedRequestAssert hasOneOfPath(String... expected) {
     isNotNull();
-    objects.assertIsIn(info, actual.getPath(), expected);
+    objects.assertIsIn(info, actual.getTarget(), expected);
     return this;
   }
 
   public RecordedRequestAssert hasBody(String utf8Expected) {
     isNotNull();
-    objects.assertEqual(info, actual.getBody().readUtf8(), utf8Expected);
+    objects.assertEqual(info, actual.getBody().utf8(), utf8Expected);
     return this;
   }
 
   public RecordedRequestAssert hasGzippedBody(byte[] expectedUncompressed) {
     isNotNull();
-    byte[] compressedBody = actual.getBody().readByteArray();
+    byte[] compressedBody = actual.getBody().toByteArray();
     byte[] uncompressedBody;
     try {
       uncompressedBody =
@@ -112,7 +112,7 @@ public final class RecordedRequestAssert
 
   public RecordedRequestAssert hasDeflatedBody(byte[] expectedUncompressed) {
     isNotNull();
-    byte[] compressedBody = actual.getBody().readByteArray();
+    byte[] compressedBody = actual.getBody().toByteArray();
     byte[] uncompressedBody;
     try {
       uncompressedBody =
@@ -126,7 +126,7 @@ public final class RecordedRequestAssert
 
   public RecordedRequestAssert hasBody(byte[] expected) {
     isNotNull();
-    arrays.assertContains(info, actual.getBody().readByteArray(), expected);
+    arrays.assertContains(info, actual.getBody().toByteArray(), expected);
     return this;
   }
 

--- a/core/src/test/java/feign/assertj/RequestTemplateAssert.java
+++ b/core/src/test/java/feign/assertj/RequestTemplateAssert.java
@@ -15,10 +15,9 @@
  */
 package feign.assertj;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-
 import feign.Request;
 import feign.RequestTemplate;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.data.MapEntry;
@@ -116,10 +115,18 @@ public final class RequestTemplateAssert
   }
 
   private String bodyAsUtf8String(Request.Body body) {
-    return assertDoesNotThrow(() -> body.writeToString(StandardCharsets.UTF_8));
+    try {
+      return body.writeToString(StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new AssertionError("Failed to write body", e);
+    }
   }
 
   private byte[] bodyAsBytes(Request.Body body) {
-    return assertDoesNotThrow(body::writeToByteArray);
+    try {
+      return body.writeToByteArray();
+    } catch (IOException e) {
+      throw new AssertionError("Failed to write body", e);
+    }
   }
 }

--- a/core/src/test/java/feign/client/AbstractClientTest.java
+++ b/core/src/test/java/feign/client/AbstractClientTest.java
@@ -17,9 +17,9 @@ package feign.client;
 
 import static feign.Util.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.fail;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import feign.Client;
 import feign.CollectionFormat;
@@ -41,11 +41,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.GZIPOutputStream;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import mockwebserver3.RecordedRequest;
 import okio.Buffer;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -64,8 +65,8 @@ public abstract class AbstractClientTest {
    */
   @Test
   public void patch() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().body("foo").build());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -81,8 +82,8 @@ public abstract class AbstractClientTest {
   }
 
   @Test
-  public void parsesRequestAndResponse() throws IOException, InterruptedException {
-    server.enqueue(new MockResponse().setBody("foo").addHeader("Foo: Bar"));
+  public void parsesRequestAndResponse() throws Exception {
+    server.enqueue(new MockResponse.Builder().body("foo").addHeader("Foo: Bar").build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -107,15 +108,15 @@ public abstract class AbstractClientTest {
 
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod()).isEqualToIgnoringCase("POST");
-    assertThat(recordedRequest.getHeader("Foo")).isEqualToIgnoringCase("Bar, Baz");
-    assertThat(recordedRequest.getHeader("Accept")).isEqualToIgnoringCase("*/*");
-    assertThat(recordedRequest.getHeader("Content-Length")).isEqualToIgnoringCase("3");
-    assertThat(recordedRequest.getBody().readUtf8()).isEqualToIgnoringCase("foo");
+    assertThat(recordedRequest.getHeaders().get("Foo")).isEqualToIgnoringCase("Bar, Baz");
+    assertThat(recordedRequest.getHeaders().get("Accept")).isEqualToIgnoringCase("*/*");
+    assertThat(recordedRequest.getHeaders().get("Content-Length")).isEqualToIgnoringCase("3");
+    assertThat(recordedRequest.getBody().utf8()).isEqualToIgnoringCase("foo");
   }
 
   @Test
-  public void reasonPhraseIsOptional() throws IOException, InterruptedException {
-    server.enqueue(new MockResponse().setStatus("HTTP/1.1 " + 200));
+  public void reasonPhraseIsOptional() throws Exception {
+    server.enqueue(new MockResponse.Builder().status("HTTP/1.1 " + 200).build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -129,12 +130,13 @@ public abstract class AbstractClientTest {
   @Test
   public void parsesErrorResponse() {
 
-    server.enqueue(new MockResponse().setResponseCode(500).setBody("ARGHH"));
+    server.enqueue(new MockResponse.Builder().code(500).body("ARGHH").build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
 
-    Throwable exception = assertThrows(FeignException.class, () -> api.get());
+    Throwable exception =
+        assertThatExceptionOfType(FeignException.class).isThrownBy(() -> api.get()).actual();
     assertThat(exception.getMessage())
         .contains(
             "[500 Server Error] during [GET] to [http://localhost:"
@@ -146,7 +148,7 @@ public abstract class AbstractClientTest {
   void parsesErrorResponseBody() {
     String expectedResponseBody = "ARGHH";
 
-    server.enqueue(new MockResponse().setResponseCode(500).setBody("ARGHH"));
+    server.enqueue(new MockResponse.Builder().code(500).body("ARGHH").build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -162,7 +164,7 @@ public abstract class AbstractClientTest {
   public void parsesUnauthorizedResponseBody() {
     String expectedResponseBody = "ARGHH";
 
-    server.enqueue(new MockResponse().setResponseCode(401).setBody("ARGHH"));
+    server.enqueue(new MockResponse.Builder().code(401).body("ARGHH").build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -176,7 +178,7 @@ public abstract class AbstractClientTest {
 
   @Test
   void safeRebuffering() {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterface api =
         newBuilder()
@@ -194,7 +196,7 @@ public abstract class AbstractClientTest {
   /** This shows that is a no-op or otherwise doesn't cause an NPE when there's no content. */
   @Test
   void safeRebuffering_noContent() {
-    server.enqueue(new MockResponse().setResponseCode(204));
+    server.enqueue(new MockResponse.Builder().code(204).build());
 
     TestInterface api =
         newBuilder()
@@ -211,7 +213,7 @@ public abstract class AbstractClientTest {
 
   @Test
   public void noResponseBodyForPost() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -221,7 +223,7 @@ public abstract class AbstractClientTest {
 
   @Test
   public void noResponseBodyForPut() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -235,7 +237,7 @@ public abstract class AbstractClientTest {
    */
   @Test
   public void noResponseBodyForPatch() {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -244,8 +246,8 @@ public abstract class AbstractClientTest {
   }
 
   @Test
-  public void parsesResponseMissingLength() throws IOException {
-    server.enqueue(new MockResponse().setChunkedBody("foo", 1));
+  public void parsesResponseMissingLength() throws Exception {
+    server.enqueue(new MockResponse.Builder().chunkedBody("foo", 1).build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -259,8 +261,8 @@ public abstract class AbstractClientTest {
   }
 
   @Test
-  void postWithSpacesInPath() throws InterruptedException {
-    server.enqueue(new MockResponse().setBody("foo"));
+  void postWithSpacesInPath() throws Exception {
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -275,7 +277,10 @@ public abstract class AbstractClientTest {
   @Test
   public void veryLongResponseNullLength() {
     server.enqueue(
-        new MockResponse().setBody("AAAAAAAA").addHeader("Content-Length", Long.MAX_VALUE));
+        new MockResponse.Builder()
+            .body("AAAAAAAA")
+            .addHeader("Content-Length", Long.MAX_VALUE)
+            .build());
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
 
@@ -286,7 +291,7 @@ public abstract class AbstractClientTest {
 
   @Test
   void responseLength() {
-    server.enqueue(new MockResponse().setBody("test"));
+    server.enqueue(new MockResponse.Builder().body("test").build());
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
 
@@ -298,7 +303,7 @@ public abstract class AbstractClientTest {
 
   @Test
   void contentTypeWithCharset() throws Exception {
-    server.enqueue(new MockResponse().setBody("AAAAAAAA"));
+    server.enqueue(new MockResponse.Builder().body("AAAAAAAA").build());
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
 
@@ -309,7 +314,7 @@ public abstract class AbstractClientTest {
 
   @Test
   void contentTypeWithoutCharset() throws Exception {
-    server.enqueue(new MockResponse().setBody("AAAAAAAA"));
+    server.enqueue(new MockResponse.Builder().body("AAAAAAAA").build());
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
 
@@ -320,20 +325,20 @@ public abstract class AbstractClientTest {
 
   @Test
   public void contentTypeDefaultsToRequestCharset() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
 
     // should use utf-8 encoding by default
     api.postWithContentType("àáâãäåèéêë", "text/plain; charset=UTF-8");
 
-    String body = server.takeRequest().getBody().readUtf8();
+    String body = server.takeRequest().getBody().utf8();
     assertThat(body).isEqualToIgnoringCase("àáâãäåèéêë");
   }
 
   @Test
   public void defaultCollectionFormat() throws Exception {
-    server.enqueue(new MockResponse().setBody("body"));
+    server.enqueue(new MockResponse.Builder().body("body").build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -349,8 +354,8 @@ public abstract class AbstractClientTest {
   }
 
   @Test
-  public void headersWithNullParams() throws InterruptedException {
-    server.enqueue(new MockResponse().setBody("body"));
+  public void headersWithNullParams() throws Exception {
+    server.enqueue(new MockResponse.Builder().body("body").build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -367,8 +372,8 @@ public abstract class AbstractClientTest {
   }
 
   @Test
-  public void headersWithNotEmptyParams() throws InterruptedException {
-    server.enqueue(new MockResponse().setBody("body"));
+  public void headersWithNotEmptyParams() throws Exception {
+    server.enqueue(new MockResponse.Builder().body("body").build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -386,7 +391,7 @@ public abstract class AbstractClientTest {
 
   @Test
   public void alternativeCollectionFormat() throws Exception {
-    server.enqueue(new MockResponse().setBody("body"));
+    server.enqueue(new MockResponse.Builder().body("body").build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -408,9 +413,10 @@ public abstract class AbstractClientTest {
     /* enqueue a zipped response */
     final String responseData = "Compressed Data";
     server.enqueue(
-        new MockResponse()
+        new MockResponse.Builder()
             .addHeader("Content-Encoding", "gzip")
-            .setBody(new Buffer().write(compress(responseData))));
+            .body(new Buffer().write(compress(responseData)))
+            .build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -418,7 +424,7 @@ public abstract class AbstractClientTest {
     String result = api.get();
 
     /* verify that the response is unzipped */
-    assertThat(result).isNotNull().isEqualToIgnoringCase(responseData);
+    assertThat(result).isEqualToIgnoringCase(responseData);
   }
 
   @Test
@@ -426,10 +432,11 @@ public abstract class AbstractClientTest {
     /* enqueue a zipped response */
     final String responseData = "Compressed Data";
     server.enqueue(
-        new MockResponse()
-            .setResponseCode(400)
+        new MockResponse.Builder()
+            .code(400)
             .addHeader("Content-Encoding", "gzip")
-            .setBody(new Buffer().write(compress(responseData))));
+            .body(new Buffer().write(compress(responseData)))
+            .build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -440,16 +447,16 @@ public abstract class AbstractClientTest {
     } catch (FeignException e) {
       /* verify that the response is unzipped */
       assertThat(e.responseBody())
-          .isNotEmpty()
+          .isPresent()
           .map(body -> new String(body.array(), StandardCharsets.UTF_8))
-          .get()
-          .isEqualTo(responseData);
+          .hasValue(responseData);
     }
   }
 
   @Test
   public void canSupportGzipOnErrorWithoutBody() throws Exception {
-    server.enqueue(new MockResponse().setResponseCode(400).addHeader("Content-Encoding", "gzip"));
+    server.enqueue(
+        new MockResponse.Builder().code(400).addHeader("Content-Encoding", "gzip").build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -460,10 +467,9 @@ public abstract class AbstractClientTest {
     } catch (FeignException e) {
       /* verify that the response is unzipped */
       assertThat(e.responseBody())
-          .isNotEmpty()
+          .isPresent()
           .map(body -> new String(body.array(), StandardCharsets.UTF_8))
-          .get()
-          .isEqualTo("");
+          .hasValue("");
     }
   }
 
@@ -472,9 +478,10 @@ public abstract class AbstractClientTest {
     /* enqueue a zipped response */
     final String responseData = "Compressed Data";
     server.enqueue(
-        new MockResponse()
+        new MockResponse.Builder()
             .addHeader("Content-Encoding", "deflate")
-            .setBody(new Buffer().write(deflate(responseData))));
+            .body(new Buffer().write(deflate(responseData)))
+            .build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -482,7 +489,7 @@ public abstract class AbstractClientTest {
     String result = api.get();
 
     /* verify that the response is unzipped */
-    assertThat(result).isNotNull().isEqualToIgnoringCase(responseData);
+    assertThat(result).isEqualToIgnoringCase(responseData);
   }
 
   @Test
@@ -490,10 +497,11 @@ public abstract class AbstractClientTest {
     /* enqueue a zipped response */
     final String responseData = "Compressed Data";
     server.enqueue(
-        new MockResponse()
-            .setResponseCode(400)
+        new MockResponse.Builder()
+            .code(400)
             .addHeader("Content-Encoding", "deflate")
-            .setBody(new Buffer().write(deflate(responseData))));
+            .body(new Buffer().write(deflate(responseData)))
+            .build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -504,17 +512,16 @@ public abstract class AbstractClientTest {
     } catch (FeignException e) {
       /* verify that the response is unzipped */
       assertThat(e.responseBody())
-          .isNotEmpty()
+          .isPresent()
           .map(body -> new String(body.array(), StandardCharsets.UTF_8))
-          .get()
-          .isEqualTo(responseData);
+          .hasValue(responseData);
     }
   }
 
   @Test
   public void canSupportDeflateOnErrorWithoutBody() throws Exception {
     server.enqueue(
-        new MockResponse().setResponseCode(400).addHeader("Content-Encoding", "deflate"));
+        new MockResponse.Builder().code(400).addHeader("Content-Encoding", "deflate").build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -525,10 +532,9 @@ public abstract class AbstractClientTest {
     } catch (FeignException e) {
       /* verify that the response is unzipped */
       assertThat(e.responseBody())
-          .isNotEmpty()
+          .isPresent()
           .map(body -> new String(body.array(), StandardCharsets.UTF_8))
-          .get()
-          .isEqualTo("");
+          .hasValue("");
     }
   }
 
@@ -537,9 +543,10 @@ public abstract class AbstractClientTest {
     /* enqueue a zipped response */
     final String responseData = "Compressed Data";
     server.enqueue(
-        new MockResponse()
+        new MockResponse.Builder()
             .addHeader("content-encoding", "gzip")
-            .setBody(new Buffer().write(compress(responseData))));
+            .body(new Buffer().write(compress(responseData)))
+            .build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -547,7 +554,7 @@ public abstract class AbstractClientTest {
     String result = api.get();
 
     /* verify that the response is unzipped */
-    assertThat(result).isNotNull().isEqualToIgnoringCase(responseData);
+    assertThat(result).isEqualToIgnoringCase(responseData);
   }
 
   @SuppressWarnings("UnusedReturnValue")
@@ -613,6 +620,11 @@ public abstract class AbstractClientTest {
       deflaterOutputStream.close();
       return bos.toByteArray();
     }
+  }
+
+  @BeforeEach
+  void setUp() throws IOException {
+    server.start();
   }
 
   @AfterEach

--- a/core/src/test/java/feign/codec/RetryAfterDecoderTest.java
+++ b/core/src/test/java/feign/codec/RetryAfterDecoderTest.java
@@ -19,7 +19,6 @@ import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import feign.codec.ErrorDecoder.RetryAfterDecoder;
-import java.text.ParseException;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import org.junit.jupiter.api.Test;
@@ -40,18 +39,18 @@ class RetryAfterDecoderTest {
   }
 
   @Test
-  void rfc822Parses() throws ParseException {
+  void rfc822Parses() throws Exception {
     assertThat(decoder.apply("Fri, 31 Dec 1999 23:59:59 GMT"))
         .isEqualTo(parseDateTime("Fri, 31 Dec 1999 23:59:59 GMT"));
   }
 
   @Test
-  void relativeSecondsParses() throws ParseException {
+  void relativeSecondsParses() throws Exception {
     assertThat(decoder.apply("86400")).isEqualTo(parseDateTime("Sun, 2 Jan 2000 00:00:00 GMT"));
   }
 
   @Test
-  void relativeSecondsParseDecimalIntegers() throws ParseException {
+  void relativeSecondsParseDecimalIntegers() throws Exception {
     assertThat(decoder.apply("86400.0")).isEqualTo(parseDateTime("Sun, 2 Jan 2000 00:00:00 GMT"));
   }
 

--- a/core/src/test/java/feign/core/ClientTest.java
+++ b/core/src/test/java/feign/core/ClientTest.java
@@ -15,8 +15,7 @@
  */
 package feign.core;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -25,7 +24,6 @@ import feign.Request;
 import feign.RequestTemplate;
 import feign.Response;
 import feign.Util;
-import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.nio.charset.Charset;
 import java.util.*;
@@ -35,7 +33,7 @@ import org.mockito.ArgumentMatchers;
 class ClientTest {
 
   @Test
-  void testClientExecute() throws IOException {
+  void clientExecute() throws Exception {
     Client client = mock(Client.class);
     RequestTemplate requestTemplate = mock(RequestTemplate.class);
     Request request =
@@ -54,11 +52,11 @@ class ClientTest {
                 .build());
     Response response = client.execute(request, null);
     String result = Util.toString(response.body().asReader(Charset.defaultCharset()));
-    assertEquals("Hello, World!", result);
+    assertThat(result).isEqualTo("Hello, World!");
   }
 
   @Test
-  void testConvertAndSendWithAcceptEncoding() throws IOException {
+  void convertAndSendWithAcceptEncoding() throws Exception {
     Map<String, Collection<String>> headers = new HashMap<>();
     List<String> acceptEncoding = new ArrayList<>();
     acceptEncoding.add("gzip");
@@ -76,11 +74,11 @@ class ClientTest {
     HttpURLConnection urlConnection = defaultClient.convertAndSend(request, options);
     Map<String, List<String>> requestProperties = urlConnection.getRequestProperties();
     // Test Avoid add "Accept-encoding" twice or more when "compression" option is enabled
-    assertEquals(1, requestProperties.get(Util.ACCEPT_ENCODING).size());
+    assertThat(requestProperties.get(Util.ACCEPT_ENCODING)).hasSize(1);
   }
 
   @Test
-  void testConvertAndSendWithContentLength() throws IOException {
+  void convertAndSendWithContentLength() throws Exception {
     Map<String, Collection<String>> headers = new HashMap<>();
     List<String> acceptEncoding = new ArrayList<>();
     headers.put(Util.CONTENT_LENGTH, Collections.singletonList("100"));
@@ -101,6 +99,6 @@ class ClientTest {
      * of HttpURLConnection. Unless set system property "sun.net.http.allowRestrictedHeaders" to
      * "true"
      */
-    assertNull(requestProperties.get(Util.CONTENT_LENGTH));
+    assertThat(requestProperties.get(Util.CONTENT_LENGTH)).isNull();
   }
 }

--- a/core/src/test/java/feign/core/DefaultClientTest.java
+++ b/core/src/test/java/feign/core/DefaultClientTest.java
@@ -16,8 +16,8 @@
 package feign.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.entry;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import feign.Client;
 import feign.Feign;
@@ -27,11 +27,9 @@ import feign.assertj.MockWebServerAssertions;
 import feign.client.AbstractClientTest;
 import feign.client.TrustingSSLSocketFactory;
 import feign.core.DefaultClient.Proxied;
-import java.io.IOException;
 import java.net.*;
 import java.util.Collections;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.SocketPolicy;
+import mockwebserver3.MockResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
@@ -47,10 +45,10 @@ public class DefaultClientTest extends AbstractClientTest {
   }
 
   @Test
-  void retriesFailedHandshake() throws IOException, InterruptedException {
-    server.useHttps(TrustingSSLSocketFactory.get("localhost"), false);
-    server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.FAIL_HANDSHAKE));
-    server.enqueue(new MockResponse());
+  void retriesFailedHandshake() throws Exception {
+    server.useHttps(TrustingSSLSocketFactory.get("localhost"));
+    server.enqueue(new MockResponse.Builder().failHandshake().build());
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "https://localhost:" + server.getPort());
@@ -60,9 +58,9 @@ public class DefaultClientTest extends AbstractClientTest {
   }
 
   @Test
-  void canOverrideSSLSocketFactory() throws IOException, InterruptedException {
-    server.useHttps(TrustingSSLSocketFactory.get("localhost"), false);
-    server.enqueue(new MockResponse());
+  void canOverrideSSLSocketFactory() throws Exception {
+    server.useHttps(TrustingSSLSocketFactory.get("localhost"));
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "https://localhost:" + server.getPort());
@@ -79,7 +77,8 @@ public class DefaultClientTest extends AbstractClientTest {
   @Test
   @Override
   public void patch() throws Exception {
-    RetryableException exception = assertThrows(RetryableException.class, super::patch);
+    RetryableException exception =
+        assertThatExceptionOfType(RetryableException.class).isThrownBy(super::patch).actual();
     assertThat(exception).hasCauseInstanceOf(ProtocolException.class);
   }
 
@@ -94,7 +93,7 @@ public class DefaultClientTest extends AbstractClientTest {
 
   @Test
   @EnabledIfSystemProperty(named = "sun.net.http.allowRestrictedHeaders", matches = "true")
-  public void noRequestBodyForPostWithAllowRestrictedHeaders() throws Exception {
+  void noRequestBodyForPostWithAllowRestrictedHeaders() throws Exception {
     super.noResponseBodyForPost();
     MockWebServerAssertions.assertThat(server.takeRequest())
         .hasMethod("POST")
@@ -113,7 +112,7 @@ public class DefaultClientTest extends AbstractClientTest {
 
   @Test
   @EnabledIfSystemProperty(named = "sun.net.http.allowRestrictedHeaders", matches = "true")
-  public void noResponseBodyForPutWithAllowRestrictedHeaders() throws Exception {
+  void noResponseBodyForPutWithAllowRestrictedHeaders() throws Exception {
     super.noResponseBodyForPut();
     MockWebServerAssertions.assertThat(server.takeRequest())
         .hasMethod("PUT")
@@ -125,14 +124,16 @@ public class DefaultClientTest extends AbstractClientTest {
   @Override
   public void noResponseBodyForPatch() {
     RetryableException exception =
-        assertThrows(RetryableException.class, super::noResponseBodyForPatch);
+        assertThatExceptionOfType(RetryableException.class)
+            .isThrownBy(super::noResponseBodyForPatch)
+            .actual();
     assertThat(exception).hasCauseInstanceOf(ProtocolException.class);
   }
 
   @Test
-  void canOverrideHostnameVerifier() throws IOException, InterruptedException {
-    server.useHttps(TrustingSSLSocketFactory.get("bad.example.com"), false);
-    server.enqueue(new MockResponse());
+  void canOverrideHostnameVerifier() throws Exception {
+    server.useHttps(TrustingSSLSocketFactory.get("bad.example.com"));
+    server.enqueue(new MockResponse.Builder().build());
 
     TestInterface api =
         Feign.builder()
@@ -159,7 +160,7 @@ public class DefaultClientTest extends AbstractClientTest {
     /* verify that the proxy */
     HttpURLConnection connection =
         proxied.getConnection(URI.create("http://www.example.com").toURL());
-    assertThat(connection).isNotNull().isInstanceOf(HttpURLConnection.class);
+    assertThat(connection).isInstanceOf(HttpURLConnection.class);
   }
 
   @Test
@@ -176,6 +177,6 @@ public class DefaultClientTest extends AbstractClientTest {
 
     HttpURLConnection connection =
         proxied.getConnection(URI.create("http://www.example.com").toURL());
-    assertThat(connection).isNotNull().isInstanceOf(HttpURLConnection.class);
+    assertThat(connection).isInstanceOf(HttpURLConnection.class);
   }
 }

--- a/core/src/test/java/feign/core/DefaultContractInheritanceTest.java
+++ b/core/src/test/java/feign/core/DefaultContractInheritanceTest.java
@@ -18,8 +18,8 @@ package feign.core;
 import static feign.assertj.FeignAssertions.assertThat;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.data.MapEntry.entry;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import feign.Body;
 import feign.Contract;
@@ -61,9 +61,9 @@ class DefaultContractInheritanceTest {
   @Test
   void parameterizedApiUnsupported() throws Exception {
     Throwable exception =
-        assertThrows(
-            IllegalStateException.class,
-            () -> contract.parseAndValidateMetadata(SimpleParameterizedBaseApi.class));
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(() -> contract.parseAndValidateMetadata(SimpleParameterizedBaseApi.class))
+            .actual();
     assertThat(exception.getMessage())
         .contains("Parameterized types unsupported: SimpleParameterizedBaseApi");
   }
@@ -158,9 +158,9 @@ class DefaultContractInheritanceTest {
   @Test
   void multipleInheritanceDoneWrong() {
     Throwable exception =
-        assertThrows(
-            IllegalStateException.class,
-            () -> contract.parseAndValidateMetadata(MultipleInheritanceDoneWrong.class));
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(() -> contract.parseAndValidateMetadata(MultipleInheritanceDoneWrong.class))
+            .actual();
     assertThat(exception.getMessage())
         .contains("Only single inheritance supported: MultipleInheritanceDoneWrong");
   }

--- a/core/src/test/java/feign/core/DefaultContractTest.java
+++ b/core/src/test/java/feign/core/DefaultContractTest.java
@@ -17,8 +17,8 @@ package feign.core;
 
 import static feign.assertj.FeignAssertions.assertThat;
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.data.MapEntry.entry;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.gson.reflect.TypeToken;
 import feign.Body;
@@ -74,7 +74,7 @@ class DefaultContractTest {
   void bodyParamIsGeneric() throws Exception {
     final MethodMetadata md = parseAndValidateMetadata(BodyParams.class, "post", List.class);
 
-    assertThat(md.bodyIndex()).isEqualTo(0);
+    assertThat(md.bodyIndex()).isZero();
     assertThat(md.bodyType()).isEqualTo(new TypeToken<List<String>>() {}.getType());
   }
 
@@ -83,16 +83,17 @@ class DefaultContractTest {
     final MethodMetadata md =
         parseAndValidateMetadata(BodyParams.class, "post", int.class, List.class);
 
-    assertThat(md.bodyIndex()).isEqualTo(1);
+    assertThat(md.bodyIndex()).isOne();
     assertThat(md.indexToName()).containsOnly(entry(0, asList("id")));
   }
 
   @Test
   void tooManyBodies() throws Exception {
     Throwable exception =
-        assertThrows(
-            IllegalStateException.class,
-            () -> parseAndValidateMetadata(BodyParams.class, "tooMany", List.class, List.class));
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(
+                () -> parseAndValidateMetadata(BodyParams.class, "tooMany", List.class, List.class))
+            .actual();
     assertThat(exception.getMessage()).contains("Method has too many Body");
   }
 
@@ -213,7 +214,7 @@ class DefaultContractTest {
             // Skips 1 as it is a url index!
             entry(2, asList("2")));
 
-    assertThat(md.urlIndex()).isEqualTo(1);
+    assertThat(md.urlIndex()).isOne();
   }
 
   @Test
@@ -282,11 +283,12 @@ class DefaultContractTest {
   @Test
   void formParamAndBodyParams() throws Exception {
     Throwable exception =
-        assertThrows(
-            IllegalStateException.class,
-            () ->
-                parseAndValidateMetadata(
-                    FormParams.class, "formParamAndBodyParams", String.class, String.class));
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(
+                () ->
+                    parseAndValidateMetadata(
+                        FormParams.class, "formParamAndBodyParams", String.class, String.class))
+            .actual();
     assertThat(exception.getMessage())
         .contains("Body parameters cannot be used with form parameters.");
   }
@@ -294,11 +296,12 @@ class DefaultContractTest {
   @Test
   void bodyParamsAndformParam() throws Exception {
     Throwable exception =
-        assertThrows(
-            IllegalStateException.class,
-            () ->
-                parseAndValidateMetadata(
-                    FormParams.class, "bodyParamsAndformParam", String.class, String.class));
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(
+                () ->
+                    parseAndValidateMetadata(
+                        FormParams.class, "bodyParamsAndformParam", String.class, String.class))
+            .actual();
     assertThat(exception.getMessage())
         .contains("Body parameters cannot be used with form parameters.");
   }
@@ -363,7 +366,7 @@ class DefaultContractTest {
     final MethodMetadata md =
         parseAndValidateMetadata(QueryMapTestInterface.class, "queryMap", Map.class);
 
-    assertThat(md.queryMapIndex()).isEqualTo(0);
+    assertThat(md.queryMapIndex()).isZero();
   }
 
   @Test
@@ -372,7 +375,7 @@ class DefaultContractTest {
         parseAndValidateMetadata(
             QueryMapTestInterface.class, "queryMapMapSubclass", SortedMap.class);
 
-    assertThat(md.queryMapIndex()).isEqualTo(0);
+    assertThat(md.queryMapIndex()).isZero();
   }
 
   @Test
@@ -401,7 +404,7 @@ class DefaultContractTest {
     final MethodMetadata md =
         parseAndValidateMetadata(QueryMapTestInterface.class, "pojoObject", Object.class);
 
-    assertThat(md.queryMapIndex()).isEqualTo(0);
+    assertThat(md.queryMapIndex()).isZero();
   }
 
   @Test
@@ -431,7 +434,7 @@ class DefaultContractTest {
     final MethodMetadata md =
         parseAndValidateMetadata(
             HeaderMapInterface.class, "headerMapSubClass", SubClassHeaders.class);
-    assertThat(md.headerMapIndex()).isEqualTo(0);
+    assertThat(md.headerMapIndex()).isZero();
   }
 
   @Test
@@ -439,7 +442,7 @@ class DefaultContractTest {
     final MethodMetadata md =
         parseAndValidateMetadata(
             HeaderMapInterface.class, "headerMapUserObject", HeaderMapUserObject.class);
-    assertThat(md.headerMapIndex()).isEqualTo(0);
+    assertThat(md.headerMapIndex()).isZero();
   }
 
   interface Methods {
@@ -828,8 +831,8 @@ class DefaultContractTest {
     } catch (Exception e) {
       if (e instanceof java.lang.reflect.InvocationTargetException) {
         Throwable cause = e.getCause();
-        if (cause instanceof RuntimeException) {
-          throw (RuntimeException) cause;
+        if (cause instanceof RuntimeException exception) {
+          throw exception;
         }
         throw new RuntimeException(cause);
       }
@@ -846,9 +849,9 @@ class DefaultContractTest {
   @Test
   void missingMethod() throws Exception {
     Throwable exception =
-        assertThrows(
-            IllegalStateException.class,
-            () -> contract.parseAndValidateMetadata(MissingMethod.class));
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(() -> contract.parseAndValidateMetadata(MissingMethod.class))
+            .actual();
     assertThat(exception.getMessage())
         .contains(
             "RequestLine annotation didn't start with an HTTP verb on method"
@@ -908,9 +911,9 @@ class DefaultContractTest {
   @Test
   void errorMessageOnMixedContracts() {
     Throwable exception =
-        assertThrows(
-            IllegalStateException.class,
-            () -> contract.parseAndValidateMetadata(MixedAnnotations.class));
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(() -> contract.parseAndValidateMetadata(MixedAnnotations.class))
+            .actual();
     assertThat(exception.getMessage()).contains("are not used by contract DefaultContract");
   }
 
@@ -964,9 +967,9 @@ class DefaultContractTest {
         !isCompiledWithParameters(NoValueParamsInterface.class), "Skip if -parameters is enabled");
 
     Throwable exception =
-        assertThrows(
-            IllegalStateException.class,
-            () -> contract.parseAndValidateMetadata(NoValueParamsInterface.class));
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(() -> contract.parseAndValidateMetadata(NoValueParamsInterface.class))
+            .actual();
 
     assertThat(exception.getMessage())
         .contains("Param annotation was empty on param 0")

--- a/core/src/test/java/feign/core/DefaultQueryMapEncoderTest.java
+++ b/core/src/test/java/feign/core/DefaultQueryMapEncoderTest.java
@@ -40,16 +40,16 @@ class DefaultQueryMapEncoderTest {
     object.baz = "bazz";
 
     Map<String, Object> encodedMap = encoder.encode(object);
-    assertThat(encodedMap).as("Unexpected encoded query map").isEqualTo(expected);
+    assertThat(encodedMap)
+        .as("Unexpected encoded query map")
+        .containsExactlyInAnyOrderEntriesOf(expected);
   }
 
   @Test
   void encodesObject_visibleFields_emptyObject() {
     VisibleFieldsObject object = new VisibleFieldsObject();
     Map<String, Object> encodedMap = encoder.encode(object);
-    assertThat(encodedMap.isEmpty())
-        .as("Non-empty map generated from null fields: " + encodedMap)
-        .isTrue();
+    assertThat(encodedMap).as("Non-empty map generated from null fields: " + encodedMap).isEmpty();
   }
 
   @Test
@@ -60,14 +60,16 @@ class DefaultQueryMapEncoderTest {
     QueryMapEncoderObject object = new QueryMapEncoderObject("fooz", "barz");
 
     Map<String, Object> encodedMap = encoder.encode(object);
-    assertThat(encodedMap).as("Unexpected encoded query map").isEqualTo(expected);
+    assertThat(encodedMap)
+        .as("Unexpected encoded query map")
+        .containsExactlyInAnyOrderEntriesOf(expected);
   }
 
   @Test
   void encodesObject_nonVisibleFields_emptyObject() {
     QueryMapEncoderObject object = new QueryMapEncoderObject(null, null);
     Map<String, Object> encodedMap = encoder.encode(object);
-    assertThat(encodedMap.isEmpty()).as("Non-empty map generated from null fields").isTrue();
+    assertThat(encodedMap).as("Non-empty map generated from null fields").isEmpty();
   }
 
   static class VisibleFieldsObject {

--- a/core/src/test/java/feign/core/RetryerTest.java
+++ b/core/src/test/java/feign/core/RetryerTest.java
@@ -15,9 +15,7 @@
  */
 package feign.core;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.*;
 
 import feign.Request;
 import feign.RetryableException;
@@ -36,8 +34,8 @@ class RetryerTest {
     final Long nonRetryable = null;
     RetryableException e = new RetryableException(-1, null, null, nonRetryable, REQUEST);
     DefaultRetryer retryer = new DefaultRetryer();
-    assertThat(retryer.attempt).isEqualTo(1);
-    assertThat(retryer.sleptForMillis).isEqualTo(0);
+    assertThat(retryer.attempt).isOne();
+    assertThat(retryer.sleptForMillis).isZero();
 
     retryer.continueOrPropagate(e);
     assertThat(retryer.attempt).isEqualTo(2);
@@ -54,7 +52,7 @@ class RetryerTest {
     retryer.continueOrPropagate(e);
     assertThat(retryer.attempt).isEqualTo(5);
     assertThat(retryer.sleptForMillis).isEqualTo(1218);
-    assertThrows(RetryableException.class, () -> retryer.continueOrPropagate(e));
+    assertThatThrownBy(() -> retryer.continueOrPropagate(e)).isInstanceOf(RetryableException.class);
   }
 
   @Test
@@ -74,11 +72,11 @@ class RetryerTest {
 
   @Test
   void neverRetryAlwaysPropagates() {
-    assertThrows(
-        RetryableException.class,
-        () ->
-            Retryer.NEVER_RETRY.continueOrPropagate(
-                new RetryableException(-1, null, null, 5000L, REQUEST)));
+    assertThatThrownBy(
+            () ->
+                Retryer.NEVER_RETRY.continueOrPropagate(
+                    new RetryableException(-1, null, null, 5000L, REQUEST)))
+        .isInstanceOf(RetryableException.class);
   }
 
   @Test

--- a/core/src/test/java/feign/core/codec/DefaultDecoderTest.java
+++ b/core/src/test/java/feign/core/codec/DefaultDecoderTest.java
@@ -17,7 +17,7 @@ package feign.core.codec;
 
 import static feign.Util.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import feign.Request;
 import feign.Request.HttpMethod;
@@ -43,7 +43,7 @@ class DefaultDecoderTest {
     Response response = knownResponse();
     Object decodedObject = decoder.decode(response, String.class);
     assertThat(decodedObject.getClass()).isEqualTo(String.class);
-    assertThat(decodedObject.toString()).isEqualTo("response body");
+    assertThat(decodedObject).hasToString("response body");
   }
 
   @Test
@@ -62,7 +62,9 @@ class DefaultDecoderTest {
   @Test
   void refusesToDecodeOtherTypes() throws Exception {
     Throwable exception =
-        assertThrows(DecodeException.class, () -> decoder.decode(knownResponse(), Document.class));
+        assertThatExceptionOfType(DecodeException.class)
+            .isThrownBy(() -> decoder.decode(knownResponse(), Document.class))
+            .actual();
     assertThat(exception.getMessage()).contains(" is not a type supported by this decoder.");
   }
 

--- a/core/src/test/java/feign/core/codec/DefaultEncoderTest.java
+++ b/core/src/test/java/feign/core/codec/DefaultEncoderTest.java
@@ -16,9 +16,9 @@
 package feign.core.codec;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import feign.Request;
 import feign.RequestTemplate;
@@ -47,8 +47,12 @@ class DefaultEncoderTest {
     encoder.encode(content, String.class, template);
     Optional<Request.Body> optionalBody = template.requestBody();
     assertThat(optionalBody).isPresent();
-    String body =
-        assertDoesNotThrow(() -> optionalBody.get().writeToString(StandardCharsets.UTF_8));
+    String body;
+    try {
+      body = optionalBody.get().writeToString(StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new AssertionError("Failed to read body", e);
+    }
     assertThat(body).contains(content);
   }
 
@@ -59,16 +63,21 @@ class DefaultEncoderTest {
     encoder.encode(content, byte[].class, template);
     Optional<Request.Body> optionalBody = template.requestBody();
     assertThat(optionalBody).isPresent();
-    byte[] body = assertDoesNotThrow(() -> optionalBody.get().writeToByteArray());
+    byte[] body;
+    try {
+      body = optionalBody.get().writeToByteArray();
+    } catch (IOException e) {
+      throw new AssertionError("Failed to read body", e);
+    }
     assertThat(body).isEqualTo(content);
   }
 
   @Test
   void refusesToEncodeOtherTypes() throws Exception {
     Throwable exception =
-        assertThrows(
-            EncodeException.class,
-            () -> encoder.encode(Clock.systemUTC(), Clock.class, new RequestTemplate()));
+        assertThatExceptionOfType(EncodeException.class)
+            .isThrownBy(() -> encoder.encode(Clock.systemUTC(), Clock.class, new RequestTemplate()))
+            .actual();
     assertThat(exception.getMessage()).contains("is not a type supported by this encoder.");
   }
 

--- a/core/src/test/java/feign/core/querymap/BeanQueryMapEncoderTest.java
+++ b/core/src/test/java/feign/core/querymap/BeanQueryMapEncoderTest.java
@@ -47,7 +47,9 @@ class BeanQueryMapEncoderTest {
 
     Map<String, Object> encodedMap = encoder.encode(normalObject);
 
-    assertThat(encodedMap).as("Unexpected encoded query map").isEqualTo(expected);
+    assertThat(encodedMap)
+        .as("Unexpected encoded query map")
+        .containsExactlyInAnyOrderEntriesOf(expected);
   }
 
   @Test
@@ -56,9 +58,7 @@ class BeanQueryMapEncoderTest {
 
     Map<String, Object> encodedMap = encoder.encode(normalObject);
 
-    assertThat(encodedMap.isEmpty())
-        .as("Non-empty map generated from null getter: " + encodedMap)
-        .isTrue();
+    assertThat(encodedMap).as("Non-empty map generated from null getter: " + encodedMap).isEmpty();
   }
 
   @Test
@@ -74,7 +74,9 @@ class BeanQueryMapEncoderTest {
 
     Map<String, Object> encodedMap = encoder.encode(subClass);
 
-    assertThat(encodedMap).as("Unexpected encoded query map").isEqualTo(expected);
+    assertThat(encodedMap)
+        .as("Unexpected encoded query map")
+        .containsExactlyInAnyOrderEntriesOf(expected);
   }
 
   @Test

--- a/core/src/test/java/feign/core/querymap/FieldQueryMapEncoderTest.java
+++ b/core/src/test/java/feign/core/querymap/FieldQueryMapEncoderTest.java
@@ -46,7 +46,9 @@ class FieldQueryMapEncoderTest {
 
     final Map<String, Object> encodedMap = encoder.encode(normalObject);
 
-    assertThat(encodedMap).as("Unexpected encoded query map").isEqualTo(expected);
+    assertThat(encodedMap)
+        .as("Unexpected encoded query map")
+        .containsExactlyInAnyOrderEntriesOf(expected);
   }
 
   @Test
@@ -55,9 +57,7 @@ class FieldQueryMapEncoderTest {
 
     final Map<String, Object> encodedMap = encoder.encode(normalObject);
 
-    assertThat(encodedMap.isEmpty())
-        .as("Non-empty map generated from null getter: " + encodedMap)
-        .isTrue();
+    assertThat(encodedMap).as("Non-empty map generated from null getter: " + encodedMap).isEmpty();
   }
 
   @Test

--- a/core/src/test/java/feign/interceptor/MethodInterceptorTest.java
+++ b/core/src/test/java/feign/interceptor/MethodInterceptorTest.java
@@ -24,21 +24,28 @@ import feign.RequestInterceptor;
 import feign.RequestLine;
 import feign.RequestTemplate;
 import feign.Response;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class MethodInterceptorTest {
 
   private final MockWebServer server = new MockWebServer();
 
+  @BeforeEach
+  void setUp() throws IOException {
+    server.start();
+  }
+
   @AfterEach
   void tearDown() throws Exception {
-    server.shutdown();
+    server.close();
   }
 
   interface Api {
@@ -51,7 +58,7 @@ class MethodInterceptorTest {
 
   @Test
   void interceptorRunsAfterContractAndBeforeRequestInterceptor() throws Exception {
-    server.enqueue(new MockResponse().setBody("ok"));
+    server.enqueue(new MockResponse.Builder().body("ok").build());
 
     AtomicReference<RequestTemplate> seenByMethodInterceptor = new AtomicReference<>();
     AtomicReference<RequestTemplate> seenByRequestInterceptor = new AtomicReference<>();
@@ -80,12 +87,12 @@ class MethodInterceptorTest {
 
     assertThat(seenByMethodInterceptor.get()).isNotNull();
     assertThat(seenByRequestInterceptor.get()).isNotNull();
-    assertThat(server.takeRequest().getHeader("X-From-Method")).isEqualTo("yes");
+    assertThat(server.takeRequest().getHeaders().get("X-From-Method")).isEqualTo("yes");
   }
 
   @Test
   void interceptorCanShortCircuit() throws Exception {
-    MethodInterceptor methodInterceptor = (invocation, chain) -> "short-circuited";
+    MethodInterceptor methodInterceptor = (_, _) -> "short-circuited";
 
     Api api =
         Feign.builder()
@@ -102,7 +109,7 @@ class MethodInterceptorTest {
   void interceptorExceptionSurfacesToCaller() {
     RuntimeException boom = new IllegalStateException("nope");
     MethodInterceptor methodInterceptor =
-        (invocation, chain) -> {
+        (_, _) -> {
           throw boom;
         };
 
@@ -117,7 +124,7 @@ class MethodInterceptorTest {
 
   @Test
   void interceptorSeesResponseAfterChainCompletes() throws Exception {
-    server.enqueue(new MockResponse().setHeader("ETag", "v1").setBody("payload"));
+    server.enqueue(new MockResponse.Builder().setHeader("ETag", "v1").body("payload").build());
 
     AtomicReference<Response> captured = new AtomicReference<>();
     MethodInterceptor methodInterceptor =
@@ -143,7 +150,7 @@ class MethodInterceptorTest {
 
   @Test
   void chainOrderIsRegistrationOrder() throws Exception {
-    server.enqueue(new MockResponse().setBody("ok"));
+    server.enqueue(new MockResponse.Builder().body("ok").build());
 
     List<String> visited = new ArrayList<>();
     MethodInterceptor first =
@@ -174,7 +181,7 @@ class MethodInterceptorTest {
 
   @Test
   void invocationExposesArguments() throws Exception {
-    server.enqueue(new MockResponse().setBody("ok"));
+    server.enqueue(new MockResponse.Builder().body("ok").build());
 
     AtomicReference<Object[]> seenArgs = new AtomicReference<>();
     MethodInterceptor methodInterceptor =

--- a/core/src/test/java/feign/optionals/OptionalDecoderTests.java
+++ b/core/src/test/java/feign/optionals/OptionalDecoderTests.java
@@ -20,10 +20,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import feign.Feign;
 import feign.RequestLine;
 import feign.core.codec.DefaultDecoder;
-import java.io.IOException;
 import java.util.Optional;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import org.junit.jupiter.api.Test;
 
 class OptionalDecoderTests {
@@ -37,10 +36,12 @@ class OptionalDecoderTests {
   }
 
   @Test
-  void simple404OptionalTest() throws IOException, InterruptedException {
+  void simple404OptionalTest() throws Exception {
     final MockWebServer server = new MockWebServer();
-    server.enqueue(new MockResponse().setResponseCode(404));
-    server.enqueue(new MockResponse().setBody("foo"));
+
+    server.start();
+    server.enqueue(new MockResponse.Builder().code(404).build());
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final OptionalInterface api =
         Feign.builder()
@@ -48,27 +49,31 @@ class OptionalDecoderTests {
             .decoder(new OptionalDecoder(new DefaultDecoder()))
             .target(OptionalInterface.class, server.url("/").toString());
 
-    assertThat(api.getAsOptional().isPresent()).isFalse();
-    assertThat(api.getAsOptional()).contains("foo");
+    assertThat(api.getAsOptional()).isEmpty();
+    assertThat(api.getAsOptional()).hasValue("foo");
   }
 
   @Test
-  void simple204OptionalTest() throws IOException, InterruptedException {
+  void simple204OptionalTest() throws Exception {
     final MockWebServer server = new MockWebServer();
-    server.enqueue(new MockResponse().setResponseCode(204));
+
+    server.start();
+    server.enqueue(new MockResponse.Builder().code(204).build());
 
     final OptionalInterface api =
         Feign.builder()
             .decoder(new OptionalDecoder(new DefaultDecoder()))
             .target(OptionalInterface.class, server.url("/").toString());
 
-    assertThat(api.getAsOptional().isPresent()).isFalse();
+    assertThat(api.getAsOptional()).isEmpty();
   }
 
   @Test
-  void test200WithOptionalString() throws IOException, InterruptedException {
+  void test200WithOptionalString() throws Exception {
     final MockWebServer server = new MockWebServer();
-    server.enqueue(new MockResponse().setResponseCode(200).setBody("foo"));
+
+    server.start();
+    server.enqueue(new MockResponse.Builder().code(200).body("foo").build());
 
     final OptionalInterface api =
         Feign.builder()
@@ -77,27 +82,30 @@ class OptionalDecoderTests {
 
     Optional<String> response = api.getAsOptional();
 
-    assertThat(response).isPresent();
-    assertThat(response).isEqualTo(Optional.of("foo"));
+    assertThat(response).hasValue("foo");
   }
 
   @Test
-  void test200WhenResponseBodyIsNull() throws IOException, InterruptedException {
+  void test200WhenResponseBodyIsNull() throws Exception {
     final MockWebServer server = new MockWebServer();
-    server.enqueue(new MockResponse().setResponseCode(200));
+
+    server.start();
+    server.enqueue(new MockResponse.Builder().code(200).build());
 
     final OptionalInterface api =
         Feign.builder()
             .decoder(new OptionalDecoder(((_, _) -> null)))
             .target(OptionalInterface.class, server.url("/").toString());
 
-    assertThat(api.getAsOptional().isPresent()).isFalse();
+    assertThat(api.getAsOptional()).isEmpty();
   }
 
   @Test
-  void test200WhenDecodingNoOptional() throws IOException, InterruptedException {
+  void test200WhenDecodingNoOptional() throws Exception {
     final MockWebServer server = new MockWebServer();
-    server.enqueue(new MockResponse().setResponseCode(200).setBody("foo"));
+
+    server.start();
+    server.enqueue(new MockResponse.Builder().code(200).body("foo").build());
 
     final OptionalInterface api =
         Feign.builder()

--- a/core/src/test/java/feign/stream/StreamDecoderTest.java
+++ b/core/src/test/java/feign/stream/StreamDecoderTest.java
@@ -32,8 +32,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation")
@@ -70,9 +70,10 @@ class StreamDecoderTest {
       """;
 
   @Test
-  void simpleStreamTest() {
+  void simpleStreamTest() throws IOException {
     MockWebServer server = new MockWebServer();
-    server.enqueue(new MockResponse().setBody("foo\nbar"));
+    server.start();
+    server.enqueue(new MockResponse.Builder().body("foo\nbar").build());
 
     StreamInterface api =
         Feign.builder()
@@ -84,14 +85,15 @@ class StreamDecoderTest {
             .target(StreamInterface.class, server.url("/").toString());
 
     try (Stream<String> stream = api.get()) {
-      assertThat(stream.collect(Collectors.toList())).isEqualTo(Arrays.asList("foo", "bar"));
+      assertThat(stream).containsExactlyElementsOf(Arrays.asList("foo", "bar"));
     }
   }
 
   @Test
-  void simpleDefaultStreamTest() {
+  void simpleDefaultStreamTest() throws IOException {
     MockWebServer server = new MockWebServer();
-    server.enqueue(new MockResponse().setBody("foo\nbar"));
+    server.start();
+    server.enqueue(new MockResponse.Builder().body("foo\nbar").build());
 
     StreamInterface api =
         Feign.builder()
@@ -105,14 +107,15 @@ class StreamDecoderTest {
             .target(StreamInterface.class, server.url("/").toString());
 
     try (Stream<String> stream = api.get()) {
-      assertThat(stream.collect(Collectors.toList())).isEqualTo(Arrays.asList("foo", "bar"));
+      assertThat(stream).containsExactlyElementsOf(Arrays.asList("foo", "bar"));
     }
   }
 
   @Test
-  void simpleDeleteDecoderTest() {
+  void simpleDeleteDecoderTest() throws IOException {
     MockWebServer server = new MockWebServer();
-    server.enqueue(new MockResponse().setBody("foo\nbar"));
+    server.start();
+    server.enqueue(new MockResponse.Builder().body("foo\nbar").build());
 
     StreamInterface api =
         Feign.builder()
@@ -131,7 +134,7 @@ class StreamDecoderTest {
   }
 
   @Test
-  void shouldCloseIteratorWhenStreamClosed() throws IOException {
+  void shouldCloseIteratorWhenStreamClosed() throws Exception {
     Response response =
         Response.builder()
             .status(200)

--- a/dropwizard-metrics5/src/test/java/feign/metrics5/Metrics5CapabilityTest.java
+++ b/dropwizard-metrics5/src/test/java/feign/metrics5/Metrics5CapabilityTest.java
@@ -15,7 +15,7 @@
  */
 package feign.metrics5;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import feign.Capability;
 import feign.Feign;
@@ -34,8 +34,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import org.junit.jupiter.api.Test;
 
-public class Metrics5CapabilityTest
-    extends AbstractMetricsTestBase<MetricRegistry, MetricName, Metric> {
+class Metrics5CapabilityTest extends AbstractMetricsTestBase<MetricRegistry, MetricName, Metric> {
 
   @Override
   protected MetricRegistry createMetricsRegistry() {
@@ -145,6 +144,6 @@ public class Metrics5CapabilityTest
         metricsRegistry.getMetrics().keySet().stream()
             .anyMatch(name -> "prod".equals(name.getTags().get("env")));
 
-    assertTrue(hasCustomTag);
+    assertThat(hasCustomTag).isTrue();
   }
 }

--- a/example-wikipedia-with-springboot/src/test/java/feign/example/wikipedia/WikipediaExampleIT.java
+++ b/example-wikipedia-with-springboot/src/test/java/feign/example/wikipedia/WikipediaExampleIT.java
@@ -42,6 +42,6 @@ class WikipediaExampleIT {
     final CommandLine cmdLine = CommandLine.parse(line);
     final int exitValue = new DefaultExecutor().execute(cmdLine);
 
-    assertThat(exitValue).isEqualTo(0);
+    assertThat(exitValue).isZero();
   }
 }

--- a/fastjson2/src/test/java/feign/fastjson2/FastJsonCodecTest.java
+++ b/fastjson2/src/test/java/feign/fastjson2/FastJsonCodecTest.java
@@ -22,7 +22,6 @@ import com.alibaba.fastjson2.TypeReference;
 import feign.Request;
 import feign.RequestTemplate;
 import feign.Response;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
@@ -143,7 +142,7 @@ class FastJsonCodecTest {
   }
 
   @Test
-  void decoderCharset() throws IOException {
+  void decoderCharset() throws Exception {
     Zone zone = new Zone("denominator.io.", "ÁÉÍÓÚÀÈÌÒÙÄËÏÖÜÑ");
 
     Map<String, Collection<String>> headers = new HashMap<>();

--- a/form-spring/pom.xml
+++ b/form-spring/pom.xml
@@ -139,6 +139,19 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>${lombok.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <configuration>
@@ -151,6 +164,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED -Dnet.bytebuddy.experimental=true</argLine>
           <runOrder>alphabetical</runOrder>
         </configuration>
       </plugin>

--- a/form-spring/src/main/java/feign/form/spring/SpringFormEncoder.java
+++ b/form-spring/src/main/java/feign/form/spring/SpringFormEncoder.java
@@ -26,7 +26,6 @@ import feign.form.FormEncoder;
 import feign.form.MultipartFormContentProcessor;
 import java.lang.reflect.Type;
 import java.util.HashMap;
-import lombok.val;
 import org.springframework.web.multipart.MultipartFile;
 
 /**
@@ -50,7 +49,7 @@ public class SpringFormEncoder extends FormEncoder {
   public SpringFormEncoder(Encoder delegate) {
     super(delegate);
 
-    val processor = (MultipartFormContentProcessor) getContentProcessor(MULTIPART);
+    final var processor = (MultipartFormContentProcessor) getContentProcessor(MULTIPART);
     processor.addFirstWriter(new SpringSingleMultipartFileWriter());
     processor.addFirstWriter(new SpringManyMultipartFilesWriter());
   }
@@ -59,21 +58,21 @@ public class SpringFormEncoder extends FormEncoder {
   public void encode(Object object, Type bodyType, RequestTemplate template)
       throws EncodeException {
     if (bodyType.equals(MultipartFile[].class)) {
-      val files = (MultipartFile[]) object;
-      val data = new HashMap<String, Object>(files.length, 1.F);
-      for (val file : files) {
+      final var files = (MultipartFile[]) object;
+      final var data = new HashMap<String, Object>(files.length, 1.F);
+      for (var file : files) {
         data.put(file.getName(), file);
       }
       super.encode(data, MAP_STRING_WILDCARD, template);
     } else if (bodyType.equals(MultipartFile.class)) {
-      val file = (MultipartFile) object;
-      val data = singletonMap(file.getName(), object);
+      final var file = (MultipartFile) object;
+      final var data = singletonMap(file.getName(), object);
       super.encode(data, MAP_STRING_WILDCARD, template);
     } else if (isMultipartFileCollection(object)) {
-      val iterable = (Iterable<?>) object;
-      val data = new HashMap<String, Object>();
-      for (val item : iterable) {
-        val file = (MultipartFile) item;
+      final var iterable = (Iterable<?>) object;
+      final var data = new HashMap<String, Object>();
+      for (var item : iterable) {
+        final var file = (MultipartFile) item;
         data.put(file.getName(), file);
       }
       super.encode(data, MAP_STRING_WILDCARD, template);
@@ -86,8 +85,8 @@ public class SpringFormEncoder extends FormEncoder {
     if (!(object instanceof Iterable)) {
       return false;
     }
-    val iterable = (Iterable<?>) object;
-    val iterator = iterable.iterator();
+    final var iterable = (Iterable<?>) object;
+    final var iterator = iterable.iterator();
     return iterator.hasNext() && iterator.next() instanceof MultipartFile;
   }
 }

--- a/form-spring/src/main/java/feign/form/spring/SpringManyMultipartFilesWriter.java
+++ b/form-spring/src/main/java/feign/form/spring/SpringManyMultipartFilesWriter.java
@@ -21,7 +21,6 @@ import feign.codec.EncodeException;
 import feign.form.multipart.AbstractWriter;
 import feign.form.multipart.Output;
 import lombok.experimental.FieldDefaults;
-import lombok.val;
 import org.springframework.web.multipart.MultipartFile;
 
 /**
@@ -42,8 +41,8 @@ public class SpringManyMultipartFilesWriter extends AbstractWriter {
     if (!(value instanceof Iterable)) {
       return false;
     }
-    val iterable = (Iterable<?>) value;
-    val iterator = iterable.iterator();
+    final var iterable = (Iterable<?>) value;
+    final var iterator = iterable.iterator();
     return iterator.hasNext() && iterator.next() instanceof MultipartFile;
   }
 
@@ -51,13 +50,13 @@ public class SpringManyMultipartFilesWriter extends AbstractWriter {
   public void write(Output output, String boundary, String key, Object value)
       throws EncodeException {
     if (value instanceof MultipartFile[]) {
-      val files = (MultipartFile[]) value;
-      for (val file : files) {
+      final var files = (MultipartFile[]) value;
+      for (var file : files) {
         fileWriter.write(output, boundary, key, file);
       }
     } else if (value instanceof Iterable) {
-      val iterable = (Iterable<?>) value;
-      for (val file : iterable) {
+      final var iterable = (Iterable<?>) value;
+      for (var file : iterable) {
         fileWriter.write(output, boundary, key, file);
       }
     } else {

--- a/form-spring/src/main/java/feign/form/spring/SpringSingleMultipartFileWriter.java
+++ b/form-spring/src/main/java/feign/form/spring/SpringSingleMultipartFileWriter.java
@@ -19,7 +19,6 @@ import feign.codec.EncodeException;
 import feign.form.multipart.AbstractWriter;
 import feign.form.multipart.Output;
 import java.io.IOException;
-import lombok.val;
 import org.springframework.web.multipart.MultipartFile;
 
 /**
@@ -36,7 +35,7 @@ public class SpringSingleMultipartFileWriter extends AbstractWriter {
 
   @Override
   protected void write(Output output, String key, Object value) throws EncodeException {
-    val file = (MultipartFile) value;
+    final var file = (MultipartFile) value;
     writeFileMetadata(output, key, file.getOriginalFilename(), file.getContentType());
 
     byte[] bytes;

--- a/form-spring/src/main/java/feign/form/spring/converter/SpringManyMultipartFilesReader.java
+++ b/form-spring/src/main/java/feign/form/spring/converter/SpringManyMultipartFilesReader.java
@@ -27,7 +27,6 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.regex.Pattern;
 import lombok.experimental.FieldDefaults;
-import lombok.val;
 import org.apache.commons.fileupload.MultipartStream;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
@@ -84,7 +83,7 @@ public class SpringManyMultipartFilesReader extends AbstractHttpMessageConverter
   @Override
   protected MultipartFile[] readInternal(
       Class<? extends MultipartFile[]> clazz, HttpInputMessage inputMessage) throws IOException {
-    val headers = inputMessage.getHeaders();
+    final var headers = inputMessage.getHeaders();
     if (headers == null) {
       throw new HttpMessageNotReadableException("There are no headers at all.", inputMessage);
     }
@@ -94,11 +93,11 @@ public class SpringManyMultipartFilesReader extends AbstractHttpMessageConverter
       throw new HttpMessageNotReadableException("Content-Type is missing.", inputMessage);
     }
 
-    val boundaryBytes = getMultiPartBoundary(contentType);
+    final var boundaryBytes = getMultiPartBoundary(contentType);
     MultipartStream multipartStream =
         new MultipartStream(inputMessage.getBody(), boundaryBytes, bufSize, null);
 
-    val multiparts = new LinkedList<ByteArrayMultipartFile>();
+    final var multiparts = new LinkedList<ByteArrayMultipartFile>();
     for (boolean nextPart = multipartStream.skipPreamble();
         nextPart;
         nextPart = multipartStream.readBoundary()) {
@@ -122,7 +121,7 @@ public class SpringManyMultipartFilesReader extends AbstractHttpMessageConverter
   }
 
   private byte[] getMultiPartBoundary(MediaType contentType) {
-    val boundaryString = unquote(contentType.getParameter("boundary"));
+    final var boundaryString = unquote(contentType.getParameter("boundary"));
     if (StringUtils.hasLength(boundaryString) == false) {
       throw new HttpMessageConversionException("Content-Type missing boundary information.");
     }
@@ -130,11 +129,11 @@ public class SpringManyMultipartFilesReader extends AbstractHttpMessageConverter
   }
 
   private ByteArrayMultipartFile readMultiPart(MultipartStream multipartStream) throws IOException {
-    val multiPartHeaders =
+    final var multiPartHeaders =
         splitIntoKeyValuePairs(
             multipartStream.readHeaders(), NEWLINES_PATTERN, COLON_PATTERN, false);
 
-    val contentDisposition =
+    final var contentDisposition =
         splitIntoKeyValuePairs(
             multiPartHeaders.get(CONTENT_DISPOSITION),
             SEMICOLON_PATTERN,
@@ -145,7 +144,7 @@ public class SpringManyMultipartFilesReader extends AbstractHttpMessageConverter
       throw new HttpMessageConversionException("Content-Disposition is not of type form-data.");
     }
 
-    val bodyStream = new ByteArrayOutputStream();
+    final var bodyStream = new ByteArrayOutputStream();
     multipartStream.readBodyData(bodyStream);
     return new ByteArrayMultipartFile(
         contentDisposition.get("name"),
@@ -159,13 +158,13 @@ public class SpringManyMultipartFilesReader extends AbstractHttpMessageConverter
       Pattern entriesSeparatorPattern,
       Pattern keyValueSeparatorPattern,
       boolean unquoteValue) {
-    val keyValuePairs = new IgnoreKeyCaseMap();
+    final var keyValuePairs = new IgnoreKeyCaseMap();
     if (StringUtils.hasLength(str)) {
-      val tokens = entriesSeparatorPattern.split(str);
-      for (val token : tokens) {
-        val pair = keyValueSeparatorPattern.split(token.trim(), 2);
-        val key = pair[0].trim();
-        val value = pair.length > 1 ? pair[1].trim() : "";
+      final var tokens = entriesSeparatorPattern.split(str);
+      for (var token : tokens) {
+        final var pair = keyValueSeparatorPattern.split(token.trim(), 2);
+        final var key = pair[0].trim();
+        final var value = pair.length > 1 ? pair[1].trim() : "";
 
         keyValuePairs.put(key, unquoteValue ? unquote(value) : value);
       }

--- a/form-spring/src/test/java/feign/form/feign/spring/converter/SpringManyMultipartFilesReaderTest.java
+++ b/form-spring/src/test/java/feign/form/feign/spring/converter/SpringManyMultipartFilesReaderTest.java
@@ -35,7 +35,7 @@ class SpringManyMultipartFilesReaderTest {
   private static final String DUMMY_MULTIPART_BOUNDARY = "Boundary_4_574237629_1500021738802";
 
   @Test
-  void readMultipartFormDataTest() throws IOException {
+  void readMultipartFormDataTest() throws Exception {
     var multipartFilesReader = new SpringManyMultipartFilesReader(4096);
     var multipartFiles =
         multipartFilesReader.read(MultipartFile[].class, new ValidMultipartMessage());

--- a/form/pom.xml
+++ b/form/pom.xml
@@ -113,6 +113,19 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>${lombok.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <configuration>

--- a/form/src/main/java/feign/form/ContentType.java
+++ b/form/src/main/java/feign/form/ContentType.java
@@ -19,7 +19,6 @@ import static lombok.AccessLevel.PRIVATE;
 
 import lombok.Getter;
 import lombok.experimental.FieldDefaults;
-import lombok.val;
 
 /**
  * Supported content types.
@@ -55,8 +54,8 @@ public enum ContentType {
       return UNDEFINED;
     }
 
-    val trimmed = str.trim();
-    for (val type : values()) {
+    final var trimmed = str.trim();
+    for (var type : values()) {
       if (trimmed.startsWith(type.getHeader())) {
         return type;
       }

--- a/form/src/main/java/feign/form/FormEncoder.java
+++ b/form/src/main/java/feign/form/FormEncoder.java
@@ -32,7 +32,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 import lombok.experimental.FieldDefaults;
-import lombok.val;
 
 /**
  * A Feign's form encoder.
@@ -68,7 +67,7 @@ public class FormEncoder implements Encoder {
   public FormEncoder(Encoder delegate) {
     this.delegate = delegate;
 
-    val list =
+    final var list =
         asList(new MultipartFormContentProcessor(delegate), new UrlencodedFormContentProcessor());
 
     processors = new HashMap<ContentType, ContentProcessor>(list.size(), 1.F);
@@ -82,7 +81,7 @@ public class FormEncoder implements Encoder {
   public void encode(Object object, Type bodyType, RequestTemplate template)
       throws EncodeException {
     String contentTypeValue = getContentTypeValue(template.headers());
-    val contentType = ContentType.of(contentTypeValue);
+    final var contentType = ContentType.of(contentTypeValue);
     if (processors.containsKey(contentType) == false) {
       delegate.encode(object, bodyType, template);
       return;
@@ -98,7 +97,7 @@ public class FormEncoder implements Encoder {
       return;
     }
 
-    val charset = getCharset(contentTypeValue);
+    final var charset = getCharset(contentTypeValue);
     processors.get(contentType).process(template, charset, data);
   }
 
@@ -114,11 +113,11 @@ public class FormEncoder implements Encoder {
 
   @SuppressWarnings("PMD.AvoidBranchingStatementAsLastInLoop")
   private String getContentTypeValue(Map<String, Collection<String>> headers) {
-    for (val entry : headers.entrySet()) {
+    for (var entry : headers.entrySet()) {
       if (!entry.getKey().equalsIgnoreCase(CONTENT_TYPE_HEADER)) {
         continue;
       }
-      for (val contentTypeValue : entry.getValue()) {
+      for (var contentTypeValue : entry.getValue()) {
         if (contentTypeValue == null) {
           continue;
         }
@@ -129,7 +128,7 @@ public class FormEncoder implements Encoder {
   }
 
   private Charset getCharset(String contentTypeValue) {
-    val matcher = CHARSET_PATTERN.matcher(contentTypeValue);
+    final var matcher = CHARSET_PATTERN.matcher(contentTypeValue);
     return matcher.find() ? Charset.forName(matcher.group(1)) : UTF_8;
   }
 }

--- a/form/src/main/java/feign/form/MultipartFormContentProcessor.java
+++ b/form/src/main/java/feign/form/MultipartFormContentProcessor.java
@@ -40,7 +40,6 @@ import java.util.Deque;
 import java.util.LinkedList;
 import java.util.Map;
 import lombok.experimental.FieldDefaults;
-import lombok.val;
 
 /**
  * Multipart form content processor.
@@ -76,19 +75,19 @@ public class MultipartFormContentProcessor implements ContentProcessor {
   @Override
   public void process(RequestTemplate template, Charset charset, Map<String, Object> data)
       throws EncodeException {
-    val boundary = Long.toHexString(System.currentTimeMillis());
-    try (val output = new Output(charset)) {
-      for (val entry : data.entrySet()) {
+    final var boundary = Long.toHexString(System.currentTimeMillis());
+    try (final var output = new Output(charset)) {
+      for (var entry : data.entrySet()) {
         if (entry == null || entry.getKey() == null || entry.getValue() == null) {
           continue;
         }
-        val writer = findApplicableWriter(entry.getValue());
+        final var writer = findApplicableWriter(entry.getValue());
         writer.write(output, boundary, entry.getKey(), entry.getValue());
       }
 
       output.write("--").write(boundary).write("--").write(CRLF);
 
-      val contentTypeHeaderValue =
+      final var contentTypeHeaderValue =
           new StringBuilder()
               .append(getSupportedContentType().getHeader())
               .append("; charset=")
@@ -103,7 +102,7 @@ public class MultipartFormContentProcessor implements ContentProcessor {
       // Feign's clients try to determine binary/string content by charset presence
       // so, I set it to null (in spite of availability charset) for backward
       // compatibility.
-      val bytes = output.toByteArray();
+      final var bytes = output.toByteArray();
       template.body(Request.Body.of(bytes));
     } catch (IOException ex) {
       throw new EncodeException("Output closing error", ex);
@@ -152,7 +151,7 @@ public class MultipartFormContentProcessor implements ContentProcessor {
   }
 
   private Writer findApplicableWriter(Object value) {
-    for (val writer : writers) {
+    for (var writer : writers) {
       if (writer.isApplicable(value)) {
         return writer;
       }

--- a/form/src/main/java/feign/form/UrlencodedFormContentProcessor.java
+++ b/form/src/main/java/feign/form/UrlencodedFormContentProcessor.java
@@ -32,7 +32,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
-import lombok.val;
 
 /**
  * An URL encoded form content processor.
@@ -53,7 +52,7 @@ public class UrlencodedFormContentProcessor implements ContentProcessor {
   @Override
   public void process(RequestTemplate template, Charset charset, Map<String, Object> data)
       throws EncodeException {
-    val bodyData = new StringBuilder();
+    final var bodyData = new StringBuilder();
     for (Entry<String, Object> entry : data.entrySet()) {
       if (entry == null || entry.getKey() == null) {
         continue;
@@ -64,14 +63,14 @@ public class UrlencodedFormContentProcessor implements ContentProcessor {
       bodyData.append(createKeyValuePair(template.collectionFormat(), entry, charset));
     }
 
-    val contentTypeValue =
+    final var contentTypeValue =
         new StringBuilder()
             .append(getSupportedContentType().getHeader())
             .append("; charset=")
             .append(charset.name())
             .toString();
 
-    val bytes = bodyData.toString().getBytes(charset);
+    final var bytes = bodyData.toString().getBytes(charset);
 
     template.header(CONTENT_TYPE_HEADER, Collections.<String>emptyList()); // reset header
     template.header(CONTENT_TYPE_HEADER, contentTypeValue);
@@ -106,7 +105,7 @@ public class UrlencodedFormContentProcessor implements ContentProcessor {
 
   private CharSequence createKeyValuePair(
       CollectionFormat collectionFormat, String key, Stream<?> values, Charset charset) {
-    val stringValues =
+    final var stringValues =
         values.filter(Objects::nonNull).map(Object::toString).collect(Collectors.toList());
     return collectionFormat.join(key, stringValues, charset);
   }

--- a/form/src/main/java/feign/form/multipart/AbstractWriter.java
+++ b/form/src/main/java/feign/form/multipart/AbstractWriter.java
@@ -19,7 +19,6 @@ import static feign.form.ContentProcessor.CRLF;
 
 import feign.codec.EncodeException;
 import java.net.URLConnection;
-import lombok.val;
 
 /**
  * A base writer class.
@@ -61,7 +60,7 @@ public abstract class AbstractWriter implements Writer {
    */
   protected void writeFileMetadata(
       Output output, String name, String fileName, String contentType) {
-    val contentDespositionBuilder =
+    final var contentDespositionBuilder =
         new StringBuilder()
             .append("Content-Disposition: form-data; name=\"")
             .append(name)
@@ -80,7 +79,7 @@ public abstract class AbstractWriter implements Writer {
       }
     }
 
-    val string =
+    final var string =
         new StringBuilder()
             .append(contentDespositionBuilder.toString())
             .append(CRLF)

--- a/form/src/main/java/feign/form/multipart/DelegateWriter.java
+++ b/form/src/main/java/feign/form/multipart/DelegateWriter.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
-import lombok.val;
 
 /**
  * A delegate writer.
@@ -47,14 +46,14 @@ public class DelegateWriter extends AbstractWriter {
 
   @Override
   protected void write(Output output, String key, Object value) throws EncodeException {
-    val fake = new RequestTemplate();
+    final var fake = new RequestTemplate();
     delegate.encode(value, value.getClass(), fake);
     fake.requestBody().ifPresent(body -> write(output, key, body));
   }
 
   private void write(Output output, String key, Request.Body body) {
     try {
-      val encoded = body.writeToString(StandardCharsets.UTF_8).replaceAll("\n", "");
+      final var encoded = body.writeToString(StandardCharsets.UTF_8).replaceAll("\n", "");
       parameterWriter.write(output, key, encoded);
     } catch (IOException e) {
       throw new EncodeException("Failed to write request body for key: " + key, e);

--- a/form/src/main/java/feign/form/multipart/FormDataWriter.java
+++ b/form/src/main/java/feign/form/multipart/FormDataWriter.java
@@ -17,7 +17,6 @@ package feign.form.multipart;
 
 import feign.codec.EncodeException;
 import feign.form.FormData;
-import lombok.val;
 
 /**
  * A {@link FormData} writer.
@@ -34,7 +33,7 @@ public class FormDataWriter extends AbstractWriter {
 
   @Override
   protected void write(Output output, String key, Object value) throws EncodeException {
-    val formData = (FormData) value;
+    final var formData = (FormData) value;
     writeFileMetadata(output, key, formData.getFileName(), formData.getContentType());
     output.write(formData.getData());
   }

--- a/form/src/main/java/feign/form/multipart/ManyFilesWriter.java
+++ b/form/src/main/java/feign/form/multipart/ManyFilesWriter.java
@@ -20,7 +20,6 @@ import static lombok.AccessLevel.PRIVATE;
 import feign.codec.EncodeException;
 import java.io.File;
 import lombok.experimental.FieldDefaults;
-import lombok.val;
 
 /**
  * A writer for multiple files.
@@ -40,8 +39,8 @@ public class ManyFilesWriter extends AbstractWriter {
     if (!(value instanceof Iterable)) {
       return false;
     }
-    val iterable = (Iterable<?>) value;
-    val iterator = iterable.iterator();
+    final var iterable = (Iterable<?>) value;
+    final var iterator = iterable.iterator();
     return iterator.hasNext() && iterator.next() instanceof File;
   }
 
@@ -49,13 +48,13 @@ public class ManyFilesWriter extends AbstractWriter {
   public void write(Output output, String boundary, String key, Object value)
       throws EncodeException {
     if (value instanceof File[]) {
-      val files = (File[]) value;
-      for (val file : files) {
+      final var files = (File[]) value;
+      for (var file : files) {
         fileWriter.write(output, boundary, key, file);
       }
     } else if (value instanceof Iterable) {
-      val iterable = (Iterable<?>) value;
-      for (val file : iterable) {
+      final var iterable = (Iterable<?>) value;
+      for (var file : iterable) {
         fileWriter.write(output, boundary, key, file);
       }
     } else {

--- a/form/src/main/java/feign/form/multipart/ManyParametersWriter.java
+++ b/form/src/main/java/feign/form/multipart/ManyParametersWriter.java
@@ -19,7 +19,6 @@ import static lombok.AccessLevel.PRIVATE;
 
 import feign.codec.EncodeException;
 import lombok.experimental.FieldDefaults;
-import lombok.val;
 
 /**
  * A multiple parameters writer.
@@ -40,8 +39,8 @@ public class ManyParametersWriter extends AbstractWriter {
     if (!(value instanceof Iterable)) {
       return false;
     }
-    val iterable = (Iterable<?>) value;
-    val iterator = iterable.iterator();
+    final var iterable = (Iterable<?>) value;
+    final var iterator = iterable.iterator();
     return iterator.hasNext() && parameterWriter.isApplicable(iterator.next());
   }
 
@@ -49,13 +48,13 @@ public class ManyParametersWriter extends AbstractWriter {
   public void write(Output output, String boundary, String key, Object value)
       throws EncodeException {
     if (value.getClass().isArray()) {
-      val objects = (Object[]) value;
-      for (val object : objects) {
+      final var objects = (Object[]) value;
+      for (var object : objects) {
         parameterWriter.write(output, boundary, key, object);
       }
     } else if (value instanceof Iterable) {
-      val iterable = (Iterable<?>) value;
-      for (val object : iterable) {
+      final var iterable = (Iterable<?>) value;
+      for (var object : iterable) {
         parameterWriter.write(output, boundary, key, object);
       }
     }

--- a/form/src/main/java/feign/form/multipart/PojoWriter.java
+++ b/form/src/main/java/feign/form/multipart/PojoWriter.java
@@ -22,7 +22,6 @@ import static lombok.AccessLevel.PRIVATE;
 import feign.codec.EncodeException;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
-import lombok.val;
 
 /**
  * A custom user's POJO writer.
@@ -43,9 +42,9 @@ public class PojoWriter extends AbstractWriter {
   @Override
   public void write(Output output, String boundary, String key, Object object)
       throws EncodeException {
-    val map = toMap(object);
-    for (val entry : map.entrySet()) {
-      val writer = findApplicableWriter(entry.getValue());
+    final var map = toMap(object);
+    for (var entry : map.entrySet()) {
+      final var writer = findApplicableWriter(entry.getValue());
       if (writer == null) {
         continue;
       }
@@ -55,7 +54,7 @@ public class PojoWriter extends AbstractWriter {
   }
 
   private Writer findApplicableWriter(Object value) {
-    for (val writer : writers) {
+    for (var writer : writers) {
       if (writer.isApplicable(value)) {
         return writer;
       }

--- a/form/src/main/java/feign/form/multipart/SingleFileWriter.java
+++ b/form/src/main/java/feign/form/multipart/SingleFileWriter.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import lombok.val;
 
 /**
  * A single-file writer.
@@ -36,18 +35,18 @@ public class SingleFileWriter extends AbstractWriter {
 
   @Override
   protected void write(Output output, String key, Object value) throws EncodeException {
-    val file = (File) value;
+    final var file = (File) value;
     writeFileMetadata(output, key, file.getName(), null);
 
     try (InputStream input = new FileInputStream(file)) {
-      val buf = new byte[4096];
+      final var buf = new byte[4096];
       int length = input.read(buf);
       while (length > 0) {
         output.write(buf, 0, length);
         length = input.read(buf);
       }
     } catch (IOException ex) {
-      val message = String.format("Writing file's '%s' content error", file.getName());
+      final var message = String.format("Writing file's '%s' content error", file.getName());
       throw new EncodeException(message, ex);
     }
   }

--- a/form/src/main/java/feign/form/multipart/SingleParameterWriter.java
+++ b/form/src/main/java/feign/form/multipart/SingleParameterWriter.java
@@ -18,7 +18,6 @@ package feign.form.multipart;
 import static feign.form.ContentProcessor.CRLF;
 
 import feign.codec.EncodeException;
-import lombok.val;
 
 /**
  * A writer for a single parameter.
@@ -34,7 +33,7 @@ public class SingleParameterWriter extends AbstractWriter {
 
   @Override
   protected void write(Output output, String key, Object value) throws EncodeException {
-    val string =
+    final var string =
         new StringBuilder()
             .append("Content-Disposition: form-data; name=\"")
             .append(key)

--- a/form/src/main/java/feign/form/util/PojoUtil.java
+++ b/form/src/main/java/feign/form/util/PojoUtil.java
@@ -31,7 +31,6 @@ import lombok.NonNull;
 import lombok.Setter;
 import lombok.SneakyThrows;
 import lombok.experimental.FieldDefaults;
-import lombok.val;
 
 /**
  * An utility class to work with POJOs.
@@ -41,33 +40,33 @@ import lombok.val;
 public final class PojoUtil {
 
   public static boolean isUserPojo(@NonNull Object object) {
-    val type = object.getClass();
-    val packageName = type.getPackage().getName();
+    final var type = object.getClass();
+    final var packageName = type.getPackage().getName();
     return !packageName.startsWith("java.");
   }
 
   public static boolean isUserPojo(@NonNull Type type) {
-    val typeName = type.toString();
+    final var typeName = type.toString();
     return !typeName.startsWith("class java.");
   }
 
   @SneakyThrows
   public static Map<String, Object> toMap(@NonNull Object object) {
-    val result = new HashMap<String, Object>();
-    val type = object.getClass();
-    for (val field : type.getDeclaredFields()) {
-      val modifiers = field.getModifiers();
+    final var result = new HashMap<String, Object>();
+    final var type = object.getClass();
+    for (var field : type.getDeclaredFields()) {
+      final var modifiers = field.getModifiers();
       if (isFinal(modifiers) || isStatic(modifiers)) {
         continue;
       }
       field.setAccessible(true);
 
-      val fieldValue = field.get(object);
+      final var fieldValue = field.get(object);
       if (fieldValue == null) {
         continue;
       }
 
-      val propertyKey =
+      final var propertyKey =
           field.isAnnotationPresent(FormProperty.class)
               ? field.getAnnotation(FormProperty.class).value()
               : field.getName();

--- a/form/src/test/java/feign/form/BasicClientTest.java
+++ b/form/src/test/java/feign/form/BasicClientTest.java
@@ -55,17 +55,17 @@ class BasicClientTest {
   }
 
   @Test
-  void testForm() {
+  void form() {
     assertThat(API.form("1", "1")).isNotNull().extracting(Response::status).isEqualTo(200);
   }
 
   @Test
-  void testFormException() {
+  void formException() {
     assertThat(API.form("1", "2")).isNotNull().extracting(Response::status).isEqualTo(400);
   }
 
   @Test
-  void testUpload() throws Exception {
+  void upload() throws Exception {
     var path =
         Path.of(Thread.currentThread().getContextClassLoader().getResource("file.txt").toURI());
     assertThat(path).exists();
@@ -74,7 +74,7 @@ class BasicClientTest {
   }
 
   @Test
-  void testUploadWithParam() throws Exception {
+  void uploadWithParam() throws Exception {
     var path =
         Path.of(Thread.currentThread().getContextClassLoader().getResource("file.txt").toURI());
     assertThat(path).exists();
@@ -83,14 +83,14 @@ class BasicClientTest {
   }
 
   @Test
-  void testJson() {
+  void json() {
     var dto = new Dto("Artem", 11);
 
     assertThat(API.json(dto)).isEqualTo("ok");
   }
 
   @Test
-  void testQueryMap() {
+  void queryMap() {
     Map<String, Object> value =
         singletonMap("filter", (Object) asList("one", "two", "three", "four"));
 
@@ -98,7 +98,7 @@ class BasicClientTest {
   }
 
   @Test
-  void testMultipleFilesArray() throws Exception {
+  void multipleFilesArray() throws Exception {
     var path1 =
         Path.of(Thread.currentThread().getContextClassLoader().getResource("file.txt").toURI());
     assertThat(path1).exists();
@@ -114,7 +114,7 @@ class BasicClientTest {
   }
 
   @Test
-  void testMultipleFilesList() throws Exception {
+  void multipleFilesList() throws Exception {
     var path1 =
         Path.of(Thread.currentThread().getContextClassLoader().getResource("file.txt").toURI());
     assertThat(path1).exists();
@@ -130,7 +130,7 @@ class BasicClientTest {
   }
 
   @Test
-  void testUploadWithDto() throws Exception {
+  void uploadWithDto() throws Exception {
     var dto = new Dto("Artem", 11);
 
     var path =
@@ -144,7 +144,7 @@ class BasicClientTest {
   }
 
   @Test
-  void testUnknownTypeFile() throws Exception {
+  void unknownTypeFile() throws Exception {
     var path =
         Path.of(Thread.currentThread().getContextClassLoader().getResource("file.abc").toURI());
     assertThat(path).exists();
@@ -153,21 +153,21 @@ class BasicClientTest {
   }
 
   @Test
-  void testFormData() throws Exception {
+  void formData() throws Exception {
     var formData = new FormData("application/custom-type", "popa.txt", "Allo".getBytes("UTF-8"));
 
     assertThat(API.uploadFormData(formData)).isEqualTo("popa.txt:application/custom-type");
   }
 
   @Test
-  void testSubmitRepeatableQueryParam() throws Exception {
+  void submitRepeatableQueryParam() throws Exception {
     var names = new String[] {"Milada", "Thais"};
     var stringResponse = API.submitRepeatableQueryParam(names);
     assertThat(stringResponse).isEqualTo("Milada and Thais");
   }
 
   @Test
-  void testSubmitRepeatableFormParam() throws Exception {
+  void submitRepeatableFormParam() throws Exception {
     var names = Arrays.asList("Milada", "Thais");
     var stringResponse = API.submitRepeatableFormParam(names);
     assertThat(stringResponse).isEqualTo("Milada and Thais");

--- a/form/src/test/java/feign/form/ByteArrayClientTest.java
+++ b/form/src/test/java/feign/form/ByteArrayClientTest.java
@@ -53,7 +53,7 @@ class ByteArrayClientTest {
   }
 
   @Test
-  void testNotTreatedAsFileUpload() {
+  void notTreatedAsFileUpload() {
     byte[] bytes = "Hello World".getBytes();
 
     assertThat(API.uploadByteArray(bytes)).isNotNull().extracting(Response::status).isEqualTo(200);

--- a/form/src/test/java/feign/form/WildCardMapTest.java
+++ b/form/src/test/java/feign/form/WildCardMapTest.java
@@ -52,7 +52,7 @@ class WildCardMapTest {
   }
 
   @Test
-  void testOk() {
+  void ok() {
     Map<String, Object> param =
         new HashMap<String, Object>() {
 
@@ -68,7 +68,7 @@ class WildCardMapTest {
   }
 
   @Test
-  void testBadRequest() {
+  void badRequest() {
     Map<String, Object> param =
         new HashMap<String, Object>() {
 

--- a/form/src/test/java/feign/form/utils/UndertowServer.java
+++ b/form/src/test/java/feign/form/utils/UndertowServer.java
@@ -51,7 +51,7 @@ public final class UndertowServer implements AutoCloseable {
    * @return listining server's url.
    */
   public String getConnectUrl() {
-    var listenerInfo = undertow.getListenerInfo().iterator().next();
+    var listenerInfo = undertow.getListenerInfo().getFirst();
 
     var address = (InetSocketAddress) listenerInfo.getAddress();
 

--- a/googlehttpclient/pom.xml
+++ b/googlehttpclient/pom.xml
@@ -54,7 +54,7 @@
 
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>mockwebserver</artifactId>
+      <artifactId>mockwebserver3</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/googlehttpclient/src/main/java/feign/googlehttpclient/GoogleHttpClient.java
+++ b/googlehttpclient/src/main/java/feign/googlehttpclient/GoogleHttpClient.java
@@ -98,7 +98,7 @@ public class GoogleHttpClient implements Client {
   }
 
   private HttpContent toHttpContent(final Request inputRequest) {
-    if (!inputRequest.httpMethod().isWithBody() || !inputRequest.body().isPresent()) {
+    if (!inputRequest.httpMethod().isWithBody() || inputRequest.body().isEmpty()) {
       return null;
     }
 

--- a/googlehttpclient/src/test/java/feign/googlehttpclient/GoogleHttpClientTest.java
+++ b/googlehttpclient/src/test/java/feign/googlehttpclient/GoogleHttpClientTest.java
@@ -27,7 +27,7 @@ import feign.Util;
 import feign.assertj.MockWebServerAssertions;
 import feign.client.AbstractClientTest;
 import java.util.Collections;
-import okhttp3.mockwebserver.MockResponse;
+import mockwebserver3.MockResponse;
 import org.junit.jupiter.api.Test;
 
 public class GoogleHttpClientTest extends AbstractClientTest {
@@ -39,12 +39,15 @@ public class GoogleHttpClientTest extends AbstractClientTest {
   // Google http client doesn't support PATCH. See:
   // https://github.com/googleapis/google-http-java-client/issues/167
   @Override
+  @Test
   public void noResponseBodyForPatch() {}
 
   @Override
+  @Test
   public void patch() {}
 
   @Override
+  @Test
   public void parsesUnauthorizedResponseBody() {}
 
   /*
@@ -52,33 +55,38 @@ public class GoogleHttpClientTest extends AbstractClientTest {
    * out-of-the-box. You can replace the transport with Apache HTTP Client.
    */
   @Override
+  @Test
   public void canSupportGzip() throws Exception {
     assumeFalse(false, "Google HTTP client client do not support gzip compression");
   }
 
   @Override
+  @Test
   public void canSupportGzipOnError() throws Exception {
     assumeFalse(false, "Google HTTP client client do not support gzip compression");
   }
 
   @Override
+  @Test
   public void canSupportDeflate() throws Exception {
     assumeFalse(false, "Google HTTP client client do not support deflate compression");
   }
 
   @Override
+  @Test
   public void canSupportDeflateOnError() throws Exception {
     assumeFalse(false, "Google HTTP client client do not support deflate compression");
   }
 
   @Override
+  @Test
   public void canExceptCaseInsensitiveHeader() throws Exception {
     assumeFalse(false, "Google HTTP client client do not support gzip compression");
   }
 
   @Test
   void contentTypeHeaderGetsAddedOnce() throws Exception {
-    server.enqueue(new MockResponse().setBody("AAAAAAAA"));
+    server.enqueue(new MockResponse.Builder().body("AAAAAAAA").build());
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
 
@@ -94,6 +102,7 @@ public class GoogleHttpClientTest extends AbstractClientTest {
   }
 
   @Override
+  @Test
   public void veryLongResponseNullLength() {
     assumeFalse(false, "JaxRS client hang if the response doesn't have a payload");
   }

--- a/graphql-apt/pom.xml
+++ b/graphql-apt/pom.xml
@@ -60,6 +60,12 @@
       <version>${auto-service-annotations.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <version>1.3.5</version>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>com.google.testing.compile</groupId>

--- a/graphql/pom.xml
+++ b/graphql/pom.xml
@@ -48,7 +48,7 @@
 
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>mockwebserver</artifactId>
+      <artifactId>mockwebserver3</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/graphql/src/test/java/feign/graphql/GraphqlClientTest.java
+++ b/graphql/src/test/java/feign/graphql/GraphqlClientTest.java
@@ -26,8 +26,8 @@ import feign.Param;
 import feign.jackson.JacksonCodec;
 import java.util.List;
 import java.util.Optional;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -88,7 +88,7 @@ class GraphqlClientTest {
 
   @AfterEach
   void tearDown() throws Exception {
-    server.shutdown();
+    server.close();
   }
 
   private TestApi buildClient() {
@@ -100,9 +100,10 @@ class GraphqlClientTest {
   @Test
   void mutationWithVariables() throws Exception {
     server.enqueue(
-        new MockResponse()
-            .setBody("{\"data\":{\"createUser\":{\"id\":\"42\",\"name\":\"Alice\"}}}")
-            .addHeader("Content-Type", "application/json"));
+        new MockResponse.Builder()
+            .body("{\"data\":{\"createUser\":{\"id\":\"42\",\"name\":\"Alice\"}}}")
+            .addHeader("Content-Type", "application/json")
+            .build());
 
     var input = new CreateUserInput();
     input.name = "Alice";
@@ -115,7 +116,7 @@ class GraphqlClientTest {
 
     var recorded = server.takeRequest();
     assertThat(recorded.getMethod()).isEqualTo("POST");
-    var body = mapper.readTree(recorded.getBody().readUtf8());
+    var body = mapper.readTree(recorded.getBody().utf8());
     assertThat(body.get("query").asText()).contains("createUser");
     assertThat(body.get("variables").get("input").get("name").asText()).isEqualTo("Alice");
   }
@@ -123,10 +124,11 @@ class GraphqlClientTest {
   @Test
   void queryWithStringVariable() throws Exception {
     server.enqueue(
-        new MockResponse()
-            .setBody(
+        new MockResponse.Builder()
+            .body(
                 "{\"data\":{\"getUser\":{\"id\":\"1\",\"name\":\"Bob\",\"email\":\"bob@test.com\"}}}")
-            .addHeader("Content-Type", "application/json"));
+            .addHeader("Content-Type", "application/json")
+            .build());
 
     var user = buildClient().getUser("1");
 
@@ -135,17 +137,18 @@ class GraphqlClientTest {
     assertThat(user.email).isEqualTo("bob@test.com");
 
     var recorded = server.takeRequest();
-    var body = mapper.readTree(recorded.getBody().readUtf8());
+    var body = mapper.readTree(recorded.getBody().utf8());
     assertThat(body.get("variables").get("id").asText()).isEqualTo("1");
   }
 
   @Test
   void noVariableQuerySetsBodyViaInterceptor() throws Exception {
     server.enqueue(
-        new MockResponse()
-            .setBody(
+        new MockResponse.Builder()
+            .body(
                 "{\"data\":{\"listPending\":[{\"id\":\"1\",\"name\":\"A\"},{\"id\":\"2\",\"name\":\"B\"}]}}")
-            .addHeader("Content-Type", "application/json"));
+            .addHeader("Content-Type", "application/json")
+            .build());
 
     var users = buildClient().listPending();
 
@@ -153,7 +156,7 @@ class GraphqlClientTest {
     assertThat(users.getFirst().name).isEqualTo("A");
 
     var recorded = server.takeRequest();
-    var body = mapper.readTree(recorded.getBody().readUtf8());
+    var body = mapper.readTree(recorded.getBody().utf8());
     assertThat(body.get("query").asText()).contains("listPending");
     assertThat(body.has("variables")).isFalse();
   }
@@ -161,9 +164,10 @@ class GraphqlClientTest {
   @Test
   void graphqlErrorsThrowException() {
     server.enqueue(
-        new MockResponse()
-            .setBody("{\"errors\":[{\"message\":\"Something went wrong\"}],\"data\":null}")
-            .addHeader("Content-Type", "application/json"));
+        new MockResponse.Builder()
+            .body("{\"errors\":[{\"message\":\"Something went wrong\"}],\"data\":null}")
+            .addHeader("Content-Type", "application/json")
+            .build());
 
     var input = new CreateUserInput();
     input.name = "Alice";
@@ -177,10 +181,11 @@ class GraphqlClientTest {
   @Test
   void singleResultFromArrayResponse() throws Exception {
     server.enqueue(
-        new MockResponse()
-            .setBody(
+        new MockResponse.Builder()
+            .body(
                 "{\"data\":{\"topUsers\":[{\"id\":\"1\",\"name\":\"Alice\",\"email\":\"a@test.com\"}]}}")
-            .addHeader("Content-Type", "application/json"));
+            .addHeader("Content-Type", "application/json")
+            .build());
 
     var user = buildClient().topUser(1);
 
@@ -191,10 +196,11 @@ class GraphqlClientTest {
   @Test
   void optionalReturnType() throws Exception {
     server.enqueue(
-        new MockResponse()
-            .setBody(
+        new MockResponse.Builder()
+            .body(
                 "{\"data\":{\"getUser\":{\"id\":\"1\",\"name\":\"Bob\",\"email\":\"bob@test.com\"}}}")
-            .addHeader("Content-Type", "application/json"));
+            .addHeader("Content-Type", "application/json")
+            .build());
 
     var user = buildClient().findUser("1");
 
@@ -206,9 +212,10 @@ class GraphqlClientTest {
   @Test
   void optionalReturnTypeEmptyWhenNull() throws Exception {
     server.enqueue(
-        new MockResponse()
-            .setBody("{\"data\":{\"getUser\":null}}")
-            .addHeader("Content-Type", "application/json"));
+        new MockResponse.Builder()
+            .body("{\"data\":{\"getUser\":null}}")
+            .addHeader("Content-Type", "application/json")
+            .build());
 
     var user = buildClient().findUser("999");
 
@@ -218,16 +225,17 @@ class GraphqlClientTest {
   @Test
   void authHeaderPassedThrough() throws Exception {
     server.enqueue(
-        new MockResponse()
-            .setBody(
+        new MockResponse.Builder()
+            .body(
                 "{\"data\":{\"getUser\":{\"id\":\"1\",\"name\":\"Bob\",\"email\":\"bob@test.com\"}}}")
-            .addHeader("Content-Type", "application/json"));
+            .addHeader("Content-Type", "application/json")
+            .build());
 
     var user = buildClient().getUserWithAuth("Bearer mytoken", "1");
 
     assertThat(user.id).isEqualTo("1");
 
     var recorded = server.takeRequest();
-    assertThat(recorded.getHeader("Authorization")).isEqualTo("Bearer mytoken");
+    assertThat(recorded.getHeaders().get("Authorization")).isEqualTo("Bearer mytoken");
   }
 }

--- a/graphql/src/test/java/feign/graphql/GraphqlDecoderOptionalFieldCodecTest.java
+++ b/graphql/src/test/java/feign/graphql/GraphqlDecoderOptionalFieldCodecTest.java
@@ -140,7 +140,7 @@ class GraphqlDecoderOptionalFieldCodecTest {
     var item = api.getItem();
 
     assertThat(item.name()).isEqualTo("test");
-    assertThat(item.step()).isPresent().hasValue("foo");
+    assertThat(item.step()).hasValue("foo");
   }
 
   private ItemApi buildClient(MockClient mockClient, JsonCodec codec) {

--- a/graphql/src/test/java/feign/graphql/GraphqlDecoderTest.java
+++ b/graphql/src/test/java/feign/graphql/GraphqlDecoderTest.java
@@ -240,7 +240,7 @@ class GraphqlDecoderTest {
 
     assertThat(result.id()).isEqualTo("1");
     assertThat(result.email()).isPresent();
-    assertThat(result.email().get()).isEqualTo("alice@test.com");
+    assertThat(result.email()).hasValue("alice@test.com");
   }
 
   @Test

--- a/graphql/src/test/java/feign/graphql/GraphqlEncoderTest.java
+++ b/graphql/src/test/java/feign/graphql/GraphqlEncoderTest.java
@@ -16,12 +16,12 @@
 package feign.graphql;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.Request;
 import feign.RequestTemplate;
 import feign.jackson.JacksonEncoder;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -55,11 +55,19 @@ class GraphqlEncoderTest {
   }
 
   private byte[] bodyAsByteArray(Request.Body body) {
-    return assertDoesNotThrow(body::writeToByteArray);
+    try {
+      return body.writeToByteArray();
+    } catch (IOException e) {
+      throw new AssertionError("Failed to write body", e);
+    }
   }
 
   private String bodyAsUtf8String(Request.Body body) {
-    return assertDoesNotThrow(() -> body.writeToString(StandardCharsets.UTF_8));
+    try {
+      return body.writeToString(StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new AssertionError("Failed to write body", e);
+    }
   }
 
   private byte[] requestBodyBytes(RequestTemplate template) {
@@ -88,7 +96,7 @@ class GraphqlEncoderTest {
   void delegatesToWrappedEncoderForNonGraphql() {
     var template = new RequestTemplate();
     encoder.encode("plain body", String.class, template);
-    assertThat(template.requestBody()).isNotEmpty();
+    assertThat(template.requestBody()).isPresent();
   }
 
   @Test

--- a/hc5/pom.xml
+++ b/hc5/pom.xml
@@ -67,7 +67,7 @@
 
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>mockwebserver</artifactId>
+      <artifactId>mockwebserver3</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/hc5/src/test/java/feign/hc5/ApacheHttp5ClientTest.java
+++ b/hc5/src/test/java/feign/hc5/ApacheHttp5ClientTest.java
@@ -17,7 +17,7 @@ package feign.hc5;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import feign.Feign;
@@ -31,8 +31,8 @@ import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.RecordedRequest;
+import mockwebserver3.MockResponse;
+import mockwebserver3.RecordedRequest;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.junit.jupiter.api.Test;
 
@@ -45,52 +45,53 @@ public class ApacheHttp5ClientTest extends AbstractClientTest {
   }
 
   @Test
-  void queryParamsAreRespectedWhenBodyIsEmpty() throws InterruptedException {
+  void queryParamsAreRespectedWhenBodyIsEmpty() throws Exception {
     final JaxRsTestInterface testInterface = buildTestInterface();
 
-    server.enqueue(new MockResponse().setBody("foo"));
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     assertThat(testInterface.withBody("foo", "bar")).isEqualTo("foo");
     final RecordedRequest request1 = server.takeRequest();
-    assertThat(request1.getPath()).isEqualTo("/withBody?foo=foo");
-    assertThat(request1.getBody().readString(StandardCharsets.UTF_8)).isEqualTo("bar");
+    assertThat(request1.getTarget()).isEqualTo("/withBody?foo=foo");
+    assertThat(request1.getBody().string(StandardCharsets.UTF_8)).isEqualTo("bar");
 
     assertThat(testInterface.withoutBody("foo")).isEqualTo("foo");
     final RecordedRequest request2 = server.takeRequest();
-    assertThat(request2.getPath()).isEqualTo("/withoutBody?foo=foo");
-    assertThat(request2.getBody().readString(StandardCharsets.UTF_8)).isEqualTo("");
+    assertThat(request2.getTarget()).isEqualTo("/withoutBody?foo=foo");
+    assertThat(request2.getBody().string(StandardCharsets.UTF_8)).isEmpty();
   }
 
   @Test
-  void followRedirectsIsTrue() throws InterruptedException {
+  void followRedirectsIsTrue() throws Exception {
     final JaxRsTestInterface testInterface = buildTestInterface();
 
     String redirectPath = getRedirectionUrl();
-    server.enqueue(buildMockResponseWithLocationHeader(redirectPath));
-    server.enqueue(new MockResponse().setBody("redirected"));
+    server.enqueue(buildMockResponseWithLocationHeader(redirectPath).build());
+    server.enqueue(new MockResponse.Builder().body("redirected").build());
     Request.Options options = buildRequestOptions(true);
 
     Object response = testInterface.withOptions(options);
-    assertThat(response).isNotNull();
-    assertThat(response).isEqualTo("redirected");
-    assertThat(server.takeRequest().getPath()).isEqualTo("/withRequestOptions");
+    assertThat(response).isNotNull().isEqualTo("redirected");
+    assertThat(server.takeRequest().getTarget()).isEqualTo("/withRequestOptions");
   }
 
   @Test
-  void followRedirectsIsFalse() throws InterruptedException {
+  void followRedirectsIsFalse() throws Exception {
     final JaxRsTestInterface testInterface = buildTestInterface();
 
     String redirectPath = getRedirectionUrl();
-    server.enqueue(buildMockResponseWithLocationHeader(redirectPath));
+    server.enqueue(buildMockResponseWithLocationHeader(redirectPath).build());
     Request.Options options = buildRequestOptions(false);
 
     FeignException feignException =
-        assertThrows(FeignException.class, () -> testInterface.withOptions(options));
+        assertThatExceptionOfType(FeignException.class)
+            .isThrownBy(() -> testInterface.withOptions(options))
+            .actual();
     assertThat(feignException.status()).isEqualTo(302);
     assertThat(feignException.responseHeaders().get("location").stream().findFirst().orElse(null))
         .isEqualTo(redirectPath);
-    assertThat(server.takeRequest().getPath()).isEqualTo("/withRequestOptions");
+    assertThat(server.takeRequest().getTarget()).isEqualTo("/withRequestOptions");
   }
 
   private JaxRsTestInterface buildTestInterface() {
@@ -100,8 +101,8 @@ public class ApacheHttp5ClientTest extends AbstractClientTest {
         .target(JaxRsTestInterface.class, "http://localhost:" + server.getPort());
   }
 
-  private MockResponse buildMockResponseWithLocationHeader(String redirectPath) {
-    return new MockResponse().setResponseCode(302).addHeader("location", redirectPath);
+  private MockResponse.Builder buildMockResponseWithLocationHeader(String redirectPath) {
+    return new MockResponse.Builder().code(302).addHeader("location", redirectPath);
   }
 
   private String getRedirectionUrl() {
@@ -113,11 +114,13 @@ public class ApacheHttp5ClientTest extends AbstractClientTest {
   }
 
   @Override
+  @Test
   public void veryLongResponseNullLength() {
     assumeTrue(false, "HC5 client seems to hang with response size equalto Long.MAX");
   }
 
   @Override
+  @Test
   public void contentTypeDefaultsToRequestCharset() throws Exception {
     assumeTrue(false, "this test is flaky on windows, but works fine.");
   }

--- a/hc5/src/test/java/feign/hc5/AsyncApacheHttp5ClientTest.java
+++ b/hc5/src/test/java/feign/hc5/AsyncApacheHttp5ClientTest.java
@@ -17,10 +17,8 @@ package feign.hc5;
 
 import static feign.assertj.MockWebServerAssertions.assertThat;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.assertj.core.api.Assertions.fail;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.data.MapEntry.entry;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -79,11 +77,13 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import okio.Buffer;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class AsyncApacheHttp5ClientTest {
@@ -91,7 +91,7 @@ public class AsyncApacheHttp5ClientTest {
 
   @Test
   void iterableQueryParams() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
@@ -103,7 +103,7 @@ public class AsyncApacheHttp5ClientTest {
 
   @Test
   void postTemplateParamsResolve() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
@@ -118,7 +118,7 @@ public class AsyncApacheHttp5ClientTest {
 
   @Test
   void postFormParams() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
@@ -134,7 +134,7 @@ public class AsyncApacheHttp5ClientTest {
 
   @Test
   void postBodyParam() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
@@ -154,7 +154,7 @@ public class AsyncApacheHttp5ClientTest {
    */
   @Test
   void bodyTypeCorrespondsWithParameterType() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final AtomicReference<Type> encodedType = new AtomicReference<>();
     final TestInterfaceAsync api =
@@ -179,7 +179,7 @@ public class AsyncApacheHttp5ClientTest {
 
   @Test
   void singleInterceptor() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder()
@@ -196,7 +196,7 @@ public class AsyncApacheHttp5ClientTest {
 
   @Test
   void multipleInterceptor() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder()
@@ -216,7 +216,7 @@ public class AsyncApacheHttp5ClientTest {
 
   @Test
   void customExpander() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
@@ -230,7 +230,7 @@ public class AsyncApacheHttp5ClientTest {
 
   @Test
   void customExpanderListParam() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
@@ -245,7 +245,7 @@ public class AsyncApacheHttp5ClientTest {
 
   @Test
   void customExpanderNullParam() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
@@ -259,7 +259,7 @@ public class AsyncApacheHttp5ClientTest {
 
   @Test
   void headerMap() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
@@ -279,7 +279,7 @@ public class AsyncApacheHttp5ClientTest {
 
   @Test
   void headerMapWithHeaderAnnotations() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
@@ -294,7 +294,7 @@ public class AsyncApacheHttp5ClientTest {
             entry("Content-Encoding", Arrays.asList("gzip")),
             entry("Custom-Header", Arrays.asList("fooValue")));
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     headerMap.put("Content-Encoding", "overrideFromMap");
 
     final CompletableFuture<?> cf = api.headerMapWithHeaderAnnotations(headerMap);
@@ -313,7 +313,7 @@ public class AsyncApacheHttp5ClientTest {
 
   @Test
   void queryMap() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
@@ -330,7 +330,7 @@ public class AsyncApacheHttp5ClientTest {
 
   @Test
   void queryMapIterableValuesExpanded() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
@@ -353,21 +353,21 @@ public class AsyncApacheHttp5ClientTest {
     final TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     Map<String, Object> queryMap = new LinkedHashMap<>();
     queryMap.put("fooKey", "fooValue");
     api.queryMapWithQueryParams("alice", queryMap);
     // query map should be expanded after built-in parameters
     assertThat(server.takeRequest()).hasPath("/?name=alice&fooKey=fooValue");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("name", "bob");
     api.queryMapWithQueryParams("alice", queryMap);
     // queries are additive
     assertThat(server.takeRequest()).hasPath("/?name=alice&name=bob");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("name", null);
     api.queryMapWithQueryParams("alice", queryMap);
@@ -380,25 +380,25 @@ public class AsyncApacheHttp5ClientTest {
     final TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     Map<String, Object> queryMap = new LinkedHashMap<>();
     queryMap.put("name", "{alice");
     api.queryMap(queryMap);
     assertThat(server.takeRequest()).hasPath("/?name=%7Balice");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("{name", "alice");
     api.queryMap(queryMap);
     assertThat(server.takeRequest()).hasPath("/?%7Bname=alice");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("name", "%7Balice");
     api.queryMapEncoded(queryMap);
     assertThat(server.takeRequest()).hasPath("/?name=%7Balice");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("%7Bname", "%7Balice");
     api.queryMapEncoded(queryMap);
@@ -412,7 +412,7 @@ public class AsyncApacheHttp5ClientTest {
 
     final CustomPojo customPojo = new CustomPojo("Name", 3);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     final CompletableFuture<?> cf = api.queryMapPojo(customPojo);
     assertThat(server.takeRequest()).hasQueryParams(Arrays.asList("name=Name", "number=3"));
     checkCFCompletedSoon(cf);
@@ -425,7 +425,7 @@ public class AsyncApacheHttp5ClientTest {
 
     final CustomPojo customPojo = new CustomPojo("Name", null);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     final CompletableFuture<?> cf = api.queryMapPojo(customPojo);
     assertThat(server.takeRequest()).hasPath("/?name=Name");
 
@@ -439,7 +439,7 @@ public class AsyncApacheHttp5ClientTest {
 
     final CustomPojo customPojo = new CustomPojo(null, null);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     api.queryMapPojo(customPojo);
     assertThat(server.takeRequest()).hasPath("/");
   }
@@ -474,20 +474,23 @@ public class AsyncApacheHttp5ClientTest {
 
   @Test
   void canOverrideErrorDecoder() throws Throwable {
-    server.enqueue(new MockResponse().setResponseCode(400).setBody("foo"));
+    server.enqueue(new MockResponse.Builder().code(400).body("foo").build());
 
     final TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder()
             .errorDecoder(new IllegalArgumentExceptionOn400())
             .target("http://localhost:" + server.getPort());
 
-    Throwable exception = assertThrows(IllegalArgumentException.class, () -> unwrap(api.post()));
+    Throwable exception =
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> unwrap(api.post()))
+            .actual();
     assertThat(exception.getMessage()).contains("bad zone name");
   }
 
   @Test
   void overrideTypeSpecificDecoder() throws Throwable {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     final TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder()
@@ -499,7 +502,7 @@ public class AsyncApacheHttp5ClientTest {
 
   @Test
   void doesntRetryAfterResponseIsSent() throws Throwable {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     final TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder()
@@ -511,13 +514,14 @@ public class AsyncApacheHttp5ClientTest {
 
     final CompletableFuture<?> cf = api.post();
     server.takeRequest();
-    Throwable exception = assertThrows(FeignException.class, () -> unwrap(cf));
+    Throwable exception =
+        assertThatExceptionOfType(FeignException.class).isThrownBy(() -> unwrap(cf)).actual();
     assertThat(exception.getMessage()).contains("timeout reading POST http://");
   }
 
   @Test
   void throwsFeignExceptionIncludingBody() throws Throwable {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     final TestInterfaceAsync api =
         AsyncFeign.builder()
@@ -542,7 +546,7 @@ public class AsyncApacheHttp5ClientTest {
 
   @Test
   void throwsFeignExceptionWithoutBody() {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     final TestInterfaceAsync api =
         AsyncFeign.builder()
@@ -557,7 +561,7 @@ public class AsyncApacheHttp5ClientTest {
     } catch (final FeignException e) {
       assertThat(e.getMessage())
           .isEqualTo("timeout reading POST http://localhost:" + server.getPort() + "/");
-      assertThat(e.contentUTF8()).isEqualTo("");
+      assertThat(e.contentUTF8()).isEmpty();
     }
   }
 
@@ -595,7 +599,7 @@ public class AsyncApacheHttp5ClientTest {
 
   @Test
   void okIfDecodeRootCauseHasNoMessage() throws Throwable {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     final TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder()
@@ -605,12 +609,12 @@ public class AsyncApacheHttp5ClientTest {
                 })
             .target("http://localhost:" + server.getPort());
 
-    assertThrows(DecodeException.class, () -> unwrap(api.post()));
+    assertThatThrownBy(() -> unwrap(api.post())).isInstanceOf(DecodeException.class);
   }
 
   @Test
   void decodingExceptionGetWrappedInDismiss404Mode() throws Throwable {
-    server.enqueue(new MockResponse().setResponseCode(404));
+    server.enqueue(new MockResponse.Builder().code(404).build());
 
     final TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder()
@@ -622,16 +626,18 @@ public class AsyncApacheHttp5ClientTest {
                 })
             .target("http://localhost:" + server.getPort());
 
-    DecodeException exception = assertThrows(DecodeException.class, () -> unwrap(api.post()));
+    DecodeException exception =
+        assertThatExceptionOfType(DecodeException.class)
+            .isThrownBy(() -> unwrap(api.post()))
+            .actual();
     assertThat(exception).hasCauseInstanceOf(NoSuchElementException.class);
   }
 
   @Test
   void decodingDoesNotSwallow404ErrorsInDismiss404Mode() throws Throwable {
-    assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(
+    assertThatThrownBy(
             () -> {
-              server.enqueue(new MockResponse().setResponseCode(404));
+              server.enqueue(new MockResponse.Builder().code(404).build());
 
               final TestInterfaceAsync api =
                   new TestInterfaceAsyncBuilder()
@@ -643,12 +649,13 @@ public class AsyncApacheHttp5ClientTest {
                   api.queryMap(Collections.<String, Object>emptyMap());
               server.takeRequest();
               unwrap(cf);
-            });
+            })
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void okIfEncodeRootCauseHasNoMessage() throws Throwable {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     final TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder()
@@ -658,7 +665,8 @@ public class AsyncApacheHttp5ClientTest {
                 })
             .target("http://localhost:" + server.getPort());
 
-    assertThrows(EncodeException.class, () -> unwrap(api.body(Arrays.asList("foo"))));
+    assertThatThrownBy(() -> unwrap(api.body(Arrays.asList("foo"))))
+        .isInstanceOf(EncodeException.class);
   }
 
   @Test
@@ -688,16 +696,14 @@ public class AsyncApacheHttp5ClientTest {
 
     assertThat(t1).isNotEqualTo(i1);
 
-    assertThat(t1.hashCode()).isEqualTo(i1.hashCode());
-
-    assertThat(t1.toString()).isEqualTo(i1.toString());
+    Assertions.assertThat(t1).hasSameHashCodeAs(i1).hasToString(i1.toString());
   }
 
   @SuppressWarnings("resource")
   @Test
   void decodeLogicSupportsByteArray() throws Throwable {
     final byte[] expectedResponse = {12, 34, 56};
-    server.enqueue(new MockResponse().setBody(new Buffer().write(expectedResponse)));
+    server.enqueue(new MockResponse.Builder().body(new Buffer().write(expectedResponse)).build());
 
     final OtherTestInterfaceAsync api =
         AsyncFeign.builder()
@@ -709,7 +715,7 @@ public class AsyncApacheHttp5ClientTest {
   @Test
   void encodeLogicSupportsByteArray() throws Exception {
     final byte[] expectedRequest = {12, 34, 56};
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final OtherTestInterfaceAsync api =
         AsyncFeign.builder()
@@ -724,7 +730,7 @@ public class AsyncApacheHttp5ClientTest {
 
   @Test
   void encodedQueryParam() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final TestInterfaceAsync api =
         new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
@@ -747,7 +753,7 @@ public class AsyncApacheHttp5ClientTest {
   }
 
   @Test
-  void responseMapperIsAppliedBeforeDelegate() throws IOException {
+  void responseMapperIsAppliedBeforeDelegate() throws Exception {
     final ResponseMappingDecoder decoder =
         new ResponseMappingDecoder(upperCaseResponseMapper(), new StringDecoder());
     final String output = (String) decoder.decode(responseWithText("response"), String.class);
@@ -779,7 +785,7 @@ public class AsyncApacheHttp5ClientTest {
 
   @Test
   void mapAndDecodeExecutesMapFunction() throws Throwable {
-    server.enqueue(new MockResponse().setBody("response!"));
+    server.enqueue(new MockResponse.Builder().body("response!").build());
 
     final TestInterfaceAsync api =
         AsyncFeign.builder()
@@ -801,7 +807,7 @@ public class AsyncApacheHttp5ClientTest {
     propertyPojo.setName("Name");
     propertyPojo.setNumber(1);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     final CompletableFuture<?> cf = api.queryMapPropertyPojo(propertyPojo);
     assertThat(server.takeRequest()).hasQueryParams(Arrays.asList("name=Name", "number=1"));
     checkCFCompletedSoon(cf);
@@ -819,7 +825,7 @@ public class AsyncApacheHttp5ClientTest {
     childPojo.setParentProtectedProperty("second");
     childPojo.setParentPublicProperty("third");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     final CompletableFuture<?> cf = api.queryMapPropertyInheritence(childPojo);
     assertThat(server.takeRequest())
         .hasQueryParams(
@@ -840,7 +846,7 @@ public class AsyncApacheHttp5ClientTest {
     propertyPojo.setName(null);
     propertyPojo.setNumber(1);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     final CompletableFuture<?> cf = api.queryMapPropertyPojo(propertyPojo);
 
     assertThat(server.takeRequest()).hasQueryParams("number=1");
@@ -857,7 +863,7 @@ public class AsyncApacheHttp5ClientTest {
 
     final PropertyPojo.ChildPojoClass propertyPojo = new PropertyPojo.ChildPojoClass();
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     final CompletableFuture<?> cf = api.queryMapPropertyPojo(propertyPojo);
     assertThat(server.takeRequest()).hasQueryParams("/");
 
@@ -869,8 +875,8 @@ public class AsyncApacheHttp5ClientTest {
 
     String redirectPath = "/redirected";
 
-    server.enqueue(buildMockResponseWithLocationHeader(redirectPath));
-    server.enqueue(new MockResponse().setBody("redirectedBody"));
+    server.enqueue(buildMockResponseWithLocationHeader(redirectPath).build());
+    server.enqueue(new MockResponse.Builder().body("redirectedBody").build());
     Request.Options options = buildRequestOptions(true);
 
     final TestInterfaceAsync api =
@@ -882,15 +888,15 @@ public class AsyncApacheHttp5ClientTest {
     assertThat(response).isNotNull();
     assertThat(response.status()).isEqualTo(200);
     assertThat(Util.toString(response.body().asReader(Util.UTF_8))).isEqualTo("redirectedBody");
-    assertThat(server.takeRequest().getPath()).isEqualTo("/");
-    assertThat(server.takeRequest().getPath()).isEqualTo("/redirected");
+    assertThat(server.takeRequest().getTarget()).isEqualTo("/");
+    assertThat(server.takeRequest().getTarget()).isEqualTo("/redirected");
   }
 
   @Test
   void followRedirectsIsFalse() throws Throwable {
     String redirectPath = "/redirected";
 
-    server.enqueue(buildMockResponseWithLocationHeader(redirectPath));
+    server.enqueue(buildMockResponseWithLocationHeader(redirectPath).build());
     Request.Options options = buildRequestOptions(false);
 
     final TestInterfaceAsync api =
@@ -903,13 +909,13 @@ public class AsyncApacheHttp5ClientTest {
     assertThat(response).isNotNull();
     assertThat(path).isNotNull();
     assertThat(response.status()).isEqualTo(302);
-    assertThat(server.takeRequest().getPath()).isEqualTo("/");
+    assertThat(server.takeRequest().getTarget()).isEqualTo("/");
     assertThat(path).contains("/redirected");
   }
 
-  private MockResponse buildMockResponseWithLocationHeader(String redirectPath) {
-    return new MockResponse()
-        .setResponseCode(302)
+  private MockResponse.Builder buildMockResponseWithLocationHeader(String redirectPath) {
+    return new MockResponse.Builder()
+        .code(302)
         .addHeader("location", "http://localhost:" + server.getPort() + redirectPath);
   }
 
@@ -1183,6 +1189,11 @@ public class AsyncApacheHttp5ClientTest {
     public Instant instant() {
       return Instant.ofEpochMilli(millis);
     }
+  }
+
+  @BeforeEach
+  void setUp() throws IOException {
+    server.start();
   }
 
   @AfterEach

--- a/hc5/src/test/java/feign/hc5/GzipHttp5ClientTest.java
+++ b/hc5/src/test/java/feign/hc5/GzipHttp5ClientTest.java
@@ -15,7 +15,7 @@
  */
 package feign.hc5;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import feign.Feign;
@@ -23,11 +23,10 @@ import feign.Feign.Builder;
 import feign.RequestLine;
 import feign.client.AbstractClientTest;
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPInputStream;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.RecordedRequest;
+import mockwebserver3.MockResponse;
+import mockwebserver3.RecordedRequest;
 import org.junit.jupiter.api.Test;
 
 /** Tests that 'Content-Encoding: gzip' is handled correctly */
@@ -39,33 +38,32 @@ public class GzipHttp5ClientTest extends AbstractClientTest {
   }
 
   @Test
-  public void testWithCompressedBody() throws InterruptedException, IOException {
+  void withCompressedBody() throws Exception {
     final TestInterface testInterface = buildTestInterface(true);
 
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
-    assertEquals("foo", testInterface.withBody("bar"));
+    assertThat(testInterface.withBody("bar")).isEqualTo("foo");
     final RecordedRequest request1 = server.takeRequest();
-    assertEquals("/test", request1.getPath());
+    assertThat(request1.getTarget()).isEqualTo("/test");
 
-    ByteArrayInputStream bodyContentIs =
-        new ByteArrayInputStream(request1.getBody().readByteArray());
+    ByteArrayInputStream bodyContentIs = new ByteArrayInputStream(request1.getBody().toByteArray());
     byte[] uncompressed = new GZIPInputStream(bodyContentIs).readAllBytes();
 
-    assertEquals("bar", new String(uncompressed, StandardCharsets.UTF_8));
+    assertThat(new String(uncompressed, StandardCharsets.UTF_8)).isEqualTo("bar");
   }
 
   @Test
-  public void testWithUncompressedBody() throws InterruptedException, IOException {
+  void withUncompressedBody() throws Exception {
     final TestInterface testInterface = buildTestInterface(false);
 
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
-    assertEquals("foo", testInterface.withBody("bar"));
+    assertThat(testInterface.withBody("bar")).isEqualTo("foo");
     final RecordedRequest request1 = server.takeRequest();
-    assertEquals("/test", request1.getPath());
+    assertThat(request1.getTarget()).isEqualTo("/test");
 
-    assertEquals("bar", request1.getBody().readString(StandardCharsets.UTF_8));
+    assertThat(request1.getBody().string(StandardCharsets.UTF_8)).isEqualTo("bar");
   }
 
   private TestInterface buildTestInterface(boolean compress) {
@@ -75,11 +73,13 @@ public class GzipHttp5ClientTest extends AbstractClientTest {
   }
 
   @Override
+  @Test
   public void veryLongResponseNullLength() {
     assumeTrue(true, "HC5 client seems to hang with response size equalto Long.MAX");
   }
 
   @Override
+  @Test
   public void contentTypeDefaultsToRequestCharset() throws Exception {
     assumeTrue(true, "this test is flaky on windows, but works fine.");
   }

--- a/http-cache/pom.xml
+++ b/http-cache/pom.xml
@@ -55,7 +55,7 @@
 
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>mockwebserver</artifactId>
+      <artifactId>mockwebserver3</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/http-cache/src/test/java/feign/cache/HttpCacheInterceptorTest.java
+++ b/http-cache/src/test/java/feign/cache/HttpCacheInterceptorTest.java
@@ -22,10 +22,12 @@ import feign.Feign;
 import feign.FeignException;
 import feign.Param;
 import feign.RequestLine;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
+import java.io.IOException;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import mockwebserver3.RecordedRequest;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class HttpCacheInterceptorTest {
@@ -33,9 +35,14 @@ class HttpCacheInterceptorTest {
   private final MockWebServer server = new MockWebServer();
   private final InMemoryHttpCacheStore store = new InMemoryHttpCacheStore();
 
+  @BeforeEach
+  void setUp() throws IOException {
+    server.start();
+  }
+
   @AfterEach
   void tearDown() throws Exception {
-    server.shutdown();
+    server.close();
   }
 
   interface Api {
@@ -54,20 +61,22 @@ class HttpCacheInterceptorTest {
 
   @Test
   void firstCallStoresEntryWhenETagPresent() throws Exception {
-    server.enqueue(new MockResponse().setHeader("ETag", "\"v1\"").setBody("payload-1"));
+    server.enqueue(
+        new MockResponse.Builder().setHeader("ETag", "\"v1\"").body("payload-1").build());
 
     String result = api().fetch("42");
 
     assertThat(result).isEqualTo("payload-1");
-    assertThat(store.size()).isEqualTo(1);
+    assertThat(store.size()).isOne();
     RecordedRequest first = server.takeRequest();
-    assertThat(first.getHeader("If-None-Match")).isNull();
+    assertThat(first.getHeaders().get("If-None-Match")).isNull();
   }
 
   @Test
   void notModifiedReturnsCachedValueAndSendsConditionalHeader() throws Exception {
-    server.enqueue(new MockResponse().setHeader("ETag", "\"v1\"").setBody("payload-1"));
-    server.enqueue(new MockResponse().setResponseCode(304));
+    server.enqueue(
+        new MockResponse.Builder().setHeader("ETag", "\"v1\"").body("payload-1").build());
+    server.enqueue(new MockResponse.Builder().code(304).build());
 
     Api api = api();
     String first = api.fetch("42");
@@ -77,14 +86,16 @@ class HttpCacheInterceptorTest {
     assertThat(second).isEqualTo("payload-1");
     server.takeRequest(); // first
     RecordedRequest revalidation = server.takeRequest();
-    assertThat(revalidation.getHeader("If-None-Match")).isEqualTo("\"v1\"");
+    assertThat(revalidation.getHeaders().get("If-None-Match")).isEqualTo("\"v1\"");
   }
 
   @Test
   void freshTwoHundredReplacesCachedEntry() throws Exception {
-    server.enqueue(new MockResponse().setHeader("ETag", "\"v1\"").setBody("payload-1"));
-    server.enqueue(new MockResponse().setHeader("ETag", "\"v2\"").setBody("payload-2"));
-    server.enqueue(new MockResponse().setResponseCode(304));
+    server.enqueue(
+        new MockResponse.Builder().setHeader("ETag", "\"v1\"").body("payload-1").build());
+    server.enqueue(
+        new MockResponse.Builder().setHeader("ETag", "\"v2\"").body("payload-2").build());
+    server.enqueue(new MockResponse.Builder().code(304).build());
 
     Api api = api();
     String first = api.fetch("42");
@@ -97,12 +108,12 @@ class HttpCacheInterceptorTest {
     server.takeRequest();
     server.takeRequest();
     RecordedRequest third304 = server.takeRequest();
-    assertThat(third304.getHeader("If-None-Match")).isEqualTo("\"v2\"");
+    assertThat(third304.getHeaders().get("If-None-Match")).isEqualTo("\"v2\"");
   }
 
   @Test
   void responseWithoutValidatorsIsNotStored() throws Exception {
-    server.enqueue(new MockResponse().setBody("payload"));
+    server.enqueue(new MockResponse.Builder().body("payload").build());
 
     api().fetch("42");
 
@@ -111,22 +122,23 @@ class HttpCacheInterceptorTest {
 
   @Test
   void postRequestsBypassCache() throws Exception {
-    server.enqueue(new MockResponse().setHeader("ETag", "\"v1\"").setBody("payload"));
+    server.enqueue(new MockResponse.Builder().setHeader("ETag", "\"v1\"").body("payload").build());
 
     api().create("body");
 
     assertThat(store.size()).isZero();
     RecordedRequest recorded = server.takeRequest();
-    assertThat(recorded.getHeader("If-None-Match")).isNull();
+    assertThat(recorded.getHeaders().get("If-None-Match")).isNull();
   }
 
   @Test
   void noStoreCacheControlPreventsStorage() throws Exception {
     server.enqueue(
-        new MockResponse()
+        new MockResponse.Builder()
             .setHeader("ETag", "\"v1\"")
             .setHeader("Cache-Control", "no-store")
-            .setBody("payload"));
+            .body("payload")
+            .build());
 
     api().fetch("42");
 
@@ -135,22 +147,27 @@ class HttpCacheInterceptorTest {
 
   @Test
   void serverErrorPropagatesAndDoesNotEvictExistingEntry() throws Exception {
-    server.enqueue(new MockResponse().setHeader("ETag", "\"v1\"").setBody("payload-1"));
-    server.enqueue(new MockResponse().setResponseCode(500).setBody("nope"));
+    server.enqueue(
+        new MockResponse.Builder().setHeader("ETag", "\"v1\"").body("payload-1").build());
+    server.enqueue(new MockResponse.Builder().code(500).body("nope").build());
 
     Api api = api();
     String first = api.fetch("42");
     assertThatThrownBy(() -> api.fetch("42")).isInstanceOf(FeignException.class);
 
     assertThat(first).isEqualTo("payload-1");
-    assertThat(store.size()).isEqualTo(1);
+    assertThat(store.size()).isOne();
   }
 
   @Test
   void lastModifiedRevalidationSendsIfModifiedSince() throws Exception {
     String lastModified = "Wed, 21 Oct 2020 07:28:00 GMT";
-    server.enqueue(new MockResponse().setHeader("Last-Modified", lastModified).setBody("payload"));
-    server.enqueue(new MockResponse().setResponseCode(304));
+    server.enqueue(
+        new MockResponse.Builder()
+            .setHeader("Last-Modified", lastModified)
+            .body("payload")
+            .build());
+    server.enqueue(new MockResponse.Builder().code(304).build());
 
     Api api = api();
     api.fetch("42");
@@ -159,6 +176,6 @@ class HttpCacheInterceptorTest {
     assertThat(second).isEqualTo("payload");
     server.takeRequest();
     RecordedRequest revalidation = server.takeRequest();
-    assertThat(revalidation.getHeader("If-Modified-Since")).isEqualTo(lastModified);
+    assertThat(revalidation.getHeaders().get("If-Modified-Since")).isEqualTo(lastModified);
   }
 }

--- a/httpclient/pom.xml
+++ b/httpclient/pom.xml
@@ -75,7 +75,7 @@
 
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>mockwebserver</artifactId>
+      <artifactId>mockwebserver3</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/httpclient/src/test/java/feign/httpclient/ApacheHttpClientTest.java
+++ b/httpclient/src/test/java/feign/httpclient/ApacheHttpClientTest.java
@@ -17,7 +17,7 @@ package feign.httpclient;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import feign.Feign;
 import feign.Feign.Builder;
@@ -32,8 +32,8 @@ import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.RecordedRequest;
+import mockwebserver3.MockResponse;
+import mockwebserver3.RecordedRequest;
 import org.apache.http.ProtocolException;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -57,59 +57,63 @@ public class ApacheHttpClientTest extends AbstractClientTest {
             .client(new ApacheHttpClient(HttpClientBuilder.create().build()))
             .target(JaxRsTestInterface.class, "http://localhost:" + server.getPort());
 
-    server.enqueue(new MockResponse().setResponseCode(303));
+    server.enqueue(new MockResponse.Builder().code(303).build());
 
     RetryableException exception =
-        assertThrows(RetryableException.class, () -> api.withoutBody("foo"));
+        assertThatExceptionOfType(RetryableException.class)
+            .isThrownBy(() -> api.withoutBody("foo"))
+            .actual();
 
     assertThat(exception.getCause()).isInstanceOf(ClientProtocolException.class);
     assertThat(exception.getCause()).hasCauseInstanceOf(ProtocolException.class);
   }
 
   @Test
-  void queryParamsAreRespectedWhenBodyIsEmpty() throws InterruptedException {
+  void queryParamsAreRespectedWhenBodyIsEmpty() throws Exception {
     final JaxRsTestInterface testInterface = buildTestInterface();
 
-    server.enqueue(new MockResponse().setBody("foo"));
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     assertThat(testInterface.withBody("foo", "bar")).isEqualTo("foo");
     final RecordedRequest request1 = server.takeRequest();
-    assertThat(request1.getPath()).isEqualTo("/withBody?foo=foo");
-    assertThat(request1.getBody().readString(StandardCharsets.UTF_8)).isEqualTo("bar");
+    assertThat(request1.getTarget()).isEqualTo("/withBody?foo=foo");
+    assertThat(request1.getBody().string(StandardCharsets.UTF_8)).isEqualTo("bar");
 
     assertThat(testInterface.withoutBody("foo")).isEqualTo("foo");
     final RecordedRequest request2 = server.takeRequest();
-    assertThat(request2.getPath()).isEqualTo("/withoutBody?foo=foo");
-    assertThat(request2.getBody().readString(StandardCharsets.UTF_8)).isEqualTo("");
+    assertThat(request2.getTarget()).isEqualTo("/withoutBody?foo=foo");
+    assertThat(request2.getBody().string(StandardCharsets.UTF_8)).isEmpty();
   }
 
   @Test
-  void followRedirectIsRespected() throws InterruptedException {
+  void followRedirectIsRespected() throws Exception {
     final JaxRsTestInterface testInterface = buildTestInterface();
 
     String redirectPath = "/redirected";
-    server.enqueue(buildMockResponseWithHeaderLocation(redirectPath));
-    server.enqueue(new MockResponse().setBody("redirect"));
+    server.enqueue(buildMockResponseWithHeaderLocation(redirectPath).build());
+    server.enqueue(new MockResponse.Builder().body("redirect").build());
     Options options = buildRequestOptions(true);
 
     assertThat(testInterface.withOptions(options)).isEqualTo("redirect");
-    assertThat(server.takeRequest().getPath()).isEqualTo("/withOptions");
-    assertThat(server.takeRequest().getPath()).isEqualTo(redirectPath);
+    assertThat(server.takeRequest().getTarget()).isEqualTo("/withOptions");
+    assertThat(server.takeRequest().getTarget()).isEqualTo(redirectPath);
   }
 
   @Test
-  void notFollowRedirectIsRespected() throws InterruptedException {
+  void notFollowRedirectIsRespected() throws Exception {
     final JaxRsTestInterface testInterface = buildTestInterface();
 
     String redirectPath = "/redirected";
-    server.enqueue(buildMockResponseWithHeaderLocation(redirectPath));
+    server.enqueue(buildMockResponseWithHeaderLocation(redirectPath).build());
     Options options = buildRequestOptions(false);
 
     FeignException feignException =
-        assertThrows(FeignException.class, () -> testInterface.withOptions(options));
+        assertThatExceptionOfType(FeignException.class)
+            .isThrownBy(() -> testInterface.withOptions(options))
+            .actual();
     assertThat(feignException.status()).isEqualTo(302);
-    assertThat(server.takeRequest().getPath()).isEqualTo("/withOptions");
+    assertThat(server.takeRequest().getTarget()).isEqualTo("/withOptions");
   }
 
   private JaxRsTestInterface buildTestInterface() {
@@ -123,9 +127,9 @@ public class ApacheHttpClientTest extends AbstractClientTest {
     return new Options(1, SECONDS, 1, SECONDS, followRedirects);
   }
 
-  private MockResponse buildMockResponseWithHeaderLocation(String redirectPath) {
-    return new MockResponse()
-        .setResponseCode(302)
+  private MockResponse.Builder buildMockResponseWithHeaderLocation(String redirectPath) {
+    return new MockResponse.Builder()
+        .code(302)
         .addHeader("location", "http://localhost:" + server.getPort() + redirectPath);
   }
 

--- a/hystrix/pom.xml
+++ b/hystrix/pom.xml
@@ -78,7 +78,7 @@
 
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>mockwebserver</artifactId>
+      <artifactId>mockwebserver3</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/hystrix/src/test/java/feign/hystrix/FallbackFactoryTest.java
+++ b/hystrix/src/test/java/feign/hystrix/FallbackFactoryTest.java
@@ -23,9 +23,10 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class FallbackFactoryTest {
@@ -39,8 +40,8 @@ public class FallbackFactoryTest {
 
   @Test
   void fallbackFactory_example_lambda() {
-    server.enqueue(new MockResponse().setResponseCode(500));
-    server.enqueue(new MockResponse().setResponseCode(404));
+    server.enqueue(new MockResponse.Builder().code(500).build());
+    server.enqueue(new MockResponse.Builder().code(404).build());
 
     TestInterface api =
         target(
@@ -69,19 +70,19 @@ public class FallbackFactoryTest {
 
   @Test
   void fallbackFactory_example_ctor() {
-    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse.Builder().code(500).build());
 
     // method reference
     TestInterface api = target(FallbackApiWithCtor::new);
 
     assertThat(api.invoke()).isEqualTo("foo");
 
-    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse.Builder().code(500).build());
 
     // lambda factory
     api = target(FallbackApiWithCtor::new);
 
-    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse.Builder().code(500).build());
 
     // old school
     api = target(FallbackApiWithCtor::new);
@@ -115,7 +116,7 @@ public class FallbackFactoryTest {
 
   @Test
   void fallbackFactory_example_retro() {
-    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse.Builder().code(500).build());
 
     TestInterface api = target(new FallbackApiRetro());
 
@@ -128,7 +129,7 @@ public class FallbackFactoryTest {
 
   @Test
   void defaultFallbackFactory_delegates() {
-    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse.Builder().code(500).build());
 
     TestInterface api = target(new FallbackFactory.Default<>(() -> "foo"));
 
@@ -137,7 +138,7 @@ public class FallbackFactoryTest {
 
   @Test
   void defaultFallbackFactory_doesntLogByDefault() {
-    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse.Builder().code(500).build());
 
     Logger logger =
         new Logger("", null) {
@@ -152,7 +153,7 @@ public class FallbackFactoryTest {
 
   @Test
   void defaultFallbackFactory_logsAtFineLevel() {
-    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse.Builder().code(500).build());
 
     AtomicBoolean logged = new AtomicBoolean();
     Logger logger =
@@ -178,6 +179,11 @@ public class FallbackFactoryTest {
   TestInterface target(FallbackFactory<? extends TestInterface> factory) {
     return HystrixFeign.builder()
         .target(TestInterface.class, "http://localhost:" + server.getPort(), factory);
+  }
+
+  @BeforeEach
+  void setUp() throws IOException {
+    server.start();
   }
 
   @AfterEach

--- a/hystrix/src/test/java/feign/hystrix/HystrixBuilderTest.java
+++ b/hystrix/src/test/java/feign/hystrix/HystrixBuilderTest.java
@@ -16,7 +16,7 @@
 package feign.hystrix;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import com.netflix.hystrix.HystrixCommand;
 import com.netflix.hystrix.HystrixCommandGroupKey;
@@ -36,10 +36,10 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import rx.Completable;
 import rx.Observable;
@@ -51,7 +51,7 @@ public class HystrixBuilderTest {
 
   @Test
   void defaultMethodReturningHystrixCommand() {
-    server.enqueue(new MockResponse().setBody("\"foo\""));
+    server.enqueue(new MockResponse.Builder().body("\"foo\"").build());
 
     final TestInterface api = target();
 
@@ -63,7 +63,7 @@ public class HystrixBuilderTest {
 
   @Test
   void hystrixCommand() {
-    server.enqueue(new MockResponse().setBody("\"foo\""));
+    server.enqueue(new MockResponse.Builder().body("\"foo\"").build());
 
     final TestInterface api = target();
 
@@ -75,7 +75,7 @@ public class HystrixBuilderTest {
 
   @Test
   void hystrixCommandFallback() {
-    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse.Builder().code(500).build());
 
     final TestInterface api = target();
 
@@ -87,7 +87,7 @@ public class HystrixBuilderTest {
 
   @Test
   void hystrixCommandInt() {
-    server.enqueue(new MockResponse().setBody("1"));
+    server.enqueue(new MockResponse.Builder().body("1").build());
 
     final TestInterface api = target();
 
@@ -99,7 +99,7 @@ public class HystrixBuilderTest {
 
   @Test
   void hystrixCommandIntFallback() {
-    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse.Builder().code(500).build());
 
     final TestInterface api = target();
 
@@ -111,7 +111,7 @@ public class HystrixBuilderTest {
 
   @Test
   void hystrixCommandList() {
-    server.enqueue(new MockResponse().setBody("[\"foo\",\"bar\"]"));
+    server.enqueue(new MockResponse.Builder().body("[\"foo\",\"bar\"]").build());
 
     final TestInterface api = target();
 
@@ -123,7 +123,7 @@ public class HystrixBuilderTest {
 
   @Test
   void hystrixCommandListFallback() {
-    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse.Builder().code(500).build());
 
     final TestInterface api = target();
 
@@ -147,7 +147,7 @@ public class HystrixBuilderTest {
 
   @Test
   void fallbacksApplyOnError() {
-    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse.Builder().code(500).build());
 
     final GitHub fallback =
         (owner, repo) -> {
@@ -167,7 +167,7 @@ public class HystrixBuilderTest {
 
   @Test
   void errorInFallbackHasExpectedBehavior() {
-    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse.Builder().code(500).build());
 
     final GitHub fallback =
         (_, _) -> {
@@ -177,7 +177,9 @@ public class HystrixBuilderTest {
     final GitHub api = target(GitHub.class, "http://localhost:" + server.getPort(), fallback);
 
     HystrixRuntimeException exception =
-        assertThrows(HystrixRuntimeException.class, () -> api.contributors("Netflix", "feign"));
+        assertThatExceptionOfType(HystrixRuntimeException.class)
+            .isThrownBy(() -> api.contributors("Netflix", "feign"))
+            .actual();
     assertThat(exception)
         .hasCauseInstanceOf(FeignException.class)
         .hasMessage("GitHub#contributors(String,String) failed and fallback failed.");
@@ -198,12 +200,14 @@ public class HystrixBuilderTest {
   @Test
   void hystrixRuntimeExceptionPropagatesOnException() {
 
-    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse.Builder().code(500).build());
 
     final GitHub api = target(GitHub.class, "http://localhost:" + server.getPort());
 
     HystrixRuntimeException exception =
-        assertThrows(HystrixRuntimeException.class, () -> api.contributors("Netflix", "feign"));
+        assertThatExceptionOfType(HystrixRuntimeException.class)
+            .isThrownBy(() -> api.contributors("Netflix", "feign"))
+            .actual();
     assertThat(exception)
         .hasCauseInstanceOf(FeignException.class)
         .hasMessage("GitHub#contributors(String,String) failed and no fallback available.");
@@ -211,233 +215,232 @@ public class HystrixBuilderTest {
 
   @Test
   void rxObservable() {
-    server.enqueue(new MockResponse().setBody("\"foo\""));
+    server.enqueue(new MockResponse.Builder().body("\"foo\"").build());
 
     final TestInterface api = target();
 
     final Observable<String> observable = api.observable();
 
     assertThat(observable).isNotNull();
-    assertThat(server.getRequestCount()).isEqualTo(0);
+    assertThat(server.getRequestCount()).isZero();
 
     final TestSubscriber<String> testSubscriber = new TestSubscriber<>();
     observable.subscribe(testSubscriber);
     testSubscriber.awaitTerminalEvent();
-    assertThat(testSubscriber.getOnNextEvents().getFirst()).isEqualTo("foo");
+    assertThat(testSubscriber.getOnNextEvents()).first().isEqualTo("foo");
   }
 
   @Test
   void rxObservableFallback() {
-    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse.Builder().code(500).build());
 
     final TestInterface api = target();
 
     final Observable<String> observable = api.observable();
 
     assertThat(observable).isNotNull();
-    assertThat(server.getRequestCount()).isEqualTo(0);
+    assertThat(server.getRequestCount()).isZero();
 
     final TestSubscriber<String> testSubscriber = new TestSubscriber<>();
     observable.subscribe(testSubscriber);
     testSubscriber.awaitTerminalEvent();
-    assertThat(testSubscriber.getOnNextEvents().getFirst()).isEqualTo("fallback");
+    assertThat(testSubscriber.getOnNextEvents()).first().isEqualTo("fallback");
   }
 
   @Test
   void rxObservableInt() {
-    server.enqueue(new MockResponse().setBody("1"));
+    server.enqueue(new MockResponse.Builder().body("1").build());
 
     final TestInterface api = target();
 
     final Observable<Integer> observable = api.intObservable();
 
     assertThat(observable).isNotNull();
-    assertThat(server.getRequestCount()).isEqualTo(0);
+    assertThat(server.getRequestCount()).isZero();
 
     final TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
     observable.subscribe(testSubscriber);
     testSubscriber.awaitTerminalEvent();
-    assertThat(testSubscriber.getOnNextEvents().getFirst()).isEqualTo(Integer.valueOf(1));
+    assertThat(testSubscriber.getOnNextEvents()).first().isEqualTo(Integer.valueOf(1));
   }
 
   @Test
   void rxObservableIntFallback() {
-    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse.Builder().code(500).build());
 
     final TestInterface api = target();
 
     final Observable<Integer> observable = api.intObservable();
 
     assertThat(observable).isNotNull();
-    assertThat(server.getRequestCount()).isEqualTo(0);
+    assertThat(server.getRequestCount()).isZero();
 
     final TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
     observable.subscribe(testSubscriber);
     testSubscriber.awaitTerminalEvent();
-    assertThat(testSubscriber.getOnNextEvents().getFirst()).isEqualTo(Integer.valueOf(0));
+    assertThat(testSubscriber.getOnNextEvents()).first().isEqualTo(Integer.valueOf(0));
   }
 
   @Test
   void rxObservableList() {
-    server.enqueue(new MockResponse().setBody("[\"foo\",\"bar\"]"));
+    server.enqueue(new MockResponse.Builder().body("[\"foo\",\"bar\"]").build());
 
     final TestInterface api = target();
 
     final Observable<List<String>> observable = api.listObservable();
 
     assertThat(observable).isNotNull();
-    assertThat(server.getRequestCount()).isEqualTo(0);
+    assertThat(server.getRequestCount()).isZero();
 
     final TestSubscriber<List<String>> testSubscriber = new TestSubscriber<>();
     observable.subscribe(testSubscriber);
     testSubscriber.awaitTerminalEvent();
-    assertThat(testSubscriber.getOnNextEvents().getFirst()).containsExactly("foo", "bar");
+    assertThat(testSubscriber.getOnNextEvents().get(0)).containsExactly("foo", "bar");
   }
 
   @Test
   void rxObservableListFall() {
-    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse.Builder().code(500).build());
 
     final TestInterface api = target();
 
     final Observable<List<String>> observable = api.listObservable();
 
     assertThat(observable).isNotNull();
-    assertThat(server.getRequestCount()).isEqualTo(0);
+    assertThat(server.getRequestCount()).isZero();
 
     final TestSubscriber<List<String>> testSubscriber = new TestSubscriber<>();
     observable.subscribe(testSubscriber);
     testSubscriber.awaitTerminalEvent();
-    assertThat(testSubscriber.getOnNextEvents().getFirst()).containsExactly("fallback");
+    assertThat(testSubscriber.getOnNextEvents().get(0)).containsExactly("fallback");
   }
 
   @Test
   void rxObservableListFall_noFallback() {
-    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse.Builder().code(500).build());
 
     final TestInterface api = targetWithoutFallback();
 
     final Observable<List<String>> observable = api.listObservable();
 
     assertThat(observable).isNotNull();
-    assertThat(server.getRequestCount()).isEqualTo(0);
+    assertThat(server.getRequestCount()).isZero();
 
     final TestSubscriber<List<String>> testSubscriber = new TestSubscriber<>();
     observable.subscribe(testSubscriber);
     testSubscriber.awaitTerminalEvent();
 
     assertThat(testSubscriber.getOnNextEvents()).isEmpty();
-    assertThat(testSubscriber.getOnErrorEvents().getFirst())
+    assertThat(testSubscriber.getOnErrorEvents().get(0))
         .isInstanceOf(HystrixRuntimeException.class)
         .hasMessage("TestInterface#listObservable() failed and no fallback available.");
   }
 
   @Test
   void rxSingle() {
-    server.enqueue(new MockResponse().setBody("\"foo\""));
+    server.enqueue(new MockResponse.Builder().body("\"foo\"").build());
 
     final TestInterface api = target();
 
     final Single<String> single = api.single();
 
     assertThat(single).isNotNull();
-    assertThat(server.getRequestCount()).isEqualTo(0);
+    assertThat(server.getRequestCount()).isZero();
 
     final TestSubscriber<String> testSubscriber = new TestSubscriber<>();
     single.subscribe(testSubscriber);
     testSubscriber.awaitTerminalEvent();
-    assertThat(testSubscriber.getOnNextEvents().getFirst()).isEqualTo("foo");
+    assertThat(testSubscriber.getOnNextEvents()).first().isEqualTo("foo");
   }
 
   @Test
   void rxSingleFallback() {
-    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse.Builder().code(500).build());
 
     final TestInterface api = target();
 
     final Single<String> single = api.single();
 
     assertThat(single).isNotNull();
-    assertThat(server.getRequestCount()).isEqualTo(0);
+    assertThat(server.getRequestCount()).isZero();
 
     final TestSubscriber<String> testSubscriber = new TestSubscriber<>();
     single.subscribe(testSubscriber);
     testSubscriber.awaitTerminalEvent();
-    assertThat(testSubscriber.getOnNextEvents().getFirst()).isEqualTo("fallback");
+    assertThat(testSubscriber.getOnNextEvents()).first().isEqualTo("fallback");
   }
 
   @Test
   void rxSingleInt() {
-    server.enqueue(new MockResponse().setBody("1"));
+    server.enqueue(new MockResponse.Builder().body("1").build());
 
     final TestInterface api = target();
 
     final Single<Integer> single = api.intSingle();
 
     assertThat(single).isNotNull();
-    assertThat(server.getRequestCount()).isEqualTo(0);
+    assertThat(server.getRequestCount()).isZero();
 
     final TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
     single.subscribe(testSubscriber);
     testSubscriber.awaitTerminalEvent();
-    assertThat(testSubscriber.getOnNextEvents().getFirst()).isEqualTo(Integer.valueOf(1));
+    assertThat(testSubscriber.getOnNextEvents()).first().isEqualTo(Integer.valueOf(1));
   }
 
   @Test
   void rxSingleIntFallback() {
-    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse.Builder().code(500).build());
 
     final TestInterface api = target();
 
     final Single<Integer> single = api.intSingle();
 
     assertThat(single).isNotNull();
-    assertThat(server.getRequestCount()).isEqualTo(0);
+    assertThat(server.getRequestCount()).isZero();
 
     final TestSubscriber<Integer> testSubscriber = new TestSubscriber<>();
     single.subscribe(testSubscriber);
     testSubscriber.awaitTerminalEvent();
-    assertThat(testSubscriber.getOnNextEvents().getFirst()).isEqualTo(Integer.valueOf(0));
+    assertThat(testSubscriber.getOnNextEvents()).first().isEqualTo(Integer.valueOf(0));
   }
 
   @Test
   void rxSingleList() {
-    server.enqueue(new MockResponse().setBody("[\"foo\",\"bar\"]"));
+    server.enqueue(new MockResponse.Builder().body("[\"foo\",\"bar\"]").build());
 
     final TestInterface api = target();
 
     final Single<List<String>> single = api.listSingle();
 
     assertThat(single).isNotNull();
-    assertThat(server.getRequestCount()).isEqualTo(0);
+    assertThat(server.getRequestCount()).isZero();
 
     final TestSubscriber<List<String>> testSubscriber = new TestSubscriber<>();
     single.subscribe(testSubscriber);
     testSubscriber.awaitTerminalEvent();
-    assertThat(testSubscriber.getOnNextEvents().getFirst()).containsExactly("foo", "bar");
+    assertThat(testSubscriber.getOnNextEvents().get(0)).containsExactly("foo", "bar");
   }
 
   @Test
   void rxSingleListFallback() {
-    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse.Builder().code(500).build());
 
     final TestInterface api = target();
 
     final Single<List<String>> single = api.listSingle();
 
     assertThat(single).isNotNull();
-    assertThat(server.getRequestCount()).isEqualTo(0);
+    assertThat(server.getRequestCount()).isZero();
 
     final TestSubscriber<List<String>> testSubscriber = new TestSubscriber<>();
     single.subscribe(testSubscriber);
     testSubscriber.awaitTerminalEvent();
-    assertThat(testSubscriber.getOnNextEvents().getFirst()).containsExactly("fallback");
+    assertThat(testSubscriber.getOnNextEvents().get(0)).containsExactly("fallback");
   }
 
   @Test
-  void completableFutureEmptyBody()
-      throws InterruptedException, ExecutionException, TimeoutException {
-    server.enqueue(new MockResponse());
+  void completableFutureEmptyBody() throws Exception {
+    server.enqueue(new MockResponse.Builder().build());
 
     final TestInterface api = target();
 
@@ -449,9 +452,8 @@ public class HystrixBuilderTest {
   }
 
   @Test
-  void completableFutureWithBody()
-      throws InterruptedException, ExecutionException, TimeoutException {
-    server.enqueue(new MockResponse().setBody("foo"));
+  void completableFutureWithBody() throws Exception {
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final TestInterface api = target();
 
@@ -463,8 +465,8 @@ public class HystrixBuilderTest {
   }
 
   @Test
-  void completableFutureFailWithoutFallback() throws TimeoutException, InterruptedException {
-    server.enqueue(new MockResponse().setResponseCode(500));
+  void completableFutureFailWithoutFallback() throws Exception {
+    server.enqueue(new MockResponse.Builder().code(500).build());
 
     final TestInterface api = target(TestInterface.class, "http://localhost:" + server.getPort());
 
@@ -480,9 +482,8 @@ public class HystrixBuilderTest {
   }
 
   @Test
-  void completableFutureFallback()
-      throws InterruptedException, ExecutionException, TimeoutException {
-    server.enqueue(new MockResponse().setResponseCode(500));
+  void completableFutureFallback() throws Exception {
+    server.enqueue(new MockResponse.Builder().code(500).build());
 
     final TestInterface api = target();
 
@@ -495,14 +496,14 @@ public class HystrixBuilderTest {
 
   @Test
   void rxCompletableEmptyBody() {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final TestInterface api = target();
 
     final Completable completable = api.completable();
 
     assertThat(completable).isNotNull();
-    assertThat(server.getRequestCount()).isEqualTo(0);
+    assertThat(server.getRequestCount()).isZero();
 
     final TestSubscriber<String> testSubscriber = new TestSubscriber<>();
     completable.subscribe(testSubscriber);
@@ -514,14 +515,14 @@ public class HystrixBuilderTest {
 
   @Test
   void rxCompletableWithBody() {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final TestInterface api = target();
 
     final Completable completable = api.completable();
 
     assertThat(completable).isNotNull();
-    assertThat(server.getRequestCount()).isEqualTo(0);
+    assertThat(server.getRequestCount()).isZero();
 
     final TestSubscriber<String> testSubscriber = new TestSubscriber<>();
     completable.subscribe(testSubscriber);
@@ -533,14 +534,14 @@ public class HystrixBuilderTest {
 
   @Test
   void rxCompletableFailWithoutFallback() {
-    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse.Builder().code(500).build());
 
     final TestInterface api = target(TestInterface.class, "http://localhost:" + server.getPort());
 
     final Completable completable = api.completable();
 
     assertThat(completable).isNotNull();
-    assertThat(server.getRequestCount()).isEqualTo(0);
+    assertThat(server.getRequestCount()).isZero();
 
     final TestSubscriber<String> testSubscriber = new TestSubscriber<>();
     completable.subscribe(testSubscriber);
@@ -551,14 +552,14 @@ public class HystrixBuilderTest {
 
   @Test
   void rxCompletableFallback() {
-    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse.Builder().code(500).build());
 
     final TestInterface api = target();
 
     final Completable completable = api.completable();
 
     assertThat(completable).isNotNull();
-    assertThat(server.getRequestCount()).isEqualTo(0);
+    assertThat(server.getRequestCount()).isZero();
 
     final TestSubscriber<String> testSubscriber = new TestSubscriber<>();
     completable.subscribe(testSubscriber);
@@ -569,7 +570,7 @@ public class HystrixBuilderTest {
 
   @Test
   void plainString() {
-    server.enqueue(new MockResponse().setBody("\"foo\""));
+    server.enqueue(new MockResponse.Builder().body("\"foo\"").build());
 
     final TestInterface api = target();
 
@@ -580,7 +581,7 @@ public class HystrixBuilderTest {
 
   @Test
   void plainStringFallback() {
-    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse.Builder().code(500).build());
 
     final TestInterface api = target();
 
@@ -591,24 +592,24 @@ public class HystrixBuilderTest {
 
   @Test
   void plainList() {
-    server.enqueue(new MockResponse().setBody("[\"foo\",\"bar\"]"));
+    server.enqueue(new MockResponse.Builder().body("[\"foo\",\"bar\"]").build());
 
     final TestInterface api = target();
 
     final List<String> list = api.getList();
 
-    assertThat(list).isNotNull().containsExactly("foo", "bar");
+    assertThat(list).containsExactly("foo", "bar");
   }
 
   @Test
   void plainListFallback() {
-    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse.Builder().code(500).build());
 
     final TestInterface api = target();
 
     final List<String> list = api.getList();
 
-    assertThat(list).isNotNull().containsExactly("fallback");
+    assertThat(list).containsExactly("fallback");
   }
 
   @Test
@@ -636,11 +637,7 @@ public class HystrixBuilderTest {
         .isNotEqualTo(i3.toString())
         .isNotEqualTo(i4.toString());
 
-    assertThat(t1).isNotEqualTo(i1);
-
-    assertThat(t1.hashCode()).isEqualTo(i1.hashCode());
-
-    assertThat(t1.toString()).isEqualTo(i1.toString());
+    assertThat(t1).isNotEqualTo(i1).hasSameHashCodeAs(i1).hasToString(i1.toString());
   }
 
   protected TestInterface target() {
@@ -810,6 +807,11 @@ public class HystrixBuilderTest {
     public CompletableFuture<String> completableFuture() {
       return CompletableFuture.completedFuture("fallback");
     }
+  }
+
+  @BeforeEach
+  void setUp() throws IOException {
+    server.start();
   }
 
   @AfterEach

--- a/hystrix/src/test/java/feign/hystrix/SetterFactoryTest.java
+++ b/hystrix/src/test/java/feign/hystrix/SetterFactoryTest.java
@@ -16,7 +16,7 @@
 package feign.hystrix;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import com.netflix.hystrix.HystrixCommand;
 import com.netflix.hystrix.HystrixCommandGroupKey;
@@ -24,9 +24,10 @@ import com.netflix.hystrix.HystrixCommandKey;
 import com.netflix.hystrix.exception.HystrixRuntimeException;
 import feign.RequestLine;
 import java.io.IOException;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class SetterFactoryTest {
@@ -41,7 +42,7 @@ public class SetterFactoryTest {
   @Test
   void customSetter() {
 
-    server.enqueue(new MockResponse().setResponseCode(500));
+    server.enqueue(new MockResponse.Builder().code(500).build());
 
     SetterFactory commandKeyIsRequestLine =
         (target, method) -> {
@@ -56,8 +57,16 @@ public class SetterFactoryTest {
             .setterFactory(commandKeyIsRequestLine)
             .target(TestInterface.class, "http://localhost:" + server.getPort());
 
-    Throwable exception = assertThrows(HystrixRuntimeException.class, () -> api.invoke());
+    Throwable exception =
+        assertThatExceptionOfType(HystrixRuntimeException.class)
+            .isThrownBy(() -> api.invoke())
+            .actual();
     assertThat(exception.getMessage()).contains("POST / failed and no fallback available.");
+  }
+
+  @BeforeEach
+  void setUp() throws IOException {
+    server.start();
   }
 
   @AfterEach

--- a/jackson-jaxb/pom.xml
+++ b/jackson-jaxb/pom.xml
@@ -84,8 +84,8 @@
     </dependency>
 
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
       <version>${jaxb-impl-2.version}</version>
       <scope>test</scope>
     </dependency>

--- a/jackson-jr/src/test/java/feign/jackson/jr/JacksonCodecTest.java
+++ b/jackson-jr/src/test/java/feign/jackson/jr/JacksonCodecTest.java
@@ -25,7 +25,6 @@ import feign.Request;
 import feign.Request.HttpMethod;
 import feign.RequestTemplate;
 import feign.Response;
-import java.io.IOException;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
@@ -185,7 +184,7 @@ class JacksonCodecTest {
   }
 
   @Test
-  void decoderCharset() throws IOException {
+  void decoderCharset() throws Exception {
     Zone zone = new Zone("denominator.io.", "ÁÉÍÓÚÀÈÌÒÙÄËÏÖÜÑ");
 
     Map<String, Collection<String>> headers = new HashMap<>();
@@ -308,7 +307,7 @@ class JacksonCodecTest {
   @ParameterizedTest
   @MethodSource("decodeGenericsArguments")
   void decodeGenerics(Response response, Type responseType, DataWrapper<?> expectedDataWrapper)
-      throws IOException {
+      throws Exception {
     assertThat(new JacksonJrDecoder().decode(response, responseType))
         .isEqualTo(expectedDataWrapper);
   }

--- a/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
+++ b/jackson/src/test/java/feign/jackson/JacksonCodecTest.java
@@ -205,7 +205,7 @@ class JacksonCodecTest {
   }
 
   @Test
-  void decoderCharset() throws IOException {
+  void decoderCharset() throws Exception {
     Zone zone = new Zone("denominator.io.", "ÁÉÍÓÚÀÈÌÒÙÄËÏÖÜÑ");
 
     Map<String, Collection<String>> headers = new HashMap<>();

--- a/jackson/src/test/java/feign/jackson/JacksonIteratorTest.java
+++ b/jackson/src/test/java/feign/jackson/JacksonIteratorTest.java
@@ -16,10 +16,7 @@
 package feign.jackson;
 
 import static feign.Util.UTF_8;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.Request;
@@ -40,73 +37,73 @@ import org.junit.jupiter.api.Test;
 class JacksonIteratorTest {
 
   @Test
-  void shouldDecodePrimitiveArrays() throws IOException {
+  void shouldDecodePrimitiveArrays() throws Exception {
     assertThat(iterator(Integer.class, "[0,1,2,3]")).toIterable().containsExactly(0, 1, 2, 3);
   }
 
   @Test
-  void shouldNotSkipElementsOnHasNext() throws IOException {
+  void shouldNotSkipElementsOnHasNext() throws Exception {
     JacksonIterator<Integer> iterator = iterator(Integer.class, "[0]");
-    assertThat(iterator.hasNext()).isTrue();
-    assertThat(iterator.hasNext()).isTrue();
-    assertThat(iterator.next()).isEqualTo(0);
-    assertThat(iterator.hasNext()).isFalse();
+    assertThat(iterator).hasNext().hasNext();
+    assertThat(iterator.next()).isZero();
+    assertThat(iterator).isExhausted();
   }
 
   @Test
-  void hasNextIsNotMandatory() throws IOException {
+  void hasNextIsNotMandatory() throws Exception {
     JacksonIterator<Integer> iterator = iterator(Integer.class, "[0]");
-    assertThat(iterator.next()).isEqualTo(0);
-    assertThat(iterator.hasNext()).isFalse();
+    assertThat(iterator.next()).isZero();
+    assertThat(iterator).isExhausted();
   }
 
   @Test
-  void expectExceptionOnNoElements() throws IOException {
+  void expectExceptionOnNoElements() throws Exception {
     JacksonIterator<Integer> iterator = iterator(Integer.class, "[0]");
-    assertThat(iterator.next()).isEqualTo(0);
+    assertThat(iterator.next()).isZero();
     assertThatThrownBy(() -> iterator.next())
         .hasMessage(null)
         .isInstanceOf(NoSuchElementException.class);
   }
 
   @Test
-  void shouldDecodeObjects() throws IOException {
+  void shouldDecodeObjects() throws Exception {
     assertThat(iterator(User.class, "[{\"login\":\"bob\"},{\"login\":\"joe\"}]"))
         .toIterable()
         .containsExactly(new User("bob"), new User("joe"));
   }
 
   @Test
-  void malformedObjectThrowsDecodeException() throws IOException {
+  void malformedObjectThrowsDecodeException() throws Exception {
     DecodeException exception =
-        assertThrows(
-            DecodeException.class,
-            () ->
-                assertThat(iterator(User.class, "[{\"login\":\"bob\"},{\"login\":\"joe..."))
-                    .toIterable()
-                    .containsOnly(new User("bob")));
+        assertThatExceptionOfType(DecodeException.class)
+            .isThrownBy(
+                () ->
+                    assertThat(iterator(User.class, "[{\"login\":\"bob\"},{\"login\":\"joe..."))
+                        .toIterable()
+                        .containsOnly(new User("bob")))
+            .actual();
     assertThat(exception).hasCauseInstanceOf(IOException.class);
   }
 
   @Test
-  void emptyBodyDecodesToEmptyIterator() throws IOException {
+  void emptyBodyDecodesToEmptyIterator() throws Exception {
     assertThat(iterator(String.class, "")).toIterable().isEmpty();
   }
 
   @Test
-  void unmodifiable() throws IOException {
-    assertThatExceptionOfType(UnsupportedOperationException.class)
-        .isThrownBy(
+  void unmodifiable() throws Exception {
+    assertThatThrownBy(
             () -> {
               JacksonIterator<String> it = iterator(String.class, "[\"test\"]");
 
               assertThat(it).toIterable().containsExactly("test");
               it.remove();
-            });
+            })
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test
-  void responseIsClosedAfterIteration() throws IOException {
+  void responseIsClosedAfterIteration() throws Exception {
     final AtomicBoolean closed = new AtomicBoolean();
 
     byte[] jsonBytes = "[false, true]".getBytes(UTF_8);
@@ -132,7 +129,7 @@ class JacksonIteratorTest {
   }
 
   @Test
-  void responseIsClosedOnParseError() throws IOException {
+  void responseIsClosedOnParseError() throws Exception {
     final AtomicBoolean closed = new AtomicBoolean();
 
     byte[] jsonBytes = "[error".getBytes(UTF_8);
@@ -153,9 +150,8 @@ class JacksonIteratorTest {
             .body(inputStream, jsonBytes.length)
             .build();
 
-    assertThrows(
-        DecodeException.class,
-        () -> assertThat(iterator(Boolean.class, response)).toIterable().hasSize(1));
+    assertThatThrownBy(() -> assertThat(iterator(Boolean.class, response)).toIterable().hasSize(1))
+        .isInstanceOf(DecodeException.class);
 
     assertThat(closed.get()).isTrue();
   }

--- a/jackson3/src/test/java/feign/jackson3/Jackson3CodecTest.java
+++ b/jackson3/src/test/java/feign/jackson3/Jackson3CodecTest.java
@@ -24,7 +24,6 @@ import feign.Request.HttpMethod;
 import feign.RequestTemplate;
 import feign.Response;
 import java.io.Closeable;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -206,7 +205,7 @@ class Jackson3CodecTest {
   }
 
   @Test
-  void decoderCharset() throws IOException {
+  void decoderCharset() throws Exception {
     Zone zone = new Zone("denominator.io.", "ÁÉÍÓÚÀÈÌÒÙÄËÏÖÜÑ");
 
     Map<String, Collection<String>> headers = new HashMap<>();

--- a/jackson3/src/test/java/feign/jackson3/examples/GitHubExample.java
+++ b/jackson3/src/test/java/feign/jackson3/examples/GitHubExample.java
@@ -30,10 +30,10 @@ public class GitHubExample {
             .decoder(new Jackson3Decoder())
             .target(GitHub.class, "https://api.github.com");
 
-    System.out.println("Let's fetch and print a list of the contributors to this library.");
+    IO.println("Let's fetch and print a list of the contributors to this library.");
     List<Contributor> contributors = github.contributors("netflix", "feign");
     for (Contributor contributor : contributors) {
-      System.out.println(contributor.login + " (" + contributor.contributions + ")");
+      IO.println(contributor.login + " (" + contributor.contributions + ")");
     }
   }
 

--- a/jackson3/src/test/java/feign/jackson3/examples/GitHubIteratorExample.java
+++ b/jackson3/src/test/java/feign/jackson3/examples/GitHubIteratorExample.java
@@ -33,12 +33,12 @@ public class GitHubIteratorExample {
             .doNotCloseAfterDecode()
             .target(GitHub.class, "https://api.github.com");
 
-    System.out.println("Let's fetch and print a list of the contributors to this library.");
+    IO.println("Let's fetch and print a list of the contributors to this library.");
     Iterator<Contributor> contributors = github.contributors("OpenFeign", "feign");
     try {
       while (contributors.hasNext()) {
         Contributor contributor = contributors.next();
-        System.out.println(contributor.login + " (" + contributor.contributions + ")");
+        IO.println(contributor.login + " (" + contributor.contributions + ")");
       }
     } finally {
       ((Closeable) contributors).close();

--- a/java11/pom.xml
+++ b/java11/pom.xml
@@ -45,7 +45,7 @@
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>mockwebserver</artifactId>
+      <artifactId>mockwebserver3</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/java11/src/test/java/feign/http2client/test/Http2ClientAsyncTest.java
+++ b/java11/src/test/java/feign/http2client/test/Http2ClientAsyncTest.java
@@ -16,11 +16,8 @@
 package feign.http2client.test;
 
 import static feign.assertj.MockWebServerAssertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.data.MapEntry.entry;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -81,10 +78,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import okio.Buffer;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class Http2ClientAsyncTest {
@@ -92,7 +91,7 @@ public class Http2ClientAsyncTest {
 
   @Test
   void iterableQueryParams() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
@@ -103,7 +102,7 @@ public class Http2ClientAsyncTest {
 
   @Test
   void postTemplateParamsResolve() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
@@ -117,7 +116,7 @@ public class Http2ClientAsyncTest {
 
   @Test
   void responseCoercesToStringBody() throws Throwable {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
@@ -128,7 +127,7 @@ public class Http2ClientAsyncTest {
 
   @Test
   void postFormParams() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
@@ -143,7 +142,7 @@ public class Http2ClientAsyncTest {
 
   @Test
   void postBodyParam() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
@@ -162,7 +161,7 @@ public class Http2ClientAsyncTest {
    */
   @Test
   void bodyTypeCorrespondsWithParameterType() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final AtomicReference<Type> encodedType = new AtomicReference<>();
     final TestInterfaceAsync api =
@@ -187,7 +186,7 @@ public class Http2ClientAsyncTest {
 
   @Test
   void singleInterceptor() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final TestInterfaceAsync api =
         newAsyncBuilder()
@@ -204,7 +203,7 @@ public class Http2ClientAsyncTest {
 
   @Test
   void multipleInterceptor() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final TestInterfaceAsync api =
         newAsyncBuilder()
@@ -224,7 +223,7 @@ public class Http2ClientAsyncTest {
 
   @Test
   void customExpander() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
@@ -237,7 +236,7 @@ public class Http2ClientAsyncTest {
 
   @Test
   void customExpanderListParam() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
@@ -251,7 +250,7 @@ public class Http2ClientAsyncTest {
 
   @Test
   void customExpanderNullParam() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
@@ -264,7 +263,7 @@ public class Http2ClientAsyncTest {
 
   @Test
   void headerMap() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
@@ -283,7 +282,7 @@ public class Http2ClientAsyncTest {
 
   @Test
   void headerMapWithHeaderAnnotations() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
@@ -297,7 +296,7 @@ public class Http2ClientAsyncTest {
             entry("Content-Encoding", Arrays.asList("deflate")),
             entry("Custom-Header", Arrays.asList("fooValue")));
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     headerMap.put("Content-Encoding", "overrideFromMap");
 
     final CompletableFuture<?> cf = api.headerMapWithHeaderAnnotations(headerMap);
@@ -316,7 +315,7 @@ public class Http2ClientAsyncTest {
 
   @Test
   void queryMap() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
@@ -332,7 +331,7 @@ public class Http2ClientAsyncTest {
 
   @Test
   void queryMapIterableValuesExpanded() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
@@ -353,21 +352,21 @@ public class Http2ClientAsyncTest {
   void queryMapWithQueryParams() throws Exception {
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     Map<String, Object> queryMap = new LinkedHashMap<>();
     queryMap.put("fooKey", "fooValue");
     api.queryMapWithQueryParams("alice", queryMap);
     // query map should be expanded after built-in parameters
     assertThat(server.takeRequest()).hasPath("/?name=alice&fooKey=fooValue");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("name", "bob");
     api.queryMapWithQueryParams("alice", queryMap);
     // queries are additive
     assertThat(server.takeRequest()).hasPath("/?name=alice&name=bob");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("name", null);
     api.queryMapWithQueryParams("alice", queryMap);
@@ -379,25 +378,25 @@ public class Http2ClientAsyncTest {
   void queryMapValueStartingWithBrace() throws Exception {
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     Map<String, Object> queryMap = new LinkedHashMap<>();
     queryMap.put("name", "{alice");
     api.queryMap(queryMap);
     assertThat(server.takeRequest()).hasPath("/?name=%7Balice");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("{name", "alice");
     api.queryMap(queryMap);
     assertThat(server.takeRequest()).hasPath("/?%7Bname=alice");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("name", "%7Balice");
     api.queryMapEncoded(queryMap);
     assertThat(server.takeRequest()).hasPath("/?name=%7Balice");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("%7Bname", "%7Balice");
     api.queryMapEncoded(queryMap);
@@ -410,7 +409,7 @@ public class Http2ClientAsyncTest {
 
     final CustomPojo customPojo = new CustomPojo("Name", 3);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     final CompletableFuture<?> cf = api.queryMapPojo(customPojo);
     assertThat(server.takeRequest()).hasQueryParams(Arrays.asList("name=Name", "number=3"));
     checkCFCompletedSoon(cf);
@@ -422,7 +421,7 @@ public class Http2ClientAsyncTest {
 
     final CustomPojo customPojo = new CustomPojo("Name", null);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     final CompletableFuture<?> cf = api.queryMapPojo(customPojo);
     assertThat(server.takeRequest()).hasPath("/?name=Name");
 
@@ -435,7 +434,7 @@ public class Http2ClientAsyncTest {
 
     final CustomPojo customPojo = new CustomPojo(null, null);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     api.queryMapPojo(customPojo);
     assertThat(server.takeRequest()).hasPath("/");
   }
@@ -470,20 +469,23 @@ public class Http2ClientAsyncTest {
 
   @Test
   void canOverrideErrorDecoder() throws Throwable {
-    server.enqueue(new MockResponse().setResponseCode(400).setBody("foo"));
+    server.enqueue(new MockResponse.Builder().code(400).body("foo").build());
 
     final TestInterfaceAsync api =
         newAsyncBuilder()
             .errorDecoder(new IllegalArgumentExceptionOn400())
             .target("http://localhost:" + server.getPort());
 
-    Throwable exception = assertThrows(IllegalArgumentException.class, () -> unwrap(api.post()));
+    Throwable exception =
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> unwrap(api.post()))
+            .actual();
     assertThat(exception.getMessage()).contains("bad zone name");
   }
 
   @Test
   void overrideTypeSpecificDecoder() throws Throwable {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     final TestInterfaceAsync api =
         newAsyncBuilder().decoder((_, _) -> "fail").target("http://localhost:" + server.getPort());
@@ -493,7 +495,7 @@ public class Http2ClientAsyncTest {
 
   @Test
   void doesntRetryAfterResponseIsSent() throws Throwable {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     final TestInterfaceAsync api =
         newAsyncBuilder()
@@ -505,13 +507,14 @@ public class Http2ClientAsyncTest {
 
     final CompletableFuture<?> cf = api.post();
     server.takeRequest();
-    Throwable exception = assertThrows(FeignException.class, () -> unwrap(cf));
+    Throwable exception =
+        assertThatExceptionOfType(FeignException.class).isThrownBy(() -> unwrap(cf)).actual();
     assertThat(exception.getMessage()).contains("timeout reading POST http://");
   }
 
   @Test
   void throwsFeignExceptionIncludingBody() throws Throwable {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     final TestInterfaceAsync api =
         newAsyncBuilder()
@@ -536,7 +539,7 @@ public class Http2ClientAsyncTest {
 
   @Test
   void throwsFeignExceptionWithoutBody() {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     final TestInterfaceAsync api =
         newAsyncBuilder()
@@ -551,7 +554,7 @@ public class Http2ClientAsyncTest {
     } catch (final FeignException e) {
       assertThat(e.getMessage())
           .isEqualTo("timeout reading POST http://localhost:" + server.getPort() + "/");
-      assertThat(e.contentUTF8()).isEqualTo("");
+      assertThat(e.contentUTF8()).isEmpty();
     }
   }
 
@@ -584,7 +587,7 @@ public class Http2ClientAsyncTest {
 
   @Test
   void okIfDecodeRootCauseHasNoMessage() throws Throwable {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     final TestInterfaceAsync api =
         newAsyncBuilder()
@@ -594,33 +597,35 @@ public class Http2ClientAsyncTest {
                 })
             .target("http://localhost:" + server.getPort());
 
-    assertThrows(DecodeException.class, () -> unwrap(api.post()));
+    assertThatThrownBy(() -> unwrap(api.post())).isInstanceOf(DecodeException.class);
   }
 
   @Test
   void decodingExceptionGetWrappedInDismiss404Mode() throws Throwable {
-    server.enqueue(new MockResponse().setResponseCode(404));
+    server.enqueue(new MockResponse.Builder().code(404).build());
 
     final TestInterfaceAsync api =
         newAsyncBuilder()
             .dismiss404()
             .decoder(
                 (response, _) -> {
-                  assertEquals(404, response.status());
+                  Assertions.assertThat(response.status()).isEqualTo(404);
                   throw new NoSuchElementException();
                 })
             .target("http://localhost:" + server.getPort());
 
-    DecodeException exception = assertThrows(DecodeException.class, () -> unwrap(api.post()));
+    DecodeException exception =
+        assertThatExceptionOfType(DecodeException.class)
+            .isThrownBy(() -> unwrap(api.post()))
+            .actual();
     assertThat(exception).hasCauseInstanceOf(NoSuchElementException.class);
   }
 
   @Test
   void decodingDoesNotSwallow404ErrorsInDismiss404Mode() throws Throwable {
-    assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(
+    assertThatThrownBy(
             () -> {
-              server.enqueue(new MockResponse().setResponseCode(404));
+              server.enqueue(new MockResponse.Builder().code(404).build());
 
               final TestInterfaceAsync api =
                   newAsyncBuilder()
@@ -632,12 +637,13 @@ public class Http2ClientAsyncTest {
                   api.queryMap(Collections.<String, Object>emptyMap());
               server.takeRequest();
               unwrap(cf);
-            });
+            })
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void okIfEncodeRootCauseHasNoMessage() throws Throwable {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     final TestInterfaceAsync api =
         newAsyncBuilder()
@@ -647,7 +653,8 @@ public class Http2ClientAsyncTest {
                 })
             .target("http://localhost:" + server.getPort());
 
-    assertThrows(EncodeException.class, () -> unwrap(api.body(Arrays.asList("foo"))));
+    assertThatThrownBy(() -> unwrap(api.body(Arrays.asList("foo"))))
+        .isInstanceOf(EncodeException.class);
   }
 
   @Test
@@ -677,16 +684,14 @@ public class Http2ClientAsyncTest {
 
     assertThat(t1).isNotEqualTo(i1);
 
-    assertThat(t1.hashCode()).isEqualTo(i1.hashCode());
-
-    assertThat(t1.toString()).isEqualTo(i1.toString());
+    Assertions.assertThat(t1).hasSameHashCodeAs(i1).hasToString(i1.toString());
   }
 
   @SuppressWarnings("resource")
   @Test
   void decodeLogicSupportsByteArray() throws Throwable {
     final byte[] expectedResponse = {12, 34, 56};
-    server.enqueue(new MockResponse().setBody(new Buffer().write(expectedResponse)));
+    server.enqueue(new MockResponse.Builder().body(new Buffer().write(expectedResponse)).build());
 
     final OtherTestInterfaceAsync api =
         newAsyncBuilder()
@@ -700,7 +705,7 @@ public class Http2ClientAsyncTest {
   @Test
   void encodeLogicSupportsByteArray() throws Exception {
     final byte[] expectedRequest = {12, 34, 56};
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final OtherTestInterfaceAsync api =
         newAsyncBuilder()
@@ -718,7 +723,7 @@ public class Http2ClientAsyncTest {
 
   @Test
   void encodedQueryParam() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
@@ -740,7 +745,7 @@ public class Http2ClientAsyncTest {
   }
 
   @Test
-  void responseMapperIsAppliedBeforeDelegate() throws IOException {
+  void responseMapperIsAppliedBeforeDelegate() throws Exception {
     final ResponseMappingDecoder decoder =
         new ResponseMappingDecoder(upperCaseResponseMapper(), new StringDecoder());
     final String output = (String) decoder.decode(responseWithText("response"), String.class);
@@ -776,7 +781,7 @@ public class Http2ClientAsyncTest {
 
   @Test
   void mapAndDecodeExecutesMapFunction() throws Throwable {
-    server.enqueue(new MockResponse().setBody("response!"));
+    server.enqueue(new MockResponse.Builder().body("response!").build());
 
     final TestInterfaceAsync api =
         AsyncFeign.builder()
@@ -798,7 +803,7 @@ public class Http2ClientAsyncTest {
     propertyPojo.setName("Name");
     propertyPojo.setNumber(1);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     final CompletableFuture<?> cf = api.queryMapPropertyPojo(propertyPojo);
     assertThat(server.takeRequest()).hasQueryParams(Arrays.asList("name=Name", "number=1"));
     checkCFCompletedSoon(cf);
@@ -816,7 +821,7 @@ public class Http2ClientAsyncTest {
     childPojo.setParentProtectedProperty("second");
     childPojo.setParentPublicProperty("third");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     final CompletableFuture<?> cf = api.queryMapPropertyInheritence(childPojo);
     assertThat(server.takeRequest())
         .hasQueryParams(
@@ -837,7 +842,7 @@ public class Http2ClientAsyncTest {
     propertyPojo.setName(null);
     propertyPojo.setNumber(1);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     final CompletableFuture<?> cf = api.queryMapPropertyPojo(propertyPojo);
 
     assertThat(server.takeRequest()).hasQueryParams("number=1");
@@ -854,7 +859,7 @@ public class Http2ClientAsyncTest {
 
     final PropertyPojo.ChildPojoClass propertyPojo = new PropertyPojo.ChildPojoClass();
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     final CompletableFuture<?> cf = api.queryMapPropertyPojo(propertyPojo);
     assertThat(server.takeRequest()).hasQueryParams("/");
 
@@ -1126,6 +1131,11 @@ public class Http2ClientAsyncTest {
     public Instant instant() {
       return Instant.ofEpochMilli(millis);
     }
+  }
+
+  @BeforeEach
+  void setUp() throws IOException {
+    server.start();
   }
 
   @AfterEach

--- a/java11/src/test/java/feign/http2client/test/Http2ClientTest.java
+++ b/java11/src/test/java/feign/http2client/test/Http2ClientTest.java
@@ -17,8 +17,8 @@ package feign.http2client.test;
 
 import static feign.Util.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.entry;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import feign.*;
@@ -32,9 +32,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.RecordedRequest;
-import org.json.JSONException;
+import mockwebserver3.MockResponse;
+import mockwebserver3.RecordedRequest;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
@@ -48,7 +47,7 @@ public class Http2ClientTest extends AbstractClientTest {
     try {
       java.net.InetAddress.getByName("nghttp2.org");
       reachable = true;
-    } catch (java.net.UnknownHostException e) {
+    } catch (java.net.UnknownHostException _) {
       // ignore
     }
     HTTPBIN_REACHABLE = reachable;
@@ -115,7 +114,7 @@ public class Http2ClientTest extends AbstractClientTest {
   @Override
   @Test
   public void reasonPhraseIsOptional() throws IOException, InterruptedException {
-    server.enqueue(new MockResponse().setStatus("HTTP/1.1 " + 200));
+    server.enqueue(new MockResponse.Builder().status("HTTP/1.1 " + 200).build());
 
     final AbstractClientTest.TestInterface api =
         newBuilder()
@@ -128,11 +127,12 @@ public class Http2ClientTest extends AbstractClientTest {
   }
 
   @Test
-  void reasonPhraseInHeader() throws IOException, InterruptedException {
+  void reasonPhraseInHeader() throws Exception {
     server.enqueue(
-        new MockResponse()
+        new MockResponse.Builder()
             .addHeader("Reason-Phrase", "There is A reason")
-            .setStatus("HTTP/1.1 " + 200));
+            .status("HTTP/1.1 " + 200)
+            .build());
 
     final AbstractClientTest.TestInterface api =
         newBuilder()
@@ -152,7 +152,8 @@ public class Http2ClientTest extends AbstractClientTest {
 
   @Test
   void timeoutTest() {
-    server.enqueue(new MockResponse().setBody("foo").setHeadersDelay(1, TimeUnit.SECONDS));
+    server.enqueue(
+        new MockResponse.Builder().body("foo").headersDelay(1, TimeUnit.SECONDS).build());
 
     final TestInterface api =
         newBuilder()
@@ -161,12 +162,13 @@ public class Http2ClientTest extends AbstractClientTest {
                 new Request.Options(500, TimeUnit.MILLISECONDS, 500, TimeUnit.MILLISECONDS, true))
             .target(TestInterface.class, server.url("/").toString());
 
-    FeignException exception = assertThrows(FeignException.class, () -> api.timeout());
+    FeignException exception =
+        assertThatExceptionOfType(FeignException.class).isThrownBy(() -> api.timeout()).actual();
     assertThat(exception).hasCauseInstanceOf(HttpTimeoutException.class);
   }
 
   @Test
-  void getWithRequestBody() throws JSONException {
+  void getWithRequestBody() throws Exception {
     assumeTrue(HTTPBIN_REACHABLE, "nghttp2.org is not reachable");
     final TestInterface api =
         newBuilder().target(TestInterface.class, "https://nghttp2.org/httpbin/");
@@ -176,7 +178,7 @@ public class Http2ClientTest extends AbstractClientTest {
   }
 
   @Test
-  void deleteWithRequestBody() throws JSONException {
+  void deleteWithRequestBody() throws Exception {
     assumeTrue(HTTPBIN_REACHABLE, "nghttp2.org is not reachable");
     final TestInterface api =
         newBuilder().target(TestInterface.class, "https://nghttp2.org/httpbin/");
@@ -188,7 +190,7 @@ public class Http2ClientTest extends AbstractClientTest {
   @Override
   @Test
   public void parsesResponseMissingLength() throws IOException {
-    server.enqueue(new MockResponse().setChunkedBody("foo", 1));
+    server.enqueue(new MockResponse.Builder().chunkedBody("foo", 1).build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -205,12 +207,13 @@ public class Http2ClientTest extends AbstractClientTest {
   @Test
   public void parsesErrorResponse() {
 
-    server.enqueue(new MockResponse().setResponseCode(500).setBody("ARGHH"));
+    server.enqueue(new MockResponse.Builder().code(500).body("ARGHH").build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
 
-    Throwable exception = assertThrows(FeignException.class, () -> api.get());
+    Throwable exception =
+        assertThatExceptionOfType(FeignException.class).isThrownBy(() -> api.get()).actual();
     assertThat(exception.getMessage())
         .contains(
             "[500] during [GET] to [http://localhost:"
@@ -221,7 +224,7 @@ public class Http2ClientTest extends AbstractClientTest {
   @Override
   @Test
   public void defaultCollectionFormat() throws Exception {
-    server.enqueue(new MockResponse().setBody("body"));
+    server.enqueue(new MockResponse.Builder().body("body").build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -239,7 +242,7 @@ public class Http2ClientTest extends AbstractClientTest {
   @Override
   @Test
   public void headersWithNotEmptyParams() throws InterruptedException {
-    server.enqueue(new MockResponse().setBody("body"));
+    server.enqueue(new MockResponse.Builder().body("body").build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -258,7 +261,7 @@ public class Http2ClientTest extends AbstractClientTest {
   @Override
   @Test
   public void headersWithNullParams() throws InterruptedException {
-    server.enqueue(new MockResponse().setBody("body"));
+    server.enqueue(new MockResponse.Builder().body("body").build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -276,7 +279,7 @@ public class Http2ClientTest extends AbstractClientTest {
 
   @Test
   public void alternativeCollectionFormat() throws Exception {
-    server.enqueue(new MockResponse().setBody("body"));
+    server.enqueue(new MockResponse.Builder().body("body").build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -296,7 +299,7 @@ public class Http2ClientTest extends AbstractClientTest {
   @Override
   @Test
   public void parsesRequestAndResponse() throws IOException, InterruptedException {
-    server.enqueue(new MockResponse().setBody("foo").addHeader("Foo: Bar"));
+    server.enqueue(new MockResponse.Builder().body("foo").addHeader("Foo: Bar").build());
 
     TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -321,10 +324,10 @@ public class Http2ClientTest extends AbstractClientTest {
 
     RecordedRequest recordedRequest = server.takeRequest();
     assertThat(recordedRequest.getMethod()).isEqualToIgnoringCase("POST");
-    assertThat(recordedRequest.getHeader("Foo")).isEqualToIgnoringCase("Bar, Baz");
-    assertThat(recordedRequest.getHeader("Accept")).isEqualToIgnoringCase("*/*");
-    assertThat(recordedRequest.getHeader("Content-Length")).isEqualToIgnoringCase("3");
-    assertThat(recordedRequest.getBody().readUtf8()).isEqualToIgnoringCase("foo");
+    assertThat(recordedRequest.getHeaders().get("Foo")).isEqualToIgnoringCase("Bar, Baz");
+    assertThat(recordedRequest.getHeaders().get("Accept")).isEqualToIgnoringCase("*/*");
+    assertThat(recordedRequest.getHeaders().get("Content-Length")).isEqualToIgnoringCase("3");
+    assertThat(recordedRequest.getBody().utf8()).isEqualToIgnoringCase("foo");
   }
 
   @Override

--- a/jaxb-jakarta/pom.xml
+++ b/jaxb-jakarta/pom.xml
@@ -33,6 +33,7 @@
     <main.java.version>11</main.java.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
+    <moditect.skip>true</moditect.skip>
   </properties>
 
   <dependencies>
@@ -60,10 +61,10 @@
 
     <!-- Test -->
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
       <version>${jaxb-impl-4.version}</version>
-      <scope>test</scope>
+      <scope>runtime</scope>
     </dependency>
   </dependencies>
 

--- a/jaxb-jakarta/src/test/java/feign/jaxb/JAXBCodecTest.java
+++ b/jaxb-jakarta/src/test/java/feign/jaxb/JAXBCodecTest.java
@@ -17,8 +17,7 @@ package feign.jaxb;
 
 import static feign.Util.UTF_8;
 import static feign.assertj.FeignAssertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import feign.Request;
 import feign.Request.HttpMethod;
@@ -33,6 +32,7 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
+import java.io.IOException;
 import java.io.StringReader;
 import java.lang.reflect.Type;
 import java.util.Collection;
@@ -74,11 +74,12 @@ class JAXBCodecTest {
 
     RequestTemplate template = new RequestTemplate();
     Throwable exception =
-        assertThrows(
-            UnsupportedOperationException.class,
-            () ->
-                new JAXBEncoder(new JAXBContextFactory.Builder().build())
-                    .encode(Collections.emptyMap(), parameterized, template));
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+            .isThrownBy(
+                () ->
+                    new JAXBEncoder(new JAXBContextFactory.Builder().build())
+                        .encode(Collections.emptyMap(), parameterized, template))
+            .actual();
     assertThat(exception.getMessage())
         .contains(
             "JAXB only supports encoding raw types. Found java.util.Map<java.lang.String, ?>");
@@ -227,11 +228,12 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\
             .build();
 
     Throwable exception =
-        assertThrows(
-            feign.codec.DecodeException.class,
-            () ->
-                new JAXBDecoder(new JAXBContextFactory.Builder().build())
-                    .decode(response, parameterized));
+        assertThatExceptionOfType(feign.codec.DecodeException.class)
+            .isThrownBy(
+                () ->
+                    new JAXBDecoder(new JAXBContextFactory.Builder().build())
+                        .decode(response, parameterized))
+            .actual();
     assertThat(exception.getMessage())
         .contains(
             """
@@ -315,9 +317,9 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\
     JAXBContextFactory factory =
         new JAXBContextFactory.Builder().withUnmarshallerSchema(getMockIntObjSchema()).build();
     DecodeException exception =
-        assertThrows(
-            DecodeException.class,
-            () -> new JAXBDecoder(factory).decode(response, MockIntObject.class));
+        assertThatExceptionOfType(DecodeException.class)
+            .isThrownBy(() -> new JAXBDecoder(factory).decode(response, MockIntObject.class))
+            .actual();
     assertThat(exception)
         .hasCauseInstanceOf(UnmarshalException.class)
         .hasMessageContaining("'Test' is not a valid value for 'integer'.");
@@ -358,9 +360,9 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\
 
     RequestTemplate template = new RequestTemplate();
     EncodeException exception =
-        assertThrows(
-            EncodeException.class,
-            () -> encoder.encode(new MockIntObject(), MockIntObject.class, template));
+        assertThatExceptionOfType(EncodeException.class)
+            .isThrownBy(() -> encoder.encode(new MockIntObject(), MockIntObject.class, template))
+            .actual();
     assertThat(exception)
         .hasCauseInstanceOf(MarshalException.class)
         .hasMessageContaining("The content of element 'mockIntObject' is not complete.");
@@ -387,7 +389,11 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\
   }
 
   private byte[] bodyAsBytes(Request.Body body) {
-    return assertDoesNotThrow(body::writeToByteArray);
+    try {
+      return body.writeToByteArray();
+    } catch (IOException e) {
+      throw new AssertionError("Failed to write body", e);
+    }
   }
 
   @XmlRootElement

--- a/jaxb-jakarta/src/test/java/feign/jaxb/JAXBContextFactoryTest.java
+++ b/jaxb-jakarta/src/test/java/feign/jaxb/JAXBContextFactoryTest.java
@@ -149,8 +149,7 @@ class JAXBContextFactoryTest {
     Field f = factory.getClass().getDeclaredField("jaxbContexts"); // NoSuchFieldException
     f.setAccessible(true);
     Map internalCache = (Map) f.get(factory); // IllegalAccessException
-    assertThat(internalCache.isEmpty()).isFalse();
-    assertThat(internalCache.size() == classes.size()).isTrue();
+    assertThat(internalCache).isNotEmpty().hasSize(classes.size());
     assertThat(internalCache.get(new JAXBContextClassCacheKey(String.class))).isNotNull();
     assertThat(internalCache.get(new JAXBContextClassCacheKey(Integer.class))).isNotNull();
   }
@@ -167,7 +166,7 @@ class JAXBContextFactoryTest {
     Field f = factory.getClass().getDeclaredField("jaxbContexts"); // NoSuchFieldException
     f.setAccessible(true);
     Map internalCache = (Map) f.get(factory); // IllegalAccessException
-    assertThat(internalCache.isEmpty()).isFalse();
+    assertThat(internalCache).isNotEmpty();
     assertThat(classes).hasSize(internalCache.size());
     assertThat(internalCache.get(new JAXBContextClassCacheKey(String.class))).isNotNull();
     assertThat(internalCache.get(new JAXBContextClassCacheKey(Integer.class))).isNotNull();
@@ -183,9 +182,11 @@ class JAXBContextFactoryTest {
 
     Field f = factory.getClass().getDeclaredField("jaxbContexts"); // NoSuchFieldException
     f.setAccessible(true);
-    Map internalCache = (Map) f.get(factory); // IllegalAccessException
-    assertThat(internalCache.isEmpty()).isFalse();
-    assertThat(internalCache).hasSize(1);
+    Map internalCache = (Map) f.get(factory);
+    assertThat(internalCache)
+        // IllegalAccessException
+        .isNotEmpty()
+        .hasSize(1);
     assertThat(
             internalCache.get(
                 new JAXBContextPackageCacheKey(
@@ -205,9 +206,11 @@ class JAXBContextFactoryTest {
 
     Field f = factory.getClass().getDeclaredField("jaxbContexts"); // NoSuchFieldException
     f.setAccessible(true);
-    Map internalCache = (Map) f.get(factory); // IllegalAccessException
-    assertThat(internalCache.isEmpty()).isFalse();
-    assertThat(internalCache).hasSize(2);
+    Map internalCache = (Map) f.get(factory);
+    assertThat(internalCache)
+        // IllegalAccessException
+        .isNotEmpty()
+        .hasSize(2);
     assertThat(
             internalCache.get(
                 new JAXBContextPackageCacheKey(

--- a/jaxb-jakarta/src/test/java/feign/jaxb/examples/AWSSignatureVersion4.java
+++ b/jaxb-jakarta/src/test/java/feign/jaxb/examples/AWSSignatureVersion4.java
@@ -16,10 +16,10 @@
 package feign.jaxb.examples;
 
 import static feign.Util.UTF_8;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import feign.Request;
 import feign.RequestTemplate;
+import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -84,7 +84,11 @@ public class AWSSignatureVersion4 {
   }
 
   private static String bodyAsUtf8String(Request.Body body) {
-    return assertDoesNotThrow(() -> body.writeToString(StandardCharsets.UTF_8));
+    try {
+      return body.writeToString(StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new AssertionError("Failed to write body", e);
+    }
   }
 
   private static String toSign(String timestamp, String credentialScope, String canonicalRequest) {

--- a/jaxb/pom.xml
+++ b/jaxb/pom.xml
@@ -29,6 +29,10 @@
   <name>Feign JAXB</name>
   <description>Feign JAXB</description>
 
+  <properties>
+    <moditect.skip>true</moditect.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -47,17 +51,17 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
       <version>${jaxb-api.version}</version>
     </dependency>
 
     <!-- JAXB RI -->
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
       <version>${jaxb-impl-2.version}</version>
-      <scope>test</scope>
+      <scope>runtime</scope>
     </dependency>
   </dependencies>
 

--- a/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
+++ b/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
@@ -17,8 +17,7 @@ package feign.jaxb;
 
 import static feign.Util.UTF_8;
 import static feign.assertj.FeignAssertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import feign.Request;
 import feign.Request.HttpMethod;
@@ -27,6 +26,7 @@ import feign.Response;
 import feign.codec.DecodeException;
 import feign.codec.EncodeException;
 import feign.codec.Encoder;
+import java.io.IOException;
 import java.io.StringReader;
 import java.lang.reflect.Type;
 import java.util.Collection;
@@ -74,11 +74,12 @@ class JAXBCodecTest {
 
     RequestTemplate template = new RequestTemplate();
     Throwable exception =
-        assertThrows(
-            UnsupportedOperationException.class,
-            () ->
-                new JAXBEncoder(new JAXBContextFactory.Builder().build())
-                    .encode(Collections.emptyMap(), parameterized, template));
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+            .isThrownBy(
+                () ->
+                    new JAXBEncoder(new JAXBContextFactory.Builder().build())
+                        .encode(Collections.emptyMap(), parameterized, template))
+            .actual();
     assertThat(exception.getMessage())
         .contains(
             "JAXB only supports encoding raw types. Found java.util.Map<java.lang.String, ?>");
@@ -227,11 +228,12 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\
             .build();
 
     Throwable exception =
-        assertThrows(
-            DecodeException.class,
-            () ->
-                new JAXBDecoder(new JAXBContextFactory.Builder().build())
-                    .decode(response, parameterized));
+        assertThatExceptionOfType(DecodeException.class)
+            .isThrownBy(
+                () ->
+                    new JAXBDecoder(new JAXBContextFactory.Builder().build())
+                        .decode(response, parameterized))
+            .actual();
     assertThat(exception.getMessage())
         .contains(
             """
@@ -315,9 +317,9 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\
     JAXBContextFactory factory =
         new JAXBContextFactory.Builder().withUnmarshallerSchema(getMockIntObjSchema()).build();
     DecodeException exception =
-        assertThrows(
-            DecodeException.class,
-            () -> new JAXBDecoder(factory).decode(response, MockIntObject.class));
+        assertThatExceptionOfType(DecodeException.class)
+            .isThrownBy(() -> new JAXBDecoder(factory).decode(response, MockIntObject.class))
+            .actual();
     assertThat(exception)
         .hasCauseInstanceOf(UnmarshalException.class)
         .hasMessageContaining("'Test' is not a valid value for 'integer'.");
@@ -359,9 +361,9 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\
 
     RequestTemplate template = new RequestTemplate();
     EncodeException exception =
-        assertThrows(
-            EncodeException.class,
-            () -> encoder.encode(new MockIntObject(), MockIntObject.class, template));
+        assertThatExceptionOfType(EncodeException.class)
+            .isThrownBy(() -> encoder.encode(new MockIntObject(), MockIntObject.class, template))
+            .actual();
     assertThat(exception)
         .hasCauseInstanceOf(MarshalException.class)
         .hasMessageContaining("The content of element 'mockIntObject' is not complete.");
@@ -388,7 +390,11 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\
   }
 
   private byte[] bodyAsBytes(Request.Body body) {
-    return assertDoesNotThrow(body::writeToByteArray);
+    try {
+      return body.writeToByteArray();
+    } catch (IOException e) {
+      throw new AssertionError("Failed to write body", e);
+    }
   }
 
   @XmlRootElement

--- a/jaxb/src/test/java/feign/jaxb/JAXBContextFactoryTest.java
+++ b/jaxb/src/test/java/feign/jaxb/JAXBContextFactoryTest.java
@@ -149,8 +149,7 @@ class JAXBContextFactoryTest {
     Field f = factory.getClass().getDeclaredField("jaxbContexts"); // NoSuchFieldException
     f.setAccessible(true);
     Map internalCache = (Map) f.get(factory); // IllegalAccessException
-    assertThat(internalCache.isEmpty()).isFalse();
-    assertThat(internalCache.size() == classes.size()).isTrue();
+    assertThat(internalCache).isNotEmpty().hasSize(classes.size());
     assertThat(internalCache.get(new JAXBContextClassCacheKey(String.class))).isNotNull();
     assertThat(internalCache.get(new JAXBContextClassCacheKey(Integer.class))).isNotNull();
   }
@@ -167,7 +166,7 @@ class JAXBContextFactoryTest {
     Field f = factory.getClass().getDeclaredField("jaxbContexts"); // NoSuchFieldException
     f.setAccessible(true);
     Map internalCache = (Map) f.get(factory); // IllegalAccessException
-    assertThat(internalCache.isEmpty()).isFalse();
+    assertThat(internalCache).isNotEmpty();
     assertThat(classes).hasSize(internalCache.size());
     assertThat(internalCache.get(new JAXBContextClassCacheKey(String.class))).isNotNull();
     assertThat(internalCache.get(new JAXBContextClassCacheKey(Integer.class))).isNotNull();
@@ -183,9 +182,11 @@ class JAXBContextFactoryTest {
 
     Field f = factory.getClass().getDeclaredField("jaxbContexts"); // NoSuchFieldException
     f.setAccessible(true);
-    Map internalCache = (Map) f.get(factory); // IllegalAccessException
-    assertThat(internalCache.isEmpty()).isFalse();
-    assertThat(internalCache).hasSize(1);
+    Map internalCache = (Map) f.get(factory);
+    assertThat(internalCache)
+        // IllegalAccessException
+        .isNotEmpty()
+        .hasSize(1);
     assertThat(
             internalCache.get(
                 new JAXBContextPackageCacheKey(
@@ -205,9 +206,11 @@ class JAXBContextFactoryTest {
 
     Field f = factory.getClass().getDeclaredField("jaxbContexts"); // NoSuchFieldException
     f.setAccessible(true);
-    Map internalCache = (Map) f.get(factory); // IllegalAccessException
-    assertThat(internalCache.isEmpty()).isFalse();
-    assertThat(internalCache).hasSize(2);
+    Map internalCache = (Map) f.get(factory);
+    assertThat(internalCache)
+        // IllegalAccessException
+        .isNotEmpty()
+        .hasSize(2);
     assertThat(
             internalCache.get(
                 new JAXBContextPackageCacheKey(

--- a/jaxb/src/test/java/feign/jaxb/examples/AWSSignatureVersion4.java
+++ b/jaxb/src/test/java/feign/jaxb/examples/AWSSignatureVersion4.java
@@ -16,10 +16,10 @@
 package feign.jaxb.examples;
 
 import static feign.Util.UTF_8;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import feign.Request;
 import feign.RequestTemplate;
+import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -84,7 +84,11 @@ public class AWSSignatureVersion4 {
   }
 
   private static String bodyAsUtf8String(Request.Body body) {
-    return assertDoesNotThrow(() -> body.writeToString(StandardCharsets.UTF_8));
+    try {
+      return body.writeToString(StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new AssertionError("Failed to write body", e);
+    }
   }
 
   private static String toSign(String timestamp, String credentialScope, String canonicalRequest) {

--- a/jaxrs/src/test/java/feign/jaxrs/JAXRSContractTestSupport.java
+++ b/jaxrs/src/test/java/feign/jaxrs/JAXRSContractTestSupport.java
@@ -18,8 +18,8 @@ package feign.jaxrs;
 import static feign.assertj.FeignAssertions.assertThat;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.data.MapEntry.entry;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import feign.MethodMetadata;
 import java.net.URI;
@@ -112,9 +112,9 @@ public abstract class JAXRSContractTestSupport<E> {
   @Test
   void producesNada() throws Exception {
     Throwable exception =
-        assertThrows(
-            IllegalStateException.class,
-            () -> parseAndValidateMetadata(producesAndConsumesClass(), "producesNada"));
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(() -> parseAndValidateMetadata(producesAndConsumesClass(), "producesNada"))
+            .actual();
     assertThat(exception.getMessage())
         .contains("Produces.value() was empty on ProducesAndConsumes#producesNada");
   }
@@ -122,9 +122,9 @@ public abstract class JAXRSContractTestSupport<E> {
   @Test
   void producesEmpty() throws Exception {
     Throwable exception =
-        assertThrows(
-            IllegalStateException.class,
-            () -> parseAndValidateMetadata(producesAndConsumesClass(), "producesEmpty"));
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(() -> parseAndValidateMetadata(producesAndConsumesClass(), "producesEmpty"))
+            .actual();
     assertThat(exception.getMessage())
         .contains("Produces.value() was empty on ProducesAndConsumes#producesEmpty");
   }
@@ -153,9 +153,9 @@ public abstract class JAXRSContractTestSupport<E> {
   @Test
   void consumesNada() throws Exception {
     Throwable exception =
-        assertThrows(
-            IllegalStateException.class,
-            () -> parseAndValidateMetadata(producesAndConsumesClass(), "consumesNada"));
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(() -> parseAndValidateMetadata(producesAndConsumesClass(), "consumesNada"))
+            .actual();
     assertThat(exception.getMessage())
         .contains("Consumes.value() was empty on ProducesAndConsumes#consumesNada");
   }
@@ -163,9 +163,9 @@ public abstract class JAXRSContractTestSupport<E> {
   @Test
   void consumesEmpty() throws Exception {
     Throwable exception =
-        assertThrows(
-            IllegalStateException.class,
-            () -> parseAndValidateMetadata(producesAndConsumesClass(), "consumesEmpty"));
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(() -> parseAndValidateMetadata(producesAndConsumesClass(), "consumesEmpty"))
+            .actual();
     assertThat(exception.getMessage())
         .contains("Consumes.value() was empty on ProducesAndConsumes#consumesEmpty");
   }
@@ -185,7 +185,7 @@ public abstract class JAXRSContractTestSupport<E> {
   void bodyParamIsGeneric() throws Exception {
     final MethodMetadata md = parseAndValidateMetadata(bodyParamsClass(), "post", List.class);
 
-    assertThat(md.bodyIndex()).isEqualTo(0);
+    assertThat(md.bodyIndex()).isZero();
     assertThat(md.bodyType())
         .isEqualTo(JAXRSContractTestSupport.class.getDeclaredField("STRING_LIST").getGenericType());
   }
@@ -193,9 +193,11 @@ public abstract class JAXRSContractTestSupport<E> {
   @Test
   void tooManyBodies() throws Exception {
     Throwable exception =
-        assertThrows(
-            IllegalStateException.class,
-            () -> parseAndValidateMetadata(bodyParamsClass(), "tooMany", List.class, List.class));
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(
+                () ->
+                    parseAndValidateMetadata(bodyParamsClass(), "tooMany", List.class, List.class))
+            .actual();
     assertThat(exception.getMessage()).contains("Method has too many Body");
   }
 
@@ -226,9 +228,10 @@ public abstract class JAXRSContractTestSupport<E> {
   @Test
   void emptyPathParam() throws Exception {
     Throwable exception =
-        assertThrows(
-            IllegalStateException.class,
-            () -> parseAndValidateMetadata(pathOnTypeClass(), "emptyPathParam", String.class));
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(
+                () -> parseAndValidateMetadata(pathOnTypeClass(), "emptyPathParam", String.class))
+            .actual();
     assertThat(exception.getMessage()).contains("PathParam.value() was empty on parameter 0");
   }
 
@@ -275,7 +278,7 @@ public abstract class JAXRSContractTestSupport<E> {
             // Skips 1 as it is a url index!
             entry(2, asList("2")));
 
-    assertThat(md.urlIndex()).isEqualTo(1);
+    assertThat(md.urlIndex()).isOne();
   }
 
   @Test
@@ -299,9 +302,11 @@ public abstract class JAXRSContractTestSupport<E> {
   @Test
   void emptyQueryParam() throws Exception {
     Throwable exception =
-        assertThrows(
-            IllegalStateException.class,
-            () -> parseAndValidateMetadata(withPathAndQueryParamsClass(), "empty", String.class));
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(
+                () ->
+                    parseAndValidateMetadata(withPathAndQueryParamsClass(), "empty", String.class))
+            .actual();
     assertThat(exception.getMessage()).contains("QueryParam.value() was empty on parameter 0");
   }
 
@@ -333,9 +338,10 @@ public abstract class JAXRSContractTestSupport<E> {
   @Test
   void emptyFormParam() throws Exception {
     Throwable exception =
-        assertThrows(
-            IllegalStateException.class,
-            () -> parseAndValidateMetadata(formParamsClass(), "emptyFormParam", String.class));
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(
+                () -> parseAndValidateMetadata(formParamsClass(), "emptyFormParam", String.class))
+            .actual();
     assertThat(exception.getMessage()).contains("FormParam.value() was empty on parameter 0");
   }
 
@@ -351,9 +357,11 @@ public abstract class JAXRSContractTestSupport<E> {
   @Test
   void emptyHeaderParam() throws Exception {
     Throwable exception =
-        assertThrows(
-            IllegalStateException.class,
-            () -> parseAndValidateMetadata(headerParamsClass(), "emptyHeaderParam", String.class));
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(
+                () ->
+                    parseAndValidateMetadata(headerParamsClass(), "emptyHeaderParam", String.class))
+            .actual();
     assertThat(exception.getMessage()).contains("HeaderParam.value() was empty on parameter 0");
   }
 

--- a/jaxrs2/pom.xml
+++ b/jaxrs2/pom.xml
@@ -103,7 +103,7 @@
 
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>mockwebserver</artifactId>
+      <artifactId>mockwebserver3</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/jaxrs2/src/test/java/feign/jaxrs2/AbstractJAXRSClientTest.java
+++ b/jaxrs2/src/test/java/feign/jaxrs2/AbstractJAXRSClientTest.java
@@ -28,7 +28,7 @@ import feign.client.AbstractClientTest;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Collections;
-import okhttp3.mockwebserver.MockResponse;
+import mockwebserver3.MockResponse;
 import org.assertj.core.data.MapEntry;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test;
 public abstract class AbstractJAXRSClientTest extends AbstractClientTest {
 
   @Override
+  @Test
   public void patch() throws Exception {
     try {
       super.patch();
@@ -45,6 +46,7 @@ public abstract class AbstractJAXRSClientTest extends AbstractClientTest {
   }
 
   @Override
+  @Test
   public void noResponseBodyForPut() throws Exception {
     try {
       super.noResponseBodyForPut();
@@ -54,6 +56,7 @@ public abstract class AbstractJAXRSClientTest extends AbstractClientTest {
   }
 
   @Override
+  @Test
   public void noResponseBodyForPatch() {
     try {
       super.noResponseBodyForPatch();
@@ -65,7 +68,7 @@ public abstract class AbstractJAXRSClientTest extends AbstractClientTest {
   @Override
   @Test
   public void reasonPhraseIsOptional() throws IOException, InterruptedException {
-    server.enqueue(new MockResponse().setStatus("HTTP/1.1 " + 200));
+    server.enqueue(new MockResponse.Builder().status("HTTP/1.1 " + 200).build());
 
     final TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -80,7 +83,7 @@ public abstract class AbstractJAXRSClientTest extends AbstractClientTest {
   @Override
   @Test
   public void parsesRequestAndResponse() throws IOException, InterruptedException {
-    server.enqueue(new MockResponse().setBody("foo").addHeader("Foo: Bar"));
+    server.enqueue(new MockResponse.Builder().body("foo").addHeader("Foo: Bar").build());
 
     final TestInterface api =
         newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
@@ -112,7 +115,7 @@ public abstract class AbstractJAXRSClientTest extends AbstractClientTest {
 
   @Test
   void contentTypeWithoutCharset2() throws Exception {
-    server.enqueue(new MockResponse().setBody("AAAAAAAA"));
+    server.enqueue(new MockResponse.Builder().body("AAAAAAAA").build());
     final JaxRSClientTestInterface api =
         newBuilder().target(JaxRSClientTestInterface.class, "http://localhost:" + server.getPort());
 
@@ -131,26 +134,31 @@ public abstract class AbstractJAXRSClientTest extends AbstractClientTest {
    * JaxRS does not support gzip and deflate compression out-of-the-box.
    */
   @Override
+  @Test
   public void canSupportGzip() throws Exception {
     assumeFalse(false, "JaxRS client do not support gzip compression");
   }
 
   @Override
+  @Test
   public void canSupportGzipOnError() throws Exception {
     assumeFalse(false, "JaxRS client do not support gzip compression");
   }
 
   @Override
+  @Test
   public void canSupportDeflate() throws Exception {
     assumeFalse(false, "JaxRS client do not support deflate compression");
   }
 
   @Override
+  @Test
   public void canSupportDeflateOnError() throws Exception {
     assumeFalse(false, "JaxRS client do not support deflate compression");
   }
 
   @Override
+  @Test
   public void canExceptCaseInsensitiveHeader() throws Exception {
     assumeFalse(false, "JaxRS client do not support gzip compression");
   }
@@ -163,6 +171,7 @@ public abstract class AbstractJAXRSClientTest extends AbstractClientTest {
   }
 
   @Override
+  @Test
   public void veryLongResponseNullLength() {
     assumeFalse(false, "JaxRS client hang if the response doesn't have a payload");
   }

--- a/jaxrs2/src/test/java/feign/jaxrs2/JAXRS2ContractWithBeanParamSupportTest.java
+++ b/jaxrs2/src/test/java/feign/jaxrs2/JAXRS2ContractWithBeanParamSupportTest.java
@@ -66,7 +66,7 @@ class JAXRS2ContractWithBeanParamSupportTest extends JAXRSContractTest {
     assertThat(methodMetadata.template())
         .hasHeaders(entry("X-Custom-Header", asList("{X-Custom-Header}")));
     assertThat(methodMetadata.template()).hasQueries(entry("query", asList("{query}")));
-    assertThat(methodMetadata.formParams()).isNotEmpty().containsExactly("form");
+    assertThat(methodMetadata.formParams()).containsExactly("form");
   }
 
   public interface Jaxrs2Internals {

--- a/jaxrs2/src/test/java/feign/jaxrs2/JAXRSClientTest.java
+++ b/jaxrs2/src/test/java/feign/jaxrs2/JAXRSClientTest.java
@@ -29,7 +29,7 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import okhttp3.mockwebserver.MockResponse;
+import mockwebserver3.MockResponse;
 import org.assertj.core.data.MapEntry;
 import org.junit.jupiter.api.Test;
 
@@ -43,7 +43,7 @@ public class JAXRSClientTest extends AbstractJAXRSClientTest {
 
   @Test
   void consumesMultipleWithContentTypeHeaderAndBody() throws Exception {
-    server.enqueue(new MockResponse().setBody("AAAAAAAA"));
+    server.enqueue(new MockResponse.Builder().body("AAAAAAAA").build());
     final JaxRSClientTestInterfaceWithJaxRsContract api =
         newBuilder()
             .contract(new JAXRSContract()) // use JAXRSContract

--- a/jaxrs3/pom.xml
+++ b/jaxrs3/pom.xml
@@ -89,7 +89,7 @@
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>mockwebserver</artifactId>
+      <artifactId>mockwebserver3</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/jaxrs3/src/test/java/feign/jaxrs/JAXRS3ContractTest.java
+++ b/jaxrs3/src/test/java/feign/jaxrs/JAXRS3ContractTest.java
@@ -73,7 +73,7 @@ class JAXRS3ContractTest extends JAXRSContractTestSupport<JAXRS3Contract> {
     assertThat(methodMetadata.template())
         .hasHeaders(entry("X-Custom-Header", asList("{X-Custom-Header}")));
     assertThat(methodMetadata.template()).hasQueries(entry("query", asList("{query}")));
-    assertThat(methodMetadata.formParams()).isNotEmpty().containsExactly("form");
+    assertThat(methodMetadata.formParams()).containsExactly("form");
   }
 
   public interface JakartaInternals {

--- a/jaxrs4/pom.xml
+++ b/jaxrs4/pom.xml
@@ -83,7 +83,7 @@
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>mockwebserver</artifactId>
+      <artifactId>mockwebserver3</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/jaxrs4/src/test/java/feign/jaxrs/JAXRS4ContractTest.java
+++ b/jaxrs4/src/test/java/feign/jaxrs/JAXRS4ContractTest.java
@@ -73,7 +73,7 @@ class JAXRS4ContractTest extends JAXRSContractTestSupport<JAXRS3Contract> {
     assertThat(methodMetadata.template())
         .hasHeaders(entry("X-Custom-Header", asList("{X-Custom-Header}")));
     assertThat(methodMetadata.template()).hasQueries(entry("query", asList("{query}")));
-    assertThat(methodMetadata.formParams()).isNotEmpty().containsExactly("form");
+    assertThat(methodMetadata.formParams()).containsExactly("form");
   }
 
   public interface JakartaInternals {

--- a/json/src/test/java/feign/json/JsonCodecTest.java
+++ b/json/src/test/java/feign/json/JsonCodecTest.java
@@ -17,7 +17,6 @@ package feign.json;
 
 import static feign.Util.toByteArray;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import feign.Feign;
 import feign.Param;
@@ -61,7 +60,7 @@ class JsonCodecTest {
   }
 
   @Test
-  void decodes() throws IOException {
+  void decodes() throws Exception {
     try (InputStream input = getClass().getResourceAsStream("/fixtures/contributors.json")) {
       byte[] response = toByteArray(input);
       mockClient.ok(HttpMethod.GET, "/repos/openfeign/feign/contributors", response);
@@ -83,11 +82,14 @@ class JsonCodecTest {
     JSONObject response = github.create("openfeign", "feign", contributor);
     Request request = mockClient.verifyOne(HttpMethod.POST, "/repos/openfeign/feign/contributors");
     assertThat(request.body()).isPresent();
-    String json =
-        assertDoesNotThrow(() -> request.body().get().writeToString(StandardCharsets.UTF_8));
-    assertThat(json).contains("\"login\":\"radio-rogal\"");
-    assertThat(json).contains("\"contributions\":0");
+    String json;
+    try {
+      json = request.body().get().writeToString(StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new AssertionError("Failed to write body", e);
+    }
+    assertThat(json).contains("\"login\":\"radio-rogal\"").contains("\"contributions\":0");
     assertThat(response.getString("login")).isEqualTo("radio-rogal");
-    assertThat(response.getInt("contributions")).isEqualTo(0);
+    assertThat(response.getInt("contributions")).isZero();
   }
 }

--- a/json/src/test/java/feign/json/JsonDecoderTest.java
+++ b/json/src/test/java/feign/json/JsonDecoderTest.java
@@ -17,7 +17,7 @@ package feign.json;
 
 import static feign.Util.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -58,7 +58,7 @@ class JsonDecoderTest {
   }
 
   @Test
-  void decodesArray() throws IOException {
+  void decodesArray() throws Exception {
     String json = "[{\"a\":\"b\",\"c\":1},123]";
     Response response =
         Response.builder()
@@ -72,7 +72,7 @@ class JsonDecoderTest {
   }
 
   @Test
-  void decodesObject() throws IOException {
+  void decodesObject() throws Exception {
     String json = "{\"a\":\"b\",\"c\":1}";
     Response response =
         Response.builder()
@@ -86,7 +86,7 @@ class JsonDecoderTest {
   }
 
   @Test
-  void decodesString() throws IOException {
+  void decodesString() throws Exception {
     String json = "qwerty";
     Response response =
         Response.builder()
@@ -100,7 +100,7 @@ class JsonDecoderTest {
   }
 
   @Test
-  void notFoundDecodesToEmpty() throws IOException {
+  void notFoundDecodesToEmpty() throws Exception {
     Response response =
         Response.builder()
             .status(404)
@@ -113,7 +113,7 @@ class JsonDecoderTest {
   }
 
   @Test
-  void nullBodyDecodesToEmpty() throws IOException {
+  void nullBodyDecodesToEmpty() throws Exception {
     Response response =
         Response.builder()
             .status(204)
@@ -126,7 +126,7 @@ class JsonDecoderTest {
   }
 
   @Test
-  void nullBodyDecodesToNullString() throws IOException {
+  void nullBodyDecodesToNullString() throws Exception {
     Response response =
         Response.builder()
             .status(204)
@@ -138,7 +138,7 @@ class JsonDecoderTest {
   }
 
   @Test
-  void emptyBodyDecodesToEmpty() throws IOException {
+  void emptyBodyDecodesToEmpty() throws Exception {
     Response response =
         Response.builder()
             .status(204)
@@ -152,7 +152,7 @@ class JsonDecoderTest {
   }
 
   @Test
-  void unknownTypeThrowsDecodeException() throws IOException {
+  void unknownTypeThrowsDecodeException() throws Exception {
     String json = "[{\"a\":\"b\",\"c\":1},123]";
     Response response =
         Response.builder()
@@ -163,13 +163,15 @@ class JsonDecoderTest {
             .request(request)
             .build();
     Exception exception =
-        assertThrows(DecodeException.class, () -> new JsonDecoder().decode(response, Clock.class));
+        assertThatExceptionOfType(DecodeException.class)
+            .isThrownBy(() -> new JsonDecoder().decode(response, Clock.class))
+            .actual();
     assertThat(exception.getMessage())
         .isEqualTo("class java.time.Clock is not a type supported by this decoder.");
   }
 
   @Test
-  void badJsonThrowsWrappedJSONException() throws IOException {
+  void badJsonThrowsWrappedJSONException() throws Exception {
     String json = "{\"a\":\"b\",\"c\":1}";
     Response response =
         Response.builder()
@@ -180,15 +182,16 @@ class JsonDecoderTest {
             .request(request)
             .build();
     Exception exception =
-        assertThrows(
-            DecodeException.class, () -> new JsonDecoder().decode(response, JSONArray.class));
+        assertThatExceptionOfType(DecodeException.class)
+            .isThrownBy(() -> new JsonDecoder().decode(response, JSONArray.class))
+            .actual();
     assertThat(exception.getMessage())
         .isEqualTo("A JSONArray text must start with '[' at 1 [character 2 line 1]");
     assertThat(exception.getCause() instanceof JSONException).isTrue();
   }
 
   @Test
-  void causedByCommonException() throws IOException {
+  void causedByCommonException() throws Exception {
     Response.Body body = mock(Response.Body.class);
     when(body.asReader(any()))
         .thenThrow(new JSONException("test exception", new Exception("test cause exception")));
@@ -201,13 +204,14 @@ class JsonDecoderTest {
             .request(request)
             .build();
     Exception exception =
-        assertThrows(
-            DecodeException.class, () -> new JsonDecoder().decode(response, JSONArray.class));
+        assertThatExceptionOfType(DecodeException.class)
+            .isThrownBy(() -> new JsonDecoder().decode(response, JSONArray.class))
+            .actual();
     assertThat(exception.getMessage()).isEqualTo("test exception");
   }
 
   @Test
-  void causedByIOException() throws IOException {
+  void causedByIOException() throws Exception {
     Response.Body body = mock(Response.Body.class);
     when(body.asReader(any()))
         .thenThrow(new JSONException("test exception", new IOException("test cause exception")));
@@ -220,12 +224,14 @@ class JsonDecoderTest {
             .request(request)
             .build();
     Exception exception =
-        assertThrows(IOException.class, () -> new JsonDecoder().decode(response, JSONArray.class));
+        assertThatExceptionOfType(IOException.class)
+            .isThrownBy(() -> new JsonDecoder().decode(response, JSONArray.class))
+            .actual();
     assertThat(exception.getMessage()).isEqualTo("test cause exception");
   }
 
   @Test
-  void checkedException() throws IOException {
+  void checkedException() throws Exception {
     Response.Body body = mock(Response.Body.class);
     when(body.asReader(any())).thenThrow(new IOException("test exception"));
     Response response =
@@ -237,12 +243,14 @@ class JsonDecoderTest {
             .request(request)
             .build();
     Exception exception =
-        assertThrows(IOException.class, () -> new JsonDecoder().decode(response, JSONArray.class));
+        assertThatExceptionOfType(IOException.class)
+            .isThrownBy(() -> new JsonDecoder().decode(response, JSONArray.class))
+            .actual();
     assertThat(exception.getMessage()).isEqualTo("test exception");
   }
 
   @Test
-  void decodesExtendedArray() throws IOException {
+  void decodesExtendedArray() throws Exception {
     String json = "[{\"a\":\"b\",\"c\":1},123]";
     Response response =
         Response.builder()
@@ -257,7 +265,7 @@ class JsonDecoderTest {
   }
 
   @Test
-  void decodeExtendedObject() throws IOException {
+  void decodeExtendedObject() throws Exception {
     String json = "{\"a\":\"b\",\"c\":1}";
     Response response =
         Response.builder()

--- a/json/src/test/java/feign/json/JsonEncoderTest.java
+++ b/json/src/test/java/feign/json/JsonEncoderTest.java
@@ -15,13 +15,12 @@
  */
 package feign.json;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.*;
 
 import feign.Request;
 import feign.RequestTemplate;
 import feign.codec.EncodeException;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import org.json.JSONArray;
@@ -74,14 +73,19 @@ class JsonEncoderTest {
   @Test
   void unknownTypeThrowsEncodeException() {
     Exception exception =
-        assertThrows(
-            EncodeException.class,
-            () -> new JsonEncoder().encode("qwerty", Clock.class, new RequestTemplate()));
+        assertThatExceptionOfType(EncodeException.class)
+            .isThrownBy(
+                () -> new JsonEncoder().encode("qwerty", Clock.class, new RequestTemplate()))
+            .actual();
     assertThat(exception.getMessage())
         .isEqualTo("class java.time.Clock is not a type supported by this encoder.");
   }
 
   private String bodyAsUtf8String(Request.Body body) {
-    return assertDoesNotThrow(() -> body.writeToString(StandardCharsets.UTF_8));
+    try {
+      return body.writeToString(StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new AssertionError("Failed to write body", e);
+    }
   }
 }

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -66,7 +66,7 @@
 
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>mockwebserver</artifactId>
+      <artifactId>mockwebserver3</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/kotlin/src/test/kotlin/feign/kotlin/CoroutineFeignTest.kt
+++ b/kotlin/src/test/kotlin/feign/kotlin/CoroutineFeignTest.kt
@@ -29,10 +29,11 @@ import feign.codec.Encoder
 import feign.codec.ErrorDecoder
 import feign.core.codec.DefaultDecoder
 import kotlinx.coroutines.runBlocking
-import okhttp3.mockwebserver.MockResponse
-import okhttp3.mockwebserver.MockWebServer
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
+
 import java.io.IOException
 import java.lang.reflect.Type
 import java.util.concurrent.atomic.AtomicBoolean
@@ -42,8 +43,10 @@ class CoroutineFeignTest {
     fun `sut should run correctly when response is basic type`(): Unit = runBlocking {
         // Arrange
         val server = MockWebServer()
+        server.start()
         val expected = "Hello Worlda"
-        server.enqueue(MockResponse().setBody(expected))
+        server.enqueue(MockResponse.Builder().body(expected)
+            .build())
         val client = TestInterfaceAsyncBuilder()
             .target("http://localhost:" + server.port)
 
@@ -58,11 +61,13 @@ class CoroutineFeignTest {
     fun `sut should run correctly when response is complex type`(): Unit = runBlocking {
         // Arrange
         val server = MockWebServer()
+        server.start()
         val expected = IceCreamOrder(
             id = "HELLO WORLD",
             no = 999,
         )
-        server.enqueue(MockResponse().setBody("{ id: '${expected.id}', no: '${expected.no}'}"))
+        server.enqueue(MockResponse.Builder().body("{ id: '${expected.id}', no: '${expected.no}'}")
+            .build())
 
         val client = TestInterfaceAsyncBuilder()
             .decoder(GsonDecoder())
@@ -79,7 +84,9 @@ class CoroutineFeignTest {
     fun `sut should run correctly when empty response is represented by java_lang_Void`(): Unit = runBlocking {
         // Arrange
         val server = MockWebServer()
-        server.enqueue(MockResponse().setBody("HELLO WORLD"))
+        server.start()
+        server.enqueue(MockResponse.Builder().body("HELLO WORLD")
+            .build())
 
         val client = TestInterfaceAsyncBuilder()
             .target("http://localhost:" + server.port)
@@ -95,23 +102,27 @@ class CoroutineFeignTest {
     fun `sut should run correctly when empty response is represented by kotlin_Unit`(): Unit = runBlocking {
         // Arrange
         val server = MockWebServer()
-        server.enqueue(MockResponse().setBody("HELLO WORLD"))
+        server.start()
+        server.enqueue(MockResponse.Builder().body("HELLO WORLD")
+            .build())
 
         val client = TestInterfaceAsyncBuilder()
             .target("http://localhost:" + server.port)
 
         // Act
-        val firstOrder: Unit = client.findOrderThatReturningUnit(orderId = 1)
+        val firstOrder: Unit? = client.findOrderThatReturningUnit(orderId = 1)
 
         // Assert
-        assertThat(firstOrder).isEqualTo(Unit)
+        assertThat(firstOrder).isNull()
     }
 
     @Test
     fun `sut should dismiss 404 responses when dismiss404 is configured on CoroutineBuilder`(): Unit = runBlocking {
         // Arrange: server returns 404; a custom decoder records whether it was invoked
         val server = MockWebServer()
-        server.enqueue(MockResponse().setResponseCode(404))
+        server.start()
+        server.enqueue(MockResponse.Builder().code(404)
+            .build())
 
         val decoderInvokedFor404 = AtomicBoolean(false)
         val recordingDecoder = Decoder { response, _ ->
@@ -136,7 +147,9 @@ class CoroutineFeignTest {
     fun `sut should run correctly when using http body`(): Unit = runBlocking {
         // Arrange
         val server = MockWebServer()
-        server.enqueue(MockResponse().setBody("HELLO WORLD"))
+        server.start()
+        server.enqueue(MockResponse.Builder().body("HELLO WORLD")
+            .build())
 
         val client = TestInterfaceAsyncBuilder()
             .target("http://localhost:" + server.port)
@@ -150,7 +163,7 @@ class CoroutineFeignTest {
         )
 
         // Assert
-        assertThat(firstOrder).isEqualTo(Unit)
+        assertThat(firstOrder).isNull()
     }
 
     internal class GsonDecoder : Decoder {

--- a/micrometer/src/test/java/feign/micrometer/AbstractMetricsTestBase.java
+++ b/micrometer/src/test/java/feign/micrometer/AbstractMetricsTestBase.java
@@ -15,10 +15,7 @@
  */
 package feign.micrometer;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.*;
 
 import feign.AsyncFeign;
 import feign.Capability;
@@ -128,7 +125,7 @@ public abstract class AbstractMetricsTestBase<MR, METRIC_ID, METRIC> {
     assertThat(clientMetrics).hasSize(2);
     clientMetrics.values().stream()
         .filter(this::doesMetricHasCounter)
-        .forEach(metric -> assertEquals(1, getMetricCounter(metric)));
+        .forEach(metric -> assertThat(getMetricCounter(metric)).isOne());
 
     final Map<METRIC_ID, METRIC> decoderMetrics =
         getFeignMetrics().entrySet().stream()
@@ -138,7 +135,7 @@ public abstract class AbstractMetricsTestBase<MR, METRIC_ID, METRIC> {
     assertThat(decoderMetrics).hasSize(2);
     decoderMetrics.values().stream()
         .filter(this::doesMetricHasCounter)
-        .forEach(metric -> assertEquals(1, getMetricCounter(metric)));
+        .forEach(metric -> assertThat(getMetricCounter(metric)).isOne());
   }
 
   protected abstract boolean doesMetricIncludeHost(METRIC_ID metricId);
@@ -205,7 +202,9 @@ public abstract class AbstractMetricsTestBase<MR, METRIC_ID, METRIC> {
             .target(new MockTarget<>(MicrometerCapabilityTest.SimpleSource.class));
 
     FeignException.NotFound thrown =
-        assertThrows(FeignException.NotFound.class, () -> source.get("0x3456789"));
+        assertThatExceptionOfType(FeignException.NotFound.class)
+            .isThrownBy(() -> source.get("0x3456789"))
+            .actual();
     assertThat(thrown).isSameAs(notFound.get());
   }
 
@@ -221,7 +220,10 @@ public abstract class AbstractMetricsTestBase<MR, METRIC_ID, METRIC> {
                     .addCapability(createMetricCapability()))
             .target(new MockTarget<>(MicrometerCapabilityTest.SimpleSource.class));
 
-    RuntimeException thrown = assertThrows(RuntimeException.class, () -> source.get("0x3456789"));
+    RuntimeException thrown =
+        assertThatExceptionOfType(RuntimeException.class)
+            .isThrownBy(() -> source.get("0x3456789"))
+            .actual();
     assertThat(thrown.getMessage()).isEqualTo("Test error");
 
     assertThat(
@@ -313,7 +315,9 @@ public abstract class AbstractMetricsTestBase<MR, METRIC_ID, METRIC> {
             .target(new MockTarget<>(MicrometerCapabilityTest.SourceWithPathExpressions.class));
 
     FeignException.NotFound thrown =
-        assertThrows(FeignException.NotFound.class, () -> source.get("123", "0x3456789"));
+        assertThatExceptionOfType(FeignException.NotFound.class)
+            .isThrownBy(() -> source.get("123", "0x3456789"))
+            .actual();
     assertThat(thrown).isSameAs(notFound.get());
 
     final Map<METRIC_ID, METRIC> decoderMetrics =

--- a/micrometer/src/test/java/feign/micrometer/FeignHeaderInstrumentationTest.java
+++ b/micrometer/src/test/java/feign/micrometer/FeignHeaderInstrumentationTest.java
@@ -43,7 +43,6 @@ import io.micrometer.observation.ObservationHandler;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.transport.RequestReplySenderContext;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import okhttp3.OkHttpClient;
 import org.junit.jupiter.api.BeforeEach;
@@ -75,15 +74,14 @@ class FeignHeaderInstrumentationTest {
 
     verify(getRequestedFor(urlEqualTo("/customers/1/carts/2")).withHeader("foo", equalTo("bar")));
     Timer timer = meterRegistry.get(METER_NAME).timer();
-    assertThat(timer.count()).isEqualTo(1);
+    assertThat(timer.count()).isOne();
     assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isPositive();
 
     assertTags();
   }
 
   @Test
-  void getTemplatedPathForUriForAsync(WireMockRuntimeInfo wmRuntimeInfo)
-      throws ExecutionException, InterruptedException {
+  void getTemplatedPathForUriForAsync(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
     stubFor(get(anyUrl()).willReturn(ok()));
 
     AsyncTestClient testClient =
@@ -92,7 +90,7 @@ class FeignHeaderInstrumentationTest {
 
     verify(getRequestedFor(urlEqualTo("/customers/1/carts/2")).withHeader("foo", equalTo("bar")));
     Timer timer = meterRegistry.get(METER_NAME).timer();
-    assertThat(timer.count()).isEqualTo(1);
+    assertThat(timer.count()).isOne();
     assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isPositive();
 
     assertTags();

--- a/mock/src/test/java/feign/mock/HttpProtocolVersionTest.java
+++ b/mock/src/test/java/feign/mock/HttpProtocolVersionTest.java
@@ -40,6 +40,6 @@ class HttpProtocolVersionTest {
     Response response = remote.test();
 
     assertThat(response.protocolVersion()).isNotNull();
-    assertThat(response.protocolVersion().toString()).isEqualTo("MOCK");
+    assertThat(response.protocolVersion()).hasToString("MOCK");
   }
 }

--- a/mock/src/test/java/feign/mock/MockClientTest.java
+++ b/mock/src/test/java/feign/mock/MockClientTest.java
@@ -16,9 +16,7 @@
 package feign.mock;
 
 import static feign.Util.toByteArray;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.assertj.core.api.Assertions.*;
 
 import feign.Body;
 import feign.Feign;
@@ -180,7 +178,7 @@ class MockClientTest {
     // making sure it received a proper response
     assertThat(contribution).isNotNull();
     assertThat(contribution.login).isEqualTo("velo");
-    assertThat(contribution.contributions).isEqualTo(0);
+    assertThat(contribution.contributions).isZero();
 
     List<Request> results =
         mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 1);
@@ -190,9 +188,13 @@ class MockClientTest {
         mockClient.verifyOne(HttpMethod.POST, "/repos/netflix/feign/contributors").body();
     assertThat(body).isPresent();
 
-    String message = assertDoesNotThrow(() -> body.get().writeToString(StandardCharsets.UTF_8));
-    assertThat(message).contains("velo_at_github");
-    assertThat(message).contains("preposterous hacker");
+    String message;
+    try {
+      message = body.get().writeToString(StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new AssertionError("Failed to write body", e);
+    }
+    assertThat(message).contains("velo_at_github").contains("preposterous hacker");
 
     mockClient.verifyStatus();
   }
@@ -270,7 +272,7 @@ class MockClientTest {
     mockClient.verifyNever(HttpMethod.POST, "/repos/netflix/feign/contributors");
     List<Request> results =
         mockClient.verifyTimes(HttpMethod.POST, "/repos/netflix/feign/contributors", 0);
-    assertThat(results).hasSize(0);
+    assertThat(results).isEmpty();
     try {
       mockClient.verifyOne(HttpMethod.POST, "/repos/netflix/feign/contributors");
       fail("");

--- a/mock/src/test/java/feign/mock/RequestHeadersTest.java
+++ b/mock/src/test/java/feign/mock/RequestHeadersTest.java
@@ -28,13 +28,13 @@ class RequestHeadersTest {
   @Test
   void shouldCreateEmptyRequestHeaders() {
     RequestHeaders headers = RequestHeaders.builder().build();
-    assertThat(headers.size()).isEqualTo(0);
+    assertThat(headers.size()).isZero();
   }
 
   @Test
   void shouldReturnZeroSizeForUnknownKey() {
     RequestHeaders headers = RequestHeaders.builder().build();
-    assertThat(headers.sizeOf("unknown")).isEqualTo(0);
+    assertThat(headers.sizeOf("unknown")).isZero();
   }
 
   @Test
@@ -43,9 +43,9 @@ class RequestHeadersTest {
         RequestHeaders.builder().add("header", "val").add("other header", "val2").build();
 
     assertThat(headers.fetch("header")).contains("val");
-    assertThat(headers.sizeOf("header")).isEqualTo(1);
+    assertThat(headers.sizeOf("header")).isOne();
     assertThat(headers.fetch("other header")).contains("val2");
-    assertThat(headers.sizeOf("other header")).isEqualTo(1);
+    assertThat(headers.sizeOf("other header")).isOne();
   }
 
   @Test
@@ -60,7 +60,7 @@ class RequestHeadersTest {
     assertThat(headers.fetch("header")).contains("val", "val3", "val4");
     assertThat(headers.sizeOf("header")).isEqualTo(3);
     assertThat(headers.fetch("other header")).contains("val2");
-    assertThat(headers.sizeOf("other header")).isEqualTo(1);
+    assertThat(headers.sizeOf("other header")).isOne();
   }
 
   @Test
@@ -68,7 +68,7 @@ class RequestHeadersTest {
     Map<String, Collection<String>> map = new HashMap<>();
     map.put("header", Arrays.asList("val", "val2"));
     RequestHeaders headers = RequestHeaders.of(map);
-    assertThat(headers.size()).isEqualTo(1);
+    assertThat(headers.size()).isOne();
   }
 
   @Test
@@ -79,6 +79,6 @@ class RequestHeadersTest {
             .add("other header", "val2")
             .add("header", Arrays.asList("val3", "val4"))
             .build();
-    assertThat(headers.toString()).isEqualTo("header=[val, val3, val4], other header=[val2]");
+    assertThat(headers).hasToString("header=[val, val3, val4], other header=[val2]");
   }
 }

--- a/mock/src/test/java/feign/mock/RequestKeyTest.java
+++ b/mock/src/test/java/feign/mock/RequestKeyTest.java
@@ -39,7 +39,7 @@ class RequestKeyTest {
   void builder() throws Exception {
     assertThat(requestKey.getMethod()).isEqualTo(HttpMethod.GET);
     assertThat(requestKey.getUrl()).isEqualTo("a");
-    assertThat(requestKey.getHeaders().size()).isEqualTo(1);
+    assertThat(requestKey.getHeaders().size()).isOne();
     assertThat(requestKey.getHeaders().fetch("my-header")).isEqualTo(Arrays.asList("val"));
   }
 
@@ -54,7 +54,7 @@ class RequestKeyTest {
 
     assertThat(requestKey.getMethod()).isEqualTo(HttpMethod.GET);
     assertThat(requestKey.getUrl()).isEqualTo("a");
-    assertThat(requestKey.getHeaders().size()).isEqualTo(1);
+    assertThat(requestKey.getHeaders().size()).isOne();
     assertThat(requestKey.getHeaders().fetch("my-header")).isEqualTo(Arrays.asList("val"));
   }
 
@@ -88,16 +88,14 @@ class RequestKeyTest {
 
   @Test
   void equalSelf() {
-    assertThat(requestKey.hashCode()).isEqualTo(requestKey.hashCode());
-    assertThat(requestKey).isEqualTo(requestKey);
+    assertThat(requestKey).hasSameHashCodeAs(requestKey).isEqualTo(requestKey);
   }
 
   @Test
   void equalMinimum() {
     RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").build();
 
-    assertThat(requestKey.hashCode()).isEqualTo(requestKey2.hashCode());
-    assertThat(requestKey).isEqualTo(requestKey2);
+    assertThat(requestKey).hasSameHashCodeAs(requestKey2).isEqualTo(requestKey2);
   }
 
   @Test
@@ -105,16 +103,15 @@ class RequestKeyTest {
     RequestHeaders headers = RequestHeaders.builder().add("my-other-header", "other value").build();
     RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").headers(headers).build();
 
-    assertThat(requestKey.hashCode()).isEqualTo(requestKey2.hashCode());
-    assertThat(requestKey).isEqualTo(requestKey2);
+    assertThat(requestKey).hasSameHashCodeAs(requestKey2).isEqualTo(requestKey2);
   }
 
   @Test
   void equalsExtended() {
     RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").build();
 
-    assertThat(requestKey.hashCode()).isEqualTo(requestKey2.hashCode());
-    assertThat(requestKey.equalsExtended(requestKey2)).isEqualTo(true);
+    assertThat(requestKey).hasSameHashCodeAs(requestKey2);
+    assertThat(requestKey.equalsExtended(requestKey2)).isTrue();
   }
 
   @Test
@@ -122,8 +119,8 @@ class RequestKeyTest {
     RequestHeaders headers = RequestHeaders.builder().add("my-other-header", "other value").build();
     RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").headers(headers).build();
 
-    assertThat(requestKey.hashCode()).isEqualTo(requestKey2.hashCode());
-    assertThat(requestKey.equalsExtended(requestKey2)).isEqualTo(false);
+    assertThat(requestKey).hasSameHashCodeAs(requestKey2);
+    assertThat(requestKey.equalsExtended(requestKey2)).isFalse();
   }
 
   @Test

--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -59,7 +59,7 @@
 
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>mockwebserver</artifactId>
+      <artifactId>mockwebserver3</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/okhttp/src/test/java/feign/okhttp/OkHttpClientAsyncTest.java
+++ b/okhttp/src/test/java/feign/okhttp/OkHttpClientAsyncTest.java
@@ -16,11 +16,8 @@
 package feign.okhttp;
 
 import static feign.assertj.MockWebServerAssertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.data.MapEntry.entry;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -80,10 +77,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import okio.Buffer;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class OkHttpClientAsyncTest {
@@ -91,7 +90,7 @@ public class OkHttpClientAsyncTest {
 
   @Test
   void iterableQueryParams() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
@@ -102,7 +101,7 @@ public class OkHttpClientAsyncTest {
 
   @Test
   void postTemplateParamsResolve() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
@@ -116,7 +115,7 @@ public class OkHttpClientAsyncTest {
 
   @Test
   void responseCoercesToStringBody() throws Throwable {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
@@ -127,7 +126,7 @@ public class OkHttpClientAsyncTest {
 
   @Test
   void postFormParams() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
@@ -142,7 +141,7 @@ public class OkHttpClientAsyncTest {
 
   @Test
   void postBodyParam() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
@@ -161,7 +160,7 @@ public class OkHttpClientAsyncTest {
    */
   @Test
   void bodyTypeCorrespondsWithParameterType() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final AtomicReference<Type> encodedType = new AtomicReference<>();
     final TestInterfaceAsync api =
@@ -186,7 +185,7 @@ public class OkHttpClientAsyncTest {
 
   @Test
   void singleInterceptor() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final TestInterfaceAsync api =
         newAsyncBuilder()
@@ -203,7 +202,7 @@ public class OkHttpClientAsyncTest {
 
   @Test
   void multipleInterceptor() throws Exception {
-    server.enqueue(new MockResponse().setBody("foo"));
+    server.enqueue(new MockResponse.Builder().body("foo").build());
 
     final TestInterfaceAsync api =
         newAsyncBuilder()
@@ -223,7 +222,7 @@ public class OkHttpClientAsyncTest {
 
   @Test
   void customExpander() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
@@ -236,7 +235,7 @@ public class OkHttpClientAsyncTest {
 
   @Test
   void customExpanderListParam() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
@@ -250,7 +249,7 @@ public class OkHttpClientAsyncTest {
 
   @Test
   void customExpanderNullParam() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
@@ -263,7 +262,7 @@ public class OkHttpClientAsyncTest {
 
   @Test
   void headerMap() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
@@ -282,7 +281,7 @@ public class OkHttpClientAsyncTest {
 
   @Test
   void headerMapWithHeaderAnnotations() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
@@ -296,7 +295,7 @@ public class OkHttpClientAsyncTest {
             entry("Content-Encoding", Arrays.asList("deflate")),
             entry("Custom-Header", Arrays.asList("fooValue")));
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     headerMap.put("Content-Encoding", "overrideFromMap");
 
     final CompletableFuture<?> cf = api.headerMapWithHeaderAnnotations(headerMap);
@@ -315,7 +314,7 @@ public class OkHttpClientAsyncTest {
 
   @Test
   void queryMap() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
@@ -331,7 +330,7 @@ public class OkHttpClientAsyncTest {
 
   @Test
   void queryMapIterableValuesExpanded() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
@@ -352,21 +351,21 @@ public class OkHttpClientAsyncTest {
   void queryMapWithQueryParams() throws Exception {
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     Map<String, Object> queryMap = new LinkedHashMap<>();
     queryMap.put("fooKey", "fooValue");
     api.queryMapWithQueryParams("alice", queryMap);
     // query map should be expanded after built-in parameters
     assertThat(server.takeRequest()).hasPath("/?name=alice&fooKey=fooValue");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("name", "bob");
     api.queryMapWithQueryParams("alice", queryMap);
     // queries are additive
     assertThat(server.takeRequest()).hasPath("/?name=alice&name=bob");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("name", null);
     api.queryMapWithQueryParams("alice", queryMap);
@@ -378,25 +377,25 @@ public class OkHttpClientAsyncTest {
   void queryMapValueStartingWithBrace() throws Exception {
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     Map<String, Object> queryMap = new LinkedHashMap<>();
     queryMap.put("name", "{alice");
     api.queryMap(queryMap);
     assertThat(server.takeRequest()).hasPath("/?name=%7Balice");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("{name", "alice");
     api.queryMap(queryMap);
     assertThat(server.takeRequest()).hasPath("/?%7Bname=alice");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("name", "%7Balice");
     api.queryMapEncoded(queryMap);
     assertThat(server.takeRequest()).hasPath("/?name=%7Balice");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     queryMap = new LinkedHashMap<>();
     queryMap.put("%7Bname", "%7Balice");
     api.queryMapEncoded(queryMap);
@@ -409,7 +408,7 @@ public class OkHttpClientAsyncTest {
 
     final CustomPojo customPojo = new CustomPojo("Name", 3);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     final CompletableFuture<?> cf = api.queryMapPojo(customPojo);
     assertThat(server.takeRequest()).hasQueryParams(Arrays.asList("name=Name", "number=3"));
     checkCFCompletedSoon(cf);
@@ -421,7 +420,7 @@ public class OkHttpClientAsyncTest {
 
     final CustomPojo customPojo = new CustomPojo("Name", null);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     final CompletableFuture<?> cf = api.queryMapPojo(customPojo);
     assertThat(server.takeRequest()).hasPath("/?name=Name");
 
@@ -434,7 +433,7 @@ public class OkHttpClientAsyncTest {
 
     final CustomPojo customPojo = new CustomPojo(null, null);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     api.queryMapPojo(customPojo);
     assertThat(server.takeRequest()).hasPath("/");
   }
@@ -469,20 +468,23 @@ public class OkHttpClientAsyncTest {
 
   @Test
   void canOverrideErrorDecoder() throws Throwable {
-    server.enqueue(new MockResponse().setResponseCode(400).setBody("foo"));
+    server.enqueue(new MockResponse.Builder().code(400).body("foo").build());
 
     final TestInterfaceAsync api =
         newAsyncBuilder()
             .errorDecoder(new IllegalArgumentExceptionOn400())
             .target("http://localhost:" + server.getPort());
 
-    Throwable exception = assertThrows(IllegalArgumentException.class, () -> unwrap(api.post()));
+    Throwable exception =
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> unwrap(api.post()))
+            .actual();
     assertThat(exception.getMessage()).contains("bad zone name");
   }
 
   @Test
   void overrideTypeSpecificDecoder() throws Throwable {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     final TestInterfaceAsync api =
         newAsyncBuilder().decoder((_, _) -> "fail").target("http://localhost:" + server.getPort());
@@ -492,7 +494,7 @@ public class OkHttpClientAsyncTest {
 
   @Test
   void doesntRetryAfterResponseIsSent() throws Throwable {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     final TestInterfaceAsync api =
         newAsyncBuilder()
@@ -504,13 +506,14 @@ public class OkHttpClientAsyncTest {
 
     final CompletableFuture<?> cf = api.post();
     server.takeRequest();
-    Throwable exception = assertThrows(FeignException.class, () -> unwrap(cf));
+    Throwable exception =
+        assertThatExceptionOfType(FeignException.class).isThrownBy(() -> unwrap(cf)).actual();
     assertThat(exception.getMessage()).contains("timeout reading POST http://");
   }
 
   @Test
   void throwsFeignExceptionIncludingBody() throws Throwable {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     final TestInterfaceAsync api =
         newAsyncBuilder()
@@ -535,7 +538,7 @@ public class OkHttpClientAsyncTest {
 
   @Test
   void throwsFeignExceptionWithoutBody() {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     final TestInterfaceAsync api =
         newAsyncBuilder()
@@ -550,7 +553,7 @@ public class OkHttpClientAsyncTest {
     } catch (final FeignException e) {
       assertThat(e.getMessage())
           .isEqualTo("timeout reading POST http://localhost:" + server.getPort() + "/");
-      assertThat(e.contentUTF8()).isEqualTo("");
+      assertThat(e.contentUTF8()).isEmpty();
     }
   }
 
@@ -583,7 +586,7 @@ public class OkHttpClientAsyncTest {
 
   @Test
   void okIfDecodeRootCauseHasNoMessage() throws Throwable {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     final TestInterfaceAsync api =
         newAsyncBuilder()
@@ -593,33 +596,35 @@ public class OkHttpClientAsyncTest {
                 })
             .target("http://localhost:" + server.getPort());
 
-    assertThrows(DecodeException.class, () -> unwrap(api.post()));
+    assertThatThrownBy(() -> unwrap(api.post())).isInstanceOf(DecodeException.class);
   }
 
   @Test
   void decodingExceptionGetWrappedInDismiss404Mode() throws Throwable {
-    server.enqueue(new MockResponse().setResponseCode(404));
+    server.enqueue(new MockResponse.Builder().code(404).build());
 
     final TestInterfaceAsync api =
         newAsyncBuilder()
             .dismiss404()
             .decoder(
                 (response, _) -> {
-                  assertEquals(404, response.status());
+                  Assertions.assertThat(response.status()).isEqualTo(404);
                   throw new NoSuchElementException();
                 })
             .target("http://localhost:" + server.getPort());
 
-    DecodeException exception = assertThrows(DecodeException.class, () -> unwrap(api.post()));
+    DecodeException exception =
+        assertThatExceptionOfType(DecodeException.class)
+            .isThrownBy(() -> unwrap(api.post()))
+            .actual();
     assertThat(exception).hasCauseInstanceOf(NoSuchElementException.class);
   }
 
   @Test
   void decodingDoesNotSwallow404ErrorsInDismiss404Mode() throws Throwable {
-    assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(
+    assertThatThrownBy(
             () -> {
-              server.enqueue(new MockResponse().setResponseCode(404));
+              server.enqueue(new MockResponse.Builder().code(404).build());
 
               final TestInterfaceAsync api =
                   newAsyncBuilder()
@@ -631,12 +636,13 @@ public class OkHttpClientAsyncTest {
                   api.queryMap(Collections.<String, Object>emptyMap());
               server.takeRequest();
               unwrap(cf);
-            });
+            })
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void okIfEncodeRootCauseHasNoMessage() throws Throwable {
-    server.enqueue(new MockResponse().setBody("success!"));
+    server.enqueue(new MockResponse.Builder().body("success!").build());
 
     final TestInterfaceAsync api =
         newAsyncBuilder()
@@ -646,7 +652,8 @@ public class OkHttpClientAsyncTest {
                 })
             .target("http://localhost:" + server.getPort());
 
-    assertThrows(EncodeException.class, () -> unwrap(api.body(Arrays.asList("foo"))));
+    assertThatThrownBy(() -> unwrap(api.body(Arrays.asList("foo"))))
+        .isInstanceOf(EncodeException.class);
   }
 
   @Test
@@ -676,16 +683,14 @@ public class OkHttpClientAsyncTest {
 
     assertThat(t1).isNotEqualTo(i1);
 
-    assertThat(t1.hashCode()).isEqualTo(i1.hashCode());
-
-    assertThat(t1.toString()).isEqualTo(i1.toString());
+    Assertions.assertThat(t1).hasSameHashCodeAs(i1).hasToString(i1.toString());
   }
 
   @SuppressWarnings("resource")
   @Test
   void decodeLogicSupportsByteArray() throws Throwable {
     final byte[] expectedResponse = {12, 34, 56};
-    server.enqueue(new MockResponse().setBody(new Buffer().write(expectedResponse)));
+    server.enqueue(new MockResponse.Builder().body(new Buffer().write(expectedResponse)).build());
 
     final OtherTestInterfaceAsync api =
         newAsyncBuilder()
@@ -699,7 +704,7 @@ public class OkHttpClientAsyncTest {
   @Test
   void encodeLogicSupportsByteArray() throws Exception {
     final byte[] expectedRequest = {12, 34, 56};
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final OtherTestInterfaceAsync api =
         newAsyncBuilder()
@@ -717,7 +722,7 @@ public class OkHttpClientAsyncTest {
 
   @Test
   void encodedQueryParam() throws Exception {
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
 
     final TestInterfaceAsync api = newAsyncBuilder().target("http://localhost:" + server.getPort());
 
@@ -739,7 +744,7 @@ public class OkHttpClientAsyncTest {
   }
 
   @Test
-  void responseMapperIsAppliedBeforeDelegate() throws IOException {
+  void responseMapperIsAppliedBeforeDelegate() throws Exception {
     final ResponseMappingDecoder decoder =
         new ResponseMappingDecoder(upperCaseResponseMapper(), new StringDecoder());
     final String output = (String) decoder.decode(responseWithText("response"), String.class);
@@ -775,7 +780,7 @@ public class OkHttpClientAsyncTest {
 
   @Test
   void mapAndDecodeExecutesMapFunction() throws Throwable {
-    server.enqueue(new MockResponse().setBody("response!"));
+    server.enqueue(new MockResponse.Builder().body("response!").build());
 
     final TestInterfaceAsync api =
         AsyncFeign.builder()
@@ -797,7 +802,7 @@ public class OkHttpClientAsyncTest {
     propertyPojo.setName("Name");
     propertyPojo.setNumber(1);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     final CompletableFuture<?> cf = api.queryMapPropertyPojo(propertyPojo);
     assertThat(server.takeRequest()).hasQueryParams(Arrays.asList("name=Name", "number=1"));
     checkCFCompletedSoon(cf);
@@ -815,7 +820,7 @@ public class OkHttpClientAsyncTest {
     childPojo.setParentProtectedProperty("second");
     childPojo.setParentPublicProperty("third");
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     final CompletableFuture<?> cf = api.queryMapPropertyInheritence(childPojo);
     assertThat(server.takeRequest())
         .hasQueryParams(
@@ -836,7 +841,7 @@ public class OkHttpClientAsyncTest {
     propertyPojo.setName(null);
     propertyPojo.setNumber(1);
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     final CompletableFuture<?> cf = api.queryMapPropertyPojo(propertyPojo);
 
     assertThat(server.takeRequest()).hasQueryParams("number=1");
@@ -853,7 +858,7 @@ public class OkHttpClientAsyncTest {
 
     final PropertyPojo.ChildPojoClass propertyPojo = new PropertyPojo.ChildPojoClass();
 
-    server.enqueue(new MockResponse());
+    server.enqueue(new MockResponse.Builder().build());
     final CompletableFuture<?> cf = api.queryMapPropertyPojo(propertyPojo);
     assertThat(server.takeRequest()).hasQueryParams("/");
 
@@ -1095,6 +1100,11 @@ public class OkHttpClientAsyncTest {
     public Instant instant() {
       return Instant.ofEpochMilli(millis);
     }
+  }
+
+  @BeforeEach
+  void setUp() throws IOException {
+    server.start();
   }
 
   @AfterEach

--- a/okhttp/src/test/java/feign/okhttp/OkHttpClientTest.java
+++ b/okhttp/src/test/java/feign/okhttp/OkHttpClientTest.java
@@ -30,7 +30,7 @@ import feign.client.AbstractClientTest;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
-import okhttp3.mockwebserver.MockResponse;
+import mockwebserver3.MockResponse;
 import org.assertj.core.data.MapEntry;
 import org.junit.jupiter.api.Test;
 
@@ -43,8 +43,8 @@ public class OkHttpClientTest extends AbstractClientTest {
   }
 
   @Test
-  public void testContentTypeWithoutCharset() throws Exception {
-    server.enqueue(new MockResponse().setBody("AAAAAAAA"));
+  void testContentTypeWithoutCharset() throws Exception {
+    server.enqueue(new MockResponse.Builder().body("AAAAAAAA").build());
     OkHttpClientTestInterface api =
         newBuilder()
             .target(OkHttpClientTestInterface.class, "http://localhost:" + server.getPort());
@@ -63,10 +63,10 @@ public class OkHttpClientTest extends AbstractClientTest {
   @Test
   void noFollowRedirect() throws Exception {
     server.enqueue(
-        new MockResponse().setResponseCode(302).addHeader("Location", server.url("redirect")));
+        new MockResponse.Builder().code(302).addHeader("Location", server.url("redirect")).build());
     // Enqueue a response to fail fast if the redirect is followed, instead of waiting for the
     // timeout
-    server.enqueue(new MockResponse().setBody("Hello"));
+    server.enqueue(new MockResponse.Builder().body("Hello").build());
 
     OkHttpClientTestInterface api =
         newBuilder()
@@ -88,8 +88,8 @@ public class OkHttpClientTest extends AbstractClientTest {
     String expectedBody = "Hello";
 
     server.enqueue(
-        new MockResponse().setResponseCode(302).addHeader("Location", server.url("redirect")));
-    server.enqueue(new MockResponse().setBody(expectedBody));
+        new MockResponse.Builder().code(302).addHeader("Location", server.url("redirect")).build());
+    server.enqueue(new MockResponse.Builder().body(expectedBody).build());
 
     OkHttpClientTestInterface api =
         newBuilder()
@@ -113,26 +113,31 @@ public class OkHttpClientTest extends AbstractClientTest {
    * manually-using-java-android
    */
   @Override
+  @Test
   public void canSupportGzip() throws Exception {
     assumeFalse(false, "OkHTTP client do not support gzip compression");
   }
 
   @Override
+  @Test
   public void canSupportGzipOnError() throws Exception {
     assumeFalse(false, "OkHTTP client do not support gzip compression");
   }
 
   @Override
+  @Test
   public void canSupportDeflate() throws Exception {
     assumeFalse(false, "OkHTTP client do not support deflate compression");
   }
 
   @Override
+  @Test
   public void canSupportDeflateOnError() throws Exception {
     assumeFalse(false, "OkHTTP client do not support deflate compression");
   }
 
   @Override
+  @Test
   public void canExceptCaseInsensitiveHeader() throws Exception {
     assumeFalse(false, "OkHTTP client do not support gzip compression");
   }

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
     <jvm.options>-Duser.language=en</jvm.options>
 
     <!-- default bytecode version for src/main -->
-    <main.java.version>1.8</main.java.version>
+    <main.java.version>11</main.java.version>
     <latest.java.version>25</latest.java.version>
 
     <!-- default bytecode version for src/test -->
@@ -232,10 +232,10 @@
     <jakarta.xml.soap-api.version>3.0.2</jakarta.xml.soap-api.version>
     <jakarta.xml.ws-api.version>4.0.3</jakarta.xml.ws-api.version>
     <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
-    <jaxb-api.version>2.3.1</jaxb-api.version>
+    <jaxb-api.version>2.3.3</jaxb-api.version>
     <jaxb-impl-2.version>2.3.9</jaxb-impl-2.version>
     <jaxb-impl-4.version>4.0.3</jaxb-impl-4.version>
-    <jaxws-api.version>2.3.1</jaxws-api.version>
+    <jaxws-api.version>2.3.3</jaxws-api.version>
     <javax.validation-api.version>2.0.1.Final</javax.validation-api.version>
     <jakarta.validation-api.version>3.1.1</jakarta.validation-api.version>
     <hibernate-validator-6.version>6.2.5.Final</hibernate-validator-6.version>
@@ -1206,8 +1206,12 @@
                 <configuration>
                   <exportDatatables>true</exportDatatables>
                   <activeRecipes>
-                    <recipe>org.openrewrite.java.migrate.UpgradeToJava8</recipe>
+                    <recipe>org.openrewrite.java.migrate.Java8toJava11</recipe>
                   </activeRecipes>
+                  <exclusions>
+                    <exclusion>**/src/test/java/**</exclusion>
+                    <exclusion>pom.xml</exclusion>
+                  </exclusions>
                 </configuration>
               </execution>
             </executions>

--- a/reactive/pom.xml
+++ b/reactive/pom.xml
@@ -93,7 +93,7 @@
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>mockwebserver</artifactId>
+      <artifactId>mockwebserver3</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/reactive/src/test/java/feign/reactive/ReactiveDelegatingContractTest.java
+++ b/reactive/src/test/java/feign/reactive/ReactiveDelegatingContractTest.java
@@ -15,7 +15,7 @@
  */
 package feign.reactive;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import feign.Contract;
 import feign.Param;
@@ -31,12 +31,12 @@ class ReactiveDelegatingContractTest {
 
   @Test
   void onlyReactiveReturnTypesSupported() {
-    assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(
+    assertThatThrownBy(
             () -> {
               Contract contract = new ReactiveDelegatingContract(new DefaultContract());
               contract.parseAndValidateMetadata(TestSynchronousService.class);
-            });
+            })
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -53,12 +53,12 @@ class ReactiveDelegatingContractTest {
 
   @Test
   void streamsAreNotSupported() {
-    assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(
+    assertThatThrownBy(
             () -> {
               Contract contract = new ReactiveDelegatingContract(new DefaultContract());
               contract.parseAndValidateMetadata(StreamsService.class);
-            });
+            })
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   public interface TestSynchronousService {

--- a/reactive/src/test/java/feign/reactive/ReactiveFeignIntegrationTest.java
+++ b/reactive/src/test/java/feign/reactive/ReactiveFeignIntegrationTest.java
@@ -15,9 +15,7 @@
  */
 package feign.reactive;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -59,9 +57,10 @@ import java.util.Collections;
 import java.util.List;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.AdditionalAnswers;
 import org.mockito.stubbing.Answer;
@@ -72,6 +71,11 @@ import reactor.test.StepVerifier;
 public class ReactiveFeignIntegrationTest {
 
   public final MockWebServer webServer = new MockWebServer();
+
+  @BeforeEach
+  void setUp() throws IOException {
+    webServer.start();
+  }
 
   private String getServerUrl() {
     return "http://localhost:" + this.webServer.getPort();
@@ -102,10 +106,10 @@ public class ReactiveFeignIntegrationTest {
 
   @Test
   void reactorTargetFull() throws Exception {
-    this.webServer.enqueue(new MockResponse().setBody("1.0"));
-    this.webServer.enqueue(new MockResponse().setBody("{ \"username\": \"test\" }"));
-    this.webServer.enqueue(new MockResponse().setBody("[{ \"username\": \"test\" }]"));
-    this.webServer.enqueue(new MockResponse().setBody("[{ \"username\": \"test\" }]"));
+    this.webServer.enqueue(new MockResponse.Builder().body("1.0").build());
+    this.webServer.enqueue(new MockResponse.Builder().body("{ \"username\": \"test\" }").build());
+    this.webServer.enqueue(new MockResponse.Builder().body("[{ \"username\": \"test\" }]").build());
+    this.webServer.enqueue(new MockResponse.Builder().body("[{ \"username\": \"test\" }]").build());
 
     TestReactorService service =
         ReactorFeign.builder()
@@ -119,34 +123,34 @@ public class ReactiveFeignIntegrationTest {
     assertThat(service).isNotNull();
 
     StepVerifier.create(service.version()).expectNext("1.0").expectComplete().verify();
-    assertThat(webServer.takeRequest().getPath()).isEqualToIgnoringCase("/version");
+    assertThat(webServer.takeRequest().getTarget()).isEqualToIgnoringCase("/version");
 
     /* test encoding and decoding */
     StepVerifier.create(service.user("test"))
         .assertNext(user -> assertThat(user).hasFieldOrPropertyWithValue("username", "test"))
         .expectComplete()
         .verify();
-    assertThat(webServer.takeRequest().getPath()).isEqualToIgnoringCase("/users/test");
+    assertThat(webServer.takeRequest().getTarget()).isEqualToIgnoringCase("/users/test");
 
     StepVerifier.create(service.usersFlux())
         .assertNext(user -> assertThat(user).hasFieldOrPropertyWithValue("username", "test"))
         .expectComplete()
         .verify();
-    assertThat(webServer.takeRequest().getPath()).isEqualToIgnoringCase("/users");
+    assertThat(webServer.takeRequest().getTarget()).isEqualToIgnoringCase("/users");
 
     StepVerifier.create(service.usersMono())
         .assertNext(
-            users -> assertThat(users.getFirst()).hasFieldOrPropertyWithValue("username", "test"))
+            users -> assertThat(users).first().hasFieldOrPropertyWithValue("username", "test"))
         .expectComplete()
         .verify();
-    assertThat(webServer.takeRequest().getPath()).isEqualToIgnoringCase("/users");
+    assertThat(webServer.takeRequest().getTarget()).isEqualToIgnoringCase("/users");
   }
 
   @Test
   void rxJavaTarget() throws Exception {
-    this.webServer.enqueue(new MockResponse().setBody("1.0"));
-    this.webServer.enqueue(new MockResponse().setBody("{ \"username\": \"test\" }"));
-    this.webServer.enqueue(new MockResponse().setBody("[{ \"username\": \"test\" }]"));
+    this.webServer.enqueue(new MockResponse.Builder().body("1.0").build());
+    this.webServer.enqueue(new MockResponse.Builder().body("{ \"username\": \"test\" }").build());
+    this.webServer.enqueue(new MockResponse.Builder().body("[{ \"username\": \"test\" }]").build());
 
     TestReactiveXService service =
         RxJavaFeign.builder()
@@ -158,48 +162,48 @@ public class ReactiveFeignIntegrationTest {
     assertThat(service).isNotNull();
 
     StepVerifier.create(service.version()).expectNext("1.0").expectComplete().verify();
-    assertThat(webServer.takeRequest().getPath()).isEqualToIgnoringCase("/version");
+    assertThat(webServer.takeRequest().getTarget()).isEqualToIgnoringCase("/version");
 
     /* test encoding and decoding */
     StepVerifier.create(service.user("test"))
         .assertNext(user -> assertThat(user).hasFieldOrPropertyWithValue("username", "test"))
         .expectComplete()
         .verify();
-    assertThat(webServer.takeRequest().getPath()).isEqualToIgnoringCase("/users/test");
+    assertThat(webServer.takeRequest().getTarget()).isEqualToIgnoringCase("/users/test");
 
     StepVerifier.create(service.users())
         .assertNext(
-            users -> assertThat(users.getFirst()).hasFieldOrPropertyWithValue("username", "test"))
+            users -> assertThat(users).first().hasFieldOrPropertyWithValue("username", "test"))
         .expectComplete()
         .verify();
-    assertThat(webServer.takeRequest().getPath()).isEqualToIgnoringCase("/users");
+    assertThat(webServer.takeRequest().getTarget()).isEqualToIgnoringCase("/users");
   }
 
   @Test
   void invocationFactoryIsNotSupported() {
-    assertThatExceptionOfType(UnsupportedOperationException.class)
-        .isThrownBy(
+    assertThatThrownBy(
             () -> {
               ReactorFeign.builder()
                   .invocationHandlerFactory((_, _) -> null)
                   .target(TestReactiveXService.class, "http://localhost");
-            });
+            })
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test
   void doNotCloseUnsupported() {
-    assertThatExceptionOfType(UnsupportedOperationException.class)
-        .isThrownBy(
+    assertThatThrownBy(
             () -> {
               ReactorFeign.builder()
                   .doNotCloseAfterDecode()
                   .target(TestReactiveXService.class, "http://localhost");
-            });
+            })
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test
   void requestInterceptor() {
-    this.webServer.enqueue(new MockResponse().setBody("1.0"));
+    this.webServer.enqueue(new MockResponse.Builder().body("1.0").build());
 
     RequestInterceptor mockInterceptor = mock(RequestInterceptor.class);
     TestReactorService service =
@@ -213,7 +217,7 @@ public class ReactiveFeignIntegrationTest {
 
   @Test
   void requestInterceptors() {
-    this.webServer.enqueue(new MockResponse().setBody("1.0"));
+    this.webServer.enqueue(new MockResponse.Builder().body("1.0").build());
 
     RequestInterceptor mockInterceptor = mock(RequestInterceptor.class);
     TestReactorService service =
@@ -227,7 +231,7 @@ public class ReactiveFeignIntegrationTest {
 
   @Test
   void responseMappers() throws Exception {
-    this.webServer.enqueue(new MockResponse().setBody("1.0"));
+    this.webServer.enqueue(new MockResponse.Builder().body("1.0").build());
 
     ResponseMapper responseMapper = mock(ResponseMapper.class);
     Decoder decoder = mock(Decoder.class);
@@ -246,7 +250,7 @@ public class ReactiveFeignIntegrationTest {
 
   @Test
   void queryMapEncoders() {
-    this.webServer.enqueue(new MockResponse().setBody("No Results Found"));
+    this.webServer.enqueue(new MockResponse.Builder().body("No Results Found").build());
 
     QueryMapEncoder encoder = mock(QueryMapEncoder.class);
     given(encoder.encode(any(Object.class))).willReturn(Collections.emptyMap());
@@ -265,7 +269,7 @@ public class ReactiveFeignIntegrationTest {
   @SuppressWarnings({"ThrowableNotThrown"})
   @Test
   void errorDecoder() {
-    this.webServer.enqueue(new MockResponse().setBody("Bad Request").setResponseCode(400));
+    this.webServer.enqueue(new MockResponse.Builder().body("Bad Request").code(400).build());
 
     ErrorDecoder errorDecoder = mock(ErrorDecoder.class);
     given(errorDecoder.decode(anyString(), any(Response.class)))
@@ -285,8 +289,8 @@ public class ReactiveFeignIntegrationTest {
 
   @Test
   void retryer() {
-    this.webServer.enqueue(new MockResponse().setBody("Not Available").setResponseCode(-1));
-    this.webServer.enqueue(new MockResponse().setBody("1.0"));
+    this.webServer.enqueue(new MockResponse.Builder().body("Not Available").code(-1).build());
+    this.webServer.enqueue(new MockResponse.Builder().body("1.0").build());
 
     Retryer retryer = new DefaultRetryer();
     Retryer spy = spy(retryer);
@@ -325,7 +329,7 @@ public class ReactiveFeignIntegrationTest {
 
   @Test
   void differentContract() throws Exception {
-    this.webServer.enqueue(new MockResponse().setBody("1.0"));
+    this.webServer.enqueue(new MockResponse.Builder().body("1.0").build());
 
     TestJaxRSReactorService service =
         ReactorFeign.builder()
@@ -333,7 +337,7 @@ public class ReactiveFeignIntegrationTest {
             .decoder(new ReactorDecoder(new DefaultDecoder()))
             .target(TestJaxRSReactorService.class, this.getServerUrl());
     StepVerifier.create(service.version()).expectNext("1.0").expectComplete().verify();
-    assertThat(webServer.takeRequest().getPath()).isEqualToIgnoringCase("/version");
+    assertThat(webServer.takeRequest().getTarget()).isEqualToIgnoringCase("/version");
   }
 
   interface TestReactorService {

--- a/ribbon/pom.xml
+++ b/ribbon/pom.xml
@@ -78,7 +78,7 @@
 
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>mockwebserver</artifactId>
+      <artifactId>mockwebserver3</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/ribbon/src/test/java/feign/ribbon/LBClientTest.java
+++ b/ribbon/src/test/java/feign/ribbon/LBClientTest.java
@@ -21,7 +21,6 @@ import feign.Request;
 import feign.Request.HttpMethod;
 import feign.ribbon.LBClient.RibbonRequest;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -39,7 +38,7 @@ class LBClientTest {
   }
 
   @Test
-  void ribbonRequest() throws URISyntaxException {
+  void ribbonRequest() throws Exception {
     // test for RibbonRequest.toRequest()
     // the url has a query whose value is an encoded json string
     String urlWithEncodedJson = "http://test.feign.com/p?q=%7b%22a%22%3a1%7d";

--- a/ribbon/src/test/java/feign/ribbon/LoadBalancingTargetTest.java
+++ b/ribbon/src/test/java/feign/ribbon/LoadBalancingTargetTest.java
@@ -22,9 +22,10 @@ import feign.Feign;
 import feign.RequestLine;
 import java.io.IOException;
 import java.net.URL;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class LoadBalancingTargetTest {
@@ -32,18 +33,24 @@ public class LoadBalancingTargetTest {
   public final MockWebServer server1 = new MockWebServer();
   public final MockWebServer server2 = new MockWebServer();
 
+  @BeforeEach
+  void setUp() throws IOException {
+    server1.start();
+    server2.start();
+  }
+
   static String hostAndPort(URL url) {
     // our build slaves have underscores in their hostnames which aren't permitted by ribbon
     return "localhost:" + url.getPort();
   }
 
   @Test
-  void loadBalancingDefaultPolicyRoundRobin() throws IOException, InterruptedException {
+  void loadBalancingDefaultPolicyRoundRobin() throws Exception {
     String name = "LoadBalancingTargetTest-loadBalancingDefaultPolicyRoundRobin";
     String serverListKey = name + ".ribbon.listOfServers";
 
-    server1.enqueue(new MockResponse().setBody("success!"));
-    server2.enqueue(new MockResponse().setBody("success!"));
+    server1.enqueue(new MockResponse.Builder().body("success!").build());
+    server2.enqueue(new MockResponse.Builder().body("success!").build());
 
     getConfigInstance()
         .setProperty(
@@ -58,8 +65,8 @@ public class LoadBalancingTargetTest {
       api.post();
       api.post();
 
-      assertThat(server1.getRequestCount()).isEqualTo(1);
-      assertThat(server2.getRequestCount()).isEqualTo(1);
+      assertThat(server1.getRequestCount()).isOne();
+      assertThat(server2.getRequestCount()).isOne();
       // TODO: verify ribbon stats match
       // assertEquals(target.lb().getLoadBalancerStats().getSingleServerStat())
     } finally {
@@ -68,11 +75,11 @@ public class LoadBalancingTargetTest {
   }
 
   @Test
-  void loadBalancingTargetPath() throws InterruptedException {
+  void loadBalancingTargetPath() throws Exception {
     String name = "LoadBalancingTargetTest-loadBalancingDefaultPolicyRoundRobin";
     String serverListKey = name + ".ribbon.listOfServers";
 
-    server1.enqueue(new MockResponse().setBody("success!"));
+    server1.enqueue(new MockResponse.Builder().body("success!").build());
 
     getConfigInstance().setProperty(serverListKey, hostAndPort(server1.url("").url()));
 
@@ -84,7 +91,7 @@ public class LoadBalancingTargetTest {
       api.get();
 
       assertThat(target.url()).isEqualTo("http:///context-path");
-      assertThat(server1.takeRequest().getPath()).isEqualTo("/context-path/servers");
+      assertThat(server1.takeRequest().getTarget()).isEqualTo("/context-path/servers");
     } finally {
       getConfigInstance().clearProperty(serverListKey);
     }

--- a/ribbon/src/test/java/feign/ribbon/PropagateFirstIOExceptionTest.java
+++ b/ribbon/src/test/java/feign/ribbon/PropagateFirstIOExceptionTest.java
@@ -15,9 +15,7 @@
  */
 package feign.ribbon;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.*;
 
 import com.netflix.client.ClientException;
 import java.io.IOException;
@@ -27,22 +25,21 @@ import org.junit.jupiter.api.Test;
 class PropagateFirstIOExceptionTest {
 
   @Test
-  void propagatesNestedIOE() throws IOException {
-    assertThatExceptionOfType(IOException.class)
-        .isThrownBy(
-            () -> {
-              RibbonClient.propagateFirstIOException(new ClientException(new IOException()));
-            });
+  void propagatesNestedIOE() throws Exception {
+    assertThatThrownBy(
+            () -> RibbonClient.propagateFirstIOException(new ClientException(new IOException())))
+        .isInstanceOf(IOException.class);
   }
 
   @Test
-  void propagatesFirstNestedIOE() throws IOException {
+  void propagatesFirstNestedIOE() throws Exception {
     IOException exception =
-        assertThrows(
-            IOException.class,
-            () ->
-                RibbonClient.propagateFirstIOException(
-                    new ClientException(new IOException(new IOException()))));
+        assertThatExceptionOfType(IOException.class)
+            .isThrownBy(
+                () ->
+                    RibbonClient.propagateFirstIOException(
+                        new ClientException(new IOException(new IOException()))))
+            .actual();
     assertThat(exception).hasCauseInstanceOf(IOException.class);
   }
 
@@ -51,17 +48,16 @@ class PropagateFirstIOExceptionTest {
    * exception
    */
   @Test
-  void propagatesDoubleNestedIOE() throws IOException {
-    assertThatExceptionOfType(ConnectException.class)
-        .isThrownBy(
-            () -> {
-              RibbonClient.propagateFirstIOException(
-                  new ClientException(new RuntimeException(new ConnectException())));
-            });
+  void propagatesDoubleNestedIOE() throws Exception {
+    assertThatThrownBy(
+            () ->
+                RibbonClient.propagateFirstIOException(
+                    new ClientException(new RuntimeException(new ConnectException()))))
+        .isInstanceOf(ConnectException.class);
   }
 
   @Test
-  void doesntPropagateWhenNotIOE() throws IOException {
+  void doesntPropagateWhenNotIOE() throws Exception {
     RibbonClient.propagateFirstIOException(new ClientException(new RuntimeException()));
   }
 }

--- a/ribbon/src/test/java/feign/ribbon/RibbonClientTest.java
+++ b/ribbon/src/test/java/feign/ribbon/RibbonClientTest.java
@@ -17,6 +17,7 @@ package feign.ribbon;
 
 import static com.netflix.config.ConfigurationManager.getConfigInstance;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
 import com.netflix.client.config.CommonClientConfigKey;
@@ -38,9 +39,9 @@ import java.net.URL;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.SocketPolicy;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import mockwebserver3.SocketEffect;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -83,9 +84,9 @@ public class RibbonClientTest {
   }
 
   @Test
-  void loadBalancingDefaultPolicyRoundRobin() throws IOException, InterruptedException {
-    server1.enqueue(new MockResponse().setBody("success!"));
-    server2.enqueue(new MockResponse().setBody("success!"));
+  void loadBalancingDefaultPolicyRoundRobin() throws Exception {
+    server1.enqueue(new MockResponse.Builder().body("success!").build());
+    server2.enqueue(new MockResponse.Builder().body("success!").build());
 
     getConfigInstance()
         .setProperty(
@@ -100,16 +101,17 @@ public class RibbonClientTest {
     api.post();
     api.post();
 
-    assertThat(server1.getRequestCount()).isEqualTo(1);
-    assertThat(server2.getRequestCount()).isEqualTo(1);
+    assertThat(server1.getRequestCount()).isOne();
+    assertThat(server2.getRequestCount()).isOne();
     // TODO: verify ribbon stats match
     // assertEquals(target.lb().getLoadBalancerStats().getSingleServerStat())
   }
 
   @Test
-  void ioExceptionRetry() throws IOException, InterruptedException {
-    server1.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
-    server1.enqueue(new MockResponse().setBody("success!"));
+  void ioExceptionRetry() throws Exception {
+    server1.enqueue(
+        new MockResponse.Builder().onRequestStart(new SocketEffect.CloseSocket()).build());
+    server1.enqueue(new MockResponse.Builder().body("success!").build());
 
     getConfigInstance().setProperty(serverListKey(), hostAndPort(server1.url("").url()));
 
@@ -126,8 +128,9 @@ public class RibbonClientTest {
   }
 
   @Test
-  void ioExceptionFailsAfterTooManyFailures() throws IOException, InterruptedException {
-    server1.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+  void ioExceptionFailsAfterTooManyFailures() throws Exception {
+    server1.enqueue(
+        new MockResponse.Builder().onRequestStart(new SocketEffect.CloseSocket()).build());
 
     getConfigInstance().setProperty(serverListKey(), hostAndPort(server1.url("").url()));
 
@@ -137,24 +140,23 @@ public class RibbonClientTest {
             .retryer(Retryer.NEVER_RETRY)
             .target(TestInterface.class, "http://" + client());
 
-    try {
-      api.post();
-      fail("No exception thrown");
-    } catch (RetryableException _) {
-
-    }
+    assertThatThrownBy(() -> api.post()).isInstanceOf(RetryableException.class);
     // TODO: why are these retrying?
-    assertThat(server1.getRequestCount()).isGreaterThanOrEqualTo(1);
+    assertThat(server1.getRequestCount()).isPositive();
     // TODO: verify ribbon stats match
     // assertEquals(target.lb().getLoadBalancerStats().getSingleServerStat())
   }
 
   @Test
-  void ribbonRetryConfigurationOnSameServer() throws IOException, InterruptedException {
-    server1.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
-    server1.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
-    server2.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
-    server2.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+  void ribbonRetryConfigurationOnSameServer() throws Exception {
+    server1.enqueue(
+        new MockResponse.Builder().onRequestStart(new SocketEffect.CloseSocket()).build());
+    server1.enqueue(
+        new MockResponse.Builder().onRequestStart(new SocketEffect.CloseSocket()).build());
+    server2.enqueue(
+        new MockResponse.Builder().onRequestStart(new SocketEffect.CloseSocket()).build());
+    server2.enqueue(
+        new MockResponse.Builder().onRequestStart(new SocketEffect.CloseSocket()).build());
 
     getConfigInstance()
         .setProperty(
@@ -168,12 +170,7 @@ public class RibbonClientTest {
             .retryer(Retryer.NEVER_RETRY)
             .target(TestInterface.class, "http://" + client());
 
-    try {
-      api.post();
-      fail("No exception thrown");
-    } catch (RetryableException _) {
-
-    }
+    assertThatThrownBy(() -> api.post()).isInstanceOf(RetryableException.class);
     assertThat(server1.getRequestCount() >= 2 || server2.getRequestCount() >= 2).isTrue();
     assertThat(server1.getRequestCount() + server2.getRequestCount()).isGreaterThanOrEqualTo(2);
     // TODO: verify ribbon stats match
@@ -181,11 +178,15 @@ public class RibbonClientTest {
   }
 
   @Test
-  void ribbonRetryConfigurationOnMultipleServers() throws IOException, InterruptedException {
-    server1.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
-    server1.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
-    server2.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
-    server2.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+  void ribbonRetryConfigurationOnMultipleServers() throws Exception {
+    server1.enqueue(
+        new MockResponse.Builder().onRequestStart(new SocketEffect.CloseSocket()).build());
+    server1.enqueue(
+        new MockResponse.Builder().onRequestStart(new SocketEffect.CloseSocket()).build());
+    server2.enqueue(
+        new MockResponse.Builder().onRequestStart(new SocketEffect.CloseSocket()).build());
+    server2.enqueue(
+        new MockResponse.Builder().onRequestStart(new SocketEffect.CloseSocket()).build());
 
     getConfigInstance()
         .setProperty(
@@ -199,14 +200,9 @@ public class RibbonClientTest {
             .retryer(Retryer.NEVER_RETRY)
             .target(TestInterface.class, "http://" + client());
 
-    try {
-      api.post();
-      fail("No exception thrown");
-    } catch (RetryableException _) {
-
-    }
-    assertThat(server1.getRequestCount()).isGreaterThanOrEqualTo(1);
-    assertThat(server1.getRequestCount()).isGreaterThanOrEqualTo(1);
+    assertThatThrownBy(() -> api.post()).isInstanceOf(RetryableException.class);
+    assertThat(server1.getRequestCount()).isPositive();
+    assertThat(server1.getRequestCount()).isPositive();
     // TODO: verify ribbon stats match
     // assertEquals(target.lb().getLoadBalancerStats().getSingleServerStat())
   }
@@ -218,14 +214,14 @@ public class RibbonClientTest {
    * contained invalid characters (ex. space).
    */
   @Test
-  void urlEncodeQueryStringParameters() throws IOException, InterruptedException {
+  void urlEncodeQueryStringParameters() throws Exception {
     String queryStringValue = "some string with space";
 
     /* values must be pct encoded, see RFC 6750 */
     String expectedQueryStringValue = "some%20string%20with%20space";
     String expectedRequestLine = "GET /?a=%s HTTP/1.1".formatted(expectedQueryStringValue);
 
-    server1.enqueue(new MockResponse().setBody("success!"));
+    server1.enqueue(new MockResponse.Builder().body("success!").build());
 
     getConfigInstance().setProperty(serverListKey(), hostAndPort(server1.url("").url()));
 
@@ -246,8 +242,8 @@ public class RibbonClientTest {
 
     Client trustSSLSockets = new DefaultClient(TrustingSSLSocketFactory.get(), null);
 
-    server1.useHttps(TrustingSSLSocketFactory.get("localhost"), false);
-    server1.enqueue(new MockResponse().setBody("success!"));
+    server1.useHttps(TrustingSSLSocketFactory.get("localhost"));
+    server1.enqueue(new MockResponse.Builder().body("success!").build());
 
     getConfigInstance().setProperty(serverListKey(), hostAndPort(server1.url("").url()));
 
@@ -256,13 +252,14 @@ public class RibbonClientTest {
             .client(RibbonClient.builder().delegate(trustSSLSockets).build())
             .target(TestInterface.class, "https://" + client());
     api.post();
-    assertThat(server1.getRequestCount()).isEqualTo(1);
+    assertThat(server1.getRequestCount()).isOne();
   }
 
   @Test
-  void ioExceptionRetryWithBuilder() throws IOException, InterruptedException {
-    server1.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
-    server1.enqueue(new MockResponse().setBody("success!"));
+  void ioExceptionRetryWithBuilder() throws Exception {
+    server1.enqueue(
+        new MockResponse.Builder().onRequestStart(new SocketEffect.CloseSocket()).build());
+    server1.enqueue(new MockResponse.Builder().body("success!").build());
 
     getConfigInstance().setProperty(serverListKey(), hostAndPort(server1.url("").url()));
 
@@ -279,9 +276,9 @@ public class RibbonClientTest {
   }
 
   @Test
-  void ribbonRetryOnStatusCodes() throws IOException, InterruptedException {
-    server1.enqueue(new MockResponse().setResponseCode(502));
-    server2.enqueue(new MockResponse().setResponseCode(503));
+  void ribbonRetryOnStatusCodes() throws Exception {
+    server1.enqueue(new MockResponse.Builder().code(502).build());
+    server2.enqueue(new MockResponse.Builder().code(503).build());
 
     getConfigInstance()
         .setProperty(
@@ -296,21 +293,16 @@ public class RibbonClientTest {
             .retryer(Retryer.NEVER_RETRY)
             .target(TestInterface.class, "http://" + client());
 
-    try {
-      api.post();
-      fail("No exception thrown");
-    } catch (Exception _) {
-
-    }
-    assertThat(server1.getRequestCount()).isEqualTo(1);
-    assertThat(server2.getRequestCount()).isEqualTo(1);
+    assertThatThrownBy(() -> api.post()).isInstanceOf(Exception.class);
+    assertThat(server1.getRequestCount()).isOne();
+    assertThat(server2.getRequestCount()).isOne();
   }
 
   @Test
   void feignOptionsFollowRedirect() {
     String expectedLocation = server2.url("").url().toString();
     server1.enqueue(
-        new MockResponse().setResponseCode(302).setHeader("Location", expectedLocation));
+        new MockResponse.Builder().code(302).setHeader("Location", expectedLocation).build());
 
     getConfigInstance().setProperty(serverListKey(), hostAndPort(server1.url("").url()));
 
@@ -327,7 +319,6 @@ public class RibbonClientTest {
       Response response = api.get();
       assertThat(response.status()).isEqualTo(302);
       Collection<String> location = response.headers().get("Location");
-      assertThat(location).isNotNull();
       assertThat(location).isNotEmpty();
       assertThat(location.iterator().next()).isEqualTo(expectedLocation);
     } catch (Exception ignored) {
@@ -340,11 +331,12 @@ public class RibbonClientTest {
   void feignOptionsNoFollowRedirect() {
     // 302 will say go to server 2
     server1.enqueue(
-        new MockResponse()
-            .setResponseCode(302)
-            .setHeader("Location", server2.url("").url().toString()));
+        new MockResponse.Builder()
+            .code(302)
+            .setHeader("Location", server2.url("").url().toString())
+            .build());
     // server 2 will send back 200 with "Hello" as body
-    server2.enqueue(new MockResponse().setResponseCode(200).setBody("Hello"));
+    server2.enqueue(new MockResponse.Builder().code(200).body("Hello").build());
 
     getConfigInstance()
         .setProperty(
@@ -363,7 +355,7 @@ public class RibbonClientTest {
     try {
       Response response = api.get();
       assertThat(response.status()).isEqualTo(200);
-      assertThat(response.body().toString()).isEqualTo("Hello");
+      assertThat(response.body()).hasToString("Hello");
     } catch (Exception ignored) {
       ignored.printStackTrace();
       fail("Shouldn't throw ");
@@ -385,15 +377,15 @@ public class RibbonClientTest {
   }
 
   @Test
-  void cleanUrlWithMatchingHostAndPart() throws IOException {
+  void cleanUrlWithMatchingHostAndPart() throws Exception {
     URI uri = RibbonClient.cleanUrl("http://questions/questions/answer/123", "questions");
-    assertThat(uri.toString()).isEqualTo("http:///questions/answer/123");
+    assertThat(uri).hasToString("http:///questions/answer/123");
   }
 
   @Test
-  void cleanUrl() throws IOException {
+  void cleanUrl() throws Exception {
     URI uri = RibbonClient.cleanUrl("http://myservice/questions/answer/123", "myservice");
-    assertThat(uri.toString()).isEqualTo("http:///questions/answer/123");
+    assertThat(uri).hasToString("http:///questions/answer/123");
   }
 
   private String client() {
@@ -423,7 +415,9 @@ public class RibbonClientTest {
   }
 
   @BeforeEach
-  void setup(TestInfo testInfo) {
+  void setup(TestInfo testInfo) throws IOException {
+    server1.start();
+    server2.start();
     Optional<Method> testMethod = testInfo.getTestMethod();
     if (testMethod.isPresent()) {
       this.testName = testMethod.get().getName();

--- a/sax/src/test/java/feign/sax/SAXDecoderTest.java
+++ b/sax/src/test/java/feign/sax/SAXDecoderTest.java
@@ -17,14 +17,12 @@ package feign.sax;
 
 import static feign.Util.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import feign.Request;
 import feign.Request.HttpMethod;
 import feign.Response;
 import feign.codec.Decoder;
-import java.io.IOException;
-import java.text.ParseException;
 import java.util.Collection;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
@@ -57,17 +55,18 @@ class SAXDecoderTest {
           .build();
 
   @Test
-  void parsesConfiguredTypes() throws ParseException, IOException {
+  void parsesConfiguredTypes() throws Exception {
     assertThat(decoder.decode(statusFailedResponse(), NetworkStatus.class))
         .isEqualTo(NetworkStatus.FAILED);
     assertThat(decoder.decode(statusFailedResponse(), String.class)).isEqualTo("Failed");
   }
 
   @Test
-  void niceErrorOnUnconfiguredType() throws ParseException, IOException {
+  void niceErrorOnUnconfiguredType() throws Exception {
     Throwable exception =
-        assertThrows(
-            IllegalStateException.class, () -> decoder.decode(statusFailedResponse(), int.class));
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(() -> decoder.decode(statusFailedResponse(), int.class))
+            .actual();
 
     assertThat(exception.getMessage()).contains("type int not in configured handlers");
   }

--- a/sax/src/test/java/feign/sax/examples/AWSSignatureVersion4.java
+++ b/sax/src/test/java/feign/sax/examples/AWSSignatureVersion4.java
@@ -16,10 +16,10 @@
 package feign.sax.examples;
 
 import static feign.Util.UTF_8;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import feign.Request;
 import feign.RequestTemplate;
+import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -84,7 +84,11 @@ public class AWSSignatureVersion4 {
   }
 
   private static String bodyAsUtf8String(Request.Body body) {
-    return assertDoesNotThrow(() -> body.writeToString(StandardCharsets.UTF_8));
+    try {
+      return body.writeToString(StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new AssertionError("Failed to write body", e);
+    }
   }
 
   private static String toSign(String timestamp, String credentialScope, String canonicalRequest) {

--- a/soap-jakarta/pom.xml
+++ b/soap-jakarta/pom.xml
@@ -61,6 +61,12 @@
       <version>${jakarta.xml.ws-api.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.sun.xml.ws</groupId>
+      <artifactId>jaxws-rt</artifactId>
+      <version>2.3.7</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>jakarta.xml.soap</groupId>
       <artifactId>jakarta.xml.soap-api</artifactId>
       <version>${jakarta.xml.soap-api.version}</version>
@@ -76,8 +82,8 @@
       <version>${saaj-impl-3.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
       <version>${jaxb-impl-4.version}</version>
       <scope>runtime</scope>
     </dependency>

--- a/soap-jakarta/src/test/java/feign/soap/SOAPCodecTest.java
+++ b/soap-jakarta/src/test/java/feign/soap/SOAPCodecTest.java
@@ -17,8 +17,7 @@ package feign.soap;
 
 import static feign.Util.UTF_8;
 import static feign.assertj.FeignAssertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import feign.Request;
 import feign.Request.HttpMethod;
@@ -35,6 +34,7 @@ import jakarta.xml.soap.SOAPElement;
 import jakarta.xml.soap.SOAPException;
 import jakarta.xml.soap.SOAPFactory;
 import jakarta.xml.soap.SOAPMessage;
+import java.io.IOException;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -85,11 +85,12 @@ class SOAPCodecTest {
 
     RequestTemplate template = new RequestTemplate();
     Throwable exception =
-        assertThrows(
-            UnsupportedOperationException.class,
-            () ->
-                new SOAPEncoder(new JAXBContextFactory.Builder().build())
-                    .encode(Collections.emptyMap(), parameterized, template));
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+            .isThrownBy(
+                () ->
+                    new SOAPEncoder(new JAXBContextFactory.Builder().build())
+                        .encode(Collections.emptyMap(), parameterized, template))
+            .actual();
     assertThat(exception.getMessage())
         .contains(
             "SOAP only supports encoding raw types. Found java.util.Map<java.lang.String, ?>");
@@ -367,11 +368,12 @@ xmlns:xsd="http://www.w3.org/2001/XMLSchema">\
             .build();
 
     Throwable exception =
-        assertThrows(
-            feign.codec.DecodeException.class,
-            () ->
-                new SOAPDecoder(new JAXBContextFactory.Builder().build())
-                    .decode(response, parameterized));
+        assertThatExceptionOfType(feign.codec.DecodeException.class)
+            .isThrownBy(
+                () ->
+                    new SOAPDecoder(new JAXBContextFactory.Builder().build())
+                        .decode(response, parameterized))
+            .actual();
     assertThat(exception.getMessage())
         .contains(
             """
@@ -460,7 +462,11 @@ xmlns:xsd="http://www.w3.org/2001/XMLSchema">\
   }
 
   private byte[] bodyAsBytes(Request.Body body) {
-    return assertDoesNotThrow(body::writeToByteArray);
+    try {
+      return body.writeToByteArray();
+    } catch (IOException e) {
+      throw new AssertionError("Failed to write body", e);
+    }
   }
 
   @XmlRootElement

--- a/soap-jakarta/src/test/java/feign/soap/SOAPFaultDecoderTest.java
+++ b/soap-jakarta/src/test/java/feign/soap/SOAPFaultDecoderTest.java
@@ -17,7 +17,7 @@ package feign.soap;
 
 import static feign.Util.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import feign.FeignException;
 import feign.Request;
@@ -43,7 +43,7 @@ class SOAPFaultDecoderTest {
   }
 
   @Test
-  void soapDecoderThrowsSOAPFaultException() throws IOException {
+  void soapDecoderThrowsSOAPFaultException() throws Exception {
 
     Response response =
         Response.builder()
@@ -61,12 +61,14 @@ class SOAPFaultDecoderTest {
             .build();
 
     Throwable exception =
-        assertThrows(SOAPFaultException.class, () -> decoder.decode(response, Object.class));
+        assertThatExceptionOfType(SOAPFaultException.class)
+            .isThrownBy(() -> decoder.decode(response, Object.class))
+            .actual();
     assertThat(exception.getMessage()).contains("Processing error");
   }
 
   @Test
-  void errorDecoderReturnsSOAPFaultException() throws IOException {
+  void errorDecoderReturnsSOAPFaultException() throws Exception {
     Response response =
         Response.builder()
             .status(400)
@@ -83,7 +85,7 @@ class SOAPFaultDecoderTest {
   }
 
   @Test
-  void errorDecoderReturnsFeignExceptionOn503Status() throws IOException {
+  void errorDecoderReturnsFeignExceptionOn503Status() throws Exception {
     Response response =
         Response.builder()
             .status(503)
@@ -103,7 +105,7 @@ class SOAPFaultDecoderTest {
   }
 
   @Test
-  void errorDecoderReturnsFeignExceptionOnEmptyFault() throws IOException {
+  void errorDecoderReturnsFeignExceptionOnEmptyFault() throws Exception {
     String responseBody =
         """
         <?xml version = '1.0' encoding = 'UTF-8'?>

--- a/soap/pom.xml
+++ b/soap/pom.xml
@@ -52,13 +52,19 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.xml.ws</groupId>
-      <artifactId>jaxws-api</artifactId>
+      <groupId>jakarta.xml.ws</groupId>
+      <artifactId>jakarta.xml.ws-api</artifactId>
       <version>${jaxws-api.version}</version>
     </dependency>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
+      <groupId>com.sun.xml.ws</groupId>
+      <artifactId>jaxws-rt</artifactId>
+      <version>2.3.7</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
       <version>${jaxb-api.version}</version>
     </dependency>
     <dependency>
@@ -67,10 +73,10 @@
       <version>${saaj-impl-1.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
       <version>${jaxb-impl-2.version}</version>
-      <scope>test</scope>
+      <scope>runtime</scope>
     </dependency>
   </dependencies>
 

--- a/soap/src/test/java/feign/soap/SOAPCodecTest.java
+++ b/soap/src/test/java/feign/soap/SOAPCodecTest.java
@@ -17,8 +17,7 @@ package feign.soap;
 
 import static feign.Util.UTF_8;
 import static feign.assertj.FeignAssertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import feign.Request;
 import feign.Request.HttpMethod;
@@ -26,6 +25,7 @@ import feign.RequestTemplate;
 import feign.Response;
 import feign.codec.Encoder;
 import feign.jaxb.JAXBContextFactory;
+import java.io.IOException;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -85,11 +85,12 @@ class SOAPCodecTest {
 
     RequestTemplate template = new RequestTemplate();
     Throwable exception =
-        assertThrows(
-            UnsupportedOperationException.class,
-            () ->
-                new SOAPEncoder(new JAXBContextFactory.Builder().build())
-                    .encode(Collections.emptyMap(), parameterized, template));
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+            .isThrownBy(
+                () ->
+                    new SOAPEncoder(new JAXBContextFactory.Builder().build())
+                        .encode(Collections.emptyMap(), parameterized, template))
+            .actual();
     assertThat(exception.getMessage())
         .contains(
             "SOAP only supports encoding raw types. Found java.util.Map<java.lang.String, ?>");
@@ -367,11 +368,12 @@ xmlns:xsd="http://www.w3.org/2001/XMLSchema">\
             .build();
 
     Throwable exception =
-        assertThrows(
-            feign.codec.DecodeException.class,
-            () ->
-                new SOAPDecoder(new JAXBContextFactory.Builder().build())
-                    .decode(response, parameterized));
+        assertThatExceptionOfType(feign.codec.DecodeException.class)
+            .isThrownBy(
+                () ->
+                    new SOAPDecoder(new JAXBContextFactory.Builder().build())
+                        .decode(response, parameterized))
+            .actual();
     assertThat(exception.getMessage())
         .contains(
             """
@@ -470,7 +472,11 @@ xmlns:xsd="http://www.w3.org/2001/XMLSchema">\
   }
 
   private byte[] bodyAsBytes(Request.Body body) {
-    return assertDoesNotThrow(body::writeToByteArray);
+    try {
+      return body.writeToByteArray();
+    } catch (IOException e) {
+      throw new AssertionError("Failed to write body", e);
+    }
   }
 
   static class ChangedProtocolAndHeaderSOAPEncoder extends SOAPEncoder {

--- a/soap/src/test/java/feign/soap/SOAPFaultDecoderTest.java
+++ b/soap/src/test/java/feign/soap/SOAPFaultDecoderTest.java
@@ -17,7 +17,7 @@ package feign.soap;
 
 import static feign.Util.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import feign.FeignException;
 import feign.Request;
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 class SOAPFaultDecoderTest {
 
   @Test
-  void soapDecoderThrowsSOAPFaultException() throws IOException {
+  void soapDecoderThrowsSOAPFaultException() throws Exception {
 
     Response response =
         Response.builder()
@@ -53,12 +53,14 @@ class SOAPFaultDecoderTest {
             .withJAXBContextFactory(new JAXBContextFactory.Builder().build())
             .build();
     Throwable exception =
-        assertThrows(SOAPFaultException.class, () -> decoder.decode(response, Object.class));
+        assertThatExceptionOfType(SOAPFaultException.class)
+            .isThrownBy(() -> decoder.decode(response, Object.class))
+            .actual();
     assertThat(exception.getMessage()).contains("Processing error");
   }
 
   @Test
-  void errorDecoderReturnsSOAPFaultException() throws IOException {
+  void errorDecoderReturnsSOAPFaultException() throws Exception {
     Response response =
         Response.builder()
             .status(400)
@@ -75,7 +77,7 @@ class SOAPFaultDecoderTest {
   }
 
   @Test
-  void errorDecoderReturnsFeignExceptionOn503Status() throws IOException {
+  void errorDecoderReturnsFeignExceptionOn503Status() throws Exception {
     Response response =
         Response.builder()
             .status(503)
@@ -95,7 +97,7 @@ class SOAPFaultDecoderTest {
   }
 
   @Test
-  void errorDecoderReturnsFeignExceptionOnEmptyFault() throws IOException {
+  void errorDecoderReturnsFeignExceptionOnEmptyFault() throws Exception {
     String responseBody =
         """
         <?xml version = '1.0' encoding = 'UTF-8'?>

--- a/spring/src/test/java/feign/spring/SpringContractTest.java
+++ b/spring/src/test/java/feign/spring/SpringContractTest.java
@@ -15,9 +15,7 @@
  */
 package feign.spring;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.*;
 
 import feign.Feign;
 import feign.Param;
@@ -172,8 +170,9 @@ class SpringContractTest {
   @Test
   void requiredRequestBodyIsNull() {
     Throwable exception =
-        assertThrows(
-            IllegalArgumentException.class, () -> resource.checkWithRequiredRequestBody(null));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> resource.checkWithRequiredRequestBody(null))
+            .actual();
     assertThat(exception.getMessage()).contains("Body parameter 0 was null");
   }
 
@@ -183,7 +182,7 @@ class SpringContractTest {
 
     Request request = mockClient.verifyOne(HttpMethod.POST, "/health/withNonRequiredRequestBody");
     assertThat(request.requestTemplate().requestBody().map(this::bodyAsUtf8String))
-        .contains("null");
+        .hasValue("null");
   }
 
   @Test
@@ -272,7 +271,9 @@ class SpringContractTest {
   @Test
   void notAHttpMethod() {
     Throwable exception =
-        assertThrows(Exception.class, () -> resource.missingResourceExceptionHandler());
+        assertThatExceptionOfType(Exception.class)
+            .isThrownBy(() -> resource.missingResourceExceptionHandler())
+            .actual();
     assertThat(exception.getMessage()).contains("is not a method handled by feign");
   }
 
@@ -285,7 +286,11 @@ class SpringContractTest {
   }
 
   private String bodyAsUtf8String(Request.Body body) {
-    return assertDoesNotThrow(() -> body.writeToString(StandardCharsets.UTF_8));
+    try {
+      return body.writeToString(StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new AssertionError("Failed to write body", e);
+    }
   }
 
   interface GenericResource<DTO> {

--- a/validation-jakarta/pom.xml
+++ b/validation-jakarta/pom.xml
@@ -74,7 +74,7 @@
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>mockwebserver</artifactId>
+      <artifactId>mockwebserver3</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/validation-jakarta/src/test/java/feign/validation/BeanValidationMethodInterceptorTest.java
+++ b/validation-jakarta/src/test/java/feign/validation/BeanValidationMethodInterceptorTest.java
@@ -26,18 +26,25 @@ import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import java.io.IOException;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class BeanValidationMethodInterceptorTest {
 
   private final MockWebServer server = new MockWebServer();
 
+  @BeforeEach
+  void setUp() throws IOException {
+    server.start();
+  }
+
   @AfterEach
   void tearDown() throws Exception {
-    server.shutdown();
+    server.close();
   }
 
   static class Payload {
@@ -77,20 +84,19 @@ class BeanValidationMethodInterceptorTest {
 
   private Api api() {
     return Feign.builder()
-        .encoder(
-            (object, bodyType, template) -> template.body(Request.Body.of(String.valueOf(object))))
+        .encoder((object, _, template) -> template.body(Request.Body.of(String.valueOf(object))))
         .methodInterceptor(BeanValidationMethodInterceptor.usingDefaultFactory())
         .target(Api.class, "http://localhost:" + server.getPort());
   }
 
   @Test
   void validBodyReachesServer() throws Exception {
-    server.enqueue(new MockResponse().setBody("ok"));
+    server.enqueue(new MockResponse.Builder().body("ok").build());
 
     String result = api().create(new Payload("a", "b"));
 
     assertThat(result).isEqualTo("ok");
-    assertThat(server.getRequestCount()).isEqualTo(1);
+    assertThat(server.getRequestCount()).isOne();
   }
 
   @Test
@@ -118,11 +124,11 @@ class BeanValidationMethodInterceptorTest {
 
   @Test
   void noArgsMethodPassesThrough() throws Exception {
-    server.enqueue(new MockResponse().setBody("ok"));
+    server.enqueue(new MockResponse.Builder().body("ok").build());
 
     String result = api().list();
 
     assertThat(result).isEqualTo("ok");
-    assertThat(server.getRequestCount()).isEqualTo(1);
+    assertThat(server.getRequestCount()).isOne();
   }
 }

--- a/validation/pom.xml
+++ b/validation/pom.xml
@@ -68,7 +68,7 @@
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>mockwebserver</artifactId>
+      <artifactId>mockwebserver3</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/validation/src/test/java/feign/validation/BeanValidationMethodInterceptorTest.java
+++ b/validation/src/test/java/feign/validation/BeanValidationMethodInterceptorTest.java
@@ -22,22 +22,29 @@ import feign.Feign;
 import feign.Param;
 import feign.Request;
 import feign.RequestLine;
+import java.io.IOException;
 import javax.validation.ConstraintViolationException;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class BeanValidationMethodInterceptorTest {
 
   private final MockWebServer server = new MockWebServer();
 
+  @BeforeEach
+  void setUp() throws IOException {
+    server.start();
+  }
+
   @AfterEach
   void tearDown() throws Exception {
-    server.shutdown();
+    server.close();
   }
 
   static class Payload {
@@ -77,20 +84,19 @@ class BeanValidationMethodInterceptorTest {
 
   private Api api() {
     return Feign.builder()
-        .encoder(
-            (object, bodyType, template) -> template.body(Request.Body.of(String.valueOf(object))))
+        .encoder((object, _, template) -> template.body(Request.Body.of(String.valueOf(object))))
         .methodInterceptor(BeanValidationMethodInterceptor.usingDefaultFactory())
         .target(Api.class, "http://localhost:" + server.getPort());
   }
 
   @Test
   void validBodyReachesServer() throws Exception {
-    server.enqueue(new MockResponse().setBody("ok"));
+    server.enqueue(new MockResponse.Builder().body("ok").build());
 
     String result = api().create(new Payload("a", "b"));
 
     assertThat(result).isEqualTo("ok");
-    assertThat(server.getRequestCount()).isEqualTo(1);
+    assertThat(server.getRequestCount()).isOne();
   }
 
   @Test
@@ -118,11 +124,11 @@ class BeanValidationMethodInterceptorTest {
 
   @Test
   void noArgsMethodPassesThrough() throws Exception {
-    server.enqueue(new MockResponse().setBody("ok"));
+    server.enqueue(new MockResponse.Builder().body("ok").build());
 
     String result = api().list();
 
     assertThat(result).isEqualTo("ok");
-    assertThat(server.getRequestCount()).isEqualTo(1);
+    assertThat(server.getRequestCount()).isOne();
   }
 }

--- a/vertx/feign-vertx/src/test/java/feign/vertx/ConnectionsLeakTests.java
+++ b/vertx/feign-vertx/src/test/java/feign/vertx/ConnectionsLeakTests.java
@@ -134,7 +134,7 @@ class ConnectionsLeakTests {
                     () -> {
                       try {
                         if (poolSize == 1) {
-                          assertThat(this.connections.size()).isLessThanOrEqualTo(2);
+                          assertThat(this.connections).hasSizeLessThanOrEqualTo(2);
                         } else {
                           assertThat(this.connections).hasSize(poolSize);
                         }

--- a/vertx/feign-vertx/src/test/java/feign/vertx/RequestPreProcessorTest.java
+++ b/vertx/feign-vertx/src/test/java/feign/vertx/RequestPreProcessorTest.java
@@ -82,7 +82,7 @@ class RequestPreProcessorTest extends AbstractFeignVertxTest {
                   if (res.succeeded()) {
                     Collection<Flavor> flavors = res.result();
                     assertThat(flavors)
-                        .hasSize(Flavor.values().length)
+                        .hasSameSizeAs(Flavor.values())
                         .containsAll(Arrays.asList(Flavor.values()));
                     testContext.completeNow();
                   } else {

--- a/vertx/feign-vertx/src/test/java/feign/vertx/RetryingTest.java
+++ b/vertx/feign-vertx/src/test/java/feign/vertx/RetryingTest.java
@@ -101,7 +101,7 @@ class RetryingTest extends AbstractFeignVertxTest {
                 () -> {
                   if (res.succeeded()) {
                     assertThat(res.result())
-                        .hasSize(Flavor.values().length)
+                        .hasSameSizeAs(Flavor.values())
                         .containsAll(Arrays.asList(Flavor.values()));
                     testContext.completeNow();
                   } else {

--- a/vertx/feign-vertx/src/test/java/feign/vertx/TimeoutHandlingTest.java
+++ b/vertx/feign-vertx/src/test/java/feign/vertx/TimeoutHandlingTest.java
@@ -115,7 +115,7 @@ class TimeoutHandlingTest extends AbstractFeignVertxTest {
                   if (res.succeeded()) {
                     Collection<Flavor> flavors = res.result();
                     assertThat(flavors)
-                        .hasSize(Flavor.values().length)
+                        .hasSameSizeAs(Flavor.values())
                         .containsAll(Arrays.asList(Flavor.values()));
                     testContext.completeNow();
                   } else {

--- a/vertx/feign-vertx/src/test/java/feign/vertx/VertxHttpClientTest.java
+++ b/vertx/feign-vertx/src/test/java/feign/vertx/VertxHttpClientTest.java
@@ -99,7 +99,7 @@ public class VertxHttpClientTest extends AbstractFeignVertxTest {
                       Collection<Flavor> flavors = res.result();
 
                       assertThat(flavors)
-                          .hasSize(Flavor.values().length)
+                          .hasSameSizeAs(Flavor.values())
                           .containsAll(Arrays.asList(Flavor.values()));
                       testContext.completeNow();
                     } else {
@@ -134,7 +134,7 @@ public class VertxHttpClientTest extends AbstractFeignVertxTest {
                       Collection<Mixin> mixins = res.result();
 
                       assertThat(mixins)
-                          .hasSize(Mixin.values().length)
+                          .hasSameSizeAs(Mixin.values())
                           .containsAll(Arrays.asList(Mixin.values()));
                       testContext.completeNow();
                     } else {

--- a/vertx/feign-vertx/src/test/java/feign/vertx/VertxHttpOptionsTest.java
+++ b/vertx/feign-vertx/src/test/java/feign/vertx/VertxHttpOptionsTest.java
@@ -106,7 +106,7 @@ class VertxHttpOptionsTest extends AbstractFeignVertxTest {
                 Collection<Flavor> flavors = res.result();
 
                 assertThat(flavors)
-                    .hasSize(Flavor.values().length)
+                    .hasSameSizeAs(Flavor.values())
                     .containsAll(Arrays.asList(Flavor.values()));
                 testContext.completeNow();
               } else {

--- a/vertx/feign-vertx4-test/src/test/java/feign/vertx/RequestPreProcessorTest.java
+++ b/vertx/feign-vertx4-test/src/test/java/feign/vertx/RequestPreProcessorTest.java
@@ -82,7 +82,7 @@ class RequestPreProcessorTest extends AbstractFeignVertxTest {
                   if (res.succeeded()) {
                     Collection<Flavor> flavors = res.result();
                     assertThat(flavors)
-                        .hasSize(Flavor.values().length)
+                        .hasSameSizeAs(Flavor.values())
                         .containsAll(Arrays.asList(Flavor.values()));
                     testContext.completeNow();
                   } else {

--- a/vertx/feign-vertx4-test/src/test/java/feign/vertx/RetryingTest.java
+++ b/vertx/feign-vertx4-test/src/test/java/feign/vertx/RetryingTest.java
@@ -101,7 +101,7 @@ class RetryingTest extends AbstractFeignVertxTest {
                 () -> {
                   if (res.succeeded()) {
                     assertThat(res.result())
-                        .hasSize(Flavor.values().length)
+                        .hasSameSizeAs(Flavor.values())
                         .containsAll(Arrays.asList(Flavor.values()));
                     testContext.completeNow();
                   } else {

--- a/vertx/feign-vertx4-test/src/test/java/feign/vertx/TimeoutHandlingTest.java
+++ b/vertx/feign-vertx4-test/src/test/java/feign/vertx/TimeoutHandlingTest.java
@@ -115,7 +115,7 @@ class TimeoutHandlingTest extends AbstractFeignVertxTest {
                   if (res.succeeded()) {
                     Collection<Flavor> flavors = res.result();
                     assertThat(flavors)
-                        .hasSize(Flavor.values().length)
+                        .hasSameSizeAs(Flavor.values())
                         .containsAll(Arrays.asList(Flavor.values()));
                     testContext.completeNow();
                   } else {

--- a/vertx/feign-vertx4-test/src/test/java/feign/vertx/VertxHttpClientTest.java
+++ b/vertx/feign-vertx4-test/src/test/java/feign/vertx/VertxHttpClientTest.java
@@ -99,7 +99,7 @@ public class VertxHttpClientTest extends AbstractFeignVertxTest {
                       Collection<Flavor> flavors = res.result();
 
                       assertThat(flavors)
-                          .hasSize(Flavor.values().length)
+                          .hasSameSizeAs(Flavor.values())
                           .containsAll(Arrays.asList(Flavor.values()));
                       testContext.completeNow();
                     } else {
@@ -134,7 +134,7 @@ public class VertxHttpClientTest extends AbstractFeignVertxTest {
                       Collection<Mixin> mixins = res.result();
 
                       assertThat(mixins)
-                          .hasSize(Mixin.values().length)
+                          .hasSameSizeAs(Mixin.values())
                           .containsAll(Arrays.asList(Mixin.values()));
                       testContext.completeNow();
                     } else {

--- a/vertx/feign-vertx4-test/src/test/java/feign/vertx/VertxHttpOptionsTest.java
+++ b/vertx/feign-vertx4-test/src/test/java/feign/vertx/VertxHttpOptionsTest.java
@@ -105,7 +105,7 @@ class VertxHttpOptionsTest extends AbstractFeignVertxTest {
                 Collection<Flavor> flavors = res.result();
 
                 assertThat(flavors)
-                    .hasSize(Flavor.values().length)
+                    .hasSameSizeAs(Flavor.values())
                     .containsAll(Arrays.asList(Flavor.values()));
                 testContext.completeNow();
               } else {


### PR DESCRIPTION
## Summary

- Raises `main.java.version` from `1.8` to `11` in the parent POM
- Runs OpenRewrite `Java8toJava11` recipe across `src/main/java` (var, text blocks, NIO charset helpers, etc.)
- Runs OpenRewrite `UpgradeToJava25` across `src/test/java` / `src/test/kotlin` (JUnit 4 → JUnit 5, AssertJ idioms, mockwebserver3 5.x API)
- Fixes several pre-existing test bugs surfaced by the JUnit 5 migration:
  - `CoroutineFeignTest`: tests were silently skipped under JUnit 4 runner; fixed `Unit` return-type assertions
  - `AnnotationErrorDecoderExceptionConstructorsTest`: reverted OpenRewrite's incorrect `isEqualTo(null)` → `containsExactlyInAnyOrderEntriesOf(null)` migration (NPE when `NO_HEADERS = null`)
  - All MockWebServer 5.x tests: added explicit `server.start()` calls (`ReactiveFeignIntegrationTest`, ribbon, and others)
- Adds `moditect.skip=true` to `feign-jaxb` and `feign-jaxb-jakarta` to fix duplicate `jakarta.activation` module name conflict introduced by the JAXB API version bump
- Adds `.antigravitycli/`, `.claude/`, `.understand-anything/` to `.gitignore`

## Test plan

- [ ] `mvn verify -Dtoolchain.skip=true` passes (BUILD SUCCESS; `GitHubExampleIT` is expected to fail in local builds — it requires `mvn clean install -Pdev`)
- [ ] All unit tests pass across feign-core, feign-api, feign-reactive, feign-kotlin, feign-jaxb, feign-jaxb-jakarta, feign-jaxrs*, ribbon, hystrix, mock, json, and all other modules