### PR TITLE
escape crlf and quotes in streaming multipart part headers

### DIFF
--- a/form/src/main/java/feign/form/multipart/AbstractPartEncoder.java
+++ b/form/src/main/java/feign/form/multipart/AbstractPartEncoder.java
@@ -42,11 +42,15 @@ public abstract class AbstractPartEncoder implements PartEncoder {
     var disposition =
         new StringBuilder("form-data; name=")
             .append(DOUBLE_QUOTE)
-            .append(name)
+            .append(escapeHeaderParameter(name))
             .append(DOUBLE_QUOTE);
 
     if (filename != null) {
-      disposition.append("; filename=").append(DOUBLE_QUOTE).append(filename).append(DOUBLE_QUOTE);
+      disposition
+          .append("; filename=")
+          .append(DOUBLE_QUOTE)
+          .append(escapeHeaderParameter(filename))
+          .append(DOUBLE_QUOTE);
     }
 
     headers.put("Content-Disposition", disposition.toString());
@@ -56,5 +60,18 @@ public abstract class AbstractPartEncoder implements PartEncoder {
     }
 
     return headers;
+  }
+
+  /**
+   * Escapes a {@code multipart/form-data} header parameter value so an attacker-supplied name or
+   * file name cannot break out of the quoted string and inject extra headers or part boundaries.
+   * Carriage return, line feed and double quote are percent-encoded, matching the WHATWG form-data
+   * encoding rules.
+   *
+   * @param value the raw parameter value.
+   * @return the escaped value, safe to place inside a quoted header parameter.
+   */
+  protected static String escapeHeaderParameter(String value) {
+    return value.replace("\r", "%0D").replace("\n", "%0A").replace("\"", "%22");
   }
 }

--- a/form/src/test/java/feign/form/multipart/AbstractPartEncoderTest.java
+++ b/form/src/test/java/feign/form/multipart/AbstractPartEncoderTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.form.multipart;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import feign.Request;
+import org.junit.jupiter.api.Test;
+
+class AbstractPartEncoderTest {
+
+  @Test
+  void nameAndFileNameWithCrlfAndQuoteAreEscaped() {
+    PartMetadata metadata =
+        new PartMetadata(
+            "a\"\r\nX-Injected: 1",
+            "body".getBytes(UTF_8),
+            "evil\"\r\nX-Injected: 1",
+            "text/plain");
+
+    Request.Body body = new ByteArrayPartEncoder().encode(metadata);
+    String disposition = ((Part) body).getHeaders().get("Content-Disposition");
+
+    assertThat(disposition)
+        .isEqualTo(
+            "form-data; name=\"a%22%0D%0AX-Injected: 1\"; filename=\"evil%22%0D%0AX-Injected: 1\"");
+    assertThat(disposition).doesNotContain("\r\nX-Injected: 1");
+  }
+}


### PR DESCRIPTION
Backport of #3417 to the streaming `MultipartFormEncoder` added in #3414, as requested there.

Repro: send a streamed multipart request whose part `name` or `FormData` `filename` contains `"` or a CRLF, e.g. `evil"\r\nX-Injected: 1`.
Cause: `AbstractPartEncoder.createHeaders` appends the field name and file name straight into the quoted `Content-Disposition` parameters, so the value can close the quote and start a new header line or part. Same issue as the legacy writers fixed in #3417, on the new streaming path.
Fix: percent-encode `\r`, `\n` and `"` in those parameters (`escapeHeaderParameter`), matching the WHATWG `multipart/form-data` encoding rules. Added `AbstractPartEncoderTest` covering an injected name and file name.