### PR TITLE
clear response body length after gzip/deflate decode

### DIFF
--- a/core/src/main/java/feign/DefaultClient.java
+++ b/core/src/main/java/feign/DefaultClient.java
@@ -122,8 +122,11 @@ public class DefaultClient implements Client {
     }
     if (stream != null && this.isGzip(headers.get(CONTENT_ENCODING))) {
       stream = new GZIPInputStream(stream);
+      // the body is now decompressed, the Content-Length described the compressed bytes
+      length = null;
     } else if (stream != null && this.isDeflate(headers.get(CONTENT_ENCODING))) {
       stream = new InflaterInputStream(stream);
+      length = null;
     }
     return Response.builder()
         .status(status)

--- a/core/src/test/java/feign/client/DefaultClientTest.java
+++ b/core/src/test/java/feign/client/DefaultClientTest.java
@@ -24,13 +24,25 @@ import feign.Client.Proxied;
 import feign.DefaultClient;
 import feign.Feign;
 import feign.Feign.Builder;
+import feign.Request;
+import feign.Request.HttpMethod;
+import feign.Request.Options;
+import feign.Response;
 import feign.RetryableException;
+import feign.Util;
 import feign.assertj.MockWebServerAssertions;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.*;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.zip.GZIPOutputStream;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.SocketPolicy;
+import okio.Buffer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
@@ -56,6 +68,42 @@ public class DefaultClientTest extends AbstractClientTest {
 
     api.post("foo");
     assertThat(server.getRequestCount()).isEqualTo(2);
+  }
+
+  @Test
+  void gzipDecodedBodyReportsUnknownLength() throws Exception {
+    // Accept-Encoding is set explicitly so HttpURLConnection leaves the gzip body for the client
+    // to decode, exercising DefaultClient's own decompression path.
+    server.enqueue(
+        new MockResponse()
+            .addHeader("Content-Encoding", "gzip")
+            .setBody(new Buffer().write(gzip("Compressed Data"))));
+
+    Map<String, Collection<String>> headers = new LinkedHashMap<>();
+    headers.put("Accept-Encoding", Collections.singletonList("gzip"));
+    Request request =
+        Request.create(
+            HttpMethod.GET,
+            "http://localhost:" + server.getPort(),
+            headers,
+            null,
+            StandardCharsets.UTF_8,
+            null);
+
+    Response response = new DefaultClient(null, null, false).execute(request, new Options());
+
+    // the body is decompressed, so the compressed Content-Length must not be reported as the length
+    assertThat(response.body().length()).isNull();
+    assertThat(Util.toString(response.body().asReader(StandardCharsets.UTF_8)))
+        .isEqualTo("Compressed Data");
+  }
+
+  private static byte[] gzip(String data) throws IOException {
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    try (GZIPOutputStream gzip = new GZIPOutputStream(bos)) {
+      gzip.write(data.getBytes(StandardCharsets.UTF_8));
+    }
+    return bos.toByteArray();
   }
 
   @Test

--- a/java11/src/main/java/feign/http2client/Http2Client.java
+++ b/java11/src/main/java/feign/http2client/Http2Client.java
@@ -130,7 +130,7 @@ public class Http2Client implements Client, AsyncClient<Object> {
 
   protected Response toFeignResponse(Request request, HttpResponse<InputStream> httpResponse) {
     final OptionalLong length = httpResponse.headers().firstValueAsLong("Content-Length");
-    final Integer contentLength =
+    Integer contentLength =
         length.isPresent() && length.getAsLong() >= 0 && length.getAsLong() <= Integer.MAX_VALUE
             ? (int) length.getAsLong()
             : null;
@@ -140,10 +140,13 @@ public class Http2Client implements Client, AsyncClient<Object> {
     if (httpResponse.headers().allValues(CONTENT_ENCODING).contains(ENCODING_GZIP)) {
       try {
         body = new GZIPInputStream(body);
+        // the body is now decompressed, the Content-Length described the compressed bytes
+        contentLength = null;
       } catch (IOException ignored) {
       }
     } else if (httpResponse.headers().allValues(CONTENT_ENCODING).contains(ENCODING_DEFLATE)) {
       body = new InflaterInputStream(body);
+      contentLength = null;
     }
 
     return Response.builder()

--- a/java11/src/test/java/feign/http2client/Http2ClientContentLengthTest.java
+++ b/java11/src/test/java/feign/http2client/Http2ClientContentLengthTest.java
@@ -20,7 +20,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import feign.Request;
 import feign.Request.HttpMethod;
 import feign.Response;
+import feign.Util;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.http.HttpClient.Version;
@@ -32,6 +34,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.zip.GZIPOutputStream;
 import javax.net.ssl.SSLSession;
 import org.junit.jupiter.api.Test;
 
@@ -83,16 +86,76 @@ class Http2ClientContentLengthTest {
     };
   }
 
+  private static HttpResponse<InputStream> gzipResponseWithContentLength(byte[] compressedBody) {
+    final HttpHeaders headers =
+        HttpHeaders.of(
+            Map.of(
+                "Content-Length", List.of(String.valueOf(compressedBody.length)),
+                "Content-Encoding", List.of("gzip")),
+            (name, value) -> true);
+    return new HttpResponse<>() {
+      @Override
+      public int statusCode() {
+        return 200;
+      }
+
+      @Override
+      public HttpRequest request() {
+        return null;
+      }
+
+      @Override
+      public Optional<HttpResponse<InputStream>> previousResponse() {
+        return Optional.empty();
+      }
+
+      @Override
+      public HttpHeaders headers() {
+        return headers;
+      }
+
+      @Override
+      public InputStream body() {
+        return new ByteArrayInputStream(compressedBody);
+      }
+
+      @Override
+      public Optional<SSLSession> sslSession() {
+        return Optional.empty();
+      }
+
+      @Override
+      public URI uri() {
+        return URI.create("http://localhost");
+      }
+
+      @Override
+      public Version version() {
+        return Version.HTTP_2;
+      }
+    };
+  }
+
+  private static byte[] gzip(String data) throws Exception {
+    final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    try (GZIPOutputStream gzip = new GZIPOutputStream(bos)) {
+      gzip.write(data.getBytes(StandardCharsets.UTF_8));
+    }
+    return bos.toByteArray();
+  }
+
+  private static Request request() {
+    return Request.create(
+        HttpMethod.GET,
+        "http://localhost",
+        Collections.emptyMap(),
+        null,
+        StandardCharsets.UTF_8,
+        null);
+  }
+
   private static Response decode(String contentLength) {
-    final Request request =
-        Request.create(
-            HttpMethod.GET,
-            "http://localhost",
-            Collections.emptyMap(),
-            null,
-            StandardCharsets.UTF_8,
-            null);
-    return new Http2Client().toFeignResponse(request, responseWithContentLength(contentLength));
+    return new Http2Client().toFeignResponse(request(), responseWithContentLength(contentLength));
   }
 
   @Test
@@ -109,5 +172,17 @@ class Http2ClientContentLengthTest {
   @Test
   void contentLengthWithinIntRangeIsPreserved() {
     assertThat(decode("1024").body().length()).isEqualTo(1024);
+  }
+
+  @Test
+  void gzipDecodedBodyReportsUnknownLength() throws Exception {
+    final byte[] compressed = gzip("Compressed Data");
+    final Response response =
+        new Http2Client().toFeignResponse(request(), gzipResponseWithContentLength(compressed));
+    // the body is transparently decompressed, so the compressed Content-Length is not the body
+    // length and must be reported as unknown
+    assertThat(response.body().length()).isNull();
+    assertThat(Util.toString(response.body().asReader(StandardCharsets.UTF_8)))
+        .isEqualTo("Compressed Data");
   }
 }


### PR DESCRIPTION
Repro: return a response with `Content-Encoding: gzip` (or `deflate`) and a `Content-Length` (the compressed size); `response.body().length()` then reports that compressed length even though feign has already decompressed the body.
Cause: `Http2Client.toFeignResponse` and `DefaultClient.convertResponse` wrap the stream in `GZIPInputStream`/`InflaterInputStream` but keep the on-the-wire `Content-Length`, so the stale value no longer matches the readable body and still gates the `MAX_RESPONSE_BUFFER_SIZE` check in `InvocationContext.disconnectResponseBodyIfNeeded` that decides whether to buffer the whole body into a `byte[]`.
Fix: report the length as `null` once a decompressing wrapper is applied, since the decompressed length is unknown per the `Body.length()` contract. The other clients leave decompression to their underlying library, so only these two build a `Response` from a manually decompressed stream.