### PR TITLE
treat invalid expression value modifier as a literal

### DIFF
--- a/core/src/main/java/feign/template/Expressions.java
+++ b/core/src/main/java/feign/template/Expressions.java
@@ -22,6 +22,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 public final class Expressions {
 
@@ -117,15 +118,26 @@ public final class Expressions {
       }
     }
 
-    /* check for an operator */
-    if (PATH_STYLE_OPERATOR.equalsIgnoreCase(operator)) {
-      return new PathStyleExpression(variableName, variablePattern);
-    }
+    /*
+     * The value modifier after the ':' is compiled as a regular expression. When the chunk is a
+     * dynamic value (for example a header-map value that happens to contain '{' and ':') the
+     * modifier is not a valid pattern, so treat the chunk as a literal instead of letting the
+     * PatternSyntaxException escape.
+     */
+    try {
+      /* check for an operator */
+      if (PATH_STYLE_OPERATOR.equalsIgnoreCase(operator)) {
+        return new PathStyleExpression(variableName, variablePattern);
+      }
 
-    /* default to simple */
-    return SimpleExpression.isSimpleExpression(value)
-        ? new SimpleExpression(variableName, variablePattern)
-        : null; // Return null if it can't be validated as a Simple Expression -- Probably a Literal
+      /* default to simple */
+      // Return null if it can't be validated as a Simple Expression -- Probably a Literal
+      return SimpleExpression.isSimpleExpression(value)
+          ? new SimpleExpression(variableName, variablePattern)
+          : null;
+    } catch (PatternSyntaxException e) {
+      return null;
+    }
   }
 
   private static String stripBraces(String expression) {

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -218,6 +218,17 @@ public class RequestTemplateTest {
     assertThat(template).hasHeaders(entry("A-Header", Collections.singletonList(json)));
   }
 
+  /** A header-map value containing brackets and a colon must not be parsed as a regex. */
+  @Test
+  void resolveTemplateWithHeaderMapValueContainingPatternModifier() {
+    String value = "{range:[1:10}";
+    RequestTemplate template =
+        new RequestTemplate().method(HttpMethod.GET).header("A-Header", value);
+
+    template.resolve(new LinkedHashMap<>());
+    assertThat(template).hasHeaders(entry("A-Header", Collections.singletonList(value)));
+  }
+
   @Test
   void resolveTemplateWithHeaderWithJson() {
     String json = "{ \"string\": \"val\", \"string2\": \"this should not be truncated\"}";

--- a/core/src/test/java/feign/template/ExpressionsTest.java
+++ b/core/src/test/java/feign/template/ExpressionsTest.java
@@ -85,6 +85,18 @@ class ExpressionsTest {
   }
 
   @Test
+  void invalidValueModifierIsTreatedAsLiteral() {
+    // The text after ':' is compiled as a regex; an invalid one must not escape as a
+    // PatternSyntaxException, the chunk is a literal instead (Expressions.create returns null).
+    assertThatNoException().isThrownBy(() -> Expressions.create("{range:[1:10}"));
+    assertThat(Expressions.create("{a:[}")).isNull();
+    assertThat(Expressions.create("{a:(}")).isNull();
+
+    // a valid value modifier still produces an expression
+    assertThat(Expressions.create("{id:[0-9]+}")).isNotNull();
+  }
+
+  @Test
   void malformedBodyTemplate() {
     String bodyTemplate = "{" + "a".repeat(65536) + "}";
 


### PR DESCRIPTION
Values supplied through `@HeaderMap` are parsed as URI templates, so a value that contains `{...:...}` is treated as an expression and the text after the `:` is compiled as a regular expression in `Expression`. A value like `{range:[1:10}` (brackets plus a colon, easy to hit with JSON-ish header data) is not a valid pattern, so `Pattern.compile` throws an uncaught `PatternSyntaxException` from `Expressions.create` and the whole request fails to build. Reported in #2739.

`Expressions.create` already returns `null` for chunks it cannot validate as an expression, and `Template.parseFragment` keeps those as literals. The fix catches `PatternSyntaxException` there and falls back to that same literal path, so a malformed value modifier is emitted verbatim instead of aborting expansion. Keeping the guard in the parser covers every template type (header, query, uri) and leaves valid `{name:regex}` expressions untouched.