### PR TITLE
honour requested charset in okhttp response body reader

### DIFF
--- a/okhttp/src/main/java/feign/okhttp/OkHttpClient.java
+++ b/okhttp/src/main/java/feign/okhttp/OkHttpClient.java
@@ -20,8 +20,10 @@ import static feign.Util.enumForName;
 import feign.AsyncClient;
 import feign.Client;
 import feign.Request.ProtocolVersion;
+import feign.Util;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.Charset;
 import java.util.Collection;
@@ -151,7 +153,8 @@ public final class OkHttpClient implements Client, AsyncClient<Object> {
 
       @Override
       public Reader asReader(Charset charset) throws IOException {
-        return asReader();
+        Util.checkNotNull(charset, "charset should not be null");
+        return new InputStreamReader(asInputStream(), charset);
       }
     };
   }

--- a/okhttp/src/test/java/feign/okhttp/OkHttpClientTest.java
+++ b/okhttp/src/test/java/feign/okhttp/OkHttpClientTest.java
@@ -18,6 +18,7 @@ package feign.okhttp;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
+import feign.Client;
 import feign.Feign;
 import feign.Feign.Builder;
 import feign.Headers;
@@ -31,6 +32,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import okhttp3.mockwebserver.MockResponse;
+import okio.Buffer;
 import org.assertj.core.data.MapEntry;
 import org.junit.jupiter.api.Test;
 
@@ -135,6 +137,27 @@ public class OkHttpClientTest extends AbstractClientTest {
   @Override
   public void canExceptCaseInsensitiveHeader() throws Exception {
     assumeFalse(false, "OkHTTP client do not support gzip compression");
+  }
+
+  @Test
+  void asReaderHonoursRequestedCharset() throws Exception {
+    // "café" encoded as ISO-8859-1: the trailing 0xE9 is not valid standalone UTF-8
+    byte[] body = {'c', 'a', 'f', (byte) 0xE9};
+    Buffer buffer = new Buffer().write(body);
+    server.enqueue(new MockResponse().setBody(buffer).addHeader("Content-Type", "text/plain"));
+
+    Client client = new OkHttpClient();
+    Request request =
+        Request.create(
+            Request.HttpMethod.GET,
+            "http://localhost:" + server.getPort(),
+            Collections.emptyMap(),
+            Request.Body.empty(),
+            null);
+    Response response = client.execute(request, new Request.Options());
+
+    assertThat(Util.toString(response.body().asReader(StandardCharsets.ISO_8859_1)))
+        .isEqualTo("café");
   }
 
   public interface OkHttpClientTestInterface {


### PR DESCRIPTION
1. `OkHttpClient`'s response `Body.asReader(Charset)` ignores the `charset` argument and delegates to the deprecated `asReader()`, which returns okhttp's `ResponseBody.charStream()` (charset taken from `Content-Type`, defaulting to UTF-8).
2. decoders read a non-buffered response via `response.body().asReader(response.charset())`, so the resolved charset is dropped on the okhttp client only; `httpclient`, `hc5` and the core `InputStreamBody`/`ByteArrayBody` all decode with the requested charset.

Repro: a `text/plain` response (no `charset` parameter) whose body is `café` as ISO-8859-1 (`63 61 66 E9`), read via `asReader(ISO_8859_1)`.
Expected: `café`.
Actual: `caf�` (decoded as UTF-8).
Fix: decode with the requested charset using `new InputStreamReader(asInputStream(), charset)`, matching the other clients.