### PR TITLE
Avoid converting empty GET bodies to POST

### DIFF
--- a/core/src/main/java/feign/DefaultClient.java
+++ b/core/src/main/java/feign/DefaultClient.java
@@ -189,7 +189,7 @@ public class DefaultClient implements Client {
 
     byte[] body = request.body();
 
-    if (body != null) {
+    if (body != null && (body.length > 0 || request.httpMethod() != Request.HttpMethod.GET)) {
       /*
        * Ignore disableRequestBuffering flag if the empty body was set, to ensure that internal
        * retry logic applies to such requests.

--- a/core/src/test/java/feign/client/DefaultClientTest.java
+++ b/core/src/test/java/feign/client/DefaultClientTest.java
@@ -24,6 +24,8 @@ import feign.Client.Proxied;
 import feign.DefaultClient;
 import feign.Feign;
 import feign.Feign.Builder;
+import feign.Request;
+import feign.Request.HttpMethod;
 import feign.RetryableException;
 import feign.assertj.MockWebServerAssertions;
 import java.io.IOException;
@@ -99,6 +101,22 @@ public class DefaultClientTest extends AbstractClientTest {
         .hasMethod("POST")
         .hasNoHeaderNamed("Content-Type")
         .hasHeaders(entry("Content-Length", Collections.singletonList("0")));
+  }
+
+  @Test
+  void emptyBodyDoesNotConvertGetToPost() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
+    Request request =
+        Request.create(
+            HttpMethod.GET,
+            "http://localhost:" + server.getPort() + "/",
+            Collections.emptyMap(),
+            new byte[0],
+            null);
+
+    new DefaultClient(null, null).execute(request, new Request.Options());
+
+    MockWebServerAssertions.assertThat(server.takeRequest()).hasMethod("GET");
   }
 
   @Test


### PR DESCRIPTION
Fixes #2872.

When the default client sends a GET request with a non-null but empty body, HttpURLConnection treats setDoOutput(true) as a signal that output will be written. That can silently turn the request into POST before it reaches the server.

This keeps the existing behavior for non-empty bodies and for methods that normally send bodies, but skips writing an empty body for GET requests so the method stays GET.

Validation:
- Added a regression test that sends a direct GET request with `new byte[0]` as the body and verifies MockWebServer receives GET.
- Confirmed the new test failed before the fix with `expected: "GET" but was: "POST"`.
- `JAVA_HOME=$(/usr/libexec/java_home -v 26) ./mvnw -pl core test`
- `git diff --check`