### PR TITLE
fall back to utf-8 for invalid content-type charset

### DIFF
--- a/core/src/main/java/feign/Response.java
+++ b/core/src/main/java/feign/Response.java
@@ -20,7 +20,9 @@ import static feign.Util.*;
 import feign.Request.ProtocolVersion;
 import java.io.*;
 import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.*;
 
 /** An immutable response to an http invocation which only returns string content. */
@@ -219,7 +221,11 @@ public final class Response implements Closeable {
           String[] charsetParts = contentTypeParmeters[1].split("=");
           if (charsetParts.length == 2 && "charset".equalsIgnoreCase(charsetParts[0].trim())) {
             String charsetString = charsetParts[1].replaceAll("\"", "");
-            return Charset.forName(charsetString);
+            try {
+              return Charset.forName(charsetString);
+            } catch (IllegalCharsetNameException | UnsupportedCharsetException e) {
+              return Util.UTF_8;
+            }
           }
         }
       }

--- a/core/src/test/java/feign/ResponseTest.java
+++ b/core/src/test/java/feign/ResponseTest.java
@@ -88,6 +88,36 @@ class ResponseTest {
   }
 
   @Test
+  void charsetDefaultsToUtf8ForIllegalCharsetName() {
+    Map<String, Collection<String>> headersMap = new LinkedHashMap<>();
+    headersMap.put("Content-Type", Collections.singletonList("text/plain; charset=@"));
+    Response response =
+        Response.builder()
+            .status(200)
+            .headers(headersMap)
+            .request(
+                Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+            .body(new byte[0])
+            .build();
+    assertThat(response.charset()).isEqualTo(Util.UTF_8);
+  }
+
+  @Test
+  void charsetDefaultsToUtf8ForUnsupportedCharset() {
+    Map<String, Collection<String>> headersMap = new LinkedHashMap<>();
+    headersMap.put("Content-Type", Collections.singletonList("text/plain; charset=made-up-99"));
+    Response response =
+        Response.builder()
+            .status(200)
+            .headers(headersMap)
+            .request(
+                Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+            .body(new byte[0])
+            .build();
+    assertThat(response.charset()).isEqualTo(Util.UTF_8);
+  }
+
+  @Test
   void headerValuesWithSameNameOnlyVaryingInCaseAreMerged() {
     Map<String, Collection<String>> headersMap = new LinkedHashMap<>();
     headersMap.put("Set-Cookie", Arrays.asList("Cookie-A=Value", "Cookie-B=Value"));

--- a/form/src/main/java/feign/form/FormEncoder.java
+++ b/form/src/main/java/feign/form/FormEncoder.java
@@ -27,6 +27,8 @@ import feign.codec.EncodeException;
 import feign.codec.Encoder;
 import java.lang.reflect.Type;
 import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -130,6 +132,13 @@ public class FormEncoder implements Encoder {
 
   private Charset getCharset(String contentTypeValue) {
     val matcher = CHARSET_PATTERN.matcher(contentTypeValue);
-    return matcher.find() ? Charset.forName(matcher.group(1)) : UTF_8;
+    if (!matcher.find()) {
+      return UTF_8;
+    }
+    try {
+      return Charset.forName(matcher.group(1));
+    } catch (IllegalCharsetNameException | UnsupportedCharsetException e) {
+      return UTF_8;
+    }
   }
 }

--- a/form/src/test/java/feign/form/FormEncoderCharsetTest.java
+++ b/form/src/test/java/feign/form/FormEncoderCharsetTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.form;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import feign.RequestTemplate;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class FormEncoderCharsetTest {
+
+  @Test
+  void illegalCharsetInContentTypeFallsBackToUtf8() {
+    RequestTemplate template = new RequestTemplate();
+    template.header("Content-Type", "application/x-www-form-urlencoded; charset=_bad");
+
+    Map<String, Object> data = new LinkedHashMap<>();
+    data.put("foo", "bar");
+
+    new FormEncoder().encode(data, Map.class, template);
+
+    assertThat(new String(template.body(), StandardCharsets.UTF_8)).isEqualTo("foo=bar");
+  }
+
+  @Test
+  void unsupportedCharsetInContentTypeFallsBackToUtf8() {
+    RequestTemplate template = new RequestTemplate();
+    template.header("Content-Type", "application/x-www-form-urlencoded; charset=made-up-99");
+
+    Map<String, Object> data = new LinkedHashMap<>();
+    data.put("foo", "bar");
+
+    new FormEncoder().encode(data, Map.class, template);
+
+    assertThat(new String(template.body(), StandardCharsets.UTF_8)).isEqualTo("foo=bar");
+  }
+}


### PR DESCRIPTION
Repro: a server response with `Content-Type: text/plain; charset=made-up-99` (or an illegal name such as `charset=@`) reaches `Response.charset()`, which is called by every JSON/text decoder (`jackson`, `json`, `fastjson2`, `jackson-jr`, `jackson3`) through `response.body().asReader(response.charset())`.
Expected: `charset()` returns its documented UTF-8 default.
Actual: `UnsupportedCharsetException` / `IllegalCharsetNameException` escapes the decoder on an otherwise valid response.
Cause: `Response.charset()` hands the charset token parsed out of the header straight to `Charset.forName` with no guard. `feign-form`'s `FormEncoder.getCharset` has the same unguarded call on the request `Content-Type`. `FeignException.getResponseCharset` already guards the identical parse.
Fix: catch `IllegalCharsetNameException`/`UnsupportedCharsetException` in both helpers and fall back to UTF-8. Regression tests cover both an illegal and an unsupported charset name.