### PR TITLE
cap negative Content-Length in GoogleHttpClient and DefaultClient

### DIFF
--- a/core/src/main/java/feign/DefaultClient.java
+++ b/core/src/main/java/feign/DefaultClient.java
@@ -111,7 +111,9 @@ public class DefaultClient implements Client {
     }
 
     Integer length = connection.getContentLength();
-    if (length == -1) {
+    if (length < 0) {
+      // -1 signals unknown or above Integer.MAX_VALUE; any other negative value is a malformed
+      // header that HttpURLConnection surfaces verbatim
       length = null;
     }
     InputStream stream;

--- a/core/src/test/java/feign/DefaultClientContentLengthTest.java
+++ b/core/src/test/java/feign/DefaultClientContentLengthTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import feign.Request.HttpMethod;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class DefaultClientContentLengthTest {
+
+  /**
+   * {@link HttpURLConnection#getContentLength()} reports the {@code Content-Length} header as-is
+   * once it fits in an {@code int}, so a malformed negative header reaches the client unchanged.
+   */
+  private static HttpURLConnection connectionWithContentLength(int contentLength)
+      throws IOException {
+    return new HttpURLConnection(new URL("http://localhost")) {
+
+      @Override
+      public int getResponseCode() {
+        return 200;
+      }
+
+      @Override
+      public String getResponseMessage() {
+        return "OK";
+      }
+
+      @Override
+      public Map<String, List<String>> getHeaderFields() {
+        return Collections.singletonMap(
+            "Content-Length", Collections.singletonList(String.valueOf(contentLength)));
+      }
+
+      @Override
+      public int getContentLength() {
+        return contentLength;
+      }
+
+      @Override
+      public InputStream getInputStream() {
+        return new ByteArrayInputStream(new byte[0]);
+      }
+
+      @Override
+      public void connect() {}
+
+      @Override
+      public void disconnect() {}
+
+      @Override
+      public boolean usingProxy() {
+        return false;
+      }
+    };
+  }
+
+  private static Response decode(int contentLength) throws IOException {
+    final Request request =
+        Request.create(
+            HttpMethod.GET,
+            "http://localhost",
+            Collections.emptyMap(),
+            null,
+            StandardCharsets.UTF_8,
+            null);
+    return new DefaultClient(null, null)
+        .convertResponse(connectionWithContentLength(contentLength), request);
+  }
+
+  @Test
+  void unknownContentLengthIsReportedAsUnknown() throws IOException {
+    // -1 is also what getContentLength() returns for a header above Integer.MAX_VALUE
+    assertThat(decode(-1).body().length()).isNull();
+  }
+
+  @Test
+  void negativeContentLengthIsReportedAsUnknown() throws IOException {
+    assertThat(decode(-5).body().length()).isNull();
+  }
+
+  @Test
+  void contentLengthWithinIntRangeIsPreserved() throws IOException {
+    assertThat(decode(1024).body().length()).isEqualTo(1024);
+  }
+}

--- a/googlehttpclient/src/main/java/feign/googlehttpclient/GoogleHttpClient.java
+++ b/googlehttpclient/src/main/java/feign/googlehttpclient/GoogleHttpClient.java
@@ -111,9 +111,10 @@ public class GoogleHttpClient implements Client {
   private final Response convertResponse(
       final Request inputRequest, final HttpResponse inputResponse) throws IOException {
     final HttpHeaders headers = inputResponse.getHeaders();
+    final Long length = headers.getContentLength();
     Integer contentLength = null;
-    if (headers.getContentLength() != null && headers.getContentLength() <= Integer.MAX_VALUE) {
-      contentLength = inputResponse.getHeaders().getContentLength().intValue();
+    if (length != null && length >= 0 && length <= Integer.MAX_VALUE) {
+      contentLength = length.intValue();
     }
     return Response.builder()
         .body(inputResponse.getContent(), contentLength)

--- a/googlehttpclient/src/test/java/feign/googlehttpclient/GoogleHttpClientContentLengthTest.java
+++ b/googlehttpclient/src/test/java/feign/googlehttpclient/GoogleHttpClientContentLengthTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.googlehttpclient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.api.client.testing.http.MockHttpTransport;
+import com.google.api.client.testing.http.MockLowLevelHttpResponse;
+import feign.Request;
+import feign.Request.HttpMethod;
+import feign.Request.Options;
+import feign.Response;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+class GoogleHttpClientContentLengthTest {
+
+  private static Response decode(String contentLength) throws IOException {
+    final MockLowLevelHttpResponse lowLevelResponse =
+        new MockLowLevelHttpResponse().setStatusCode(200).setContent("");
+    lowLevelResponse.addHeader("Content-Length", contentLength);
+    final MockHttpTransport transport =
+        new MockHttpTransport.Builder().setLowLevelHttpResponse(lowLevelResponse).build();
+    final Request request =
+        Request.create(
+            HttpMethod.GET,
+            "http://localhost",
+            Collections.emptyMap(),
+            null,
+            StandardCharsets.UTF_8,
+            null);
+    return new GoogleHttpClient(transport).execute(request, new Options());
+  }
+
+  @Test
+  void contentLengthAboveIntMaxIsReportedAsUnknown() throws IOException {
+    // 2^31, a valid Content-Length larger than Integer.MAX_VALUE
+    assertThat(decode("2147483648").body().length()).isNull();
+  }
+
+  @Test
+  void negativeContentLengthIsReportedAsUnknown() throws IOException {
+    assertThat(decode("-1").body().length()).isNull();
+  }
+
+  @Test
+  void contentLengthWithinIntRangeIsPreserved() throws IOException {
+    assertThat(decode("1024").body().length()).isEqualTo(1024);
+  }
+}


### PR DESCRIPTION
`GoogleHttpClient#convertResponse` narrows the response `Content-Length` to an
`Integer` but only guards the upper bound:

```java
if (headers.getContentLength() != null && headers.getContentLength() <= Integer.MAX_VALUE) {
  contentLength = inputResponse.getHeaders().getContentLength().intValue();
}
```

A negative header value therefore passes through unchanged.
`Response.Body#length()` is documented as:

> length in bytes, if known. Null if unknown or greater than `Integer.MAX_VALUE`.

so a malformed `Content-Length: -1` ends up reported as `length() == -1`
instead of `null`.

### Clients audited

| Client | Guard before this PR | |
| --- | --- | --- |
| `OkHttpClient` | `>= 0 && <= Integer.MAX_VALUE` | ok |
| `ApacheHttpClient` | `>= 0 && <= Integer.MAX_VALUE` | ok |
| `ApacheHttp5Client` | `>= 0 && <= Integer.MAX_VALUE` | ok |
| `Http2Client` | `>= 0 && <= Integer.MAX_VALUE` | ok, added in #3431 |
| `GoogleHttpClient` | upper bound only | fixed here |
| `DefaultClient` (core) | `== -1` only | fixed here |

The first revision of this PR said `GoogleHttpClient` was the only client left
without the guard. That was wrong. @kdelay pointed out that `core`'s
`DefaultClient` special-cases `-1` alone, and it is the client used when none is
configured. `Client.Default` and `Client.Proxied` extend it, so all three share
that code path.

### Is a negative value other than -1 actually reachable?

Yes. `HttpURLConnection#getContentLength()` returns the header verbatim once it
fits in an `int`, and collapses to `-1` only when the value is absent or does not
fit. Measured against a raw socket reply on JDK 17, 21 and 26:

```
Content-Length: -5            ->  getContentLength() = -5
Content-Length: -2147483648   ->  getContentLength() = -2147483648
Content-Length: -1            ->  getContentLength() = -1
Content-Length: 3000000000    ->  getContentLength() = -1   (above Integer.MAX_VALUE)
```

Widening `DefaultClient` from `== -1` to `< 0` therefore reports a malformed
value as unknown while leaving both the `-1` and the over-2GB cases untouched.

### Why it matters

`InvocationContext` decides whether a response can be buffered with:

```java
&& response.body().length() != null
&& response.body().length() <= MAX_RESPONSE_BUFFER_SIZE;
```

A negative length is non-null and compares below the threshold, so it silently
passes a check that is meant to reject unknown lengths.

### Verification

One test per client, both mirroring `Http2ClientContentLengthTest` from #3431.
Each one fails on master for the negative case. Reverting only the
`DefaultClient` guard while keeping its test:

```
[ERROR] DefaultClientContentLengthTest.negativeContentLengthIsReportedAsUnknown
expected: null
 but was: -5
[ERROR] Tests run: 3, Failures: 1, Errors: 0, Skipped: 0
```

With both fixes in place:

- `mvn -pl googlehttpclient verify` -> 24 tests, 0 failures, 0 errors, BUILD SUCCESS
- `mvn -pl core test` -> 637 tests, 0 failures, 3 skipped, 2 errors

The two `core` errors are `OptionsTest.normalResponseTest` and
`OptionsTest.normalResponseForChildOptionsTest`, both `Read timed out`. They
reproduce identically on an unmodified `master` checkout on this machine, so
they are environmental and unrelated to this change.

`license:check`, `git-code-format:validate-code-format` and `japicmp` pass on
both modules.

### Scope

The `DefaultClient` change is a separate commit, so it is easy to drop if you
would rather keep this PR to the Google client and take `core` separately.
