### PR TITLE
Make Expressions max length configurable (fixes #2916)

### DIFF
--- a/core/src/main/java/feign/template/Expressions.java
+++ b/core/src/main/java/feign/template/Expressions.java
@@ -25,7 +25,14 @@ import java.util.regex.Pattern;
 
 public final class Expressions {
 
-  private static final int MAX_EXPRESSION_LENGTH = 10000;
+  /**
+   * System property controlling the maximum allowed length of a single expression. Defaults to
+   * {@link #DEFAULT_MAX_EXPRESSION_LENGTH}. Setting it to {@code 0} (or any non-positive value)
+   * disables the length check entirely.
+   */
+  static final String MAX_EXPRESSION_LENGTH_PROPERTY = "feign.template.expression.maxLength";
+
+  private static final int DEFAULT_MAX_EXPRESSION_LENGTH = 10000;
 
   private static final String PATH_STYLE_OPERATOR = ";";
 
@@ -73,10 +80,16 @@ public final class Expressions {
       throw new IllegalArgumentException("an expression is required.");
     }
 
-    /* Check if the expression is too long */
-    if (expression.length() > MAX_EXPRESSION_LENGTH) {
+    /*
+     * Check if the expression is too long. The limit is configurable through the
+     * "feign.template.expression.maxLength" system property and can be disabled by setting it to a
+     * non-positive value.
+     */
+    final int maxExpressionLength =
+        Integer.getInteger(MAX_EXPRESSION_LENGTH_PROPERTY, DEFAULT_MAX_EXPRESSION_LENGTH);
+    if (maxExpressionLength > 0 && expression.length() > maxExpressionLength) {
       throw new IllegalArgumentException(
-          "expression is too long. Max length: " + MAX_EXPRESSION_LENGTH);
+          "expression is too long. Max length: " + maxExpressionLength);
     }
 
     /* create a new regular expression matcher for the expression */

--- a/core/src/test/java/feign/template/ExpressionsTest.java
+++ b/core/src/test/java/feign/template/ExpressionsTest.java
@@ -16,12 +16,52 @@
 package feign.template;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatObject;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collections;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 class ExpressionsTest {
+
+  @AfterEach
+  void clearMaxExpressionLengthProperty() {
+    System.clearProperty(Expressions.MAX_EXPRESSION_LENGTH_PROPERTY);
+  }
+
+  @Test
+  void tooLongExpressionFailsWithDefaultLimit() {
+    String tooLong = "{" + "a".repeat(10001) + "}";
+    assertThatThrownBy(() -> Expressions.create(tooLong))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("expression is too long");
+  }
+
+  @Test
+  void maxExpressionLengthIsConfigurable() {
+    System.setProperty(Expressions.MAX_EXPRESSION_LENGTH_PROPERTY, "5");
+    assertThatThrownBy(() -> Expressions.create("{foobar}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Max length: 5");
+  }
+
+  @Test
+  void lengthCheckCanBeDisabled() {
+    // An expression well beyond the default 10000 limit, expressed as a name plus a regular
+    // expression value modifier so the disabled length check is exercised in isolation.
+    String longExpression = "{name:" + "a".repeat(15000) + "}";
+    assertThatThrownBy(() -> Expressions.create(longExpression))
+        .as("guarded by default limit")
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("expression is too long");
+
+    System.setProperty(Expressions.MAX_EXPRESSION_LENGTH_PROPERTY, "0");
+    assertThatNoException()
+        .as("length check disabled")
+        .isThrownBy(() -> Expressions.create(longExpression));
+  }
 
   @Test
   void simpleExpression() {


### PR DESCRIPTION
Fixes #2916

### Problem
`feign.template.Expressions` hard-codes the maximum length of a single template expression to `MAX_EXPRESSION_LENGTH = 10000`. Any expression longer than that fails with `IllegalArgumentException: expression is too long. Max length: 10000`, with no way to raise or disable the limit. As noted in the issue, applications that legitimately need longer expressions have no escape hatch.

### Change
- The limit is now read from the `feign.template.expression.maxLength` system property, defaulting to `10000` (unchanged behavior).
- Setting the property to `0` (or any non-positive value) **disables** the length check entirely, as requested in the issue.

The constant was used in a single place (`Expressions.create`), so the change is self-contained and the default keeps existing behavior intact.

### Tests
Added `ExpressionsTest` cases:
- `tooLongExpressionFailsWithDefaultLimit` — default 10000 limit still rejects over-long expressions.
- `maxExpressionLengthIsConfigurable` — a custom limit is honored (`Max length: 5`).
- `lengthCheckCanBeDisabled` — with the property set to `0`, an expression beyond the default limit is accepted.

Verification done: built and ran `./mvnw -pl core -am test -Dtest=ExpressionsTest` (7/7 pass) and validated formatting with the project's `git-code-format-maven-plugin:validate-code-format`. All commits are DCO signed-off.