### PR TITLE
Honor jdk.httpclient.allowRestrictedHeaders in Http2Client (#2975)

### DIFF
--- a/java11/src/main/java/feign/http2client/Http2Client.java
+++ b/java11/src/main/java/feign/http2client/Http2Client.java
@@ -242,13 +242,26 @@ public class Http2Client implements Client, AsyncClient<Object> {
    *
    * @see jdk.internal.net.http.common.Utils.DISALLOWED_HEADERS_SET
    */
-  private static final Set<String> DISALLOWED_HEADERS_SET;
+  private static final Set<String> DISALLOWED_HEADERS_SET =
+      disallowedHeaders(System.getProperty("jdk.httpclient.allowRestrictedHeaders"));
 
-  static {
+  /**
+   * Builds the set of headers the underlying JDK HttpClient refuses to send. Mirrors {@code
+   * jdk.internal.net.http.common.Utils#getDisallowedHeaders()}: headers listed (comma separated) in
+   * the {@code jdk.httpclient.allowRestrictedHeaders} system property are removed from the set, so
+   * that callers who opt in at the JDK level (e.g. to set {@code Host}) are not silently filtered
+   * out here as well.
+   */
+  static Set<String> disallowedHeaders(String allowRestrictedHeaders) {
     // A case insensitive TreeSet of strings.
     final TreeSet<String> treeSet = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
     treeSet.addAll(Set.of("connection", "content-length", "expect", "host", "upgrade"));
-    DISALLOWED_HEADERS_SET = Collections.unmodifiableSet(treeSet);
+    if (allowRestrictedHeaders != null) {
+      for (String header : allowRestrictedHeaders.split(",")) {
+        treeSet.remove(header.trim());
+      }
+    }
+    return Collections.unmodifiableSet(treeSet);
   }
 
   private Map<String, Collection<String>> filterRestrictedHeaders(

--- a/java11/src/test/java/feign/http2client/Http2ClientHeadersTest.java
+++ b/java11/src/test/java/feign/http2client/Http2ClientHeadersTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.http2client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class Http2ClientHeadersTest {
+
+  @Test
+  void filtersAllRestrictedHeadersByDefault() {
+    assertThat(Http2Client.disallowedHeaders(null))
+        .contains("connection", "content-length", "expect", "host", "upgrade");
+  }
+
+  @Test
+  void allowsHeaderListedInSystemProperty() {
+    assertThat(Http2Client.disallowedHeaders("host"))
+        .doesNotContain("host")
+        .contains("connection", "content-length", "expect", "upgrade");
+  }
+
+  @Test
+  void allowsMultipleHeadersCaseInsensitivelyAndIgnoresWhitespace() {
+    assertThat(Http2Client.disallowedHeaders("Host, Connection"))
+        .doesNotContain("host", "connection")
+        .contains("content-length", "expect", "upgrade");
+  }
+}


### PR DESCRIPTION
Fixes #2975

## Problem
The JDK `HttpClient` lets callers opt in to sending otherwise restricted headers (e.g. `Host`, `Connection`) by setting the `jdk.httpclient.allowRestrictedHeaders` system property. However `Http2Client` keeps its **own** hard-coded `DISALLOWED_HEADERS_SET` and strips those headers in `filterRestrictedHeaders(...)` *before* the request reaches the JDK client. As a result, even with `-Djdk.httpclient.allowRestrictedHeaders=host` the `Host` header is silently dropped and Feign sends the host derived from the URL instead.

## Change
`Http2Client` now mirrors `jdk.internal.net.http.common.Utils#getDisallowedHeaders()`: any header listed (comma-separated) in the `jdk.httpclient.allowRestrictedHeaders` system property is removed from the disallowed set, so opting in at the JDK level is no longer defeated by Feign's own filter. Default behavior (property unset) is unchanged — all of `connection, content-length, expect, host, upgrade` remain filtered.

The header-set construction was extracted into a package-private `disallowedHeaders(String)` method to keep it pure and unit-testable.

## Test evidence
Added `Http2ClientHeadersTest` covering the default set, single-header opt-in, and multi-header/case-insensitive/whitespace handling:

```
./mvnw -pl java11 -am test -Dtest=Http2ClientHeadersTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```
Code format validated via `git-code-format-maven-plugin:validate-code-format` (BUILD SUCCESS).

Verification done: confirmed bug pattern still on master (static `DISALLOWED_HEADERS_SET` strips headers unconditionally); no in-flight PR or linked branch for #2975; no self-claim in thread (maintainer invited a PR with tests on 2026-06-04); change is code-only in `.java`; commit carries DCO sign-off.