### PR TITLE
escape crlf and quotes in multipart Content-Disposition headers

### DIFF
--- a/form/src/main/java/feign/form/multipart/AbstractWriter.java
+++ b/form/src/main/java/feign/form/multipart/AbstractWriter.java
@@ -64,10 +64,14 @@ public abstract class AbstractWriter implements Writer {
     val contentDespositionBuilder =
         new StringBuilder()
             .append("Content-Disposition: form-data; name=\"")
-            .append(name)
+            .append(escapeHeaderParameter(name))
             .append("\"");
     if (fileName != null) {
-      contentDespositionBuilder.append("; ").append("filename=\"").append(fileName).append("\"");
+      contentDespositionBuilder
+          .append("; ")
+          .append("filename=\"")
+          .append(escapeHeaderParameter(fileName))
+          .append("\"");
     }
 
     String fileContentType = contentType;
@@ -93,5 +97,18 @@ public abstract class AbstractWriter implements Writer {
             .toString();
 
     output.write(string);
+  }
+
+  /**
+   * Escapes a {@code multipart/form-data} header parameter value so an attacker-supplied name or
+   * file name cannot break out of the quoted string and inject extra headers or part boundaries.
+   * Carriage return, line feed and double quote are percent-encoded, matching the WHATWG form-data
+   * encoding rules.
+   *
+   * @param value the raw parameter value.
+   * @return the escaped value, safe to place inside a quoted header parameter.
+   */
+  protected static String escapeHeaderParameter(String value) {
+    return value.replace("\r", "%0D").replace("\n", "%0A").replace("\"", "%22");
   }
 }

--- a/form/src/main/java/feign/form/multipart/SingleParameterWriter.java
+++ b/form/src/main/java/feign/form/multipart/SingleParameterWriter.java
@@ -37,7 +37,7 @@ public class SingleParameterWriter extends AbstractWriter {
     val string =
         new StringBuilder()
             .append("Content-Disposition: form-data; name=\"")
-            .append(key)
+            .append(escapeHeaderParameter(key))
             .append('"')
             .append(CRLF)
             .append("Content-Type: text/plain; charset=")

--- a/form/src/test/java/feign/form/multipart/AbstractWriterTest.java
+++ b/form/src/test/java/feign/form/multipart/AbstractWriterTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.form.multipart;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import feign.form.FormData;
+import org.junit.jupiter.api.Test;
+
+class AbstractWriterTest {
+
+  @Test
+  void fileNameWithCrlfAndQuoteIsEscaped() {
+    Output output = new Output(UTF_8);
+    FormData formData =
+        new FormData("text/plain", "evil\"\r\nX-Injected: 1", "body".getBytes(UTF_8));
+
+    new FormDataWriter().write(output, "boundary", "file", formData);
+    String written = new String(output.toByteArray(), UTF_8);
+
+    assertThat(written).contains("filename=\"evil%22%0D%0AX-Injected: 1\"");
+    assertThat(written).doesNotContain("\r\nX-Injected: 1");
+  }
+
+  @Test
+  void parameterNameWithCrlfIsEscaped() {
+    Output output = new Output(UTF_8);
+
+    new SingleParameterWriter().write(output, "boundary", "a\"\r\nX-Injected: 1", "value");
+    String written = new String(output.toByteArray(), UTF_8);
+
+    assertThat(written).contains("name=\"a%22%0D%0AX-Injected: 1\"");
+    assertThat(written).doesNotContain("\r\nX-Injected: 1");
+  }
+}


### PR DESCRIPTION
Repro: send a multipart request whose `FormData.fileName` (or a `File` name / field name) contains `"` or a CRLF, e.g. `evil"\r\nX-Injected: 1`.
Cause: `AbstractWriter.writeFileMetadata` and `SingleParameterWriter` append the field name and file name straight into the quoted `Content-Disposition` parameters, so the value can close the quote and start a new header line or part.
Fix: percent-encode `\r`, `\n` and `"` in those parameters inside the writer, matching the WHATWG `multipart/form-data` encoding rules. Added `AbstractWriterTest` covering an injected file name and field name.