### PR TITLE
Support deflate request encoding in HC5

### DIFF
--- a/hc5/src/main/java/feign/hc5/ApacheHttp5Client.java
+++ b/hc5/src/main/java/feign/hc5/ApacheHttp5Client.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.config.Configurable;
 import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.entity.DeflateCompressingEntity;
 import org.apache.hc.client5.http.entity.GzipCompressingEntity;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
@@ -126,6 +127,7 @@ public final class ApacheHttp5Client implements Client {
     // request headers
     boolean hasAcceptHeader = false;
     boolean isGzip = false;
+    boolean isDeflate = false;
     for (final Map.Entry<String, Collection<String>> headerEntry : request.headers().entrySet()) {
       final String headerName = headerEntry.getKey();
       if (headerName.equalsIgnoreCase(ACCEPT_HEADER_NAME)) {
@@ -139,13 +141,8 @@ public final class ApacheHttp5Client implements Client {
       }
       if (headerName.equalsIgnoreCase(Util.CONTENT_ENCODING)) {
         isGzip = headerEntry.getValue().stream().anyMatch(Util.ENCODING_GZIP::equalsIgnoreCase);
-        boolean isDeflate =
+        isDeflate =
             headerEntry.getValue().stream().anyMatch(Util.ENCODING_DEFLATE::equalsIgnoreCase);
-        if (isDeflate) {
-          // DeflateCompressingEntity not available in hc5 yet
-          throw new IllegalArgumentException(
-              "Deflate Content-Encoding is not supported by feign-hc5");
-        }
       }
       for (final String headerValue : headerEntry.getValue()) {
         requestBuilder.addHeader(headerName, headerValue);
@@ -175,6 +172,8 @@ public final class ApacheHttp5Client implements Client {
       }
       if (isGzip) {
         entity = new GzipCompressingEntity(entity);
+      } else if (isDeflate) {
+        entity = new DeflateCompressingEntity(entity);
       }
       requestBuilder.setEntity(entity);
     } else {

--- a/hc5/src/main/java/feign/hc5/AsyncApacheHttp5Client.java
+++ b/hc5/src/main/java/feign/hc5/AsyncApacheHttp5Client.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.zip.DeflaterOutputStream;
 import java.util.zip.GZIPOutputStream;
 import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
@@ -121,6 +122,7 @@ public final class AsyncApacheHttp5Client implements AsyncClient<HttpClientConte
     // request headers
     boolean hasAcceptHeader = false;
     boolean isGzip = false;
+    boolean isDeflate = false;
     for (final Map.Entry<String, Collection<String>> headerEntry : request.headers().entrySet()) {
       final String headerName = headerEntry.getKey();
       if (headerName.equalsIgnoreCase(ACCEPT_HEADER_NAME)) {
@@ -134,13 +136,8 @@ public final class AsyncApacheHttp5Client implements AsyncClient<HttpClientConte
       }
       if (headerName.equalsIgnoreCase(Util.CONTENT_ENCODING)) {
         isGzip = headerEntry.getValue().stream().anyMatch(Util.ENCODING_GZIP::equalsIgnoreCase);
-        boolean isDeflate =
+        isDeflate =
             headerEntry.getValue().stream().anyMatch(Util.ENCODING_DEFLATE::equalsIgnoreCase);
-        if (isDeflate) {
-          // DeflateCompressingEntity not available in hc5 yet
-          throw new IllegalArgumentException(
-              "Deflate Content-Encoding is not supported by feign-hc5");
-        }
       }
 
       for (final String headerValue : headerEntry.getValue()) {
@@ -155,21 +152,38 @@ public final class AsyncApacheHttp5Client implements AsyncClient<HttpClientConte
     // request body
     // final Body requestBody = request.requestBody();
     byte[] data = request.body();
-    if (isGzip && data != null && data.length > 0) {
-      // compress if needed
-      try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
-          GZIPOutputStream gzipOs = new GZIPOutputStream(baos, true)) {
-        gzipOs.write(data);
-        gzipOs.flush();
-        data = baos.toByteArray();
-      } catch (IOException suppressed) { // NOPMD
-      }
+    if (isGzip && data != null) {
+      data = gzip(data);
+    } else if (isDeflate && data != null) {
+      data = deflate(data);
     }
     if (data != null) {
       httpRequest.setBody(data, getContentType(request));
     }
 
     return httpRequest;
+  }
+
+  private static byte[] gzip(byte[] data) {
+    try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        GZIPOutputStream gzip = new GZIPOutputStream(baos)) {
+      gzip.write(data);
+      gzip.finish();
+      return baos.toByteArray();
+    } catch (IOException e) {
+      throw new IllegalStateException("Unable to gzip request body", e);
+    }
+  }
+
+  private static byte[] deflate(byte[] data) {
+    try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DeflaterOutputStream deflater = new DeflaterOutputStream(baos)) {
+      deflater.write(data);
+      deflater.finish();
+      return baos.toByteArray();
+    } catch (IOException e) {
+      throw new IllegalStateException("Unable to deflate request body", e);
+    }
   }
 
   private ContentType getContentType(Request request) {

--- a/hc5/src/test/java/feign/hc5/AsyncApacheHttp5ClientTest.java
+++ b/hc5/src/test/java/feign/hc5/AsyncApacheHttp5ClientTest.java
@@ -149,6 +149,83 @@ public class AsyncApacheHttp5ClientTest {
     checkCFCompletedSoon(cf);
   }
 
+  @Test
+  void postGZIPEncodedBodyParam() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
+
+    final TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+
+    final CompletableFuture<?> cf =
+        api.gzipBody(Arrays.asList("netflix", "denominator", "password"));
+
+    assertThat(server.takeRequest())
+        .hasGzippedBody("[netflix, denominator, password]".getBytes(Util.UTF_8));
+
+    checkCFCompletedSoon(cf);
+  }
+
+  @Test
+  void postGZIPEncodedEmptyBodyParam() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
+
+    final TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+
+    final CompletableFuture<?> cf = api.gzipBody("");
+
+    assertThat(server.takeRequest()).hasGzippedBody(new byte[0]);
+
+    checkCFCompletedSoon(cf);
+  }
+
+  @Test
+  void postGZIPAndDeflateEncodedBodyParam() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
+
+    final TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder()
+            .requestInterceptor(req -> req.header("Content-Encoding", "gzip", "deflate"))
+            .target("http://localhost:" + server.getPort());
+
+    final CompletableFuture<?> cf = api.body(Arrays.asList("netflix", "denominator", "password"));
+
+    assertThat(server.takeRequest())
+        .hasGzippedBody("[netflix, denominator, password]".getBytes(Util.UTF_8));
+
+    checkCFCompletedSoon(cf);
+  }
+
+  @Test
+  void postDeflateEncodedBodyParam() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
+
+    final TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+
+    final CompletableFuture<?> cf =
+        api.deflateBody(Arrays.asList("netflix", "denominator", "password"));
+
+    assertThat(server.takeRequest())
+        .hasDeflatedBody("[netflix, denominator, password]".getBytes(Util.UTF_8));
+
+    checkCFCompletedSoon(cf);
+  }
+
+  @Test
+  void postDeflateEncodedEmptyBodyParam() throws Exception {
+    server.enqueue(new MockResponse().setBody("foo"));
+
+    final TestInterfaceAsync api =
+        new TestInterfaceAsyncBuilder().target("http://localhost:" + server.getPort());
+
+    final CompletableFuture<?> cf = api.deflateBody("");
+
+    assertThat(server.takeRequest()).hasDeflatedBody(new byte[0]);
+
+    checkCFCompletedSoon(cf);
+  }
+
   /**
    * The type of a parameter value may not be the desired type to encode as. Prefer the interface
    * type.
@@ -950,8 +1027,16 @@ public class AsyncApacheHttp5ClientTest {
     CompletableFuture<Void> gzipBody(List<String> contents);
 
     @RequestLine("POST /")
+    @Headers("Content-Encoding: gzip")
+    CompletableFuture<Void> gzipBody(String contents);
+
+    @RequestLine("POST /")
     @Headers("Content-Encoding: deflate")
     CompletableFuture<Void> deflateBody(List<String> contents);
+
+    @RequestLine("POST /")
+    @Headers("Content-Encoding: deflate")
+    CompletableFuture<Void> deflateBody(String contents);
 
     @RequestLine("POST /")
     CompletableFuture<Void> form(

--- a/hc5/src/test/java/feign/hc5/DeflateHttp5ClientTest.java
+++ b/hc5/src/test/java/feign/hc5/DeflateHttp5ClientTest.java
@@ -25,13 +25,13 @@ import feign.client.AbstractClientTest;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.zip.GZIPInputStream;
+import java.util.zip.InflaterInputStream;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.Test;
 
-/** Tests that 'Content-Encoding: gzip' is handled correctly */
-public class GzipHttp5ClientTest extends AbstractClientTest {
+/** Tests that 'Content-Encoding: deflate' is handled correctly */
+public class DeflateHttp5ClientTest extends AbstractClientTest {
 
   @Override
   public Builder newBuilder() {
@@ -47,32 +47,31 @@ public class GzipHttp5ClientTest extends AbstractClientTest {
     assertEquals("foo", testInterface.withBody("bar"));
     final RecordedRequest request1 = server.takeRequest();
     assertEquals("/test", request1.getPath());
+    assertEquals("deflate", request1.getHeader("Content-Encoding"));
 
     ByteArrayInputStream bodyContentIs =
         new ByteArrayInputStream(request1.getBody().readByteArray());
-    byte[] uncompressed = new GZIPInputStream(bodyContentIs).readAllBytes();
+    byte[] uncompressed = new InflaterInputStream(bodyContentIs).readAllBytes();
 
     assertEquals("bar", new String(uncompressed, StandardCharsets.UTF_8));
   }
 
   @Test
-  public void testWithGzipAndDeflateHeaders() throws InterruptedException, IOException {
-    final TestInterface testInterface =
-        newBuilder()
-            .requestInterceptor(req -> req.header("Content-Encoding", "gzip", "deflate"))
-            .target(TestInterface.class, "http://localhost:" + server.getPort());
+  public void testWithEmptyCompressedBody() throws InterruptedException, IOException {
+    final TestInterface testInterface = buildTestInterface(true);
 
     server.enqueue(new MockResponse().setBody("foo"));
 
-    assertEquals("foo", testInterface.withBody("bar"));
+    assertEquals("foo", testInterface.withBody(""));
     final RecordedRequest request1 = server.takeRequest();
     assertEquals("/test", request1.getPath());
+    assertEquals("deflate", request1.getHeader("Content-Encoding"));
 
     ByteArrayInputStream bodyContentIs =
         new ByteArrayInputStream(request1.getBody().readByteArray());
-    byte[] uncompressed = new GZIPInputStream(bodyContentIs).readAllBytes();
+    byte[] uncompressed = new InflaterInputStream(bodyContentIs).readAllBytes();
 
-    assertEquals("bar", new String(uncompressed, StandardCharsets.UTF_8));
+    assertEquals(0, uncompressed.length);
   }
 
   @Test
@@ -90,7 +89,7 @@ public class GzipHttp5ClientTest extends AbstractClientTest {
 
   private TestInterface buildTestInterface(boolean compress) {
     return newBuilder()
-        .requestInterceptor(req -> req.header("Content-Encoding", compress ? "gzip" : ""))
+        .requestInterceptor(req -> req.header("Content-Encoding", compress ? "deflate" : ""))
         .target(TestInterface.class, "http://localhost:" + server.getPort());
   }
 


### PR DESCRIPTION
Spring Cloud OpenFeign request compression can add `Content-Encoding: gzip,deflate`. `feign-hc5` currently rejects any request that includes `deflate`, so the request fails before it is sent.

This removes the unconditional rejection and adds request deflate support in HC5. The sync client uses Apache HttpClient 5's `DeflateCompressingEntity`; the async client compresses the simple request body bytes directly. When both `gzip` and `deflate` are present, `gzip` remains the effective encoding, matching Feign's existing default client precedence.

The same error was reproduced in Spring Cloud OpenFeign versions 4.1.2, 4.1.5, and 5.0.2 prior to the modification.
After applying the `feign-hc5` changes, we confirmed that the same application is working correctly.

Tests:

* `./mvnw -Pdev -pl hc5 -Dtest=DeflateHttp5ClientTest,GzipHttp5ClientTest,AsyncApacheHttp5ClientTest test`
* `./mvnw -Pdev -pl hc5 -am clean test`


Fixes #2460