### PR TITLE
Fix duplicate Content-Length handling in DefaultClient

### DIFF
--- a/core/src/main/java/feign/DefaultClient.java
+++ b/core/src/main/java/feign/DefaultClient.java
@@ -170,7 +170,6 @@ public class DefaultClient implements Client {
         if (field.equals(CONTENT_LENGTH)) {
           if (!gzipEncodedRequest && !deflateEncodedRequest) {
             contentLength = Integer.valueOf(value);
-            connection.addRequestProperty(field, value);
           }
         }
         // Avoid add "Accept-encoding" twice or more when "compression" option is enabled

--- a/core/src/test/java/feign/ClientTest.java
+++ b/core/src/test/java/feign/ClientTest.java
@@ -17,12 +17,19 @@ package feign;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
@@ -99,5 +106,35 @@ class ClientTest {
      * "true"
      */
     assertNull(requestProperties.get(Util.CONTENT_LENGTH));
+  }
+
+  @Test
+  void testConvertAndSendDoesNotAddContentLengthHeaderForBody() throws IOException {
+    Map<String, Collection<String>> headers = new LinkedHashMap<>();
+    headers.put(Util.CONTENT_LENGTH, Collections.singletonList("3"));
+
+    HttpURLConnection connection = mock(HttpURLConnection.class);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    when(connection.getOutputStream()).thenReturn(output);
+    DefaultClient defaultClient =
+        new DefaultClient(null, null) {
+          @Override
+          public HttpURLConnection getConnection(URL url) {
+            return connection;
+          }
+        };
+    Request request =
+        Request.create(
+            Request.HttpMethod.POST,
+            "http://example.com",
+            headers,
+            "foo".getBytes(StandardCharsets.UTF_8),
+            StandardCharsets.UTF_8,
+            mock(RequestTemplate.class));
+
+    defaultClient.convertAndSend(request, mock(Request.Options.class));
+
+    verify(connection, never()).addRequestProperty(eq(Util.CONTENT_LENGTH), anyString());
+    assertEquals("foo", new String(output.toByteArray(), StandardCharsets.UTF_8));
   }
 }


### PR DESCRIPTION
Fixes #2862.

`RequestTemplate.body(...)` records the request body length as a `Content-Length` header. `DefaultClient.convertAndSend(...)` used that value in two ways for non-compressed request bodies: it kept the length for fixed-length streaming mode and also added it as a normal request property. With `HttpURLConnection`, the body/output path can manage the request length itself, so adding the header manually can produce duplicate `Content-Length` values when restricted headers are allowed.

This change keeps the parsed content length for the existing `disableRequestBuffering` / fixed-length streaming path, but stops adding `Content-Length` through `addRequestProperty(...)` for request bodies.

Tests:

```bash
mvn -pl core -Dtoolchain.skip=true -Dtest=ClientTest#testConvertAndSendDoesNotAddContentLengthHeaderForBody test
mvn -pl core -Dtoolchain.skip=true -Dtest=ClientTest test
mvn -pl core -Dtoolchain.skip=true -Dtest=DefaultClientTest test
mvn -pl core -Dtoolchain.skip=true test
git diff --check
```

Note: I used `-Dtoolchain.skip=true` locally because this machine does not have a Maven JDK 8 toolchain configured; the core module still compiled and ran its test suite successfully.