### PR TITLE
fix(template): treat invalid expression pattern modifier as literal

### DIFF
--- a/core/src/main/java/feign/template/Expressions.java
+++ b/core/src/main/java/feign/template/Expressions.java
@@ -22,6 +22,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 public final class Expressions {
 
@@ -104,15 +105,23 @@ public final class Expressions {
       }
     }
 
-    /* check for an operator */
-    if (PATH_STYLE_OPERATOR.equalsIgnoreCase(operator)) {
-      return new PathStyleExpression(variableName, variablePattern);
-    }
+    try {
+      /* check for an operator */
+      if (PATH_STYLE_OPERATOR.equalsIgnoreCase(operator)) {
+        return new PathStyleExpression(variableName, variablePattern);
+      }
 
-    /* default to simple */
-    return SimpleExpression.isSimpleExpression(value)
-        ? new SimpleExpression(variableName, variablePattern)
-        : null; // Return null if it can't be validated as a Simple Expression -- Probably a Literal
+      /* default to simple; null if it can't be validated as a Simple Expression -- probably a literal */
+      return SimpleExpression.isSimpleExpression(value)
+          ? new SimpleExpression(variableName, variablePattern)
+          : null;
+    } catch (PatternSyntaxException e) {
+      /*
+       * the ':' value modifier did not contain a valid regular expression, so this is not a usable
+       * expression -- treat it as a literal instead of failing template construction.
+       */
+      return null;
+    }
   }
 
   private static String stripBraces(String expression) {

--- a/core/src/test/java/feign/template/ExpressionsTest.java
+++ b/core/src/test/java/feign/template/ExpressionsTest.java
@@ -45,6 +45,17 @@ class ExpressionsTest {
   }
 
   @Test
+  void invalidPatternModifierIsTreatedAsLiteral() {
+    /*
+     * gh-2739: a header-map value such as "{test:[abc}" parses as a "{name:pattern}" expression,
+     * but the ':' modifier ("[abc") is not a valid regular expression. Compiling it must not blow
+     * up template construction with a PatternSyntaxException -- it should fall back to a literal.
+     */
+    Expression expression = Expressions.create("{test:[abc}");
+    assertThatObject(expression).isNull();
+  }
+
+  @Test
   void malformedBodyTemplate() {
     String bodyTemplate = "{" + "a".repeat(65536) + "}";
 


### PR DESCRIPTION
Fixes #2739

### Root cause
A header-map value (or any template fragment) such as `{test:[abc}` is parsed by `Expressions.create` as a `{name:pattern}` expression, where the part after `:` is treated as a regex value modifier. `Expression`'s constructor compiles that modifier eagerly via `Pattern.compile(...)`, so when the modifier is not a valid regular expression (`[abc` → *Unclosed character class*) a `PatternSyntaxException` was thrown during template construction. With a `Map` header value containing brackets/colons this surfaces as the stack trace in the issue (`HeaderTemplate.create` → `Template` → `Expressions.create` → `Pattern.compile`).

### Change
`Expressions.create` already returns `null` to signal "this is not a usable expression — treat the chunk as a literal" (e.g. for nested expressions and non-simple candidates). This extends that existing contract: a `PatternSyntaxException` raised while building the expression is caught and `create` returns `null`, so the fragment falls back to a `Literal` in `Template.parseFragment` instead of failing template construction. Valid expressions such as `{id:[0-9]+}` are unaffected.

### Test evidence
Added `ExpressionsTest.invalidPatternModifierIsTreatedAsLiteral` — `Expressions.create("{test:[abc}")` previously threw `PatternSyntaxException`; it now returns `null` (literal). 

Verification done: built and ran the affected tests with the project toolchain — `./mvnw -pl core test -Dtest='feign.template.**'` → 80 tests pass (including the new one), no regression; code formatting validated via `git-code-format-maven-plugin:validate-code-format` (BUILD SUCCESS); commit carries a DCO `Signed-off-by` trailer.
