### PR TITLE
avoid duplicate Content-Length header in DefaultClient

### DIFF
--- a/core/src/main/java/feign/DefaultClient.java
+++ b/core/src/main/java/feign/DefaultClient.java
@@ -218,7 +218,9 @@ public class DefaultClient implements Client {
       }
     }
 
-    if (body == null && request.httpMethod().isWithBody()) {
+    if (body == null
+        && request.httpMethod().isWithBody()
+        && !request.headers().containsKey(CONTENT_LENGTH)) {
       // To use this Header, set 'sun.net.http.allowRestrictedHeaders' property true.
       connection.addRequestProperty("Content-Length", "0");
     }

--- a/core/src/main/java/feign/DefaultClient.java
+++ b/core/src/main/java/feign/DefaultClient.java
@@ -172,7 +172,7 @@ public class DefaultClient implements Client {
         hasAcceptHeader = true;
       }
       for (String value : request.headers().get(field)) {
-        if (field.equals(CONTENT_LENGTH)) {
+        if (field.equalsIgnoreCase(CONTENT_LENGTH)) {
           if (!gzipEncodedRequest && !deflateEncodedRequest) {
             contentLength = Integer.valueOf(value);
           }

--- a/core/src/test/java/feign/client/DefaultClientTest.java
+++ b/core/src/test/java/feign/client/DefaultClientTest.java
@@ -24,6 +24,8 @@ import feign.Client.Proxied;
 import feign.DefaultClient;
 import feign.Feign;
 import feign.Feign.Builder;
+import feign.Headers;
+import feign.RequestLine;
 import feign.RetryableException;
 import feign.assertj.MockWebServerAssertions;
 import java.io.IOException;
@@ -99,6 +101,25 @@ public class DefaultClientTest extends AbstractClientTest {
         .hasMethod("POST")
         .hasNoHeaderNamed("Content-Type")
         .hasHeaders(entry("Content-Length", Collections.singletonList("0")));
+  }
+
+  @Test
+  @EnabledIfSystemProperty(named = "sun.net.http.allowRestrictedHeaders", matches = "true")
+  public void contentLengthHeaderIsNotDuplicatedForBodylessRequest() throws Exception {
+    server.enqueue(new MockResponse());
+
+    ContentLengthInterface api =
+        newBuilder().target(ContentLengthInterface.class, "http://localhost:" + server.getPort());
+
+    api.postEmpty();
+
+    assertThat(server.takeRequest().getHeaders().values("Content-Length")).containsExactly("0");
+  }
+
+  interface ContentLengthInterface {
+    @RequestLine("POST /")
+    @Headers("Content-Length: 0")
+    void postEmpty();
   }
 
   @Test

--- a/core/src/test/java/feign/client/DefaultClientTest.java
+++ b/core/src/test/java/feign/client/DefaultClientTest.java
@@ -41,6 +41,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.zip.GZIPOutputStream;
 import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
 import okhttp3.mockwebserver.SocketPolicy;
 import okio.Buffer;
 import org.junit.jupiter.api.Test;
@@ -147,6 +148,51 @@ public class DefaultClientTest extends AbstractClientTest {
         .hasMethod("POST")
         .hasNoHeaderNamed("Content-Type")
         .hasHeaders(entry("Content-Length", Collections.singletonList("0")));
+  }
+
+  @Test
+  void lowerCaseContentLengthHeaderIsUsedForFixedLengthStreamingMode() throws Exception {
+    server.enqueue(new MockResponse());
+    byte[] body = "hello".getBytes(StandardCharsets.UTF_8);
+    Map<String, Collection<String>> headers = new LinkedHashMap<>();
+    headers.put("content-length", Collections.singletonList(String.valueOf(body.length)));
+    Request request =
+        Request.create(
+            HttpMethod.POST,
+            "http://localhost:" + server.getPort() + "/",
+            headers,
+            body,
+            StandardCharsets.UTF_8,
+            null);
+
+    // the two-arg constructor disables request buffering, so a recognised Content-Length selects
+    // fixed-length streaming mode and the JDK emits the header itself, exactly once
+    new DefaultClient(null, null).execute(request, new Request.Options());
+
+    RecordedRequest recordedRequest = server.takeRequest();
+    assertThat(recordedRequest.getHeaders().values("Content-Length"))
+        .containsExactly(String.valueOf(body.length));
+    assertThat(recordedRequest.getHeader("Transfer-Encoding")).isNull();
+  }
+
+  @Test
+  @EnabledIfSystemProperty(named = "sun.net.http.allowRestrictedHeaders", matches = "true")
+  public void contentLengthHeaderIsNotDuplicatedForBodylessRequest() throws Exception {
+    server.enqueue(new MockResponse());
+    Map<String, Collection<String>> headers = new LinkedHashMap<>();
+    headers.put("content-length", Collections.singletonList("0"));
+    Request request =
+        Request.create(
+            HttpMethod.POST,
+            "http://localhost:" + server.getPort() + "/",
+            headers,
+            null,
+            StandardCharsets.UTF_8,
+            null);
+
+    new DefaultClient(null, null).execute(request, new Request.Options());
+
+    assertThat(server.takeRequest().getHeaders().values("Content-Length")).containsExactly("0");
   }
 
   @Test


### PR DESCRIPTION
Repro: a request whose template carries a non-canonically cased `content-length` header. For a body-less `POST` with `sun.net.http.allowRestrictedHeaders=true`, the header loop forwards `content-length` via `addRequestProperty` and the body-less fallback then adds `Content-Length: 0`, so the field goes out twice. RFC 7230 §3.3.2 forbids generating multiple `Content-Length` fields; the duplicate is ambiguous framing and servers reject it (Tomcat returns `400`, #2862). The same missed comparison means a lower-cased `content-length` on a request with a body is not picked up for `setFixedLengthStreamingMode` under `disableRequestBuffering`, so the request goes out chunked instead of fixed-length.
Cause: the header loop compares with `field.equals(CONTENT_LENGTH)`, but `request.headers()` preserves the caller's original casing.
Fix: compare with `equalsIgnoreCase`, so any casing is captured into the local `contentLength` and never forwarded; the JDK stays the only writer of the header.

`lowerCaseContentLengthHeaderIsUsedForFixedLengthStreamingMode` runs ungated in CI: fixed-length streaming mode makes the JDK emit the header itself, so no restricted-headers flag is needed. Before the fix the request goes out chunked with no `Content-Length`; after, exactly one. `contentLengthHeaderIsNotDuplicatedForBodylessRequest` covers the wire-level duplicate from #2862; it stays gated on `sun.net.http.allowRestrictedHeaders` since the duplicate only reaches the wire with that flag set.
