### PR TITLE
strip crlf from resolved header template values

### DIFF
--- a/core/src/main/java/feign/template/HeaderTemplate.java
+++ b/core/src/main/java/feign/template/HeaderTemplate.java
@@ -141,7 +141,10 @@ public final class HeaderTemplate {
 
   public Collection<String> getValues() {
     return Collections.unmodifiableList(
-        this.values.stream().map(Template::toString).collect(Collectors.toList()));
+        this.values.stream()
+            .map(Template::toString)
+            .map(HeaderTemplate::stripCrlf)
+            .collect(Collectors.toList()));
   }
 
   public List<String> getVariables() {
@@ -167,7 +170,7 @@ public final class HeaderTemplate {
           continue;
         }
 
-        expanded.add(result);
+        expanded.add(stripCrlf(result));
       }
     }
 
@@ -177,5 +180,17 @@ public final class HeaderTemplate {
     }
 
     return result.toString();
+  }
+
+  /**
+   * Removes carriage return and line feed characters from a resolved header value. Values are
+   * written to the header verbatim, so a CR or LF in a value would terminate the header line and
+   * inject additional headers.
+   *
+   * @param value to sanitise.
+   * @return the value without CR or LF characters.
+   */
+  private static String stripCrlf(String value) {
+    return value.replace("\r", "").replace("\n", "");
   }
 }

--- a/core/src/test/java/feign/RequestTemplateTest.java
+++ b/core/src/test/java/feign/RequestTemplateTest.java
@@ -198,6 +198,17 @@ public class RequestTemplateTest {
   }
 
   @Test
+  void resolveTemplateStripsCrlfFromHeaderSubstitution() {
+    RequestTemplate template =
+        new RequestTemplate().method(HttpMethod.GET).header("X-Custom", "{value}");
+
+    template = template.resolve(mapOf("value", "legit\r\nX-Injected: evil"));
+
+    assertThat(template)
+        .hasHeaders(entry("X-Custom", Collections.singletonList("legitX-Injected: evil")));
+  }
+
+  @Test
   void resolveTemplateWithHeaderWithEscapedCurlyBrace() {
     RequestTemplate template =
         new RequestTemplate().method(HttpMethod.GET).header("Encoded", "{{{{dont_expand_me}}");

--- a/core/src/test/java/feign/template/HeaderTemplateTest.java
+++ b/core/src/test/java/feign/template/HeaderTemplateTest.java
@@ -123,6 +123,24 @@ class HeaderTemplateTest {
   }
 
   @Test
+  void it_should_strip_crlf_from_expanded_values() {
+    HeaderTemplate headerTemplate =
+        HeaderTemplate.create("X-Custom", Collections.singletonList("{value}"));
+    assertThat(
+            headerTemplate.expand(Collections.singletonMap("value", "legit\r\nX-Injected: evil")))
+        .isEqualTo("legitX-Injected: evil");
+  }
+
+  @Test
+  void it_should_strip_crlf_from_literal_values() {
+    HeaderTemplate headerTemplate =
+        HeaderTemplate.create("X-Custom", Collections.singletonList("legit\r\nX-Injected: evil"));
+    assertThat(new ArrayList<>(headerTemplate.getValues()))
+        .containsExactly("legitX-Injected: evil");
+    assertThat(headerTemplate.expand(Collections.emptyMap())).isEqualTo("legitX-Injected: evil");
+  }
+
+  @Test
   void it_should_support_json_literal_values() {
     HeaderTemplate headerTemplate =
         HeaderTemplate.create("CustomHeader", Collections.singletonList("{jsonParam}"));


### PR DESCRIPTION
Repro: resolve a templated header (`@Headers("X-Custom: {value}")`, or a `@HeaderMap` entry) with `value` set to `legit\r\nX-Injected: evil`.
Expected: one `X-Custom` header.
Actual: the `CR`/`LF` survives into the header value, breaking the line and injecting an `X-Injected` request header.
Cause: `HeaderTemplate` expands header values with `EncodingOptions.NOT_REQUIRED`, so `expand` (templated values, via `RequestTemplate.resolve`) and `getValues` (`@HeaderMap` values added after `resolve` and read back when the `Request` is built) emit them verbatim. Query and URI templates pct-encode their values, so headers are the only un-encoded expansion path.
Fix: strip `\r` and `\n` from each value in both producers, matching the multipart `Content-Type` strip in #3432.