### PR TITLE
encode string request body with utf-8 not the platform default

### DIFF
--- a/core/src/main/java/feign/Request.java
+++ b/core/src/main/java/feign/Request.java
@@ -554,7 +554,7 @@ public final class Request implements Serializable {
     }
 
     public static Body create(String data) {
-      return new Body(data.getBytes());
+      return create(data, Util.UTF_8);
     }
 
     public static Body create(String data, Charset charset) {

--- a/core/src/test/java/feign/RequestTest.java
+++ b/core/src/test/java/feign/RequestTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign;
+
+import static feign.Util.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import feign.Request.Body;
+import org.junit.jupiter.api.Test;
+
+public class RequestTest {
+
+  @Test
+  void stringBodyIsEncodedWithUtf8NotThePlatformDefault() {
+    String content = "spécial-çhars-€";
+
+    Body body = Body.create(content);
+
+    assertThat(body.asBytes()).isEqualTo(content.getBytes(UTF_8));
+    assertThat(body.getEncoding()).hasValue(UTF_8);
+    assertThat(body.isBinary()).isFalse();
+    assertThat(body.asString()).isEqualTo(content);
+  }
+}


### PR DESCRIPTION
Repro: build a body with `Request.Body.create(String)` on a JVM whose default charset is not UTF-8 (`-Dfile.encoding=ISO-8859-1`) and send a non-ASCII payload such as `"é"`; the bytes on the wire are the ISO-8859-1 encoding, not the UTF-8 the rest of feign and the declared `Content-Type` assume.
Cause: `create(String)` encodes with `data.getBytes()`, the platform-default charset, and leaves the body `encoding` null so it is flagged binary. Every other body path defaults to UTF-8 (`RequestTemplate.body(String)` and the `create(String, Charset)` overload), so the result is deployment-dependent and the dropped charset means `asString()`/`charset()` cannot recover the text.
Fix: delegate to `create(data, UTF_8)` so the bytes are deterministic UTF-8 and the charset is recorded, matching the sibling overload.