### PR TITLE
Open observation scope and stop on non-FeignException errors

### DIFF
--- a/micrometer/src/main/java/feign/micrometer/MicrometerObservationCapability.java
+++ b/micrometer/src/main/java/feign/micrometer/MicrometerObservationCapability.java
@@ -18,10 +18,10 @@ package feign.micrometer;
 import feign.AsyncClient;
 import feign.Capability;
 import feign.Client;
-import feign.FeignException;
 import feign.Response;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
+import java.util.concurrent.CompletionException;
 
 /** Wrap feign {@link Client} with metrics. */
 public class MicrometerObservationCapability implements Capability {
@@ -55,13 +55,15 @@ public class MicrometerObservationCapability implements Capability {
                   this.observationRegistry)
               .start();
 
-      try {
+      try (Observation.Scope scope = observation.openScope()) {
         Response response = client.execute(request, options);
-        finalizeObservation(feignContext, observation, null, response);
+        feignContext.setResponse(response);
         return response;
-      } catch (FeignException ex) {
-        finalizeObservation(feignContext, observation, ex, null);
+      } catch (Throwable ex) {
+        observation.error(ex);
         throw ex;
+      } finally {
+        observation.stop();
       }
     };
   }
@@ -80,24 +82,29 @@ public class MicrometerObservationCapability implements Capability {
                   this.observationRegistry)
               .start();
 
-      try {
+      try (Observation.Scope scope = observation.openScope()) {
         return client
             .execute(feignContext.getCarrier(), options, context)
-            .whenComplete((r, ex) -> finalizeObservation(feignContext, observation, ex, r));
-      } catch (FeignException ex) {
-        finalizeObservation(feignContext, observation, ex, null);
-
+            .whenComplete(
+                (response, ex) -> {
+                  feignContext.setResponse(response);
+                  if (ex != null) {
+                    observation.error(unwrap(ex));
+                  }
+                  observation.stop();
+                });
+      } catch (Throwable ex) {
+        observation.error(ex);
+        observation.stop();
         throw ex;
       }
     };
   }
 
-  private void finalizeObservation(
-      FeignContext feignContext, Observation observation, Throwable ex, Response response) {
-    feignContext.setResponse(response);
-    if (ex != null) {
-      observation.error(ex);
+  private static Throwable unwrap(Throwable ex) {
+    if (ex instanceof CompletionException && ex.getCause() != null) {
+      return ex.getCause();
     }
-    observation.stop();
+    return ex;
   }
 }

--- a/micrometer/src/test/java/feign/micrometer/MicrometerObservationCapabilityTest.java
+++ b/micrometer/src/test/java/feign/micrometer/MicrometerObservationCapabilityTest.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.micrometer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import feign.AsyncClient;
+import feign.AsyncFeign;
+import feign.Client;
+import feign.Feign;
+import feign.RequestLine;
+import feign.Retryer;
+import feign.Target.HardCodedTarget;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationHandler;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioural tests for {@link MicrometerObservationCapability} focusing on the cases that the
+ * existing capability did not cover:
+ *
+ * <ul>
+ *   <li>The observation is current (via {@code Observation.Scope}) while the client executes, so
+ *       downstream handlers — most notably tracing handlers that propagate trace/span ids into the
+ *       MDC — see the Feign-scoped observation rather than the parent.
+ *   <li>Exceptions thrown by the underlying client that are <em>not</em> {@code FeignException} —
+ *       {@code IOException}, {@code SocketTimeoutException}, runtime exceptions thrown by a custom
+ *       {@code ErrorDecoder}, and so on — still close the observation and record the error.
+ * </ul>
+ */
+class MicrometerObservationCapabilityTest {
+
+  interface TestClient {
+    @RequestLine("GET /")
+    String get();
+  }
+
+  interface AsyncTestClient {
+    @RequestLine("GET /")
+    CompletableFuture<String> get();
+  }
+
+  private TestObservationRegistry observationRegistry;
+
+  @BeforeEach
+  void setUp() {
+    this.observationRegistry = TestObservationRegistry.create();
+  }
+
+  @Test
+  void scopeIsOpenDuringClientExecution() {
+    AtomicReference<Observation> observedDuringExecute = new AtomicReference<>();
+    Client client =
+        (request, options) -> {
+          observedDuringExecute.set(observationRegistry.getCurrentObservation());
+          return feign.Response.builder()
+              .status(200)
+              .reason("OK")
+              .request(request)
+              .headers(java.util.Collections.emptyMap())
+              .build();
+        };
+
+    TestClient feignClient =
+        Feign.builder()
+            .client(client)
+            .addCapability(new MicrometerObservationCapability(observationRegistry))
+            .target(new HardCodedTarget<>(TestClient.class, "http://localhost"));
+
+    feignClient.get();
+
+    assertThat(observedDuringExecute.get())
+        .as("observation must be active (scoped) while the underlying client executes")
+        .isNotNull();
+    assertThat(observationRegistry.getCurrentObservation())
+        .as("observation must no longer be current after the call returns")
+        .isNull();
+  }
+
+  @Test
+  void recordsNonFeignExceptionThrownByClient() {
+    // Feign's SynchronousMethodHandler wraps IOExceptions, so callers don't see the original
+    // throwable. The observation captured by the capability sits below that wrapping, and is the
+    // only place the underlying error is recorded against the trace.
+    SocketTimeoutException underlying = new SocketTimeoutException("connect timed out");
+
+    Client client =
+        (request, options) -> {
+          throw underlying;
+        };
+
+    TestClient feignClient =
+        Feign.builder()
+            .client(client)
+            .retryer(Retryer.NEVER_RETRY)
+            .addCapability(new MicrometerObservationCapability(observationRegistry))
+            .target(new HardCodedTarget<>(TestClient.class, "http://localhost"));
+
+    assertThatThrownBy(feignClient::get).isInstanceOf(Exception.class);
+
+    TestObservationRegistryAssert.assertThat(observationRegistry)
+        .hasSingleObservationThat()
+        .hasBeenStopped()
+        .hasError(underlying);
+  }
+
+  @Test
+  void recordsRuntimeExceptionThrownByClient() {
+    RuntimeException underlying = new RuntimeException("boom");
+
+    Client client =
+        (request, options) -> {
+          throw underlying;
+        };
+
+    TestClient feignClient =
+        Feign.builder()
+            .client(client)
+            .retryer(Retryer.NEVER_RETRY)
+            .addCapability(new MicrometerObservationCapability(observationRegistry))
+            .target(new HardCodedTarget<>(TestClient.class, "http://localhost"));
+
+    assertThatThrownBy(feignClient::get).isInstanceOf(Exception.class);
+
+    TestObservationRegistryAssert.assertThat(observationRegistry)
+        .hasSingleObservationThat()
+        .hasBeenStopped()
+        .hasError(underlying);
+  }
+
+  @Test
+  void asyncScopeIsOpenDuringClientExecution() {
+    AtomicReference<Observation> observedDuringExecute = new AtomicReference<>();
+    AsyncClient<Object> client =
+        (request, options, context) -> {
+          observedDuringExecute.set(observationRegistry.getCurrentObservation());
+          return CompletableFuture.completedFuture(
+              feign.Response.builder()
+                  .status(200)
+                  .reason("OK")
+                  .request(request)
+                  .headers(java.util.Collections.emptyMap())
+                  .build());
+        };
+
+    AsyncTestClient feignClient =
+        AsyncFeign.<Object>builder()
+            .client(client)
+            .addCapability(new MicrometerObservationCapability(observationRegistry))
+            .target(new HardCodedTarget<>(AsyncTestClient.class, "http://localhost"));
+
+    feignClient.get().join();
+
+    assertThat(observedDuringExecute.get())
+        .as("observation must be active while the async client kicks off the request")
+        .isNotNull();
+  }
+
+  @Test
+  void asyncRecordsNonFeignExceptionFromFailedFuture() {
+    IOException underlying = new IOException("connection reset");
+
+    AsyncClient<Object> client =
+        (request, options, context) -> {
+          CompletableFuture<feign.Response> failed = new CompletableFuture<>();
+          failed.completeExceptionally(underlying);
+          return failed;
+        };
+
+    AsyncTestClient feignClient =
+        AsyncFeign.<Object>builder()
+            .client(client)
+            .retryer(Retryer.NEVER_RETRY)
+            .addCapability(new MicrometerObservationCapability(observationRegistry))
+            .target(new HardCodedTarget<>(AsyncTestClient.class, "http://localhost"));
+
+    assertThatThrownBy(() -> feignClient.get().join()).isInstanceOf(CompletionException.class);
+
+    TestObservationRegistryAssert.assertThat(observationRegistry)
+        .hasSingleObservationThat()
+        .hasBeenStopped()
+        .hasError(underlying);
+  }
+
+  @Test
+  void asyncRecordsSynchronousExceptionFromClient() {
+    RuntimeException underlying = new RuntimeException("immediate failure");
+
+    AsyncClient<Object> client =
+        (request, options, context) -> {
+          throw underlying;
+        };
+
+    AsyncTestClient feignClient =
+        AsyncFeign.<Object>builder()
+            .client(client)
+            .retryer(Retryer.NEVER_RETRY)
+            .addCapability(new MicrometerObservationCapability(observationRegistry))
+            .target(new HardCodedTarget<>(AsyncTestClient.class, "http://localhost"));
+
+    assertThatThrownBy(feignClient::get).isInstanceOf(RuntimeException.class);
+
+    TestObservationRegistryAssert.assertThat(observationRegistry)
+        .hasSingleObservationThat()
+        .hasBeenStopped()
+        .hasError(underlying);
+  }
+
+  @Test
+  void parentObservationIsRestoredAfterCall() {
+    Observation parent = Observation.start("parent", observationRegistry);
+    try (Observation.Scope ignored = parent.openScope()) {
+
+      Client client =
+          (request, options) ->
+              feign.Response.builder()
+                  .status(200)
+                  .reason("OK")
+                  .request(request)
+                  .headers(java.util.Collections.emptyMap())
+                  .build();
+
+      TestClient feignClient =
+          Feign.builder()
+              .client(client)
+              .addCapability(new MicrometerObservationCapability(observationRegistry))
+              .target(new HardCodedTarget<>(TestClient.class, "http://localhost"));
+
+      feignClient.get();
+
+      assertThat(observationRegistry.getCurrentObservation())
+          .as("parent observation must still be current after the Feign call completes")
+          .isSameAs(parent);
+    } finally {
+      parent.stop();
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void scopeReceivesObservationCarryingFeignContext() {
+    AtomicReference<Observation.Context> seenContext = new AtomicReference<>();
+
+    observationRegistry
+        .observationConfig()
+        .observationHandler(
+            new ObservationHandler<Observation.Context>() {
+              @Override
+              public void onScopeOpened(Observation.Context context) {
+                seenContext.set(context);
+              }
+
+              @Override
+              public boolean supportsContext(Observation.Context context) {
+                return true;
+              }
+            });
+
+    Client client =
+        (request, options) ->
+            feign.Response.builder()
+                .status(200)
+                .reason("OK")
+                .request(request)
+                .headers(java.util.Collections.emptyMap())
+                .build();
+
+    TestClient feignClient =
+        Feign.builder()
+            .client(client)
+            .addCapability(new MicrometerObservationCapability(observationRegistry))
+            .target(new HardCodedTarget<>(TestClient.class, "http://localhost"));
+
+    feignClient.get();
+
+    assertThat(seenContext.get())
+        .as("scope must propagate the FeignContext to ObservationHandler#onScopeOpened")
+        .isInstanceOf(FeignContext.class);
+  }
+}


### PR DESCRIPTION
## Summary

`MicrometerObservationCapability` had two related defects that left users without correct tracing or metrics when their feign-instrumented call did anything other than complete successfully or fail with a `FeignException`:

1. **The new observation was never made current** (#2406). The capability called `observation.start()` but never `observation.openScope()`. Any `ObservationHandler` that looks at the current observation — most notably the tracing handler that copies `traceId`/`spanId` into the MDC — saw the **parent** observation while the Feign call ran. Log lines emitted from inside the call were tagged with the wrong span id, breaking distributed-tracing log correlation.
2. **Only `FeignException` was caught** (#2566). The actual clients Feign delegates to throw client-specific types directly: JDK `HttpURLConnection` throws `SocketTimeoutException` / `ConnectException`, Apache HC5 throws `HttpHostConnectException`, OkHttp throws `IOException`. None of those are `FeignException`. They flew past the `catch`, the observation was never stopped, `observation.error(...)` was never called — so the timer was never committed, the trace stayed open, and one failed request quietly leaked an observation context.

Both fixes are small and live in the same handful of lines, so this PR addresses them together.

## What changed

In `MicrometerObservationCapability`:

- The synchronous and asynchronous `enrich` paths now open the observation as a `Scope` (`try (Observation.Scope scope = observation.openScope()) { … }`). The observation is the current observation while the underlying client runs, so MDC-propagating handlers see the Feign span — not the parent.
- The `catch` clause widened from `FeignException` to `Throwable`. Anything thrown by the underlying client is now captured by `observation.error(...)` and the observation is always stopped in `finally`. On the async path the same widening is applied to the synchronous portion of `execute` and to the `whenComplete` callback.
- The async path now unwraps `CompletionException` before recording, so the error stamped on the observation is the underlying cause rather than the executor wrapper.
- `finalizeObservation` collapsed into the inline logic now that the lifecycle is symmetrical.

## Why this shape

`Observation.Scope` is the documented mechanism in Micrometer for making an observation visible to downstream code — handlers, propagators, baggage. `start()` only marks the observation as in-flight; without `openScope()` the registry's `getCurrentObservation()` keeps returning the parent. Opening the scope inside a `try-with-resources` keeps the scope tied to the call boundary, so a thrown exception still closes it cleanly and the parent observation is correctly restored afterwards.

Catching `Throwable` rather than `Exception` is deliberate: the contract here is "the observation must be closed no matter what happens inside this block." `finally { observation.stop(); }` is what makes that true, and `catch (Throwable)` is what makes sure `observation.error(...)` gets the right cause attached before stop.

## Tests

Added `MicrometerObservationCapabilityTest` (uses `TestObservationRegistry` from `micrometer-observation-test`, already on the classpath via `micrometer-test`) covering:

- `scopeIsOpenDuringClientExecution` — `observationRegistry.getCurrentObservation()` returns the Feign observation while the underlying `Client` runs, and is `null` again afterwards. Locks in the fix for #2406.
- `recordsNonFeignExceptionThrownByClient` / `recordsRuntimeExceptionThrownByClient` — when the `Client` throws `SocketTimeoutException` / `RuntimeException`, the observation is stopped and the underlying error is recorded. Locks in #2566. (`Retryer.NEVER_RETRY` is used so the test asserts on the single observation produced, not on retry copies.)
- `asyncScopeIsOpenDuringClientExecution` — same for the async path.
- `asyncRecordsNonFeignExceptionFromFailedFuture` — a future completing exceptionally with `IOException` records the original `IOException` on the observation (not a `CompletionException` wrapper).
- `asyncRecordsSynchronousExceptionFromClient` — synchronous throws from inside `AsyncClient.execute` also stop the observation.
- `parentObservationIsRestoredAfterCall` — confirms the scope correctly returns to the caller's observation, so we aren't accidentally clobbering ambient tracing context.
- `scopeReceivesObservationCarryingFeignContext` — verifies the `FeignContext` is the context delivered to `ObservationHandler#onScopeOpened`, which is what tracing handlers actually read.

Existing tests still pass: `mvn -pl micrometer test` → 26 tests, 0 failures across `MicrometerCapabilityTest`, `MicrometerObservationRegistryCapabilityTest`, `FeignHeaderInstrumentationTest`, and the new class.

Fixes #2406
Fixes #2566