### PR TITLE
honour response charset in StringDecoder

### DIFF
--- a/core/src/main/java/feign/codec/StringDecoder.java
+++ b/core/src/main/java/feign/codec/StringDecoder.java
@@ -31,7 +31,7 @@ public class StringDecoder implements Decoder {
       return null;
     }
     if (String.class.equals(type)) {
-      return Util.toString(body.asReader(Util.UTF_8));
+      return Util.toString(body.asReader(response.charset()));
     }
     throw new DecodeException(
         response.status(),

--- a/core/src/test/java/feign/codec/DefaultDecoderTest.java
+++ b/core/src/test/java/feign/codec/DefaultDecoderTest.java
@@ -25,6 +25,7 @@ import feign.Response;
 import feign.Util;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -43,6 +44,24 @@ class DefaultDecoderTest {
     Object decodedObject = decoder.decode(response, String.class);
     assertThat(decodedObject.getClass()).isEqualTo(String.class);
     assertThat(decodedObject.toString()).isEqualTo("response body");
+  }
+
+  @Test
+  void decodesToStringHonouringContentTypeCharset() throws Exception {
+    String content = "él pingüino";
+    byte[] body = content.getBytes(StandardCharsets.ISO_8859_1);
+    Map<String, Collection<String>> headers = new HashMap<>();
+    headers.put("Content-Type", Collections.singleton("text/plain; charset=ISO-8859-1"));
+    Response response =
+        Response.builder()
+            .status(200)
+            .reason("OK")
+            .headers(headers)
+            .request(Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, UTF_8))
+            .body(new ByteArrayInputStream(body), body.length)
+            .build();
+    Object decodedObject = decoder.decode(response, String.class);
+    assertThat(decodedObject).isEqualTo(content);
   }
 
   @Test


### PR DESCRIPTION
Repro: a `String`-returning method against a server that replies `Content-Type: text/plain; charset=ISO-8859-1` with body byte `0xE9`.
Expected: `é`.
Actual: `U+FFFD`, because the byte is run through a UTF-8 reader.
Cause: `StringDecoder.decode` reads the body with `asReader(Util.UTF_8)`, so the charset `response.charset()` already resolves from `Content-Type` is dropped. `DefaultDecoder` extends it, so this is the default behaviour for every non-UTF-8 `String` response.
Fix: decode with `response.charset()`, which already falls back to UTF-8 when none is declared, matching the JSON decoders (`jackson`, `json`, `fastjson2`, `jackson-jr`).