### PR TITLE
Enforce Java 11 response body timeouts

### DIFF
--- a/java11/src/main/java/feign/http2client/Http2Client.java
+++ b/java11/src/main/java/feign/http2client/Http2Client.java
@@ -38,6 +38,7 @@ import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpRequest.Builder;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
+import java.net.http.HttpTimeoutException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
@@ -52,12 +53,25 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
 
 public class Http2Client implements Client, AsyncClient<Object> {
+
+  private static final ScheduledExecutorService BODY_READ_TIMEOUT_EXECUTOR =
+      Executors.newSingleThreadScheduledExecutor(
+          runnable -> {
+            Thread thread = new Thread(runnable, "feign-http2client-body-timeout");
+            thread.setDaemon(true);
+            return thread;
+          });
 
   private final HttpClient client;
 
@@ -109,7 +123,7 @@ public class Http2Client implements Client, AsyncClient<Object> {
       throw new IOException(e);
     }
 
-    return toFeignResponse(request, httpResponse);
+    return toFeignResponse(request, httpResponse, options);
   }
 
   @Override
@@ -125,17 +139,22 @@ public class Http2Client implements Client, AsyncClient<Object> {
     HttpClient clientForRequest = getOrCreateClient(options);
     CompletableFuture<HttpResponse<InputStream>> future =
         clientForRequest.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofInputStream());
-    return future.thenApply(httpResponse -> toFeignResponse(request, httpResponse));
+    return future.thenApply(httpResponse -> toFeignResponse(request, httpResponse, options));
   }
 
   protected Response toFeignResponse(Request request, HttpResponse<InputStream> httpResponse) {
+    return toFeignResponse(request, httpResponse, null);
+  }
+
+  private Response toFeignResponse(
+      Request request, HttpResponse<InputStream> httpResponse, Options options) {
     final OptionalLong length = httpResponse.headers().firstValueAsLong("Content-Length");
     final Integer contentLength =
         length.isPresent() && length.getAsLong() >= 0 && length.getAsLong() <= Integer.MAX_VALUE
             ? (int) length.getAsLong()
             : null;
 
-    InputStream body = httpResponse.body();
+    InputStream body = withReadTimeout(httpResponse.body(), options);
 
     if (httpResponse.headers().allValues(CONTENT_ENCODING).contains(ENCODING_GZIP)) {
       try {
@@ -154,6 +173,110 @@ public class Http2Client implements Client, AsyncClient<Object> {
         .status(httpResponse.statusCode())
         .headers(castMapCollectType(httpResponse.headers().map()))
         .build();
+  }
+
+  private static InputStream withReadTimeout(InputStream body, Options options) {
+    if (body == null || options == null || options.readTimeout() <= 0) {
+      return body;
+    }
+    return new TimeoutInputStream(body, options.readTimeout(), options.readTimeoutUnit());
+  }
+
+  private static final class TimeoutInputStream extends InputStream {
+
+    private final InputStream delegate;
+    private final long timeout;
+    private final TimeUnit timeoutUnit;
+
+    private TimeoutInputStream(InputStream delegate, long timeout, TimeUnit timeoutUnit) {
+      this.delegate = delegate;
+      this.timeout = timeout;
+      this.timeoutUnit = timeoutUnit;
+    }
+
+    @Override
+    public int read() throws IOException {
+      return readWithTimeout(delegate::read);
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+      return readWithTimeout(() -> delegate.read(b, off, len));
+    }
+
+    @Override
+    public int available() throws IOException {
+      return delegate.available();
+    }
+
+    @Override
+    public void close() throws IOException {
+      delegate.close();
+    }
+
+    private int readWithTimeout(BodyRead read) throws IOException {
+      final AtomicBoolean completed = new AtomicBoolean(false);
+      final AtomicBoolean timedOut = new AtomicBoolean(false);
+      final ScheduledFuture<?> timeoutFuture =
+          BODY_READ_TIMEOUT_EXECUTOR.schedule(
+              () -> {
+                if (completed.compareAndSet(false, true)) {
+                  timedOut.set(true);
+                  try {
+                    delegate.close();
+                  } catch (IOException ignored) {
+                  }
+                }
+              },
+              timeout,
+              timeoutUnit);
+
+      try {
+        final int result = read.read();
+        if (completed.compareAndSet(false, true)) {
+          timeoutFuture.cancel(false);
+          return result;
+        }
+        throw timeoutException(null);
+      } catch (IOException e) {
+        if (completed.compareAndSet(false, true)) {
+          timeoutFuture.cancel(false);
+        }
+        final HttpTimeoutException timeoutException = findTimeoutException(e);
+        if (timedOut.get() || timeoutException != null) {
+          throw timeoutException == null ? timeoutException(e) : timeoutException;
+        }
+        throw e;
+      } catch (RuntimeException e) {
+        if (completed.compareAndSet(false, true)) {
+          timeoutFuture.cancel(false);
+        }
+        throw e;
+      }
+    }
+
+    private static HttpTimeoutException timeoutException(IOException cause) {
+      final HttpTimeoutException exception = new HttpTimeoutException("response timed out");
+      if (cause != null) {
+        exception.initCause(cause);
+      }
+      return exception;
+    }
+
+    private static HttpTimeoutException findTimeoutException(Throwable throwable) {
+      Throwable current = throwable;
+      while (current != null) {
+        if (current instanceof HttpTimeoutException) {
+          return (HttpTimeoutException) current;
+        }
+        current = current.getCause();
+      }
+      return null;
+    }
+  }
+
+  private interface BodyRead {
+    int read() throws IOException;
   }
 
   private HttpClient getOrCreateClient(Options options) {

--- a/java11/src/main/java/feign/http2client/Http2Client.java
+++ b/java11/src/main/java/feign/http2client/Http2Client.java
@@ -32,6 +32,7 @@ import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpClient.Redirect;
 import java.net.http.HttpClient.Version;
+import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublisher;
 import java.net.http.HttpRequest.BodyPublishers;
@@ -57,14 +58,15 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
+import javax.net.ssl.SSLSession;
 
 public class Http2Client implements Client, AsyncClient<Object> {
 
+  // Shared by all clients so response-body deadlines do not create one thread per client.
   private static final ScheduledExecutorService BODY_READ_TIMEOUT_EXECUTOR =
       Executors.newSingleThreadScheduledExecutor(
           runnable -> {
@@ -143,18 +145,13 @@ public class Http2Client implements Client, AsyncClient<Object> {
   }
 
   protected Response toFeignResponse(Request request, HttpResponse<InputStream> httpResponse) {
-    return toFeignResponse(request, httpResponse, null);
-  }
-
-  private Response toFeignResponse(
-      Request request, HttpResponse<InputStream> httpResponse, Options options) {
     final OptionalLong length = httpResponse.headers().firstValueAsLong("Content-Length");
     Integer contentLength =
         length.isPresent() && length.getAsLong() >= 0 && length.getAsLong() <= Integer.MAX_VALUE
             ? (int) length.getAsLong()
             : null;
 
-    InputStream body = withReadTimeout(httpResponse.body(), options);
+    InputStream body = httpResponse.body();
 
     if (httpResponse.headers().allValues(CONTENT_ENCODING).contains(ENCODING_GZIP)) {
       try {
@@ -178,6 +175,15 @@ public class Http2Client implements Client, AsyncClient<Object> {
         .build();
   }
 
+  protected Response toFeignResponse(
+      Request request, HttpResponse<InputStream> httpResponse, Options options) {
+    final InputStream body = httpResponse.body();
+    final InputStream timedBody = withReadTimeout(body, options);
+    return toFeignResponse(
+        request,
+        body == timedBody ? httpResponse : new TimeoutHttpResponse(httpResponse, timedBody));
+  }
+
   private static InputStream withReadTimeout(InputStream body, Options options) {
     if (body == null || options == null || options.readTimeout() <= 0) {
       return body;
@@ -188,23 +194,51 @@ public class Http2Client implements Client, AsyncClient<Object> {
   private static final class TimeoutInputStream extends InputStream {
 
     private final InputStream delegate;
-    private final long timeout;
-    private final TimeUnit timeoutUnit;
+    private final ScheduledFuture<?> timeoutFuture;
+    private volatile boolean timedOut;
 
     private TimeoutInputStream(InputStream delegate, long timeout, TimeUnit timeoutUnit) {
       this.delegate = delegate;
-      this.timeout = timeout;
-      this.timeoutUnit = timeoutUnit;
+      this.timeoutFuture =
+          BODY_READ_TIMEOUT_EXECUTOR.schedule(
+              () -> {
+                timedOut = true;
+                try {
+                  delegate.close();
+                } catch (IOException ignored) {
+                }
+              },
+              timeout,
+              timeoutUnit);
     }
 
     @Override
     public int read() throws IOException {
-      return readWithTimeout(delegate::read);
+      try {
+        return afterRead(delegate.read());
+      } catch (IOException e) {
+        throw translateException(e);
+      }
     }
 
     @Override
     public int read(byte[] b, int off, int len) throws IOException {
-      return readWithTimeout(() -> delegate.read(b, off, len));
+      try {
+        return afterRead(delegate.read(b, off, len));
+      } catch (IOException e) {
+        throw translateException(e);
+      }
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+      try {
+        final long skipped = delegate.skip(n);
+        checkTimedOut();
+        return skipped;
+      } catch (IOException e) {
+        throw translateException(e);
+      }
     }
 
     @Override
@@ -213,49 +247,49 @@ public class Http2Client implements Client, AsyncClient<Object> {
     }
 
     @Override
+    public synchronized void mark(int readLimit) {
+      delegate.mark(readLimit);
+    }
+
+    @Override
+    public synchronized void reset() throws IOException {
+      delegate.reset();
+    }
+
+    @Override
+    public boolean markSupported() {
+      return delegate.markSupported();
+    }
+
+    @Override
     public void close() throws IOException {
+      timeoutFuture.cancel(false);
       delegate.close();
     }
 
-    private int readWithTimeout(BodyRead read) throws IOException {
-      final AtomicBoolean completed = new AtomicBoolean(false);
-      final AtomicBoolean timedOut = new AtomicBoolean(false);
-      final ScheduledFuture<?> timeoutFuture =
-          BODY_READ_TIMEOUT_EXECUTOR.schedule(
-              () -> {
-                if (completed.compareAndSet(false, true)) {
-                  timedOut.set(true);
-                  try {
-                    delegate.close();
-                  } catch (IOException ignored) {
-                  }
-                }
-              },
-              timeout,
-              timeoutUnit);
-
-      try {
-        final int result = read.read();
-        if (completed.compareAndSet(false, true)) {
-          timeoutFuture.cancel(false);
-          return result;
-        }
-        throw timeoutException(null);
-      } catch (IOException e) {
-        if (completed.compareAndSet(false, true)) {
-          timeoutFuture.cancel(false);
-        }
-        final HttpTimeoutException timeoutException = findTimeoutException(e);
-        if (timedOut.get() || timeoutException != null) {
-          throw timeoutException == null ? timeoutException(e) : timeoutException;
-        }
-        throw e;
-      } catch (RuntimeException e) {
-        if (completed.compareAndSet(false, true)) {
-          timeoutFuture.cancel(false);
-        }
-        throw e;
+    private int afterRead(int result) throws HttpTimeoutException {
+      checkTimedOut();
+      if (result == -1) {
+        timeoutFuture.cancel(false);
       }
+      return result;
+    }
+
+    private void checkTimedOut() throws HttpTimeoutException {
+      if (timedOut) {
+        throw timeoutException(null);
+      }
+    }
+
+    private IOException translateException(IOException exception) {
+      final HttpTimeoutException timeoutException = findTimeoutException(exception);
+      if (timeoutException != null) {
+        return timeoutException;
+      }
+      if (timedOut) {
+        return timeoutException(exception);
+      }
+      return exception;
     }
 
     private static HttpTimeoutException timeoutException(IOException cause) {
@@ -278,8 +312,55 @@ public class Http2Client implements Client, AsyncClient<Object> {
     }
   }
 
-  private interface BodyRead {
-    int read() throws IOException;
+  private static final class TimeoutHttpResponse implements HttpResponse<InputStream> {
+
+    private final HttpResponse<InputStream> delegate;
+    private final InputStream body;
+
+    private TimeoutHttpResponse(HttpResponse<InputStream> delegate, InputStream body) {
+      this.delegate = delegate;
+      this.body = body;
+    }
+
+    @Override
+    public int statusCode() {
+      return delegate.statusCode();
+    }
+
+    @Override
+    public HttpRequest request() {
+      return delegate.request();
+    }
+
+    @Override
+    public Optional<HttpResponse<InputStream>> previousResponse() {
+      return delegate.previousResponse();
+    }
+
+    @Override
+    public HttpHeaders headers() {
+      return delegate.headers();
+    }
+
+    @Override
+    public InputStream body() {
+      return body;
+    }
+
+    @Override
+    public Optional<SSLSession> sslSession() {
+      return delegate.sslSession();
+    }
+
+    @Override
+    public URI uri() {
+      return delegate.uri();
+    }
+
+    @Override
+    public Version version() {
+      return delegate.version();
+    }
   }
 
   private HttpClient getOrCreateClient(Options options) {

--- a/java11/src/test/java/feign/http2client/Http2ClientContentLengthTest.java
+++ b/java11/src/test/java/feign/http2client/Http2ClientContentLengthTest.java
@@ -16,6 +16,7 @@
 package feign.http2client;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import feign.Request;
 import feign.Request.HttpMethod;
@@ -23,17 +24,21 @@ import feign.Response;
 import feign.Util;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.http.HttpClient.Version;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPOutputStream;
 import javax.net.ssl.SSLSession;
 import org.junit.jupiter.api.Test;
@@ -41,6 +46,11 @@ import org.junit.jupiter.api.Test;
 class Http2ClientContentLengthTest {
 
   private static HttpResponse<InputStream> responseWithContentLength(String contentLength) {
+    return responseWithContentLength(contentLength, new ByteArrayInputStream(new byte[0]));
+  }
+
+  private static HttpResponse<InputStream> responseWithContentLength(
+      String contentLength, InputStream body) {
     final HttpHeaders headers =
         HttpHeaders.of(Map.of("Content-Length", List.of(contentLength)), (name, value) -> true);
     return new HttpResponse<>() {
@@ -66,7 +76,7 @@ class Http2ClientContentLengthTest {
 
       @Override
       public InputStream body() {
-        return new ByteArrayInputStream(new byte[0]);
+        return body;
       }
 
       @Override
@@ -184,5 +194,47 @@ class Http2ClientContentLengthTest {
     assertThat(response.body().length()).isNull();
     assertThat(Util.toString(response.body().asReader(StandardCharsets.UTF_8)))
         .isEqualTo("Compressed Data");
+  }
+
+  @Test
+  void responseBodyTimeoutUsesOneStreamDeadline() throws Exception {
+    final CountDownLatch closed = new CountDownLatch(1);
+    final InputStream body =
+        new ByteArrayInputStream(new byte[] {1}) {
+          @Override
+          public void close() throws IOException {
+            closed.countDown();
+            super.close();
+          }
+        };
+    final Request.Options options =
+        new Request.Options(1, TimeUnit.SECONDS, 1, TimeUnit.MILLISECONDS, true);
+    final Response response =
+        new Http2Client().toFeignResponse(request(), responseWithContentLength("1", body), options);
+
+    assertThat(closed.await(5, TimeUnit.SECONDS)).isTrue();
+    assertThrows(HttpTimeoutException.class, response.body().asInputStream()::read);
+  }
+
+  @Test
+  void responseBodyTimeoutPreservesStreamOperations() throws Exception {
+    final Request.Options options =
+        new Request.Options(1, TimeUnit.SECONDS, 1, TimeUnit.MINUTES, true);
+    final Response response =
+        new Http2Client()
+            .toFeignResponse(
+                request(),
+                responseWithContentLength("3", new ByteArrayInputStream(new byte[] {1, 2, 3})),
+                options);
+    final InputStream body = response.body().asInputStream();
+
+    assertThat(body.markSupported()).isTrue();
+    body.mark(3);
+    assertThat(body.read()).isEqualTo(1);
+    assertThat(body.skip(1)).isEqualTo(1);
+    assertThat(body.read()).isEqualTo(3);
+    body.reset();
+    assertThat(body.read()).isEqualTo(1);
+    body.close();
   }
 }

--- a/java11/src/test/java/feign/http2client/test/Http2ClientAsyncTest.java
+++ b/java11/src/test/java/feign/http2client/test/Http2ClientAsyncTest.java
@@ -63,6 +63,7 @@ import feign.querymap.FieldQueryMapEncoder;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.net.URI;
+import java.net.http.HttpTimeoutException;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Instant;
@@ -508,6 +509,23 @@ public class Http2ClientAsyncTest {
     server.takeRequest();
     Throwable exception = assertThrows(FeignException.class, () -> unwrap(cf));
     assertThat(exception.getMessage()).contains("timeout reading POST http://");
+  }
+
+  @Test
+  void timeoutReadingResponseBody() throws Throwable {
+    server.enqueue(new MockResponse().setBody("foo").setBodyDelay(1, TimeUnit.SECONDS));
+
+    final TestInterfaceAsync api =
+        newAsyncBuilder()
+            .options(
+                new Request.Options(500, TimeUnit.MILLISECONDS, 500, TimeUnit.MILLISECONDS, true))
+            .target("http://localhost:" + server.getPort());
+
+    final CompletableFuture<?> cf = api.post();
+    server.takeRequest();
+
+    Throwable exception = assertThrows(FeignException.class, () -> unwrap(cf));
+    assertThat(exception).hasCauseInstanceOf(HttpTimeoutException.class);
   }
 
   @Test
@@ -1057,6 +1075,11 @@ public class Http2ClientAsyncTest {
 
     TestInterfaceAsyncBuilder dismiss404() {
       delegate.dismiss404();
+      return this;
+    }
+
+    TestInterfaceAsyncBuilder options(Request.Options options) {
+      delegate.options(options);
       return this;
     }
 

--- a/java11/src/test/java/feign/http2client/test/Http2ClientAsyncTest.java
+++ b/java11/src/test/java/feign/http2client/test/Http2ClientAsyncTest.java
@@ -45,6 +45,7 @@ import feign.RequestLine;
 import feign.RequestTemplate;
 import feign.Response;
 import feign.ResponseMapper;
+import feign.Retryer;
 import feign.Target;
 import feign.Target.HardCodedTarget;
 import feign.Util;
@@ -517,6 +518,7 @@ public class Http2ClientAsyncTest {
 
     final TestInterfaceAsync api =
         newAsyncBuilder()
+            .retryer(Retryer.NEVER_RETRY)
             .options(
                 new Request.Options(500, TimeUnit.MILLISECONDS, 500, TimeUnit.MILLISECONDS, true))
             .target("http://localhost:" + server.getPort());
@@ -1080,6 +1082,11 @@ public class Http2ClientAsyncTest {
 
     TestInterfaceAsyncBuilder options(Request.Options options) {
       delegate.options(options);
+      return this;
+    }
+
+    TestInterfaceAsyncBuilder retryer(Retryer retryer) {
+      delegate.retryer(retryer);
       return this;
     }
 

--- a/java11/src/test/java/feign/http2client/test/Http2ClientTest.java
+++ b/java11/src/test/java/feign/http2client/test/Http2ClientTest.java
@@ -176,6 +176,21 @@ public class Http2ClientTest extends AbstractClientTest {
   }
 
   @Test
+  void timeoutReadingResponseBody() {
+    server.enqueue(new MockResponse().setBody("foo").setBodyDelay(1, TimeUnit.SECONDS));
+
+    final TestInterface api =
+        newBuilder()
+            .retryer(Retryer.NEVER_RETRY)
+            .options(
+                new Request.Options(500, TimeUnit.MILLISECONDS, 500, TimeUnit.MILLISECONDS, true))
+            .target(TestInterface.class, server.url("/").toString());
+
+    FeignException exception = assertThrows(FeignException.class, () -> api.timeout());
+    assertThat(exception).hasCauseInstanceOf(HttpTimeoutException.class);
+  }
+
+  @Test
   void getWithRequestBody() throws Exception {
     // MockWebServer rejects GET requests carrying a body ("Request must not have a body"),
     // so this test runs against a minimal local socket server instead.

--- a/java11/src/test/java/feign/http2client/test/Http2ClientTest.java
+++ b/java11/src/test/java/feign/http2client/test/Http2ClientTest.java
@@ -191,6 +191,32 @@ public class Http2ClientTest extends AbstractClientTest {
   }
 
   @Test
+  void invokesTwoArgumentResponseOverride() {
+    server.enqueue(new MockResponse().setBody("foo"));
+    final TwoArgumentOverrideClient client = new TwoArgumentOverrideClient();
+    final TestInterface api =
+        Feign.builder()
+            .client(client)
+            .target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    assertThat(api.get()).isEqualTo("foo");
+    assertThat(client.invoked).isTrue();
+  }
+
+  @Test
+  void invokesThreeArgumentResponseOverride() {
+    server.enqueue(new MockResponse().setBody("foo"));
+    final ThreeArgumentOverrideClient client = new ThreeArgumentOverrideClient();
+    final TestInterface api =
+        Feign.builder()
+            .client(client)
+            .target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    assertThat(api.get()).isEqualTo("foo");
+    assertThat(client.invoked).isTrue();
+  }
+
+  @Test
   void getWithRequestBody() throws Exception {
     // MockWebServer rejects GET requests carrying a body ("Request must not have a body"),
     // so this test runs against a minimal local socket server instead.
@@ -393,5 +419,31 @@ public class Http2ClientTest extends AbstractClientTest {
   @Override
   public Feign.Builder newBuilder() {
     return Feign.builder().client(new Http2Client());
+  }
+
+  private static final class TwoArgumentOverrideClient extends Http2Client {
+
+    private boolean invoked;
+
+    @Override
+    protected Response toFeignResponse(
+        Request request, java.net.http.HttpResponse<InputStream> response) {
+      invoked = true;
+      return super.toFeignResponse(request, response);
+    }
+  }
+
+  private static final class ThreeArgumentOverrideClient extends Http2Client {
+
+    private boolean invoked;
+
+    @Override
+    protected Response toFeignResponse(
+        Request request,
+        java.net.http.HttpResponse<InputStream> response,
+        Request.Options options) {
+      invoked = true;
+      return super.toFeignResponse(request, response, options);
+    }
   }
 }


### PR DESCRIPTION
## Summary

This updates the Java 11 `Http2Client` response handling so the configured Feign read timeout also applies while the response body is being read.

The existing request timeout still covers waiting for the response headers, but `BodyHandlers.ofInputStream()` can hand back a response before the body has arrived. The response body stream is now wrapped with a read-timeout guard, preserving the existing streaming response behavior while failing stalled body reads with `HttpTimeoutException`.

## Tests

- `mvn --batch-mode -Dtoolchain.skip=true -pl java11 -am -Dtest=Http2ClientTest#timeoutReadingResponseBody,Http2ClientAsyncTest#timeoutReadingResponseBody -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn --batch-mode -Dtoolchain.skip=true -pl java11 -am -Dtest=Http2ClientTest,Http2ClientAsyncTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn --batch-mode -Dtoolchain.skip=true -pl java11 -am -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn --batch-mode -Dtoolchain.skip=true -pl java11 -am -DskipTests validate`
- `mvn --batch-mode -Dtoolchain.skip=true -pl java11 -am git-code-format:validate-code-format`

Fixes #3068