### PR TITLE
feat: create streamable multipart body encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
   these cases. (https://github.com/OpenFeign/feign/pull/3396)
 * Added `feign.form.MultipartFormEncoder`, a new encoder for streaming multipart request bodies. It can stream
   multipart parts from `File`, `Path`, `InputStream`, and custom `Request.Body` implementations without buffering the
-  whole payload in memory.
+  whole payload in memory. (https://github.com/OpenFeign/feign/pull/3414)
 
 ### Version 13.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * `DefaultEncoder` now supports streaming request bodies for `File`, `Path`, `InputStream`, and `Request.Body` types,
   avoiding in-memory buffering. New `Request.PathBody` and `Request.InputStreamBody` implementations are provided for
   these cases. (https://github.com/OpenFeign/feign/pull/3396)
+* Added `feign.form.MultipartFormEncoder`, a new encoder for streaming multipart request bodies. It can stream
+  multipart parts from `File`, `Path`, `InputStream`, and custom `Request.Body` implementations without buffering the
+  whole payload in memory.
 
 ### Version 13.12
 

--- a/MIGRATION-v14.md
+++ b/MIGRATION-v14.md
@@ -25,12 +25,12 @@ The **breaking changes** primarily affect code that interacts directly with requ
 This is an additive, non-breaking change. Existing `DefaultEncoder` users do not need to modify code; users can now opt
 into streaming by passing these types.
 
-### `MultipartFormEncoder` streaming support (non-breaking)
+### `MultipartFormEncoder` streaming support (non-breaking) (https://github.com/OpenFeign/feign/pull/3414)
 
-`feign.form.MultipartFormEncoder` can now encode multipart requests as streaming `Request.Body` instances.
+`feign.form.MultipartFormEncoder` was introduced to encode multipart requests as streaming `Request.Body` instances.
 This is also additive and non-breaking: existing multipart clients continue to work, and users can opt into streaming
-parts such as `File`, `Path`, `InputStream`, or custom `Request.Body` implementations without changing their
-existing request mappings.
+parts such as `File`, `Path`, `InputStream`, or custom `Request.Body` implementations by migrating from `FormEncoder` to
+`MultipartFormEncoder`.
 
 ---
 

--- a/MIGRATION-v14.md
+++ b/MIGRATION-v14.md
@@ -25,6 +25,13 @@ The **breaking changes** primarily affect code that interacts directly with requ
 This is an additive, non-breaking change. Existing `DefaultEncoder` users do not need to modify code; users can now opt
 into streaming by passing these types.
 
+### `MultipartFormEncoder` streaming support (non-breaking)
+
+`feign.form.MultipartFormEncoder` can now encode multipart requests as streaming `Request.Body` instances.
+This is also additive and non-breaking: existing multipart clients continue to work, and users can opt into streaming
+parts such as `File`, `Path`, `InputStream`, or custom `Request.Body` implementations without changing their
+existing request mappings.
+
 ---
 
 ## Breaking Changes

--- a/README.md
+++ b/README.md
@@ -1444,6 +1444,55 @@ In the example above, the `sendPhoto` method uses the `photo` parameter using th
   someApi.sendPhoto(true, formData);
 ```
 
+#### Streaming multipart/form-data (Feign 14+)
+
+Starting with Feign 14, you can stream `multipart/form-data` request bodies with low memory overhead using
+`feign.form.MultipartFormEncoder`. This encoder avoids loading entire file parts into memory, allowing you to transfer
+large payloads directly via streaming types like `java.nio.file.Path`.
+
+To customize part specifics (such as explicit filenames or content types), use the `feign.form.multipart.FormData`
+wrapper object.
+
+> [!NOTE]
+> Ensure you import `feign.form.multipart.FormData` rather than the legacy `feign.form.FormData` container.
+
+```java
+class Pizza {
+    String name;
+    List<String> ingredients;
+}
+
+interface PizzaClient {
+    @RequestLine("POST /api/v1/pizzas")
+    void create(
+        @Param("category") String category,
+        @Param("image") File image,
+        @Param("pizza") FormData<Pizza> pizza
+    );
+}
+
+PizzaClient pizzaClient = Feign.builder()
+    .encoder(MultipartFormEncoder.builder()
+        .partBodyEncoders(List.of(new Jackson3Encoder()))
+        .build()
+    )
+    .target(PizzaClient.class, "https://api.pizza.com");
+
+Pizza pizza = new Pizza();
+pizza.name = "Margherita";
+pizza.ingredients = List.of("Tomato", "Mozzarella", "Basil");
+
+pizzaClient.create(
+    "premium-crust",
+
+    // to be streamed
+    new File("margherita.png"),
+
+    // to be converted to JSON via Jackson3Encoder
+    new FormData<>(pizza).contentType("application/json")
+);
+```
+
 ### Spring MultipartFile and Spring Cloud Netflix @FeignClient support
 
 You can also use Form Encoder with Spring `MultipartFile` and `@FeignClient`.
@@ -1546,5 +1595,31 @@ public interface DownloadClient {
       });
     }
   }
+}
+```
+
+#### Streaming Spring MultipartFile (Feign 14+)
+
+If you are using Spring Cloud OpenFeign and need to stream large `MultipartFile` payloads without consuming significant
+JVM memory, you can use `feign.form.spring.MultipartFileEncoder`. This encoder processes files as streams instead of
+loading their entire content into memory.
+
+```java
+@Configuration
+public class StreamingMultipartConfig {
+
+  @Bean
+  public Encoder feignFormEncoder() {
+    return MultipartFormEncoder.builder()
+            .partEncoders(encoders -> encoders.addFirst(new MultipartFileEncoder()))
+            .build();
+  }
+}
+
+@FeignClient(name = "large-file-upload-service", configuration = StreamingMultipartConfig.class)
+public interface LargeFileUploadClient {
+
+  @RequestMapping(value = "/upload", method = RequestMethod.POST, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  void uploadLargeFile(@RequestBody MultipartFile file);
 }
 ```

--- a/api/src/main/java/feign/Request.java
+++ b/api/src/main/java/feign/Request.java
@@ -408,6 +408,29 @@ public final class Request implements Serializable {
     }
 
     /**
+     * Indicates whether this {@link PathBody} is equal to another object.
+     *
+     * @param o {@inheritDoc}
+     * @return {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+      if (!(o instanceof PathBody)) return false;
+      PathBody pathBody = (PathBody) o;
+      return Objects.equals(path, pathBody.path);
+    }
+
+    /**
+     * Returns a hash code value for this {@link PathBody}.
+     *
+     * @return {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(path);
+    }
+
+    /**
      * Returns a string representation of the body content, which includes the file path and its
      * size in bytes (or "unknown size" if the content length cannot be determined). This provides a
      * human-readable description of the body content for debugging or logging purposes.
@@ -420,7 +443,7 @@ public final class Request implements Serializable {
       long contentLength = contentLength();
       String size = contentLength < 0 ? "unknown size" : contentLength + " bytes";
 
-      return "[Content of " + path + "(" + size + ")]";
+      return "[Content of " + path + " (" + size + ")]";
     }
   }
 
@@ -453,6 +476,29 @@ public final class Request implements Serializable {
     @Override
     public void writeTo(OutputStream outputStream) throws IOException {
       Util.copy(inputStream, outputStream);
+    }
+
+    /**
+     * Indicates whether this {@link InputStreamBody} is equal to another object.
+     *
+     * @param o {@inheritDoc}
+     * @return {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+      if (!(o instanceof InputStreamBody)) return false;
+      InputStreamBody that = (InputStreamBody) o;
+      return Objects.equals(inputStream, that.inputStream);
+    }
+
+    /**
+     * Returns a hash code value for this {@link InputStreamBody}.
+     *
+     * @return {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(inputStream);
     }
 
     /**
@@ -666,7 +712,7 @@ public final class Request implements Serializable {
 
     @Override
     public void writeTo(OutputStream outputStream) throws IOException {
-      Objects.requireNonNull(outputStream, "outputStream is required").write(content);
+      outputStream.write(content);
     }
 
     @Override

--- a/api/src/main/java/feign/Util.java
+++ b/api/src/main/java/feign/Util.java
@@ -62,6 +62,8 @@ public class Util {
   /** The HTTP Content-Encoding header field name. */
   public static final String CONTENT_ENCODING = "Content-Encoding";
 
+  public static final String CONTENT_TYPE = "Content-Type";
+
   /** The HTTP Accept-Encoding header field name. */
   public static final String ACCEPT_ENCODING = "Accept-Encoding";
 

--- a/api/src/main/java/feign/Util.java
+++ b/api/src/main/java/feign/Util.java
@@ -62,6 +62,7 @@ public class Util {
   /** The HTTP Content-Encoding header field name. */
   public static final String CONTENT_ENCODING = "Content-Encoding";
 
+  /** The HTTP Content-Type header field name. */
   public static final String CONTENT_TYPE = "Content-Type";
 
   /** The HTTP Accept-Encoding header field name. */

--- a/api/src/main/java/feign/codec/Encoder.java
+++ b/api/src/main/java/feign/codec/Encoder.java
@@ -31,7 +31,7 @@ import java.lang.reflect.Type;
  * void create(User user);
  * </pre>
  *
- * Example implementation: <br>
+ * <p>Example implementation: <br>
  *
  * <p>
  *
@@ -66,6 +66,7 @@ import java.lang.reflect.Type;
  * Session login(@Param(&quot;username&quot;) String username, @Param(&quot;password&quot;) String password);
  * </pre>
  */
+@FunctionalInterface
 public interface Encoder {
   /** Type literal for {@code Map<String, ?>}, indicating the object to encode is a form. */
   Type MAP_STRING_WILDCARD = Util.MAP_STRING_WILDCARD;
@@ -80,4 +81,16 @@ public interface Encoder {
    * @throws EncodeException when encoding failed due to a checked exception.
    */
   void encode(Object object, Type bodyType, RequestTemplate template) throws EncodeException;
+
+  /**
+   * Indicates whether this encoder supports encoding the given content type. Default implementation
+   * returns {@code true} for all content types.
+   *
+   * @param contentType the content type to check for support
+   * @return {@code true} if this encoder supports encoding the given content type, {@code false}
+   *     otherwise
+   */
+  default boolean supports(String contentType) {
+    return true;
+  }
 }

--- a/api/src/main/java/feign/codec/XmlEncoder.java
+++ b/api/src/main/java/feign/codec/XmlEncoder.java
@@ -15,18 +15,17 @@
  */
 package feign.codec;
 
-import feign.Experimental;
-
-@Experimental
-public interface JsonEncoder extends Encoder {
+/** An {@link Encoder} that encodes request bodies as XML. */
+@FunctionalInterface
+public interface XmlEncoder extends Encoder {
   /**
    * {@inheritDoc}
    *
    * @param contentType {@inheritDoc}
-   * @return {@code true} if the given {@code contentType} is a JSON media type, {@code false}
+   * @return {@code true} if the given {@code contentType} is an XML media type, {@code false}
    */
   @Override
   default boolean supports(String contentType) {
-    return contentType != null && contentType.trim().matches("(?i)\\w+/(?:[\\w._-]+\\+)?json.*");
+    return contentType != null && contentType.trim().matches("(?i)\\w+/(?:[\\w._-]+\\+)?xml.*");
   }
 }

--- a/form-spring/pom.xml
+++ b/form-spring/pom.xml
@@ -134,6 +134,13 @@
       <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
+      <version>${wiremock.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/form-spring/src/main/java/feign/form/spring/MultipartFileEncoder.java
+++ b/form-spring/src/main/java/feign/form/spring/MultipartFileEncoder.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.form.spring;
+
+import feign.Request;
+import feign.form.multipart.AbstractPartEncoder;
+import feign.form.multipart.Part;
+import feign.form.multipart.PartMetadata;
+import java.io.IOException;
+import java.io.OutputStream;
+import lombok.NonNull;
+import org.springframework.web.multipart.MultipartFile;
+
+/** Encoder for {@link MultipartFile} instances. */
+public class MultipartFileEncoder extends AbstractPartEncoder {
+  /**
+   * Encodes the content of the part using given {@link MultipartFile}.
+   *
+   * @param partMetadata {@inheritDoc}
+   * @return {@inheritDoc}
+   */
+  @Override
+  public Request.Body encode(PartMetadata partMetadata) {
+    var multipartFile = (MultipartFile) partMetadata.content().orElseThrow();
+
+    return new Part(
+        createHeaders(
+            multipartFile.getName(),
+            multipartFile.getOriginalFilename(),
+            multipartFile.getContentType()),
+        new MultipartFileBody(multipartFile));
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @param partMetadata {@inheritDoc}
+   * @return {@code true} if the content of the part is an instance of {@link MultipartFile}, {@code
+   *     false} otherwise
+   */
+  @Override
+  public boolean supports(PartMetadata partMetadata) {
+    return partMetadata.content().filter(MultipartFile.class::isInstance).isPresent();
+  }
+
+  private record MultipartFileBody(@NonNull MultipartFile multipartFile) implements Request.Body {
+    @Override
+    public void writeTo(OutputStream outputStream) throws IOException {
+      multipartFile.getInputStream().transferTo(outputStream);
+    }
+
+    @Override
+    public long contentLength() {
+      return multipartFile.getSize();
+    }
+
+    @Override
+    public String toString() {
+      return "[Binary data (" + contentLength() + " bytes)]";
+    }
+  }
+}

--- a/form-spring/src/test/java/feign/form/feign/spring/SpringStreamingMultipartFormTest.java
+++ b/form-spring/src/test/java/feign/form/feign/spring/SpringStreamingMultipartFormTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.form.feign.spring;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aMultipart;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import feign.Util;
+import feign.codec.Encoder;
+import feign.form.MultipartFormEncoder;
+import feign.form.spring.MultipartFileEncoder;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.multipart.MultipartFile;
+
+@SpringBootTest
+@WireMockTest(httpPort = 8080)
+class SpringStreamingMultipartFormTest {
+  private static final String REQUEST_PATH = "/";
+
+  @Autowired private SpringStreamingMultipartFormTestClient testClient;
+
+  @Test
+  void shouldSendMultipartFile() {
+    var name = "data";
+    var filename =
+        SpringStreamingMultipartFormTest.class.getSimpleName() + "_shouldSendMultipartFile.txt";
+    var contentType = MediaType.TEXT_PLAIN_VALUE;
+    var expected = "Hello, World!";
+    var multipartFile =
+        new MockMultipartFile(
+            name, filename, contentType, expected.getBytes(StandardCharsets.UTF_8));
+
+    stubFor(post(REQUEST_PATH).willReturn(ok()));
+
+    testClient.sendMultipartFile(multipartFile);
+
+    verify(
+        postRequestedFor(urlPathEqualTo(REQUEST_PATH))
+            .withHeader(Util.CONTENT_TYPE, containing(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .withRequestBodyPart(
+                aMultipart()
+                    .withName(name)
+                    .withFileName(filename)
+                    .withHeader(Util.CONTENT_TYPE, equalTo(contentType))
+                    .withBody(equalTo(expected))
+                    .build()));
+  }
+
+  @FeignClient(name = "spring-streaming-multipart-form-test-client", url = "http://localhost:8080")
+  private interface SpringStreamingMultipartFormTestClient {
+    @RequestMapping(
+        value = REQUEST_PATH,
+        method = RequestMethod.POST,
+        consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    void sendMultipartFile(@RequestBody MultipartFile data);
+  }
+
+  @Configuration
+  private static class SpringStreamingMultipartFormTestConfiguration {
+    @Bean
+    public Encoder feignEncoder() {
+      return MultipartFormEncoder.builder()
+          .partEncoders(encoders -> encoders.addFirst(new MultipartFileEncoder()))
+          .build();
+    }
+  }
+}

--- a/form/pom.xml
+++ b/form/pom.xml
@@ -108,6 +108,13 @@
       <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
+      <version>${wiremock.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/form/src/main/java/feign/form/MultipartFormEncoder.java
+++ b/form/src/main/java/feign/form/MultipartFormEncoder.java
@@ -37,9 +37,9 @@ import feign.form.multipart.PartResolverChain;
 import feign.form.multipart.PathPartEncoder;
 import feign.form.util.PojoUtil;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -111,7 +111,7 @@ public class MultipartFormEncoder implements Encoder {
       Consumer<List<PartEncoder>> partEncodersCustomizer,
       Collection<Encoder> partBodyEncoders) {
     var pathPartEncoder = new PathPartEncoder();
-    var partEncoders = new ArrayList<PartEncoder>();
+    var partEncoders = new LinkedList<PartEncoder>();
 
     partEncoders.add(new ByteArrayPartEncoder());
     partEncoders.add(new FilePartEncoder(pathPartEncoder));
@@ -124,7 +124,7 @@ public class MultipartFormEncoder implements Encoder {
       partEncodersCustomizer.accept(partEncoders);
     }
 
-    var partResolvers = new ArrayList<PartResolver>();
+    var partResolvers = new LinkedList<PartResolver>();
 
     partResolvers.add(new FormDataPartResolver());
     partResolvers.add(new ArrayPartResolver());

--- a/form/src/main/java/feign/form/MultipartFormEncoder.java
+++ b/form/src/main/java/feign/form/MultipartFormEncoder.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.form;
+
+import feign.RequestTemplate;
+import feign.Util;
+import feign.codec.EncodeException;
+import feign.codec.Encoder;
+import feign.core.codec.DefaultEncoder;
+import feign.form.multipart.ArrayPartResolver;
+import feign.form.multipart.ByteArrayPartEncoder;
+import feign.form.multipart.DefaultPartEncoder;
+import feign.form.multipart.DelegatingPartEncoder;
+import feign.form.multipart.FilePartEncoder;
+import feign.form.multipart.FormDataPartResolver;
+import feign.form.multipart.InputStreamPartEncoder;
+import feign.form.multipart.IterablePartResolver;
+import feign.form.multipart.LeafPartResolver;
+import feign.form.multipart.MultipartFormBody;
+import feign.form.multipart.PartEncoder;
+import feign.form.multipart.PartMetadata;
+import feign.form.multipart.PartResolver;
+import feign.form.multipart.PartResolverChain;
+import feign.form.multipart.PathPartEncoder;
+import feign.form.util.PojoUtil;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+/** An {@link Encoder} that encodes a request body as {@code multipart/form-data}. */
+@RequiredArgsConstructor
+public class MultipartFormEncoder implements Encoder {
+  @NonNull private final Encoder delegate;
+
+  @NonNull private final PartResolverChain partResolverChain;
+
+  /**
+   * Creates a new {@link MultipartFormEncoder} with a {@link DefaultEncoder} delegate and a default
+   * {@link PartResolverChain} that supports {@link FormData}, arrays, iterables, and scalar parts.
+   */
+  public MultipartFormEncoder() {
+    this((Encoder) null);
+  }
+
+  /**
+   * Creates a new {@link MultipartFormEncoder} with the given delegate {@link Encoder} and a
+   * default {@link PartResolverChain} that supports {@link FormData}, arrays, iterables, and scalar
+   * parts.
+   *
+   * @param delegate the delegate {@link Encoder} to use for encoding non-multipart request bodies.
+   *     If {@code null}, a default {@link DefaultEncoder} will be used.
+   */
+  public MultipartFormEncoder(Encoder delegate) {
+    this(delegate, null, null, null);
+  }
+
+  /**
+   * Creates a new {@link MultipartFormEncoder} with the given {@link PartResolverChain} and a
+   * default {@link DefaultEncoder} delegate.
+   *
+   * @param partResolverChain the {@link PartResolverChain} to use for resolving multipart parts. If
+   *     {@code null}, a default {@link PartResolverChain} that supports {@link FormData}, arrays,
+   *     iterables, and scalar parts will be used.
+   */
+  public MultipartFormEncoder(PartResolverChain partResolverChain) {
+    this(defaultDelegate(), partResolverChain);
+  }
+
+  @Builder
+  private MultipartFormEncoder(
+      Encoder delegate,
+      Consumer<List<PartResolver>> partResolvers,
+      Consumer<List<PartEncoder>> partEncoders,
+      Collection<Encoder> partBodyEncoders) {
+    this(
+        Objects.requireNonNullElseGet(delegate, MultipartFormEncoder::defaultDelegate),
+        buildPartResolverOrchestrator(
+            partResolvers,
+            partEncoders,
+            Objects.requireNonNullElseGet(partBodyEncoders, Collections::emptyList)));
+  }
+
+  private static Encoder defaultDelegate() {
+    return new DefaultEncoder();
+  }
+
+  private static PartResolverChain buildPartResolverOrchestrator(
+      Consumer<List<PartResolver>> partResolversCustomizer,
+      Consumer<List<PartEncoder>> partEncodersCustomizer,
+      Collection<Encoder> partBodyEncoders) {
+    var pathPartEncoder = new PathPartEncoder();
+    var partEncoders = new ArrayList<PartEncoder>();
+
+    partEncoders.add(new ByteArrayPartEncoder());
+    partEncoders.add(new FilePartEncoder(pathPartEncoder));
+    partEncoders.add(pathPartEncoder);
+    partEncoders.add(new InputStreamPartEncoder());
+    partEncoders.add(new DelegatingPartEncoder(partBodyEncoders));
+    partEncoders.add(new DefaultPartEncoder());
+
+    if (partEncodersCustomizer != null) {
+      partEncodersCustomizer.accept(partEncoders);
+    }
+
+    var partResolvers = new ArrayList<PartResolver>();
+
+    partResolvers.add(new FormDataPartResolver());
+    partResolvers.add(new ArrayPartResolver());
+    partResolvers.add(new IterablePartResolver());
+    partResolvers.add(new LeafPartResolver(partEncoders));
+
+    if (partResolversCustomizer != null) {
+      partResolversCustomizer.accept(partResolvers);
+    }
+
+    return new PartResolverChain(partResolvers);
+  }
+
+  /**
+   * Encodes the given {@code object} as a multipart form body if the request template indicates a
+   * {@code multipart/form-data} content type. Otherwise, delegates to the provided {@link Encoder}.
+   *
+   * @param object {@inheritDoc}
+   * @param bodyType {@inheritDoc}
+   * @param template {@inheritDoc}
+   * @throws EncodeException {@inheritDoc}
+   */
+  @Override
+  public void encode(Object object, Type bodyType, RequestTemplate template)
+      throws EncodeException {
+    if (!isMultipart(template)) {
+      delegate.encode(object, bodyType, template);
+      return;
+    }
+
+    var formData = getFormData(object, bodyType);
+
+    if (formData.isEmpty()) {
+      delegate.encode(object, bodyType, template);
+      return;
+    }
+
+    var multipartFormBody =
+        formData.entrySet().stream()
+            .flatMap(
+                entry ->
+                    partResolverChain.resolve(new PartMetadata(entry.getKey(), entry.getValue())))
+            .collect(Collectors.collectingAndThen(Collectors.toList(), MultipartFormBody::new));
+
+    template.header(Util.CONTENT_TYPE, Collections.emptyList()); // reset header
+    template.header(
+        Util.CONTENT_TYPE, "multipart/form-data; boundary=" + multipartFormBody.boundary());
+    template.body(multipartFormBody);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @param contentType {@inheritDoc}
+   * @return {@code true} if the given {@code contentType} is not {@code null} and starts with
+   *     {@code multipart/form-data} (case-insensitive), {@code false} otherwise.
+   */
+  @Override
+  public boolean supports(String contentType) {
+    return contentType != null
+        && contentType.trim().toLowerCase().startsWith("multipart/form-data");
+  }
+
+  private boolean isMultipart(RequestTemplate template) {
+    return template.headers().getOrDefault(Util.CONTENT_TYPE, Collections.emptyList()).stream()
+        .anyMatch(this::supports);
+  }
+
+  private Map<String, Object> getFormData(Object object, Type bodyType) {
+    if (object instanceof Map) {
+      @SuppressWarnings("unchecked")
+      var formData = (Map<String, Object>) object;
+
+      return formData;
+    }
+
+    return PojoUtil.isUserPojo(bodyType) ? PojoUtil.toMap(object) : Collections.emptyMap();
+  }
+}

--- a/form/src/main/java/feign/form/multipart/AbstractPartEncoder.java
+++ b/form/src/main/java/feign/form/multipart/AbstractPartEncoder.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.form.multipart;
+
+import feign.Util;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Base class for {@link PartEncoder} implementations that provides common functionality for
+ * creating headers for multipart form data parts.
+ */
+public abstract class AbstractPartEncoder implements PartEncoder {
+  private static final char DOUBLE_QUOTE = '"';
+
+  /**
+   * Creates headers for a multipart form data part based on the provided name, filename, and
+   * content type.
+   *
+   * @param name the name of the form field
+   * @param filename the optional filename to include in the {@code Content-Disposition} header; may
+   *     be {@code null}
+   * @param contentType the optional content type to include in the {@code Content-Type} header; may
+   *     be {@code null}
+   * @return a map of headers for the multipart form data part
+   */
+  protected Map<String, String> createHeaders(String name, String filename, String contentType) {
+    var headers = new LinkedHashMap<String, String>();
+    var disposition =
+        new StringBuilder("form-data; name=")
+            .append(DOUBLE_QUOTE)
+            .append(name)
+            .append(DOUBLE_QUOTE);
+
+    if (filename != null) {
+      disposition.append("; filename=").append(DOUBLE_QUOTE).append(filename).append(DOUBLE_QUOTE);
+    }
+
+    headers.put("Content-Disposition", disposition.toString());
+
+    if (contentType != null) {
+      headers.put(Util.CONTENT_TYPE, contentType);
+    }
+
+    return headers;
+  }
+}

--- a/form/src/main/java/feign/form/multipart/ArrayPartResolver.java
+++ b/form/src/main/java/feign/form/multipart/ArrayPartResolver.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.form.multipart;
+
+import feign.Request;
+import feign.codec.EncodeException;
+import java.lang.reflect.Array;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * Resolves array content by creating a part for each element in the array. Byte arrays are excluded
+ * since they are commonly used to represent binary data and should be treated as a single part.
+ */
+public class ArrayPartResolver implements PartResolver {
+  /**
+   * Resolves the given part metadata by delegating each array element to the {@code chain}.
+   *
+   * @param partMetadata {@inheritDoc}
+   * @param chain {@inheritDoc}
+   * @return {@inheritDoc}
+   * @throws EncodeException {@inheritDoc}
+   */
+  @Override
+  public Stream<Request.Body> resolve(PartMetadata partMetadata, PartResolverChain chain)
+      throws EncodeException {
+    var content = partMetadata.content().orElseThrow();
+
+    return IntStream.range(0, Array.getLength(content))
+        .mapToObj(
+            i ->
+                chain.resolve(
+                    new PartMetadata(
+                        partMetadata.name(),
+                        Array.get(content, i),
+                        partMetadata.filenameOverride().orElse(null),
+                        partMetadata.contentTypeOverride().orElse(null))))
+        .flatMap(Function.identity());
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @param partMetadata {@inheritDoc}
+   * @return {@code true} if the content is an array (excluding byte arrays), {@code false}
+   *     otherwise
+   */
+  @Override
+  public boolean supports(PartMetadata partMetadata) {
+    return partMetadata
+        .content()
+        .filter(content -> content.getClass().isArray() && !(content instanceof byte[]))
+        .isPresent();
+  }
+}

--- a/form/src/main/java/feign/form/multipart/ByteArrayPartEncoder.java
+++ b/form/src/main/java/feign/form/multipart/ByteArrayPartEncoder.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.form.multipart;
+
+import feign.Request;
+
+/** A {@link PartEncoder} that encodes a part with a byte array content. */
+public class ByteArrayPartEncoder extends AbstractPartEncoder {
+  /**
+   * Creates a {@link Request.Body} from a given byte array part content.
+   *
+   * @param partMetadata {@inheritDoc}
+   * @return {@inheritDoc}
+   */
+  @Override
+  public Request.Body encode(PartMetadata partMetadata) {
+    return new Part(
+        createHeaders(
+            partMetadata.name(),
+            partMetadata.filenameOverride().orElse(null),
+            partMetadata.contentTypeOverride().orElse(null)),
+        Request.Body.of((byte[]) partMetadata.content().orElseThrow()));
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @param partMetadata {@inheritDoc}
+   * @return {@code true} if the part content is a byte array, {@code false} otherwise
+   */
+  @Override
+  public boolean supports(PartMetadata partMetadata) {
+    return partMetadata.content().filter(byte[].class::isInstance).isPresent();
+  }
+}

--- a/form/src/main/java/feign/form/multipart/DefaultPartEncoder.java
+++ b/form/src/main/java/feign/form/multipart/DefaultPartEncoder.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.form.multipart;
+
+import feign.Request;
+
+/** Default implementation of {@link PartEncoder}. Supports all types of parts. */
+public class DefaultPartEncoder extends AbstractPartEncoder {
+  /**
+   * Creates a {@link Request.Body} from the given {@link PartMetadata} making {@code
+   * partMetadata.content.toString()} a body content.
+   *
+   * @param partMetadata {@inheritDoc}
+   * @return {@inheritDoc}
+   */
+  @Override
+  public Request.Body encode(PartMetadata partMetadata) {
+    return new Part(
+        createHeaders(
+            partMetadata.name(),
+            partMetadata.filenameOverride().orElse(null),
+            partMetadata.contentTypeOverride().orElse(null)),
+        Request.Body.of(partMetadata.content().orElseThrow().toString()));
+  }
+}

--- a/form/src/main/java/feign/form/multipart/DelegatingPartEncoder.java
+++ b/form/src/main/java/feign/form/multipart/DelegatingPartEncoder.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.form.multipart;
+
+import feign.Request;
+import feign.RequestTemplate;
+import feign.codec.EncodeException;
+import feign.codec.Encoder;
+import java.util.Collection;
+import java.util.Optional;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * A {@link PartEncoder} that delegates the encoding of the part body to a collection of {@link
+ * Encoder}s based on the content type.
+ */
+@RequiredArgsConstructor
+public class DelegatingPartEncoder extends AbstractPartEncoder {
+  @NonNull private final Collection<Encoder> delegates;
+
+  /**
+   * Creates a {@link Request.Body} for the given {@link PartMetadata} by delegating the encoding of
+   * the part body to the appropriate {@link Encoder} based on the content type.
+   *
+   * @param partMetadata {@inheritDoc}
+   * @return {@inheritDoc}
+   * @throws EncodeException {@inheritDoc}
+   */
+  @Override
+  public Request.Body encode(PartMetadata partMetadata) throws EncodeException {
+    var contentType = partMetadata.contentTypeOverride().orElseThrow();
+
+    return new Part(
+        createHeaders(
+            partMetadata.name(), partMetadata.filenameOverride().orElse(null), contentType),
+        createBody(contentType, partMetadata.content().orElse(null)));
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @param partMetadata {@inheritDoc}
+   * @return {@code true} if there is an {@link Encoder} available for the content type, {@code
+   *     false} otherwise
+   */
+  @Override
+  public boolean supports(PartMetadata partMetadata) {
+    return partMetadata.contentTypeOverride().flatMap(this::findEncoder).isPresent();
+  }
+
+  private Optional<Encoder> findEncoder(String contentType) {
+    return delegates.stream().filter(encoder -> encoder.supports(contentType)).findFirst();
+  }
+
+  private Request.Body createBody(String contentType, Object content) throws EncodeException {
+    var encoder =
+        findEncoder(contentType)
+            .orElseThrow(
+                () -> new EncodeException("No encoder found for content type: " + contentType));
+    var requestTemplate = new RequestTemplate();
+
+    encoder.encode(content, content.getClass(), requestTemplate);
+
+    return requestTemplate
+        .requestBody()
+        .orElseThrow(() -> new EncodeException("Body part was not encoded: " + content));
+  }
+}

--- a/form/src/main/java/feign/form/multipart/FilePartEncoder.java
+++ b/form/src/main/java/feign/form/multipart/FilePartEncoder.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.form.multipart;
+
+import feign.Request;
+import java.io.File;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+/** A {@link PartEncoder} that delegates to another {@link PartEncoder} for {@link File} content. */
+@RequiredArgsConstructor
+public class FilePartEncoder extends AbstractPartEncoder {
+  @NonNull private final PartEncoder delegate;
+
+  /**
+   * Creates a {@link Request.Body} from the given {@link PartMetadata} by converting the content to
+   * a {@link java.nio.file.Path} and delegating to the provided {@link PartEncoder}.
+   *
+   * @param partMetadata {@inheritDoc}
+   * @return {@inheritDoc}
+   */
+  @Override
+  public Request.Body encode(PartMetadata partMetadata) {
+    return delegate.encode(toPathPartMetadata(partMetadata));
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @param partMetadata {@inheritDoc}
+   * @return {@code true} if the content is a {@link File} and the delegate supports it, {@code
+   *     false} otherwise
+   */
+  @Override
+  public boolean supports(PartMetadata partMetadata) {
+    return partMetadata
+        .content()
+        .filter(
+            content ->
+                content instanceof File && delegate.supports(toPathPartMetadata(partMetadata)))
+        .isPresent();
+  }
+
+  private PartMetadata toPathPartMetadata(PartMetadata partMetadata) {
+    return new PartMetadata(
+        partMetadata.name(),
+        partMetadata.content().map(content -> ((File) content).toPath()).orElseThrow(),
+        partMetadata.filenameOverride().orElse(null),
+        partMetadata.contentTypeOverride().orElse(null));
+  }
+}

--- a/form/src/main/java/feign/form/multipart/FormData.java
+++ b/form/src/main/java/feign/form/multipart/FormData.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.form.multipart;
+
+import java.util.Optional;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
+
+/**
+ * A wrapper for multipart form data. It allows to specify content, content type and filename for a
+ * multipart part. The content is required, while content type and filename are optional.
+ *
+ * @param <T> type of the content
+ */
+@Data
+@RequiredArgsConstructor
+@Accessors(fluent = true)
+public class FormData<T> {
+  private final T content;
+  private String contentType;
+  private String filename;
+
+  /**
+   * Gets the content of the multipart part.
+   *
+   * @return an {@link Optional} containing the content, or an empty {@link Optional} if the content
+   *     is {@code null}.
+   */
+  public Optional<T> content() {
+    return Optional.ofNullable(content);
+  }
+
+  /**
+   * Gets the content type of the multipart part.
+   *
+   * @return an {@link Optional} containing the content type, or an empty {@link Optional} if the
+   *     content type is {@code null}.
+   */
+  public Optional<String> contentType() {
+    return Optional.ofNullable(contentType);
+  }
+
+  /**
+   * Gets the filename of the multipart part.
+   *
+   * @return an {@link Optional} containing the filename, or an empty {@link Optional} if the
+   *     filename is {@code null}.
+   */
+  public Optional<String> filename() {
+    return Optional.ofNullable(filename);
+  }
+}

--- a/form/src/main/java/feign/form/multipart/FormDataPartResolver.java
+++ b/form/src/main/java/feign/form/multipart/FormDataPartResolver.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.form.multipart;
+
+import feign.Request;
+import feign.codec.EncodeException;
+import java.util.stream.Stream;
+
+/**
+ * A {@link PartResolver} that resolves {@link FormData} into one or more {@link Request.Body}
+ * instances.
+ */
+public class FormDataPartResolver implements PartResolver {
+  /**
+   * Resolves the given {@code partMetadata} into one or more {@link Request.Body} instances by
+   * delegating to the {@code chain} with a new {@link PartMetadata} created from the given {@code
+   * partMetadata} and the content of the {@link FormData}.
+   *
+   * @param partMetadata {@inheritDoc}
+   * @param chain {@inheritDoc}
+   * @return {@inheritDoc}
+   * @throws EncodeException {@inheritDoc}
+   */
+  @Override
+  public Stream<Request.Body> resolve(PartMetadata partMetadata, PartResolverChain chain)
+      throws EncodeException {
+    var formData = (FormData<?>) partMetadata.content().orElseThrow();
+
+    return chain.resolve(
+        new PartMetadata(
+            partMetadata.name(),
+            formData.content().orElse(null),
+            formData.filename().orElse(null),
+            formData.contentType().orElse(null)));
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @param partMetadata {@inheritDoc}
+   * @return {@code true} if the content of the given {@code partMetadata} is an instance of {@link
+   *     FormData}, {@code false} otherwise.
+   */
+  @Override
+  public boolean supports(PartMetadata partMetadata) {
+    return partMetadata.content().filter(FormData.class::isInstance).isPresent();
+  }
+}

--- a/form/src/main/java/feign/form/multipart/InputStreamPartEncoder.java
+++ b/form/src/main/java/feign/form/multipart/InputStreamPartEncoder.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.form.multipart;
+
+import feign.Request;
+import java.io.InputStream;
+
+/**
+ * A {@link PartEncoder} implementation that supports multipart parts with {@link InputStream}
+ * content.
+ */
+public class InputStreamPartEncoder extends AbstractPartEncoder {
+  /**
+   * Creates a {@link Request.Body} from the given {@link PartMetadata} making the content of the
+   * part an {@link InputStream} body content.
+   *
+   * @param partMetadata {@inheritDoc}
+   * @return {@inheritDoc}
+   */
+  @Override
+  public Request.Body encode(PartMetadata partMetadata) {
+    return new Part(
+        createHeaders(
+            partMetadata.name(),
+            partMetadata.filenameOverride().orElse(null),
+            partMetadata.contentTypeOverride().orElse(null)),
+        new Request.InputStreamBody((InputStream) partMetadata.content().orElseThrow()));
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @param partMetadata {@inheritDoc}
+   * @return {@code true} if the content of the part is an {@link InputStream}, {@code false}
+   *     otherwise
+   */
+  @Override
+  public boolean supports(PartMetadata partMetadata) {
+    return partMetadata.content().filter(InputStream.class::isInstance).isPresent();
+  }
+}

--- a/form/src/main/java/feign/form/multipart/IterablePartResolver.java
+++ b/form/src/main/java/feign/form/multipart/IterablePartResolver.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.form.multipart;
+
+import feign.Request;
+import feign.codec.EncodeException;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * A {@link PartResolver} that resolves {@link Iterable} content by delegating to the next resolver
+ * in the chain for each item in the {@link Iterable}.
+ */
+public class IterablePartResolver implements PartResolver {
+  /**
+   * Resolves the given {@code partMetadata} by treating its content as an {@link Iterable} and
+   * delegating to the {@code chain} with a new {@link PartMetadata} created from the given {@code
+   * partMetadata} and each item in the {@link Iterable}.
+   *
+   * @param partMetadata {@inheritDoc}
+   * @param chain {@inheritDoc}
+   * @return {@inheritDoc}
+   * @throws EncodeException {@inheritDoc}
+   */
+  @Override
+  public Stream<Request.Body> resolve(PartMetadata partMetadata, PartResolverChain chain)
+      throws EncodeException {
+    return StreamSupport.stream(
+            ((Iterable<?>) partMetadata.content().orElseThrow()).spliterator(), false)
+        .flatMap(
+            item ->
+                chain.resolve(
+                    new PartMetadata(
+                        partMetadata.name(),
+                        item,
+                        partMetadata.filenameOverride().orElse(null),
+                        partMetadata.contentTypeOverride().orElse(null))));
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @param partMetadata {@inheritDoc}
+   * @return {@code true} if the content of the given {@code partMetadata} is an instance of {@link
+   *     Iterable} and not an instance of {@link Path}, {@code false} otherwise.
+   */
+  @Override
+  public boolean supports(PartMetadata partMetadata) {
+    return partMetadata
+        .content()
+        .filter(content -> content instanceof Iterable && !(content instanceof Path))
+        .isPresent();
+  }
+}

--- a/form/src/main/java/feign/form/multipart/LeafPartResolver.java
+++ b/form/src/main/java/feign/form/multipart/LeafPartResolver.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.form.multipart;
+
+import feign.Request;
+import feign.codec.EncodeException;
+import java.util.Collection;
+import java.util.stream.Stream;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * A {@link PartResolver} that resolves a multipart part into a single {@link Request.Body} using
+ * the first {@link PartEncoder} that supports the given {@link PartMetadata}.
+ */
+@RequiredArgsConstructor
+public class LeafPartResolver implements PartResolver {
+  @NonNull private final Collection<PartEncoder> partEncoders;
+
+  /**
+   * Resolves the given {@code partMetadata} into a single {@link Request.Body} using the first
+   * {@link PartEncoder} that supports the given {@code partMetadata}.
+   *
+   * @param partMetadata {@inheritDoc}
+   * @param chain {@inheritDoc}
+   * @return {@inheritDoc}
+   * @throws EncodeException {@inheritDoc}
+   */
+  @Override
+  public Stream<Request.Body> resolve(PartMetadata partMetadata, PartResolverChain chain)
+      throws EncodeException {
+    return partEncoders.stream()
+        .filter(encoder -> encoder.supports(partMetadata))
+        .findFirst()
+        .map(encoder -> Stream.of(encoder.encode(partMetadata)))
+        .orElseThrow(
+            () -> new EncodeException("No part encoder found for a part: " + partMetadata));
+  }
+}

--- a/form/src/main/java/feign/form/multipart/MultipartFormBody.java
+++ b/form/src/main/java/feign/form/multipart/MultipartFormBody.java
@@ -52,7 +52,7 @@ public class MultipartFormBody implements Request.Body {
    * Writes the multipart form body to the given output stream. The body is written in the following
    * format:
    *
-   * <pre>
+   * <pre>{@code
    * --boundary
    * headers
    *
@@ -63,7 +63,7 @@ public class MultipartFormBody implements Request.Body {
    * body
    * ...
    * --boundary--
-   * </pre>
+   * }</pre>
    *
    * @param outputStream {@inheritDoc}
    * @throws IOException {@inheritDoc}

--- a/form/src/main/java/feign/form/multipart/MultipartFormBody.java
+++ b/form/src/main/java/feign/form/multipart/MultipartFormBody.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.form.multipart;
+
+import feign.Request;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
+
+/** A multipart form body that can be used to send {@code multipart/form-data} requests. */
+@Data
+@RequiredArgsConstructor
+@Accessors(fluent = true)
+public class MultipartFormBody implements Request.Body {
+  private static final String CRLF = "\r\n";
+  private static final String DOUBLE_DASH = "--";
+
+  @NonNull private final Collection<Request.Body> parts;
+
+  @NonNull private final String boundary;
+
+  /**
+   * Creates a new {@link MultipartFormBody} with the given parts and a random boundary.
+   *
+   * @param parts the parts of the multipart form body
+   */
+  public MultipartFormBody(List<Request.Body> parts) {
+    this(parts, UUID.randomUUID().toString());
+  }
+
+  /**
+   * Writes the multipart form body to the given output stream. The body is written in the following
+   * format:
+   *
+   * <pre>
+   * --boundary
+   * headers
+   *
+   * body
+   * --boundary
+   * headers
+   *
+   * body
+   * ...
+   * --boundary--
+   * </pre>
+   *
+   * @param outputStream {@inheritDoc}
+   * @throws IOException {@inheritDoc}
+   */
+  @Override
+  public void writeTo(OutputStream outputStream) throws IOException {
+    for (var part : parts) {
+      writeString(outputStream, DOUBLE_DASH, boundary, CRLF);
+      part.writeTo(outputStream);
+      writeString(outputStream, CRLF);
+    }
+
+    writeString(outputStream, DOUBLE_DASH, boundary, DOUBLE_DASH, CRLF);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @return the content length of the multipart form body, or {@code -1} if any of the parts has an
+   *     unknown content length
+   */
+  @Override
+  public long contentLength() {
+    var partsLengths = parts.stream().mapToLong(Request.Body::contentLength).summaryStatistics();
+
+    return partsLengths.getMin() < 0
+        ? Request.Body.super.contentLength()
+        : partsLengths.getSum() + (6L + boundary.length()) * (parts.size() + 1);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @return {@code true} if all parts of the multipart form body are repeatable, {@code false}
+   *     otherwise
+   */
+  @Override
+  public boolean isRepeatable() {
+    return parts.stream().allMatch(Request.Body::isRepeatable);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @return a string representation of the multipart form body, which includes the boundary and the
+   *     string representation of each part
+   */
+  @Override
+  public String toString() {
+    var builder = new StringBuilder();
+
+    for (var part : parts) {
+      builder.append(DOUBLE_DASH).append(boundary).append(CRLF).append(part).append(CRLF);
+    }
+
+    return builder.append(DOUBLE_DASH).append(boundary).append(DOUBLE_DASH).append(CRLF).toString();
+  }
+
+  private void writeString(OutputStream outputStream, String... values) throws IOException {
+    for (var value : values) {
+      outputStream.write(value.getBytes(StandardCharsets.UTF_8));
+    }
+  }
+}

--- a/form/src/main/java/feign/form/multipart/Part.java
+++ b/form/src/main/java/feign/form/multipart/Part.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.form.multipart;
+
+import feign.Request;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Delegate;
+
+/** A multipart part consisting of headers and a body. */
+@Data
+@RequiredArgsConstructor
+public class Part implements Request.Body {
+  private static final String CRLF = "\r\n";
+
+  @NonNull private final Map<String, String> headers;
+
+  @NonNull @Delegate private final Request.Body body;
+
+  /**
+   * Writes the multipart part to the given output stream. The part is written in the following
+   * format:
+   *
+   * <pre>
+   * headers
+   *
+   * body content
+   * </pre>
+   *
+   * @param outputStream {@inheritDoc}
+   * @throws IOException {@inheritDoc}
+   */
+  @Override
+  public void writeTo(OutputStream outputStream) throws IOException {
+    outputStream.write(headersToString().getBytes(StandardCharsets.UTF_8));
+    body.writeTo(outputStream);
+  }
+
+  /**
+   * Returns the content length of the multipart part, which is the sum of the content length of the
+   * body and the length of the headers.
+   *
+   * @return the content length of the multipart part, or {@code -1} if the content length of the
+   *     body is unknown
+   */
+  @Override
+  public long contentLength() {
+    var contentLength = body.contentLength();
+
+    return contentLength < 0 ? contentLength : contentLength + headersToString().length();
+  }
+
+  /**
+   * Returns a string representation of the multipart part, which consists of the headers and the
+   * body content.
+   *
+   * @return a string representation of the multipart part
+   */
+  @Override
+  public String toString() {
+    return headersToString() + body;
+  }
+
+  private String headersToString() {
+    return headers.entrySet().stream()
+            .map(entry -> entry.getKey() + ": " + entry.getValue())
+            .collect(Collectors.joining(CRLF))
+        + CRLF
+        + CRLF;
+  }
+}

--- a/form/src/main/java/feign/form/multipart/Part.java
+++ b/form/src/main/java/feign/form/multipart/Part.java
@@ -40,11 +40,11 @@ public class Part implements Request.Body {
    * Writes the multipart part to the given output stream. The part is written in the following
    * format:
    *
-   * <pre>
+   * <pre>{@code
    * headers
    *
    * body content
-   * </pre>
+   * }</pre>
    *
    * @param outputStream {@inheritDoc}
    * @throws IOException {@inheritDoc}

--- a/form/src/main/java/feign/form/multipart/PartEncoder.java
+++ b/form/src/main/java/feign/form/multipart/PartEncoder.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.form.multipart;
+
+import feign.Request;
+import feign.codec.EncodeException;
+
+/**
+ * A strategy that encodes a {@link PartMetadata} into a {@link Request.Body}. It's recommended to
+ * use {@link AbstractPartEncoder} as a base class for custom implementations.
+ *
+ * @see AbstractPartEncoder
+ */
+@FunctionalInterface
+public interface PartEncoder {
+  /**
+   * Encodes the given {@link PartMetadata} into a {@link Request.Body}.
+   *
+   * @param partMetadata the metadata of the part to encode
+   * @return the encoded part as a {@link Request.Body}
+   * @throws EncodeException if encoding fails
+   */
+  Request.Body encode(PartMetadata partMetadata) throws EncodeException;
+
+  /**
+   * Determines whether this encoder supports encoding the given {@link PartMetadata}. By default,
+   * it returns {@code true}.
+   *
+   * @param partMetadata the metadata of the part to check for support
+   * @return {@code true} if this encoder supports encoding the given part metadata, {@code false}
+   *     otherwise
+   */
+  default boolean supports(PartMetadata partMetadata) {
+    return true;
+  }
+}

--- a/form/src/main/java/feign/form/multipart/PartMetadata.java
+++ b/form/src/main/java/feign/form/multipart/PartMetadata.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.form.multipart;
+
+import java.util.Optional;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import lombok.experimental.Accessors;
+
+/** Metadata for a single multipart part. */
+@Value
+@RequiredArgsConstructor
+@Accessors(fluent = true)
+public class PartMetadata {
+  /** Form field name; never {@code null}. */
+  @NonNull String name;
+
+  /** Content of the part. May be {@code null}. */
+  Object content;
+
+  /** Optional filename written into {@code Content-Disposition: ...; filename="<value>"}. */
+  String filenameOverride;
+
+  /** Optional media type written as {@code Content-Type: <value>}. */
+  String contentTypeOverride;
+
+  /**
+   * Constructs a new {@link PartMetadata} with the given name and content, and no filename or
+   * content type overrides.
+   *
+   * @param name form field name; must not be {@code null}
+   * @param content content of the part; may be {@code null}
+   */
+  public PartMetadata(String name, Object content) {
+    this(name, content, null, null);
+  }
+
+  /**
+   * Returns the content of the part as an {@link Optional}.
+   *
+   * @return an {@link Optional} containing the content of the part, or an empty {@link Optional} if
+   *     the content is {@code null}
+   */
+  public Optional<Object> content() {
+    return Optional.ofNullable(content);
+  }
+
+  /**
+   * Returns the filename override of the part as an {@link Optional}.
+   *
+   * @return an {@link Optional} containing the filename override of the part, or an empty {@link
+   *     Optional} if the filename override is {@code null}
+   */
+  public Optional<String> filenameOverride() {
+    return Optional.ofNullable(filenameOverride);
+  }
+
+  /**
+   * Returns the content type override of the part as an {@link Optional}.
+   *
+   * @return an {@link Optional} containing the content type override of the part, or an empty
+   *     {@link Optional} if the content type override is {@code null}
+   */
+  public Optional<String> contentTypeOverride() {
+    return Optional.ofNullable(contentTypeOverride);
+  }
+}

--- a/form/src/main/java/feign/form/multipart/PartResolver.java
+++ b/form/src/main/java/feign/form/multipart/PartResolver.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.form.multipart;
+
+import feign.Request;
+import feign.codec.EncodeException;
+import java.util.stream.Stream;
+
+/**
+ * A strategy for resolving {@link PartMetadata} into one or more {@link Request.Body} instances.
+ */
+@FunctionalInterface
+public interface PartResolver {
+  /**
+   * Resolves the given {@link PartMetadata} into one or more {@link Request.Body} instances.
+   *
+   * @param partMetadata the metadata of the part to resolve
+   * @param chain the chain of resolvers to delegate to if this resolver cannot handle the part
+   * @return a stream of {@link Request.Body} instances representing the resolved part
+   * @throws EncodeException if an error occurs during encoding the part
+   */
+  Stream<Request.Body> resolve(PartMetadata partMetadata, PartResolverChain chain)
+      throws EncodeException;
+
+  /**
+   * Determines whether this resolver supports the given {@link PartMetadata}. By default, it
+   * returns {@code true}.
+   *
+   * @param partMetadata the metadata of the part to check for support
+   * @return {@code true} if this resolver supports the given part metadata, {@code false} otherwise
+   */
+  default boolean supports(PartMetadata partMetadata) {
+    return true;
+  }
+}

--- a/form/src/main/java/feign/form/multipart/PartResolverChain.java
+++ b/form/src/main/java/feign/form/multipart/PartResolverChain.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.form.multipart;
+
+import feign.Request;
+import feign.codec.EncodeException;
+import java.util.Collection;
+import java.util.stream.Stream;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * A chain of {@link PartResolver} instances that can resolve a {@link PartMetadata} into one or
+ * more {@link Request.Body} instances.
+ */
+@RequiredArgsConstructor
+public class PartResolverChain {
+  @NonNull private final Collection<PartResolver> partResolvers;
+
+  /**
+   * Resolves the given {@link PartMetadata} into one or more {@link Request.Body} instances by
+   * delegating to the first {@link PartResolver} that supports the given {@code partMetadata}.
+   *
+   * @param partMetadata the metadata of the part to resolve
+   * @return a stream of {@link Request.Body} instances representing the resolved part
+   * @throws EncodeException if an error occurs during resolving/encoding the part
+   */
+  public Stream<Request.Body> resolve(PartMetadata partMetadata) throws EncodeException {
+    if (partMetadata.content().isEmpty()) {
+      return Stream.empty();
+    }
+
+    return partResolvers.stream()
+        .filter(resolver -> resolver.supports(partMetadata))
+        .findFirst()
+        .map(resolver -> resolver.resolve(partMetadata, this))
+        .orElseThrow(() -> new EncodeException("No resolver found for part: " + partMetadata));
+  }
+}

--- a/form/src/main/java/feign/form/multipart/PathPartEncoder.java
+++ b/form/src/main/java/feign/form/multipart/PathPartEncoder.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.form.multipart;
+
+import feign.Request;
+import java.net.URLConnection;
+import java.nio.file.Path;
+
+/** Encodes a {@link Path} as a multipart part. */
+public class PathPartEncoder extends AbstractPartEncoder {
+  /**
+   * Encodes the given {@link PartMetadata} into a {@link Request.Body}.
+   *
+   * @param partMetadata {@inheritDoc}
+   * @return {@inheritDoc}
+   */
+  @Override
+  public Request.Body encode(PartMetadata partMetadata) {
+    var path = (Path) partMetadata.content().orElseThrow();
+    var filename =
+        partMetadata
+            .filenameOverride()
+            .orElseGet(
+                () -> {
+                  var fileName = path.getFileName();
+
+                  return fileName != null ? fileName.toString() : null;
+                });
+    var contentType =
+        partMetadata
+            .contentTypeOverride()
+            .orElseGet(
+                () -> {
+                  if (filename != null) {
+                    var guessedContentType = URLConnection.guessContentTypeFromName(filename);
+
+                    if (guessedContentType != null) {
+                      return guessedContentType;
+                    }
+                  }
+
+                  return "application/octet-stream";
+                });
+
+    return new Part(
+        createHeaders(partMetadata.name(), filename, contentType), new Request.PathBody(path));
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @param partMetadata {@inheritDoc}
+   * @return {@code true} if the content of the given {@code partMetadata} is an instance of {@link
+   *     Path}, {@code false} otherwise.
+   */
+  @Override
+  public boolean supports(PartMetadata partMetadata) {
+    return partMetadata.content().filter(Path.class::isInstance).isPresent();
+  }
+}

--- a/form/src/test/java/feign/form/StreamingMultipartFormTest.java
+++ b/form/src/test/java/feign/form/StreamingMultipartFormTest.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.form;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aMultipart;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import feign.Feign;
+import feign.Headers;
+import feign.Param;
+import feign.RequestLine;
+import feign.Util;
+import feign.form.multipart.FormData;
+import feign.jackson.JacksonEncoder;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import lombok.Cleanup;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.http.MediaType;
+
+@WireMockTest
+public class StreamingMultipartFormTest {
+  private static final String REQUEST_PATH = "/";
+  private static final String REQUEST_LINE = "POST " + REQUEST_PATH;
+  private static final String MULTIPART_FORM_DATA_HEADER =
+      Util.CONTENT_TYPE + ": " + MediaType.MULTIPART_FORM_DATA_VALUE;
+  private static final String PARAM_NAME = "data";
+
+  private MultipartFormTestClient testClient;
+
+  @BeforeEach
+  public void setup(WireMockRuntimeInfo wmRuntimeInfo) {
+    testClient =
+        Feign.builder()
+            .encoder(
+                MultipartFormEncoder.builder()
+                    .partBodyEncoders(List.of(new JacksonEncoder()))
+                    .build())
+            .target(MultipartFormTestClient.class, wmRuntimeInfo.getHttpBaseUrl());
+
+    stubFor(post(REQUEST_PATH).willReturn(ok()));
+  }
+
+  @Test
+  void shouldSendStringArray() {
+    var joker = "Joker";
+    var harleyQuinn = "Harley Quinn";
+    var catwoman = "Catwoman";
+    var villains = new String[] {joker, harleyQuinn, catwoman};
+
+    testClient.sendStringArray(villains);
+
+    verify(
+        postRequestedFor(urlPathEqualTo(REQUEST_PATH))
+            .withHeader(Util.CONTENT_TYPE, containing(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .withRequestBodyPart(aMultipart().withName(PARAM_NAME).withBody(equalTo(joker)).build())
+            .withRequestBodyPart(
+                aMultipart().withName(PARAM_NAME).withBody(equalTo(harleyQuinn)).build())
+            .withRequestBodyPart(
+                aMultipart().withName(PARAM_NAME).withBody(equalTo(catwoman)).build()));
+  }
+
+  @Test
+  void shouldSendByteArray() {
+    var expected = "Hello, World!";
+
+    testClient.sendByteArray(expected.getBytes(StandardCharsets.UTF_8));
+
+    verify(
+        postRequestedFor(urlPathEqualTo(REQUEST_PATH))
+            .withHeader(Util.CONTENT_TYPE, containing(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .withRequestBodyPart(
+                aMultipart().withName(PARAM_NAME).withBody(equalTo(expected)).build()));
+  }
+
+  @Test
+  void shouldSendString() {
+    var expected = "Hello, World!";
+
+    testClient.sendString(expected);
+
+    verify(
+        postRequestedFor(urlPathEqualTo(REQUEST_PATH))
+            .withHeader(Util.CONTENT_TYPE, containing(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .withRequestBodyPart(
+                aMultipart().withName(PARAM_NAME).withBody(equalTo(expected)).build()));
+  }
+
+  @Test
+  void shouldSendJson() {
+    var movie = new Movie("The Dark Knight", "Christopher Nolan");
+    var expected =
+        """
+                {
+                  "title": "The Dark Knight",
+                  "director": "Christopher Nolan"
+                }
+                """;
+
+    testClient.sendMovie(new FormData<>(movie).contentType(MediaType.APPLICATION_JSON_VALUE));
+
+    verify(
+        postRequestedFor(urlPathEqualTo(REQUEST_PATH))
+            .withHeader(Util.CONTENT_TYPE, containing(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .withRequestBodyPart(
+                aMultipart()
+                    .withName(PARAM_NAME)
+                    .withHeader(Util.CONTENT_TYPE, equalTo(MediaType.APPLICATION_JSON_VALUE))
+                    .withBody(equalToJson(expected))
+                    .build()));
+  }
+
+  @Test
+  void shouldSendFile(@TempDir File tempDir) throws IOException {
+    var expected = "Hello, World!";
+    var file =
+        new File(tempDir, StreamingMultipartFormTest.class.getSimpleName() + "_shouldSendFile.txt");
+
+    Files.writeString(file.toPath(), expected);
+
+    testClient.sendFile(file);
+
+    verify(
+        postRequestedFor(urlPathEqualTo(REQUEST_PATH))
+            .withHeader(Util.CONTENT_TYPE, containing(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .withRequestBodyPart(
+                aMultipart()
+                    .withName(PARAM_NAME)
+                    .withFileName(file.getName())
+                    .withHeader(Util.CONTENT_TYPE, equalTo(MediaType.TEXT_PLAIN_VALUE))
+                    .withBody(equalTo(expected))
+                    .build()));
+  }
+
+  @Test
+  void shouldSendOctetStreamFile(@TempDir File tempDir) throws IOException {
+    var expected = "Hello, World!";
+    var file =
+        new File(
+            tempDir,
+            StreamingMultipartFormTest.class.getSimpleName() + "_shouldSendOctetStreamFile");
+
+    Files.writeString(file.toPath(), expected);
+
+    testClient.sendFile(file);
+
+    verify(
+        postRequestedFor(urlPathEqualTo(REQUEST_PATH))
+            .withHeader(Util.CONTENT_TYPE, containing(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .withRequestBodyPart(
+                aMultipart()
+                    .withName(PARAM_NAME)
+                    .withFileName(file.getName())
+                    .withHeader(
+                        Util.CONTENT_TYPE, equalTo(MediaType.APPLICATION_OCTET_STREAM_VALUE))
+                    .withBody(equalTo(expected))
+                    .build()));
+  }
+
+  @Test
+  void shouldSendFileWithOverriddenFilenameAndContentType(@TempDir File tempDir)
+      throws IOException {
+    var expected = "Hello, World!";
+    var filename =
+        StreamingMultipartFormTest.class.getSimpleName()
+            + "_shouldSendFileWithOverriddenFilenameAndContentType.txt";
+    var file =
+        new File(
+            tempDir,
+            StreamingMultipartFormTest.class.getSimpleName()
+                + "_shouldSendFileWithOverriddenFilenameAndContentType.md");
+
+    Files.writeString(file.toPath(), expected);
+
+    testClient.sendFileFormData(
+        new FormData<>(file).filename(filename).contentType(MediaType.TEXT_PLAIN_VALUE));
+
+    verify(
+        postRequestedFor(urlPathEqualTo(REQUEST_PATH))
+            .withHeader(Util.CONTENT_TYPE, containing(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .withRequestBodyPart(
+                aMultipart()
+                    .withName(PARAM_NAME)
+                    .withFileName(filename)
+                    .withHeader(Util.CONTENT_TYPE, equalTo(MediaType.TEXT_PLAIN_VALUE))
+                    .withBody(equalTo(expected))
+                    .build()));
+  }
+
+  @Test
+  void shouldSendInputStream() throws IOException {
+    var expected = "Hello, World!";
+    @Cleanup var inputStream = new ByteArrayInputStream(expected.getBytes(StandardCharsets.UTF_8));
+
+    testClient.sendInputStream(inputStream);
+
+    verify(
+        postRequestedFor(urlPathEqualTo(REQUEST_PATH))
+            .withHeader(Util.CONTENT_TYPE, containing(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .withRequestBodyPart(
+                aMultipart().withName(PARAM_NAME).withBody(equalTo(expected)).build()));
+  }
+
+  @Test
+  void shouldSendStringList() {
+    var joker = "Joker";
+    var harleyQuinn = "Harley Quinn";
+    var catwoman = "Catwoman";
+    var villains = List.of(joker, harleyQuinn, catwoman);
+
+    testClient.sendStringIterable(villains);
+
+    verify(
+        postRequestedFor(urlPathEqualTo(REQUEST_PATH))
+            .withHeader(Util.CONTENT_TYPE, containing(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .withRequestBodyPart(aMultipart().withName(PARAM_NAME).withBody(equalTo(joker)).build())
+            .withRequestBodyPart(
+                aMultipart().withName(PARAM_NAME).withBody(equalTo(harleyQuinn)).build())
+            .withRequestBodyPart(
+                aMultipart().withName(PARAM_NAME).withBody(equalTo(catwoman)).build()));
+  }
+
+  @Test
+  void shouldSendPath(@TempDir Path tempDir) throws IOException {
+    var expected = "Hello, World!";
+    var path =
+        tempDir.resolve(StreamingMultipartFormTest.class.getSimpleName() + "_shouldSendPath.txt");
+
+    Files.writeString(path, expected);
+
+    testClient.sendPath(path);
+
+    verify(
+        postRequestedFor(urlPathEqualTo(REQUEST_PATH))
+            .withHeader(Util.CONTENT_TYPE, containing(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .withRequestBodyPart(
+                aMultipart()
+                    .withName(PARAM_NAME)
+                    .withFileName(path.getFileName().toString())
+                    .withHeader(Util.CONTENT_TYPE, equalTo(MediaType.TEXT_PLAIN_VALUE))
+                    .withBody(equalTo(expected))
+                    .build()));
+  }
+
+  private interface MultipartFormTestClient {
+    @RequestLine(REQUEST_LINE)
+    @Headers(MULTIPART_FORM_DATA_HEADER)
+    void sendStringArray(@Param(PARAM_NAME) String[] data);
+
+    @RequestLine(REQUEST_LINE)
+    @Headers(MULTIPART_FORM_DATA_HEADER)
+    void sendByteArray(@Param(PARAM_NAME) byte[] data);
+
+    @RequestLine(REQUEST_LINE)
+    @Headers(MULTIPART_FORM_DATA_HEADER)
+    void sendString(@Param(PARAM_NAME) String data);
+
+    @RequestLine(REQUEST_LINE)
+    @Headers(MULTIPART_FORM_DATA_HEADER)
+    void sendMovie(@Param(PARAM_NAME) FormData<Movie> data);
+
+    @RequestLine(REQUEST_LINE)
+    @Headers(MULTIPART_FORM_DATA_HEADER)
+    void sendFile(@Param(PARAM_NAME) File data);
+
+    @RequestLine(REQUEST_LINE)
+    @Headers(MULTIPART_FORM_DATA_HEADER)
+    void sendFileFormData(@Param(PARAM_NAME) FormData<File> data);
+
+    @RequestLine(REQUEST_LINE)
+    @Headers(MULTIPART_FORM_DATA_HEADER)
+    void sendInputStream(@Param(PARAM_NAME) InputStream data);
+
+    @RequestLine(REQUEST_LINE)
+    @Headers(MULTIPART_FORM_DATA_HEADER)
+    void sendStringIterable(@Param(PARAM_NAME) Iterable<String> data);
+
+    @RequestLine(REQUEST_LINE)
+    @Headers(MULTIPART_FORM_DATA_HEADER)
+    void sendPath(@Param(PARAM_NAME) Path data);
+  }
+
+  private record Movie(
+      @JsonProperty("title") String title, @JsonProperty("director") String director) {}
+}

--- a/jackson-jaxb/src/main/java/feign/jackson/jaxb/JacksonJaxbJsonEncoder.java
+++ b/jackson-jaxb/src/main/java/feign/jackson/jaxb/JacksonJaxbJsonEncoder.java
@@ -23,12 +23,12 @@ import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
 import feign.Request;
 import feign.RequestTemplate;
 import feign.codec.EncodeException;
-import feign.codec.Encoder;
+import feign.codec.JsonEncoder;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Type;
 
-public final class JacksonJaxbJsonEncoder implements Encoder {
+public final class JacksonJaxbJsonEncoder implements JsonEncoder {
   private final JacksonJaxbJsonProvider jacksonJaxbJsonProvider;
 
   public JacksonJaxbJsonEncoder() {

--- a/jackson-jr/src/main/java/feign/jackson/jr/JacksonJrEncoder.java
+++ b/jackson-jr/src/main/java/feign/jackson/jr/JacksonJrEncoder.java
@@ -21,11 +21,12 @@ import feign.Request;
 import feign.RequestTemplate;
 import feign.codec.EncodeException;
 import feign.codec.Encoder;
+import feign.codec.JsonEncoder;
 import java.io.IOException;
 import java.lang.reflect.Type;
 
 /** A {@link Encoder} that uses Jackson Jr to convert objects to String or byte representation. */
-public class JacksonJrEncoder extends JacksonJrMapper implements Encoder {
+public class JacksonJrEncoder extends JacksonJrMapper implements JsonEncoder {
 
   public JacksonJrEncoder() {
     super();

--- a/jaxb-jakarta/src/main/java/feign/jaxb/JAXBEncoder.java
+++ b/jaxb-jakarta/src/main/java/feign/jaxb/JAXBEncoder.java
@@ -18,7 +18,7 @@ package feign.jaxb;
 import feign.Request;
 import feign.RequestTemplate;
 import feign.codec.EncodeException;
-import feign.codec.Encoder;
+import feign.codec.XmlEncoder;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
 import java.io.StringWriter;
@@ -43,7 +43,7 @@ import java.lang.reflect.Type;
  * <p>The JAXBContextFactory should be reused across requests as it caches the created JAXB
  * contexts.
  */
-public class JAXBEncoder implements Encoder {
+public class JAXBEncoder implements XmlEncoder {
 
   private final JAXBContextFactory jaxbContextFactory;
 

--- a/jaxb/src/main/java/feign/jaxb/JAXBEncoder.java
+++ b/jaxb/src/main/java/feign/jaxb/JAXBEncoder.java
@@ -18,7 +18,7 @@ package feign.jaxb;
 import feign.Request;
 import feign.RequestTemplate;
 import feign.codec.EncodeException;
-import feign.codec.Encoder;
+import feign.codec.XmlEncoder;
 import java.io.StringWriter;
 import java.lang.reflect.Type;
 import javax.xml.bind.JAXBException;
@@ -43,7 +43,7 @@ import javax.xml.bind.Marshaller;
  * <p>The JAXBContextFactory should be reused across requests as it caches the created JAXB
  * contexts.
  */
-public class JAXBEncoder implements Encoder {
+public class JAXBEncoder implements XmlEncoder {
 
   private final JAXBContextFactory jaxbContextFactory;
 

--- a/json/src/main/java/feign/json/JsonEncoder.java
+++ b/json/src/main/java/feign/json/JsonEncoder.java
@@ -20,7 +20,6 @@ import static java.lang.String.format;
 import feign.Request;
 import feign.RequestTemplate;
 import feign.codec.EncodeException;
-import feign.codec.Encoder;
 import java.lang.reflect.Type;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -52,7 +51,7 @@ import org.json.JSONObject;
  *   github.create("openfeign", "feign", contributor);
  * </pre>
  */
-public class JsonEncoder implements Encoder {
+public class JsonEncoder implements feign.codec.JsonEncoder {
 
   @Override
   public void encode(Object object, Type bodyType, RequestTemplate template)

--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,7 @@
     <mockito.version>5.23.0</mockito.version>
     <fastjson2.version>2.0.61.android8</fastjson2.version>
     <jsonassert.version>1.5.3</jsonassert.version>
+    <wiremock.version>3.13.2</wiremock.version>
 
     <git-code-format-maven-plugin.version>6.0</git-code-format-maven-plugin.version>
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>

--- a/soap-jakarta/src/main/java/feign/soap/SOAPEncoder.java
+++ b/soap-jakarta/src/main/java/feign/soap/SOAPEncoder.java
@@ -18,7 +18,7 @@ package feign.soap;
 import feign.Request;
 import feign.RequestTemplate;
 import feign.codec.EncodeException;
-import feign.codec.Encoder;
+import feign.codec.XmlEncoder;
 import feign.jaxb.JAXBContextFactory;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
@@ -83,7 +83,7 @@ import org.w3c.dom.Document;
  * <p>The JAXBContextFactory should be reused across requests as it caches the created JAXB
  * contexts.
  */
-public class SOAPEncoder implements Encoder {
+public class SOAPEncoder implements XmlEncoder {
 
   private static final String DEFAULT_SOAP_PROTOCOL = SOAPConstants.SOAP_1_1_PROTOCOL;
 

--- a/soap/src/main/java/feign/soap/SOAPEncoder.java
+++ b/soap/src/main/java/feign/soap/SOAPEncoder.java
@@ -18,7 +18,7 @@ package feign.soap;
 import feign.Request;
 import feign.RequestTemplate;
 import feign.codec.EncodeException;
-import feign.codec.Encoder;
+import feign.codec.XmlEncoder;
 import feign.jaxb.JAXBContextFactory;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -83,7 +83,7 @@ import org.w3c.dom.Document;
  * <p>The JAXBContextFactory should be reused across requests as it caches the created JAXB
  * contexts.
  */
-public class SOAPEncoder implements Encoder {
+public class SOAPEncoder implements XmlEncoder {
 
   private static final String DEFAULT_SOAP_PROTOCOL = SOAPConstants.SOAP_1_1_PROTOCOL;
 


### PR DESCRIPTION
## Summary

The third PR in a series related to #2734.

Introduces `feign.form.MultipartFormEncoder` — a new, fully streamable encoder for `multipart/form-data` requests. Unlike the existing `FormEncoder`, it writes each part directly to the underlying `OutputStream` without buffering the whole payload in memory, making it practical for large file uploads.

This is an **additive, non-breaking change.** Existing `FormEncoder` users are not affected. See [MIGRATION-v14.md](MIGRATION-v14.md) for notes.

> [!NOTE]
> **For maintainers:** existing `FormEncoder` (non-streaming) coexists in the same package as new `MultipartFormEncoder` (streaming). While I tried to add explicit notes to `README.md`, new users may get confused by these two encoders as well as `feign.form.FormData` (existing) vs `feign.form.multipart.FormData` (new) container classes. I decided not to remove any existing encoders so that this PR (a) becomes non-breaking and (b) does not introduce `UrlencodedFormEncoder` which is out of #2734 scope.
> If you prefer to remove the existing `FormEncoder` so that the users don't get confused, then this PR will become breaking. The same goes to `feign.form.spring.SpringFormEncoder` & `feign.form.spring.MultipartFileEncoder`.

---

## What's new

### `feign.form.MultipartFormEncoder`

The top-level encoder. It intercepts requests whose `Content-Type` is `multipart/form-data` and serialises all parameters as a streamed multipart body. Everything else is forwarded to a configurable delegate encoder (`DefaultEncoder` by default).

Constructor / builder options:

| API | Purpose |
|---|---|
| `new MultipartFormEncoder()` | Sensible defaults; use as a drop-in |
| `new MultipartFormEncoder(Encoder delegate)` | Custom delegate for non-multipart bodies |
| `MultipartFormEncoder.builder()` | Full control: custom part resolvers, part encoders, and delegate body encoders (JSON, XML, …) |

### `feign.form.multipart.FormData<T>`

A wrapper that lets callers supply an explicit `filename` and/or `contentType` for any single part, without changing the method signature:

```java
interface UploadClient {
    @RequestLine("POST /upload")
    void upload(
        @Param("metadata") FormData<Metadata> metadata,
        @Param("file") File file
    );
}

// At call site:
client.upload(
    new FormData<>(metadata).contentType("application/json"),
    new File("report.pdf")
);
```

> **Note:** import `feign.form.multipart.FormData`, not the legacy `feign.form.FormData`.

### Built-in part type support

| Part value type | Behaviour |
|---|---|
| `byte[]` | Sent as-is |
| `java.io.File` | Streamed via `Request.PathBody`; filename and MIME type inferred from the file name |
| `java.nio.file.Path` | Same as `File`; `application/octet-stream` fallback when MIME type cannot be guessed |
| `java.io.InputStream` | Streamed via `Request.InputStreamBody` |
| `FormData<?>` | Unwraps and re-resolves the inner content with optional overrides |
| Array (non-`byte[]`) | Expands into one part per element |
| `Iterable<?>` | Expands into one part per element |
| Any other object | `toString()` fallback (same as legacy `FormEncoder`) |
| Object + explicit `contentType` | Delegated to a registered `Encoder` (e.g. `JacksonEncoder`, `Gson3Encoder`) |

### `feign.form.spring.MultipartFileEncoder` (new, `form-spring` module)

Streams Spring's `MultipartFile` directly to the wire without loading the file into a `byte[]`:

```java
@Bean
public Encoder feignFormEncoder() {
    return MultipartFormEncoder.builder()
        .partEncoders(encoders -> encoders.addFirst(new MultipartFileEncoder()))
        .build();
}
```

---

## Architecture

The encoder is built around a **chain-of-responsibility** pattern with two orthogonal SPI layers:

```
MultipartFormEncoder
  └── PartResolverChain
        ├── FormDataPartResolver   // unwraps FormData<?>
        ├── ArrayPartResolver      // explodes arrays
        ├── IterablePartResolver   // explodes iterables
        └── LeafPartResolver       // hands off to PartEncoders
              ├── ByteArrayPartEncoder
              ├── FilePartEncoder  ──► PathPartEncoder
              ├── PathPartEncoder
              ├── InputStreamPartEncoder
              ├── DelegatingPartEncoder  // routes by Content-Type to Encoder
              └── DefaultPartEncoder     // toString() fallback
```

Both the resolver list and the encoder list are **mutable** before construction (`Consumer<List<PartResolver>>` / `Consumer<List<PartEncoder>>`), so callers can prepend, append, or replace entries without subclassing.

### `MultipartFormBody`

Implements `Request.Body` and writes the RFC 7578 wire format directly to the `OutputStream`:

- UUID-based random boundary, generated once per request.
- `contentLength()` is accurate when all parts report a known size (so `Content-Length` is set precisely); propagates `-1` when any part is unknown-length (e.g. `InputStream`).
- `isRepeatable()` delegates to all parts.

---

## API additions

### `feign.codec.Encoder`

```java
@FunctionalInterface            // <-- newly annotated
public interface Encoder {
    void encode(Object object, Type bodyType, RequestTemplate template)
        throws EncodeException;

    // NEW — lets DelegatingPartEncoder route by Content-Type
    default boolean supports(String contentType) { return true; }
}
```

### `feign.codec.JsonEncoder` / `feign.codec.XmlEncoder`

Two new marker sub-interfaces that implement `supports()` with appropriate content-type regexes (e.g. `\w+/(\w+\+)?json.*`). Existing encoder implementations have been updated to implement the right interface:

| Encoder | Now implements |
|---|---|
| `feign.json.JsonEncoder` | `feign.codec.JsonEncoder` |
| `JacksonJrEncoder` | `feign.codec.JsonEncoder` |
| `JacksonJaxbJsonEncoder` | `feign.codec.JsonEncoder` |
| `JAXBEncoder` (javax & jakarta) | `feign.codec.XmlEncoder` |
| `SOAPEncoder` (javax & jakarta) | `feign.codec.XmlEncoder` |

This is the mechanism by which `DelegatingPartEncoder` knows which encoder to invoke for a part annotated with `contentType("application/json")`.

### Minor `Request.Body` fixes

- `PathBody` and `InputStreamBody` — added `equals()` / `hashCode()`.
- `PathBody.toString()` — fixed whitespace: `(N bytes)` → ` (N bytes)`.
- `BytesBody.writeTo()` — removed redundant `Objects.requireNonNull` on `outputStream` (the contract already guarantees non-null).

### `Util.CONTENT_TYPE`

Added a public `"Content-Type"` string constant to eliminate scattered inline literals.

---

## Tests

| Test class | What it covers |
|---|---|
| `StreamingMultipartFormTest` | WireMock-based: `String`, `String[]`, `byte[]`, `File` (text, octet-stream), `Path`, `InputStream`, `List<String>`, `FormData<Movie>` (JSON via `JacksonEncoder`), filename + content-type override via `FormData` |
| `SpringStreamingMultipartFormTest` | Spring Boot + WireMock: `MultipartFile` streamed via `MultipartFileEncoder` |

Both use **WireMock 3.13.2**, added as a test-scoped dependency in `form/pom.xml` and `form-spring/pom.xml`.
