### PR TITLE
cap Content-Length before narrowing to int in Http2Client

### DIFF
--- a/java11/src/main/java/feign/http2client/Http2Client.java
+++ b/java11/src/main/java/feign/http2client/Http2Client.java
@@ -130,6 +130,10 @@ public class Http2Client implements Client, AsyncClient<Object> {
 
   protected Response toFeignResponse(Request request, HttpResponse<InputStream> httpResponse) {
     final OptionalLong length = httpResponse.headers().firstValueAsLong("Content-Length");
+    final Integer contentLength =
+        length.isPresent() && length.getAsLong() >= 0 && length.getAsLong() <= Integer.MAX_VALUE
+            ? (int) length.getAsLong()
+            : null;
 
     InputStream body = httpResponse.body();
 
@@ -144,7 +148,7 @@ public class Http2Client implements Client, AsyncClient<Object> {
 
     return Response.builder()
         .protocolVersion(enumForName(ProtocolVersion.class, httpResponse.version()))
-        .body(body, length.isPresent() ? (int) length.getAsLong() : null)
+        .body(body, contentLength)
         .reason(httpResponse.headers().firstValue("Reason-Phrase").orElse(null))
         .request(request)
         .status(httpResponse.statusCode())

--- a/java11/src/test/java/feign/http2client/Http2ClientContentLengthTest.java
+++ b/java11/src/test/java/feign/http2client/Http2ClientContentLengthTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.http2client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import feign.Request;
+import feign.Request.HttpMethod;
+import feign.Response;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient.Version;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.net.ssl.SSLSession;
+import org.junit.jupiter.api.Test;
+
+class Http2ClientContentLengthTest {
+
+  private static HttpResponse<InputStream> responseWithContentLength(String contentLength) {
+    final HttpHeaders headers =
+        HttpHeaders.of(Map.of("Content-Length", List.of(contentLength)), (name, value) -> true);
+    return new HttpResponse<>() {
+      @Override
+      public int statusCode() {
+        return 200;
+      }
+
+      @Override
+      public HttpRequest request() {
+        return null;
+      }
+
+      @Override
+      public Optional<HttpResponse<InputStream>> previousResponse() {
+        return Optional.empty();
+      }
+
+      @Override
+      public HttpHeaders headers() {
+        return headers;
+      }
+
+      @Override
+      public InputStream body() {
+        return new ByteArrayInputStream(new byte[0]);
+      }
+
+      @Override
+      public Optional<SSLSession> sslSession() {
+        return Optional.empty();
+      }
+
+      @Override
+      public URI uri() {
+        return URI.create("http://localhost");
+      }
+
+      @Override
+      public Version version() {
+        return Version.HTTP_2;
+      }
+    };
+  }
+
+  private static Response decode(String contentLength) {
+    final Request request =
+        Request.create(
+            HttpMethod.GET,
+            "http://localhost",
+            Collections.emptyMap(),
+            null,
+            StandardCharsets.UTF_8,
+            null);
+    return new Http2Client().toFeignResponse(request, responseWithContentLength(contentLength));
+  }
+
+  @Test
+  void contentLengthAboveIntMaxIsReportedAsUnknown() {
+    // 2^31, a valid Content-Length larger than Integer.MAX_VALUE
+    assertThat(decode("2147483648").body().length()).isNull();
+  }
+
+  @Test
+  void negativeContentLengthIsReportedAsUnknown() {
+    assertThat(decode("-1").body().length()).isNull();
+  }
+
+  @Test
+  void contentLengthWithinIntRangeIsPreserved() {
+    assertThat(decode("1024").body().length()).isEqualTo(1024);
+  }
+}


### PR DESCRIPTION
1. `Http2Client.toFeignResponse` narrows the response `Content-Length` with `(int) length.getAsLong()` and no range check.
2. A server sending `Content-Length: 2147483648` (2^31) wraps to `-2147483648`, and `Content-Length: -1` is forwarded as-is.

`Response.Body.length()` is documented to be `null` when the length is unknown or greater than `Integer.MAX_VALUE`, and `okhttp`, `httpclient`, `hc5` and `googlehttpclient` already cap before narrowing. The wrapped negative length also slips past the `response.body().length() <= MAX_RESPONSE_BUFFER_SIZE` check in `InvocationContext` that decides whether to buffer the whole response into memory. Capped so the `int` is returned only for `0 <= length <= Integer.MAX_VALUE`, otherwise `null`.

`repro`: `Http2ClientContentLengthTest` builds an `HttpResponse` with a given `Content-Length` and reads `body().length()`.
- `Content-Length: 2147483648` expected `null`, before `-2147483648`.
- `Content-Length: -1` expected `null`, before `-1`.
- `Content-Length: 1024` stays `1024`.