### PR TITLE
Let capabilities supply response interceptors

### DIFF
--- a/core/src/main/java/feign/BaseBuilder.java
+++ b/core/src/main/java/feign/BaseBuilder.java
@@ -316,10 +316,21 @@ public abstract class BaseBuilder<B extends BaseBuilder<B, T>, T> implements Clo
       // enrich each response interceptor, then enrich the list as a whole
       ResponseInterceptor[] responseArray =
           clone.responseInterceptors.toArray(new ResponseInterceptor[0]);
-      for (int i = 0; i < responseArray.length; i++) {
-        responseArray[i] =
+      if (responseArray.length == 0) {
+        ResponseInterceptor defaultResponseInterceptor = (context, chain) -> chain.next(context);
+        ResponseInterceptor enrichedResponseInterceptor =
             (ResponseInterceptor)
-                Capability.enrich(responseArray[i], ResponseInterceptor.class, capabilities);
+                Capability.enrich(
+                    defaultResponseInterceptor, ResponseInterceptor.class, capabilities);
+        if (enrichedResponseInterceptor != defaultResponseInterceptor) {
+          responseArray = new ResponseInterceptor[] {enrichedResponseInterceptor};
+        }
+      } else {
+        for (int i = 0; i < responseArray.length; i++) {
+          responseArray[i] =
+              (ResponseInterceptor)
+                  Capability.enrich(responseArray[i], ResponseInterceptor.class, capabilities);
+        }
       }
       ResponseInterceptors responseInterceptors =
           (ResponseInterceptors)

--- a/core/src/test/java/feign/BaseBuilderTest.java
+++ b/core/src/test/java/feign/BaseBuilderTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.RETURNS_MOCKS;
 
 import java.lang.reflect.Field;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -61,5 +62,26 @@ class BaseBuilderTest {
       throws IllegalArgumentException, IllegalAccessException {
     test(
         Feign.builder().requestInterceptor(_ -> {}).responseInterceptor((ic, c) -> c.next(ic)), 10);
+  }
+
+  @Test
+  void capabilityCanProvideResponseInterceptorWhenNoneConfigured() {
+    AtomicInteger enrichCalls = new AtomicInteger();
+    ResponseInterceptor capabilityInterceptor = (context, chain) -> chain.next(context);
+
+    Feign.Builder enrichedBuilder =
+        Feign.builder()
+            .addCapability(
+                new Capability() {
+                  @Override
+                  public ResponseInterceptor enrich(ResponseInterceptor responseInterceptor) {
+                    enrichCalls.incrementAndGet();
+                    return capabilityInterceptor;
+                  }
+                })
+            .enrich();
+
+    assertThat(enrichCalls).hasValue(1);
+    assertThat(enrichedBuilder.responseInterceptors).containsExactly(capabilityInterceptor);
   }
 }


### PR DESCRIPTION
## Summary

`Capability.enrich(ResponseInterceptor)` was only called for configured response interceptors. If a capability wanted to supply the response interceptor itself, there was no component for it to enrich, so the interceptor was never installed.

This keeps the existing per-interceptor enrichment path, and adds a default pass-through response interceptor only for the empty-list case. If a capability replaces that default interceptor, the replacement is installed before the response interceptor list is enriched as a whole.

## Tests

- `./mvnw -pl core -Dtoolchain.skip=true -Dtest=feign.BaseBuilderTest#capabilityCanProvideResponseInterceptorWhenNoneConfigured test`
- `./mvnw -pl core -Dtoolchain.skip=true -Dtest=feign.BaseBuilderTest test`
- `./mvnw -pl core -Dtoolchain.skip=true test`
- `git diff --check`

Fixes #2935
