### PR TITLE
honour response charset in gson and jackson iterator decoders

### DIFF
--- a/gson/src/main/java/feign/gson/GsonDecoder.java
+++ b/gson/src/main/java/feign/gson/GsonDecoder.java
@@ -15,7 +15,6 @@
  */
 package feign.gson;
 
-import static feign.Util.UTF_8;
 import static feign.Util.ensureClosed;
 
 import com.google.gson.Gson;
@@ -50,7 +49,7 @@ public class GsonDecoder implements Decoder, JsonDecoder {
   public Object decode(Response response, Type type) throws IOException {
     if (response.status() == 404 || response.status() == 204) return Util.emptyValueOf(type);
     if (response.body() == null) return null;
-    Reader reader = response.body().asReader(UTF_8);
+    Reader reader = response.body().asReader(response.charset());
     try {
       return gson.fromJson(reader, type);
     } catch (JsonIOException e) {

--- a/gson/src/test/java/feign/gson/GsonCodecTest.java
+++ b/gson/src/test/java/feign/gson/GsonCodecTest.java
@@ -29,7 +29,9 @@ import feign.RequestTemplate;
 import feign.Response;
 import feign.Util;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -72,6 +74,28 @@ class GsonCodecTest {
             .body("{\"foo\": 1}", UTF_8)
             .build();
     assertThat(map)
+        .isEqualTo(
+            new GsonDecoder().decode(response, new TypeToken<Map<String, Object>>() {}.getType()));
+  }
+
+  @Test
+  void decodesUsingResponseCharset() throws Exception {
+    Map<String, Object> expected = new LinkedHashMap<>();
+    expected.put("name", "ÁÉÍÓÚ");
+
+    Map<String, Collection<String>> headers = new LinkedHashMap<>();
+    headers.put("Content-Type", Arrays.asList("application/json;charset=ISO-8859-1"));
+
+    Response response =
+        Response.builder()
+            .status(200)
+            .reason("OK")
+            .request(
+                Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+            .headers(headers)
+            .body("{\"name\":\"ÁÉÍÓÚ\"}".getBytes(StandardCharsets.ISO_8859_1))
+            .build();
+    assertThat(expected)
         .isEqualTo(
             new GsonDecoder().decode(response, new TypeToken<Map<String, Object>>() {}.getType()));
   }

--- a/jackson/src/main/java/feign/jackson/JacksonIteratorDecoder.java
+++ b/jackson/src/main/java/feign/jackson/JacksonIteratorDecoder.java
@@ -15,7 +15,6 @@
  */
 package feign.jackson;
 
-import static feign.Util.UTF_8;
 import static feign.Util.ensureClosed;
 
 import com.fasterxml.jackson.core.JsonParser;
@@ -72,7 +71,7 @@ public final class JacksonIteratorDecoder implements Decoder {
   public Object decode(Response response, Type type) throws IOException {
     if (response.status() == 404 || response.status() == 204) return Util.emptyValueOf(type);
     if (response.body() == null) return null;
-    Reader reader = response.body().asReader(UTF_8);
+    Reader reader = response.body().asReader(response.charset());
     if (!reader.markSupported()) {
       reader = new BufferedReader(reader, 1);
     }

--- a/jackson/src/test/java/feign/jackson/JacksonIteratorTest.java
+++ b/jackson/src/test/java/feign/jackson/JacksonIteratorTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.Request;
 import feign.Request.HttpMethod;
@@ -31,8 +32,16 @@ import feign.jackson.JacksonIteratorDecoder.JacksonIterator;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
@@ -161,6 +170,29 @@ class JacksonIteratorTest {
         () -> assertThat(iterator(Boolean.class, response)).toIterable().hasSize(1));
 
     assertThat(closed.get()).isTrue();
+  }
+
+  @Test
+  void decodeUsesResponseCharset() throws IOException {
+    Map<String, Collection<String>> headers = new HashMap<>();
+    headers.put("Content-Type", Arrays.asList("application/json;charset=ISO-8859-1"));
+
+    Response response =
+        Response.builder()
+            .status(200)
+            .reason("OK")
+            .request(
+                Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+            .headers(headers)
+            .body("[{\"login\":\"ÁÉÍÓÚ\"}]".getBytes(StandardCharsets.ISO_8859_1))
+            .build();
+    Object decoded =
+        JacksonIteratorDecoder.create()
+            .decode(response, new TypeReference<Iterator<User>>() {}.getType());
+    List<Object> users = new ArrayList<>();
+    ((Iterator<?>) decoded).forEachRemaining(users::add);
+    assertThat(users).hasSize(1);
+    assertThat((User) users.get(0)).containsEntry("login", "ÁÉÍÓÚ");
   }
 
   static class User extends LinkedHashMap<String, Object> {

--- a/jackson3/src/main/java/feign/jackson3/Jackson3IteratorDecoder.java
+++ b/jackson3/src/main/java/feign/jackson3/Jackson3IteratorDecoder.java
@@ -15,7 +15,6 @@
  */
 package feign.jackson3;
 
-import static feign.Util.UTF_8;
 import static feign.Util.ensureClosed;
 
 import feign.Response;
@@ -75,7 +74,7 @@ public final class Jackson3IteratorDecoder implements Decoder {
   public Object decode(Response response, Type type) throws IOException {
     if (response.status() == 404 || response.status() == 204) return Util.emptyValueOf(type);
     if (response.body() == null) return null;
-    Reader reader = response.body().asReader(UTF_8);
+    Reader reader = response.body().asReader(response.charset());
     if (!reader.markSupported()) {
       reader = new BufferedReader(reader, 1);
     }

--- a/jackson3/src/test/java/feign/jackson3/Jackson3CodecTest.java
+++ b/jackson3/src/test/java/feign/jackson3/Jackson3CodecTest.java
@@ -264,6 +264,38 @@ class Jackson3CodecTest {
     assertThat(asList((Iterator<?>) decoded)).isEqualTo(zones);
   }
 
+  @Test
+  void decodesIteratorUsingResponseCharset() throws Exception {
+    Map<String, Collection<String>> headers = new HashMap<>();
+    headers.put("Content-Type", Arrays.asList("application/json;charset=ISO-8859-1"));
+
+    Response response =
+        Response.builder()
+            .status(200)
+            .reason("OK")
+            .request(
+                Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+            .headers(headers)
+            .body(
+                new String(
+                        "" //
+                            + "[ {"
+                            + System.lineSeparator()
+                            + "  \"name\" : \"denominator.io.\","
+                            + System.lineSeparator()
+                            + "  \"id\" : \"ÁÉÍÓÚÀÈÌÒÙÄËÏÖÜÑ\""
+                            + System.lineSeparator()
+                            + "} ]")
+                    .getBytes(StandardCharsets.ISO_8859_1))
+            .build();
+    Object decoded =
+        Jackson3IteratorDecoder.create()
+            .decode(response, new TypeReference<Iterator<Zone>>() {}.getType());
+    List<?> zones = asList((Iterator<?>) decoded);
+    assertThat(zones).hasSize(1);
+    assertThat((Zone) zones.get(0)).containsEntry("id", "ÁÉÍÓÚÀÈÌÒÙÄËÏÖÜÑ");
+  }
+
   private <T> List<T> asList(Iterator<T> iter) {
     final List<T> copy = new ArrayList<>();
     while (iter.hasNext()) {


### PR DESCRIPTION
Repro: a server response with `Content-Type: application/json; charset=ISO-8859-1` and an `ISO-8859-1` encoded body decoded through `GsonDecoder`, `JacksonIteratorDecoder` or `Jackson3IteratorDecoder`.
Cause: those three read the body with `asReader(UTF_8)`, dropping `response.charset()`, so non-ASCII bytes come back as `U+FFFD`. The sibling `JacksonDecoder`, `Jackson3Decoder`, `Fastjson2Decoder`, `JacksonJrDecoder` and `JsonDecoder` already pass `response.charset()`.
Fix: pass `response.charset()` in the three decoders, matching the siblings. `response.charset()` already defaults to UTF-8, so plain UTF-8 responses are unchanged. Regression test added per module.