### PR TITLE
build(deps): consolidate spring-web/spring-context into single spring.version 7.0.8

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
-      <version>${spring-context.version}</version>
+      <version>${spring.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/form-spring/pom.xml
+++ b/form-spring/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
-      <version>${spring-web.version}</version>
+      <version>${spring.version}</version>
       <scope>compile</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -253,8 +253,7 @@
     <saaj-impl-3.version>3.0.2</saaj-impl-3.version>
     <spring-cloud-dependencies.version>2025.1.2</spring-cloud-dependencies.version>
     <spring-cloud-starter-openfeign.version>5.0.2</spring-cloud-starter-openfeign.version>
-    <spring-context.version>7.0.7</spring-context.version>
-    <spring-web.version>7.0.7</spring-web.version>
+    <spring.version>7.0.8</spring.version>
     <undertow-core.version>2.4.1.Final</undertow-core.version>
     <utils-java.version>1.18.0</utils-java.version>
   </properties>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -31,7 +31,6 @@
 
   <properties>
     <main.java.version>17</main.java.version>
-    <spring.version>7.0.7</spring.version>
   </properties>
 
   <dependencies>

--- a/spring4/pom.xml
+++ b/spring4/pom.xml
@@ -36,10 +36,6 @@
     </relocation>
   </distributionManagement>
 
-  <properties>
-    <spring.version>4.3.30.RELEASE</spring.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>io.github.openfeign</groupId>


### PR DESCRIPTION
Combines the two Spring dependency bumps (#3404 spring-web, #3402 spring-context) into a single change.

- Replaces the separate `spring-context.version` and `spring-web.version` properties with a single `spring.version` (bumped 7.0.7 → 7.0.8) in the parent pom.
- Updates `core`, `form-spring`, and `spring` to reference `${spring.version}` (the `spring` module previously pinned its own copy).
- `spring.version` is now defined only in the parent pom. Removed the unused `spring.version=4.3.30.RELEASE` from the `feign-spring4` relocation stub (it was never referenced).

Supersedes #3404 and #3402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)