### PR TITLE
encode soap request body with the configured charset

### DIFF
--- a/soap-jakarta/src/main/java/feign/soap/SOAPEncoder.java
+++ b/soap-jakarta/src/main/java/feign/soap/SOAPEncoder.java
@@ -131,7 +131,7 @@ public class SOAPEncoder implements Encoder {
       } else {
         soapMessage.writeTo(bos);
       }
-      template.body(bos.toString());
+      template.body(bos.toByteArray(), charsetEncoding);
     } catch (SOAPException
         | JAXBException
         | ParserConfigurationException

--- a/soap-jakarta/src/test/java/feign/soap/SOAPCodecTest.java
+++ b/soap-jakarta/src/test/java/feign/soap/SOAPCodecTest.java
@@ -132,6 +132,40 @@ class SOAPCodecTest {
   }
 
   @Test
+  void encodesSoapWithNonAsciiContentInConfiguredCharset() {
+    JAXBContextFactory jaxbContextFactory =
+        new JAXBContextFactory.Builder().withMarshallerJAXBEncoding("UTF-16").build();
+
+    Encoder encoder =
+        new SOAPEncoder.Builder()
+            .withJAXBContextFactory(jaxbContextFactory)
+            .withCharsetEncoding(StandardCharsets.UTF_16)
+            .build();
+
+    GetPrice mock = new GetPrice();
+    mock.item = new Item();
+    mock.item.value = "Café";
+
+    RequestTemplate template = new RequestTemplate();
+    encoder.encode(mock, GetPrice.class, template);
+
+    String soapEnvelop =
+        """
+        <?xml version="1.0" encoding="UTF-16" ?>\
+        <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">\
+        <SOAP-ENV:Header/>\
+        <SOAP-ENV:Body>\
+        <GetPrice>\
+        <Item>Café</Item>\
+        </GetPrice>\
+        </SOAP-ENV:Body>\
+        </SOAP-ENV:Envelope>\
+        """;
+    byte[] utf16Bytes = soapEnvelop.getBytes(StandardCharsets.UTF_16LE);
+    assertThat(template).hasBody(utf16Bytes);
+  }
+
+  @Test
   void encodesSoapWithCustomJAXBSchemaLocation() {
     JAXBContextFactory jaxbContextFactory =
         new JAXBContextFactory.Builder()

--- a/soap/src/main/java/feign/soap/SOAPEncoder.java
+++ b/soap/src/main/java/feign/soap/SOAPEncoder.java
@@ -135,7 +135,7 @@ public class SOAPEncoder implements Encoder {
       } else {
         soapMessage.writeTo(bos);
       }
-      template.body(new String(bos.toByteArray()));
+      template.body(bos.toByteArray(), charsetEncoding);
     } catch (SOAPException
         | JAXBException
         | ParserConfigurationException

--- a/soap/src/test/java/feign/soap/SOAPCodecTest.java
+++ b/soap/src/test/java/feign/soap/SOAPCodecTest.java
@@ -132,6 +132,40 @@ class SOAPCodecTest {
   }
 
   @Test
+  void encodesSoapWithNonAsciiContentInConfiguredCharset() {
+    JAXBContextFactory jaxbContextFactory =
+        new JAXBContextFactory.Builder().withMarshallerJAXBEncoding("UTF-16").build();
+
+    Encoder encoder =
+        new SOAPEncoder.Builder()
+            .withJAXBContextFactory(jaxbContextFactory)
+            .withCharsetEncoding(StandardCharsets.UTF_16)
+            .build();
+
+    GetPrice mock = new GetPrice();
+    mock.item = new Item();
+    mock.item.value = "Café";
+
+    RequestTemplate template = new RequestTemplate();
+    encoder.encode(mock, GetPrice.class, template);
+
+    String soapEnvelop =
+        """
+        <?xml version="1.0" encoding="UTF-16" ?>\
+        <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">\
+        <SOAP-ENV:Header/>\
+        <SOAP-ENV:Body>\
+        <GetPrice>\
+        <Item>Café</Item>\
+        </GetPrice>\
+        </SOAP-ENV:Body>\
+        </SOAP-ENV:Envelope>\
+        """;
+    byte[] utf16Bytes = soapEnvelop.getBytes(StandardCharsets.UTF_16LE);
+    assertThat(template).hasBody(utf16Bytes);
+  }
+
+  @Test
   void encodesSoapWithCustomJAXBSchemaLocation() {
     JAXBContextFactory jaxbContextFactory =
         new JAXBContextFactory.Builder()


### PR DESCRIPTION
Repro: configure `SOAPEncoder` with `withCharsetEncoding(UTF-16)` and encode an object whose body holds a non-ASCII character (e.g. `Café`).
Expected: the request body bytes match the `UTF-16` declared in the XML prolog the marshaller wrote.
Actual: the body is mangled. `SOAPEncoder.encode` writes the message to a `ByteArrayOutputStream` in `charsetEncoding`, then the soap module does `new String(bos.toByteArray())` and soap-jakarta does `bos.toString()`. Both decode those bytes with the JVM platform default charset, and `RequestTemplate.body(String)` re-encodes as `UTF-8`, so the configured encoding is dropped and any non-ASCII content is corrupted (pure ASCII survives by accident, which is why the existing tests miss it).
Fix: hand the marshalled bytes to `template.body(bos.toByteArray(), charsetEncoding)` in both modules, the same way `UrlencodedFormContentProcessor` already passes bytes plus charset.

Regression test in both `SOAPCodecTest` files encodes non-ASCII content under `UTF-16`.