### PR TITLE
encode collection values in urlencoded form bodies

### DIFF
--- a/form/src/main/java/feign/form/UrlencodedFormContentProcessor.java
+++ b/form/src/main/java/feign/form/UrlencodedFormContentProcessor.java
@@ -106,7 +106,10 @@ public class UrlencodedFormContentProcessor implements ContentProcessor {
   private CharSequence createKeyValuePair(
       CollectionFormat collectionFormat, String key, Stream<?> values, Charset charset) {
     val stringValues =
-        values.filter(Objects::nonNull).map(Object::toString).collect(Collectors.toList());
+        values
+            .filter(Objects::nonNull)
+            .map(value -> encode(value, charset))
+            .collect(Collectors.toList());
     return collectionFormat.join(key, stringValues, charset);
   }
 }

--- a/form/src/test/java/feign/form/UrlencodedFormContentProcessorTest.java
+++ b/form/src/test/java/feign/form/UrlencodedFormContentProcessorTest.java
@@ -47,6 +47,20 @@ class UrlencodedFormContentProcessorTest {
   }
 
   @Test
+  void arrayValueEncodesReservedCharacters() {
+    assertEncodedBody(
+        "from=%2B987654321&to=%2B123456789&tags=a%26b%3Dc&tags=d",
+        new String[] {"a&b=c", "d"}, Client::map);
+  }
+
+  @Test
+  void collectionValueEncodesReservedCharacters() {
+    assertEncodedBody(
+        "from=%2B987654321&to=%2B123456789&tags=a%26b%3Dc&tags=d",
+        Arrays.asList("a&b=c", "d"), Client::map);
+  }
+
+  @Test
   void arrayValueUsesCsvCollectionFormat() {
     assertEncodedBody(
         "from=%2B987654321&to=%2B123456789&tags=one%2Ctwo",


### PR DESCRIPTION
Repro: post an `application/x-www-form-urlencoded` form whose value is a collection or array, e.g. a `tags` field of `["a&b=c", "d"]`. The body comes out as `tags=a&b=c&tags=d`, smuggling an extra `b=c` field into the request the downstream service parses.
Cause: `UrlencodedFormContentProcessor.createKeyValuePair` collects collection and array values with `Object::toString` and passes them to `CollectionFormat.join`, which encodes the field name and the separator but writes each value verbatim. The scalar path already runs values through `encode`, so only collection-valued fields leak reserved characters.
Fix: encode each collection value with the same `encode(value, charset)` helper before the join, matching the scalar path. `QueryTemplate` is the only other `CollectionFormat.join` caller and already passes pre-encoded values, so `join` itself is left untouched. Added regression tests for the array and collection paths.