### PR TITLE
strip crlf from multipart Content-Type header

### DIFF
--- a/form/src/main/java/feign/form/multipart/AbstractWriter.java
+++ b/form/src/main/java/feign/form/multipart/AbstractWriter.java
@@ -89,7 +89,7 @@ public abstract class AbstractWriter implements Writer {
             .append(contentDespositionBuilder.toString())
             .append(CRLF)
             .append("Content-Type: ")
-            .append(fileContentType)
+            .append(stripCrlf(fileContentType))
             .append(CRLF)
             .append("Content-Transfer-Encoding: binary")
             .append(CRLF)
@@ -110,5 +110,18 @@ public abstract class AbstractWriter implements Writer {
    */
   protected static String escapeHeaderParameter(String value) {
     return value.replace("\r", "%0D").replace("\n", "%0A").replace("\"", "%22");
+  }
+
+  /**
+   * Removes carriage return and line feed from a media type so an attacker-supplied content type
+   * cannot inject extra part headers or boundaries. Unlike a quoted parameter the {@code
+   * Content-Type} value is not quoted, so it cannot be percent-encoded without corrupting a
+   * legitimate media type; the control characters are dropped instead.
+   *
+   * @param contentType the raw content type value.
+   * @return the content type with CR and LF removed.
+   */
+  protected static String stripCrlf(String contentType) {
+    return contentType.replace("\r", "").replace("\n", "");
   }
 }

--- a/form/src/main/java/feign/form/multipart/SingleParameterWriter.java
+++ b/form/src/main/java/feign/form/multipart/SingleParameterWriter.java
@@ -58,7 +58,7 @@ public class SingleParameterWriter extends AbstractWriter {
             .append('"')
             .append(CRLF)
             .append("Content-Type: ")
-            .append(contentTypeHeader)
+            .append(stripCrlf(contentTypeHeader))
             .append(CRLF)
             .append(CRLF)
             .append(value.toString())

--- a/form/src/test/java/feign/form/multipart/AbstractWriterTest.java
+++ b/form/src/test/java/feign/form/multipart/AbstractWriterTest.java
@@ -46,4 +46,29 @@ class AbstractWriterTest {
     assertThat(written).contains("name=\"a%22%0D%0AX-Injected: 1\"");
     assertThat(written).doesNotContain("\r\nX-Injected: 1");
   }
+
+  @Test
+  void fileContentTypeWithCrlfIsStripped() {
+    Output output = new Output(UTF_8);
+    FormData formData =
+        new FormData("text/plain\r\nX-Injected: 1", "file.txt", "body".getBytes(UTF_8));
+
+    new FormDataWriter().write(output, "boundary", "file", formData);
+    String written = new String(output.toByteArray(), UTF_8);
+
+    assertThat(written).contains("Content-Type: text/plainX-Injected: 1");
+    assertThat(written).doesNotContain("\r\nX-Injected: 1");
+  }
+
+  @Test
+  void parameterContentTypeWithCrlfIsStripped() {
+    Output output = new Output(UTF_8);
+
+    new SingleParameterWriter()
+        .writeWithContentType(output, "name", "value", "text/plain\r\nX-Injected: 1");
+    String written = new String(output.toByteArray(), UTF_8);
+
+    assertThat(written).contains("Content-Type: text/plainX-Injected: 1");
+    assertThat(written).doesNotContain("\r\nX-Injected: 1");
+  }
 }


### PR DESCRIPTION
Repro: encode a `FormData` whose content type carries `CR`/`LF`, e.g. `new FormData("text/plain\r\nX-Injected: 1", "f.txt", bytes)`.
Cause: `AbstractWriter.writeFileMetadata` and `SingleParameterWriter.writeWithContentType` append the part `Content-Type` value verbatim, so a forwarded upload content type breaks out of the header and injects extra part headers. #3417 escaped the `Content-Disposition` `name`/`filename` parameters but left this header value alone.
Fix: strip `CR` and `LF` from the content type in the writers before it reaches the header. The value is unquoted so it cannot be percent-encoded like the quoted parameters without corrupting a legitimate media type.