### PR TITLE
generate multipart boundary from SecureRandom

### DIFF
--- a/form/src/main/java/feign/form/MultipartFormContentProcessor.java
+++ b/form/src/main/java/feign/form/MultipartFormContentProcessor.java
@@ -33,6 +33,7 @@ import feign.form.multipart.SingleParameterWriter;
 import feign.form.multipart.Writer;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.security.SecureRandom;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
@@ -48,6 +49,8 @@ import lombok.val;
  */
 @FieldDefaults(level = PRIVATE, makeFinal = true)
 public class MultipartFormContentProcessor implements ContentProcessor {
+
+  private static final SecureRandom RANDOM = new SecureRandom();
 
   Deque<Writer> writers;
 
@@ -75,7 +78,7 @@ public class MultipartFormContentProcessor implements ContentProcessor {
   @Override
   public void process(RequestTemplate template, Charset charset, Map<String, Object> data)
       throws EncodeException {
-    val boundary = Long.toHexString(System.currentTimeMillis());
+    val boundary = randomBoundary();
     try (val output = new Output(charset)) {
       for (val entry : data.entrySet()) {
         if (entry == null || entry.getKey() == null || entry.getValue() == null) {
@@ -157,5 +160,16 @@ public class MultipartFormContentProcessor implements ContentProcessor {
       }
     }
     return defaultPerocessor;
+  }
+
+  private static String randomBoundary() {
+    val token = new byte[16];
+    RANDOM.nextBytes(token);
+    val builder = new StringBuilder(token.length * 2);
+    for (val octet : token) {
+      builder.append(Character.forDigit((octet >> 4) & 0xF, 16));
+      builder.append(Character.forDigit(octet & 0xF, 16));
+    }
+    return builder.toString();
   }
 }

--- a/form/src/test/java/feign/form/MultipartBoundaryTest.java
+++ b/form/src/test/java/feign/form/MultipartBoundaryTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.form;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import feign.RequestTemplate;
+import feign.codec.Encoder;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MultipartBoundaryTest {
+
+  private static final Encoder NOOP_DELEGATE = (object, bodyType, template) -> {};
+
+  @Test
+  void boundaryIsNotDerivedFromTheClock() {
+    long before = System.currentTimeMillis();
+    String boundary = generateBoundary();
+    long after = System.currentTimeMillis();
+
+    for (long millis = before; millis <= after; millis++) {
+      assertThat(boundary).isNotEqualTo(Long.toHexString(millis));
+    }
+  }
+
+  @Test
+  void boundaryDiffersBetweenRequests() {
+    assertThat(generateBoundary()).isNotEqualTo(generateBoundary());
+  }
+
+  private static String generateBoundary() {
+    MultipartFormContentProcessor processor = new MultipartFormContentProcessor(NOOP_DELEGATE);
+    RequestTemplate template = new RequestTemplate();
+
+    Map<String, Object> data = new LinkedHashMap<>();
+    data.put("field", "value");
+    processor.process(template, UTF_8, data);
+
+    String contentType = template.headers().get("Content-Type").iterator().next();
+    int index = contentType.indexOf("boundary=");
+    return contentType.substring(index + "boundary=".length());
+  }
+}


### PR DESCRIPTION
Repro: `MultipartBoundaryTest` drives `MultipartFormContentProcessor.process` and reads the boundary back out of the generated `Content-Type` header; on the current code it equals `Long.toHexString(System.currentTimeMillis())` for the millisecond the request was built.
Cause: the boundary is derived from the wall clock, so it is low-entropy and guessable. RFC 2046 needs the boundary to never appear in a part, and against attacker-controlled body bytes the only guarantee is that the delimiter is unpredictable. A caller forwarding untrusted data into a field or filename value can embed `\r\n--<boundary>` and inject or truncate parts, which the `Content-Disposition` escaping in #3417 cannot cover because part bodies are written verbatim.
Fix: build the boundary from a shared `SecureRandom` as 128-bit lowercase hex.