### PR TITLE
Add streaming decoder support

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -19,7 +19,7 @@
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>develocity-maven-extension</artifactId>
-        <version>2.4.2</version>
+        <version>2.5.0</version>
     </extension>
     <extension>
         <groupId>com.gradle</groupId>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -24,6 +24,6 @@
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>common-custom-user-data-maven-extension</artifactId>
-        <version>2.2.0</version>
+        <version>2.3.0</version>
     </extension>
 </extensions>

--- a/api/src/main/java/feign/InvocationContext.java
+++ b/api/src/main/java/feign/InvocationContext.java
@@ -69,7 +69,7 @@ public class InvocationContext {
 
   public Object proceed() throws Exception {
     if (returnType == Response.class) {
-      return response;
+      return disconnectResponseBodyIfNeeded(response);
     }
 
     boolean noClose = false;
@@ -107,23 +107,23 @@ public class InvocationContext {
     }
   }
 
-  //
-  //  private static Response disconnectResponseBodyIfNeeded(Response response) throws IOException {
-  //    final boolean shouldDisconnectResponseBody =
-  //        response.body() != null
-  //            && response.body().length() != null
-  //            && response.body().length() <= MAX_RESPONSE_BUFFER_SIZE;
-  //    if (!shouldDisconnectResponseBody) {
-  //      return response;
-  //    }
-  //
-  //    try {
-  //      final byte[] bodyData = Util.toByteArray(response.body().asInputStream());
-  //      return response.toBuilder().body(bodyData).build();
-  //    } finally {
-  //      ensureClosed(response.body());
-  //    }
-  //  }
+  
+    private static Response disconnectResponseBodyIfNeeded(Response response) throws IOException {
+      final boolean shouldDisconnectResponseBody =
+          response.body() != null
+              && response.body().length() != null
+              && response.body().length() <= MAX_RESPONSE_BUFFER_SIZE;
+      if (!shouldDisconnectResponseBody) {
+        return response;
+      }
+  
+      try {
+        final byte[] bodyData = Util.toByteArray(response.body().asInputStream());
+        return response.toBuilder().body(bodyData).build();
+      } finally {
+        ensureClosed(response.body());
+      }
+    }
 
   private Object decode(Response response, Type returnType) {
     try {

--- a/api/src/main/java/feign/InvocationContext.java
+++ b/api/src/main/java/feign/InvocationContext.java
@@ -21,6 +21,8 @@ import static feign.Util.ensureClosed;
 import feign.codec.DecodeException;
 import feign.codec.Decoder;
 import feign.codec.ErrorDecoder;
+
+import java.io.Closeable;
 import java.io.IOException;
 import java.lang.reflect.Type;
 
@@ -68,9 +70,11 @@ public class InvocationContext {
 
   public Object proceed() throws Exception {
     if (returnType == Response.class) {
-      return disconnectResponseBodyIfNeeded(response);
+      return response;
     }
 
+    boolean noClose = false;
+    
     try {
       final boolean shouldDecodeResponseBody =
           (response.status() >= 200 && response.status() < 300)
@@ -86,6 +90,11 @@ public class InvocationContext {
       }
 
       Class<?> rawType = Types.getRawType(returnType);
+      
+      if(Closeable.class.isAssignableFrom(rawType)) {
+    	  	noClose = true;
+      }
+      
       if (TypedResponse.class.isAssignableFrom(rawType)) {
         Type bodyType = Types.resolveLastTypeParameter(returnType, TypedResponse.class);
         return TypedResponse.builder(response).body(decode(response, bodyType)).build();
@@ -93,28 +102,28 @@ public class InvocationContext {
 
       return decode(response, returnType);
     } finally {
-      if (closeAfterDecode) {
+      if (closeAfterDecode && !noClose) {
         ensureClosed(response.body());
       }
     }
   }
-
-  private static Response disconnectResponseBodyIfNeeded(Response response) throws IOException {
-    final boolean shouldDisconnectResponseBody =
-        response.body() != null
-            && response.body().length() != null
-            && response.body().length() <= MAX_RESPONSE_BUFFER_SIZE;
-    if (!shouldDisconnectResponseBody) {
-      return response;
-    }
-
-    try {
-      final byte[] bodyData = Util.toByteArray(response.body().asInputStream());
-      return response.toBuilder().body(bodyData).build();
-    } finally {
-      ensureClosed(response.body());
-    }
-  }
+//
+//  private static Response disconnectResponseBodyIfNeeded(Response response) throws IOException {
+//    final boolean shouldDisconnectResponseBody =
+//        response.body() != null
+//            && response.body().length() != null
+//            && response.body().length() <= MAX_RESPONSE_BUFFER_SIZE;
+//    if (!shouldDisconnectResponseBody) {
+//      return response;
+//    }
+//
+//    try {
+//      final byte[] bodyData = Util.toByteArray(response.body().asInputStream());
+//      return response.toBuilder().body(bodyData).build();
+//    } finally {
+//      ensureClosed(response.body());
+//    }
+//  }
 
   private Object decode(Response response, Type returnType) {
     try {

--- a/api/src/main/java/feign/InvocationContext.java
+++ b/api/src/main/java/feign/InvocationContext.java
@@ -21,7 +21,6 @@ import static feign.Util.ensureClosed;
 import feign.codec.DecodeException;
 import feign.codec.Decoder;
 import feign.codec.ErrorDecoder;
-
 import java.io.Closeable;
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -74,7 +73,7 @@ public class InvocationContext {
     }
 
     boolean noClose = false;
-    
+
     try {
       final boolean shouldDecodeResponseBody =
           (response.status() >= 200 && response.status() < 300)
@@ -90,11 +89,11 @@ public class InvocationContext {
       }
 
       Class<?> rawType = Types.getRawType(returnType);
-      
-      if(Closeable.class.isAssignableFrom(rawType)) {
-    	  	noClose = true;
+
+      if (Closeable.class.isAssignableFrom(rawType)) {
+        noClose = true;
       }
-      
+
       if (TypedResponse.class.isAssignableFrom(rawType)) {
         Type bodyType = Types.resolveLastTypeParameter(returnType, TypedResponse.class);
         return TypedResponse.builder(response).body(decode(response, bodyType)).build();
@@ -107,23 +106,24 @@ public class InvocationContext {
       }
     }
   }
-//
-//  private static Response disconnectResponseBodyIfNeeded(Response response) throws IOException {
-//    final boolean shouldDisconnectResponseBody =
-//        response.body() != null
-//            && response.body().length() != null
-//            && response.body().length() <= MAX_RESPONSE_BUFFER_SIZE;
-//    if (!shouldDisconnectResponseBody) {
-//      return response;
-//    }
-//
-//    try {
-//      final byte[] bodyData = Util.toByteArray(response.body().asInputStream());
-//      return response.toBuilder().body(bodyData).build();
-//    } finally {
-//      ensureClosed(response.body());
-//    }
-//  }
+
+  //
+  //  private static Response disconnectResponseBodyIfNeeded(Response response) throws IOException {
+  //    final boolean shouldDisconnectResponseBody =
+  //        response.body() != null
+  //            && response.body().length() != null
+  //            && response.body().length() <= MAX_RESPONSE_BUFFER_SIZE;
+  //    if (!shouldDisconnectResponseBody) {
+  //      return response;
+  //    }
+  //
+  //    try {
+  //      final byte[] bodyData = Util.toByteArray(response.body().asInputStream());
+  //      return response.toBuilder().body(bodyData).build();
+  //    } finally {
+  //      ensureClosed(response.body());
+  //    }
+  //  }
 
   private Object decode(Response response, Type returnType) {
     try {

--- a/api/src/main/java/feign/InvocationContext.java
+++ b/api/src/main/java/feign/InvocationContext.java
@@ -107,23 +107,22 @@ public class InvocationContext {
     }
   }
 
-  
-    private static Response disconnectResponseBodyIfNeeded(Response response) throws IOException {
-      final boolean shouldDisconnectResponseBody =
-          response.body() != null
-              && response.body().length() != null
-              && response.body().length() <= MAX_RESPONSE_BUFFER_SIZE;
-      if (!shouldDisconnectResponseBody) {
-        return response;
-      }
-  
-      try {
-        final byte[] bodyData = Util.toByteArray(response.body().asInputStream());
-        return response.toBuilder().body(bodyData).build();
-      } finally {
-        ensureClosed(response.body());
-      }
+  private static Response disconnectResponseBodyIfNeeded(Response response) throws IOException {
+    final boolean shouldDisconnectResponseBody =
+        response.body() != null
+            && response.body().length() != null
+            && response.body().length() <= MAX_RESPONSE_BUFFER_SIZE;
+    if (!shouldDisconnectResponseBody) {
+      return response;
     }
+
+    try {
+      final byte[] bodyData = Util.toByteArray(response.body().asInputStream());
+      return response.toBuilder().body(bodyData).build();
+    } finally {
+      ensureClosed(response.body());
+    }
+  }
 
   private Object decode(Response response, Type returnType) {
     try {

--- a/api/src/main/java/feign/Util.java
+++ b/api/src/main/java/feign/Util.java
@@ -59,6 +59,9 @@ public class Util {
   /** The HTTP Content-Length header field name. */
   public static final String CONTENT_LENGTH = "Content-Length";
 
+  /** The HTTP Content-Type header field name. */
+  public static final String CONTENT_TYPE = "Content-Type";
+  
   /** The HTTP Content-Encoding header field name. */
   public static final String CONTENT_ENCODING = "Content-Encoding";
 

--- a/api/src/main/java/feign/Util.java
+++ b/api/src/main/java/feign/Util.java
@@ -61,7 +61,7 @@ public class Util {
 
   /** The HTTP Content-Type header field name. */
   public static final String CONTENT_TYPE = "Content-Type";
-  
+
   /** The HTTP Content-Encoding header field name. */
   public static final String CONTENT_ENCODING = "Content-Encoding";
 

--- a/api/src/main/java/feign/utils/ContentTypeParser.java
+++ b/api/src/main/java/feign/utils/ContentTypeParser.java
@@ -15,14 +15,12 @@
  */
 package feign.utils;
 
+import feign.Util;
 import java.nio.charset.Charset;
-import java.nio.charset.UnsupportedCharsetException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
-
-import feign.Util;
 
 public final class ContentTypeParser {
 
@@ -76,14 +74,14 @@ public final class ContentTypeParser {
   }
 
   private static Charset charsetOrNull(String charsetStr) {
-	  
-	  try {
-		return Charset.forName(charsetStr);
-	  } catch (Exception e) {
-		return null;
-	  }
+
+    try {
+      return Charset.forName(charsetStr);
+    } catch (Exception e) {
+      return null;
+    }
   }
-  
+
   /** Represents the parsed results of a Content-Type header */
   public static class ContentTypeResult {
     public static final ContentTypeResult MISSING = new ContentTypeResult("", null);

--- a/api/src/main/java/feign/utils/ContentTypeParser.java
+++ b/api/src/main/java/feign/utils/ContentTypeParser.java
@@ -1,0 +1,88 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package feign.utils;
+
+import java.nio.charset.Charset;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import feign.Util;
+
+public final class ContentTypeParser {
+
+	private ContentTypeParser() {
+	}
+
+	public static ContentTypeResult parseContentTypeFromHeaders(Map<String, Collection<String>> headers, String ifMissing) {
+		// The header map *should* be a case insensitive treemap
+		for (String val : headers.getOrDefault(Util.CONTENT_TYPE, Collections.emptyList())) {
+			return parseContentTypeHeader(val);
+		}
+
+		return new ContentTypeResult(ifMissing, null);
+	}
+
+	public static ContentTypeResult parseContentTypeHeader(String contentTypeHeader) {
+
+      String[] contentTypeParmeters = contentTypeHeader.split(";");
+      String contentType = contentTypeParmeters[0];
+      String charsetString = "";
+      if (contentTypeParmeters.length > 1) {
+        String[] charsetParts = contentTypeParmeters[1].split("=");
+        if (charsetParts.length == 2 && "charset".equalsIgnoreCase(charsetParts[0].trim())) {
+          // TODO: 20260727 - this doesn't implement the full parser definition for the content-type header (esp related to quoted strings, etc...) - see https://www.w3.org/Protocols/rfc1341/4_Content-Type.html
+          charsetString = charsetParts[1].trim();
+          if (charsetString.length() > 1 &&  charsetString.startsWith("\"") && charsetString.endsWith("\""))
+        	  	charsetString = charsetString.substring(1, charsetString.length()-1);
+        }
+      }
+
+      return new ContentTypeResult(contentType, Charset.forName(charsetString, null));
+	}
+
+	public static class ContentTypeResult{
+		public static final ContentTypeResult MISSING = new ContentTypeResult("", null);
+
+		private String contentType;
+		private Optional<Charset> charset;
+
+		public ContentTypeResult(String contentType, Charset charset) {
+			this.contentType = contentType;
+			this.charset = Optional.ofNullable(charset);
+		}
+
+		public String getContentType() {
+			return contentType;
+		}
+
+		public Optional<Charset> getCharset() {
+			return charset;
+		}
+	}
+}

--- a/api/src/main/java/feign/utils/ContentTypeParser.java
+++ b/api/src/main/java/feign/utils/ContentTypeParser.java
@@ -15,12 +15,14 @@
  */
 package feign.utils;
 
-import feign.Util;
 import java.nio.charset.Charset;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+
+import feign.Util;
 
 public final class ContentTypeParser {
 
@@ -70,9 +72,18 @@ public final class ContentTypeParser {
       }
     }
 
-    return new ContentTypeResult(contentType, Charset.forName(charsetString, null));
+    return new ContentTypeResult(contentType, charsetOrNull(charsetString));
   }
 
+  private static Charset charsetOrNull(String charsetStr) {
+	  
+	  try {
+		return Charset.forName(charsetStr);
+	  } catch (Exception e) {
+		return null;
+	  }
+  }
+  
   /** Represents the parsed results of a Content-Type header */
   public static class ContentTypeResult {
     public static final ContentTypeResult MISSING = new ContentTypeResult("", null);

--- a/api/src/main/java/feign/utils/ContentTypeParser.java
+++ b/api/src/main/java/feign/utils/ContentTypeParser.java
@@ -1,28 +1,17 @@
 /*
- * ====================================================================
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- * ====================================================================
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * This software consists of voluntary contributions made by many
- * individuals on behalf of the Apache Software Foundation.  For more
- * information on the Apache Software Foundation, please see
- * <http://www.apache.org/>.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package feign.utils;
 

--- a/api/src/main/java/feign/utils/ContentTypeParser.java
+++ b/api/src/main/java/feign/utils/ContentTypeParser.java
@@ -15,83 +15,85 @@
  */
 package feign.utils;
 
+import feign.Util;
 import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
-import feign.Util;
-
 public final class ContentTypeParser {
 
-	private ContentTypeParser() {
-	}
+  private ContentTypeParser() {}
 
-	/**
-	 * Parses and returns information about the Content-Type header 
-	 * @param headers the headers to parse
-	 * @return a ContentTypeResult that has the content-type information (or Optional.empty() if the Content-Type header is not in the headers) 
-	 */
-	public static Optional<ContentTypeResult> parseContentTypeFromHeaders(Map<String, Collection<String>> headers) {
-		// The header map *should* be a case insensitive treemap
-		for (String val : headers.getOrDefault(Util.CONTENT_TYPE, Collections.emptyList())) {
-			return Optional.of(parseContentTypeHeader(val));
-		}
+  /**
+   * Parses and returns information about the Content-Type header
+   *
+   * @param headers the headers to parse
+   * @return a ContentTypeResult that has the content-type information (or Optional.empty() if the
+   *     Content-Type header is not in the headers)
+   */
+  public static Optional<ContentTypeResult> parseContentTypeFromHeaders(
+      Map<String, Collection<String>> headers) {
+    // The header map *should* be a case insensitive treemap
+    for (String val : headers.getOrDefault(Util.CONTENT_TYPE, Collections.emptyList())) {
+      return Optional.of(parseContentTypeHeader(val));
+    }
 
-		return Optional.empty();
-	}
+    return Optional.empty();
+  }
 
-	/**
-	 * Parses and returns information about a string that is a valid formatting Content-Type header value
-	 * @param contentTypeHeader the Content-Type header value to parse
-	 * @return a ContentTypeResult that has the content-type information (or Optional.empty() if the Content-Type header is not in the headers) 
-	 */
-	public static ContentTypeResult parseContentTypeHeader(String contentTypeHeader) {
+  /**
+   * Parses and returns information about a string that is a valid formatting Content-Type header
+   * value
+   *
+   * @param contentTypeHeader the Content-Type header value to parse
+   * @return a ContentTypeResult that has the content-type information (or Optional.empty() if the
+   *     Content-Type header is not in the headers)
+   */
+  public static ContentTypeResult parseContentTypeHeader(String contentTypeHeader) {
 
-      String[] contentTypeParmeters = contentTypeHeader.split(";");
-      String contentType = contentTypeParmeters[0];
-      String charsetString = "";
-      if (contentTypeParmeters.length > 1) {
-        String[] charsetParts = contentTypeParmeters[1].split("=");
-        if (charsetParts.length == 2 && "charset".equalsIgnoreCase(charsetParts[0].trim())) {
-          // TODO: 20260727 - this doesn't implement the full parser definition for the content-type header (esp related to quoted strings, etc...) - see https://www.w3.org/Protocols/rfc1341/4_Content-Type.html
-          charsetString = charsetParts[1].trim();
-          if (charsetString.length() > 1 &&  charsetString.startsWith("\"") && charsetString.endsWith("\""))
-        	  	charsetString = charsetString.substring(1, charsetString.length()-1);
-        }
+    String[] contentTypeParmeters = contentTypeHeader.split(";");
+    String contentType = contentTypeParmeters[0];
+    String charsetString = "";
+    if (contentTypeParmeters.length > 1) {
+      String[] charsetParts = contentTypeParmeters[1].split("=");
+      if (charsetParts.length == 2 && "charset".equalsIgnoreCase(charsetParts[0].trim())) {
+        // TODO: 20260727 - this doesn't implement the full parser definition for the content-type
+        // header (esp related to quoted strings, etc...) - see
+        // https://www.w3.org/Protocols/rfc1341/4_Content-Type.html
+        charsetString = charsetParts[1].trim();
+        if (charsetString.length() > 1
+            && charsetString.startsWith("\"")
+            && charsetString.endsWith("\""))
+          charsetString = charsetString.substring(1, charsetString.length() - 1);
       }
+    }
 
-      return new ContentTypeResult(contentType, Charset.forName(charsetString, null));
-	}
+    return new ContentTypeResult(contentType, Charset.forName(charsetString, null));
+  }
 
-	/**
-	 * Represents the parsed results of a Content-Type header
-	 */
-	public static class ContentTypeResult{
-		public static final ContentTypeResult MISSING = new ContentTypeResult("", null);
+  /** Represents the parsed results of a Content-Type header */
+  public static class ContentTypeResult {
+    public static final ContentTypeResult MISSING = new ContentTypeResult("", null);
 
-		/**
-		 * The content type portion of the header string
-		 */
-		private String contentType;
-		
-		/**
-		 * The charset portion of the header string (if specified)
-		 */
-		private Optional<Charset> charset;
+    /** The content type portion of the header string */
+    private String contentType;
 
-		public ContentTypeResult(String contentType, Charset charset) {
-			this.contentType = contentType;
-			this.charset = Optional.ofNullable(charset);
-		}
+    /** The charset portion of the header string (if specified) */
+    private Optional<Charset> charset;
 
-		public String getContentType() {
-			return contentType;
-		}
+    public ContentTypeResult(String contentType, Charset charset) {
+      this.contentType = contentType;
+      this.charset = Optional.ofNullable(charset);
+    }
 
-		public Optional<Charset> getCharset() {
-			return charset;
-		}
-	}
+    public String getContentType() {
+      return contentType;
+    }
+
+    public Optional<Charset> getCharset() {
+      return charset;
+    }
+  }
 }

--- a/api/src/main/java/feign/utils/ContentTypeParser.java
+++ b/api/src/main/java/feign/utils/ContentTypeParser.java
@@ -39,15 +39,25 @@ public final class ContentTypeParser {
 	private ContentTypeParser() {
 	}
 
-	public static ContentTypeResult parseContentTypeFromHeaders(Map<String, Collection<String>> headers, String ifMissing) {
+	/**
+	 * Parses and returns information about the Content-Type header 
+	 * @param headers the headers to parse
+	 * @return a ContentTypeResult that has the content-type information (or Optional.empty() if the Content-Type header is not in the headers) 
+	 */
+	public static Optional<ContentTypeResult> parseContentTypeFromHeaders(Map<String, Collection<String>> headers) {
 		// The header map *should* be a case insensitive treemap
 		for (String val : headers.getOrDefault(Util.CONTENT_TYPE, Collections.emptyList())) {
-			return parseContentTypeHeader(val);
+			return Optional.of(parseContentTypeHeader(val));
 		}
 
-		return new ContentTypeResult(ifMissing, null);
+		return Optional.empty();
 	}
 
+	/**
+	 * Parses and returns information about a string that is a valid formatting Content-Type header value
+	 * @param contentTypeHeader the Content-Type header value to parse
+	 * @return a ContentTypeResult that has the content-type information (or Optional.empty() if the Content-Type header is not in the headers) 
+	 */
 	public static ContentTypeResult parseContentTypeHeader(String contentTypeHeader) {
 
       String[] contentTypeParmeters = contentTypeHeader.split(";");
@@ -66,10 +76,20 @@ public final class ContentTypeParser {
       return new ContentTypeResult(contentType, Charset.forName(charsetString, null));
 	}
 
+	/**
+	 * Represents the parsed results of a Content-Type header
+	 */
 	public static class ContentTypeResult{
 		public static final ContentTypeResult MISSING = new ContentTypeResult("", null);
 
+		/**
+		 * The content type portion of the header string
+		 */
 		private String contentType;
+		
+		/**
+		 * The charset portion of the header string (if specified)
+		 */
 		private Optional<Charset> charset;
 
 		public ContentTypeResult(String contentType, Charset charset) {

--- a/api/src/test/java/feign/MultipleLoggerTest.java
+++ b/api/src/test/java/feign/MultipleLoggerTest.java
@@ -23,7 +23,8 @@ import org.junit.jupiter.api.io.TempDirDeletionStrategy.IgnoreFailures;
 
 public class MultipleLoggerTest {
 
-  @TempDir(deletionStrategy = IgnoreFailures.class) public File tmp;
+  @TempDir(deletionStrategy = IgnoreFailures.class)
+  public File tmp;
 
   private static java.util.logging.Logger getInnerLogger(Logger.JavaLogger logger)
       throws Exception {

--- a/api/src/test/java/feign/MultipleLoggerTest.java
+++ b/api/src/test/java/feign/MultipleLoggerTest.java
@@ -19,10 +19,11 @@ import java.io.File;
 import java.lang.reflect.Field;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.io.TempDirDeletionStrategy.IgnoreFailures;
 
 public class MultipleLoggerTest {
 
-  @TempDir public File tmp;
+  @TempDir(deletionStrategy = IgnoreFailures.class) public File tmp;
 
   private static java.util.logging.Logger getInnerLogger(Logger.JavaLogger logger)
       throws Exception {

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -32,7 +32,7 @@
     <jmh.version>1.37</jmh.version>
     <rx.netty.version>0.5.3</rx.netty.version>
     <rx.java.version>1.3.8</rx.java.version>
-    <netty.version>4.2.15.Final</netty.version>
+    <netty.version>4.2.16.Final</netty.version>
     <moditect.skip>true</moditect.skip>
   </properties>
 

--- a/core/src/test/java/feign/core/codec/InputStreamAndReaderDecoder.java
+++ b/core/src/test/java/feign/core/codec/InputStreamAndReaderDecoder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package feign.core.codec;
 
 import feign.FeignException;

--- a/core/src/test/java/feign/core/codec/InputStreamAndReaderDecoder.java
+++ b/core/src/test/java/feign/core/codec/InputStreamAndReaderDecoder.java
@@ -1,15 +1,16 @@
 package feign.core.codec;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.lang.reflect.Type;
+
 import feign.FeignException;
 import feign.Response;
 import feign.Util;
 import feign.codec.DecodeException;
 import feign.codec.Decoder;
 import feign.utils.ContentTypeParser;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Reader;
-import java.lang.reflect.Type;
 
 public class InputStreamAndReaderDecoder implements Decoder {
   private final Decoder delegateDecoder;
@@ -28,9 +29,10 @@ public class InputStreamAndReaderDecoder implements Decoder {
       return response
           .body()
           .asReader(
-              ContentTypeParser.parseContentTypeFromHeaders(response.headers(), "UTF-8")
-                  .getCharset()
-                  .orElse(Util.UTF_8));
+              ContentTypeParser.parseContentTypeFromHeaders(response.headers())
+              	.map(ctr -> ctr.getCharset().orElse(Util.UTF_8) )
+              	.orElse(Util.UTF_8)
+             );
 
     if (delegateDecoder == null) return null;
 

--- a/core/src/test/java/feign/core/codec/InputStreamAndReaderDecoder.java
+++ b/core/src/test/java/feign/core/codec/InputStreamAndReaderDecoder.java
@@ -1,0 +1,39 @@
+package feign.core.codec;
+
+import feign.FeignException;
+import feign.Response;
+import feign.Util;
+import feign.codec.DecodeException;
+import feign.codec.Decoder;
+import feign.utils.ContentTypeParser;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.lang.reflect.Type;
+
+public class InputStreamAndReaderDecoder implements Decoder {
+  private final Decoder delegateDecoder;
+
+  public InputStreamAndReaderDecoder(Decoder delegate) {
+    this.delegateDecoder = delegate;
+  }
+
+  @Override
+  public Object decode(Response response, Type type)
+      throws IOException, DecodeException, FeignException {
+
+    if (InputStream.class.equals(type)) return response.body().asInputStream();
+
+    if (Reader.class.equals(type))
+      return response
+          .body()
+          .asReader(
+              ContentTypeParser.parseContentTypeFromHeaders(response.headers(), "UTF-8")
+                  .getCharset()
+                  .orElse(Util.UTF_8));
+
+    if (delegateDecoder == null) return null;
+
+    return delegateDecoder.decode(response, type);
+  }
+}

--- a/core/src/test/java/feign/core/codec/InputStreamAndReaderDecoder.java
+++ b/core/src/test/java/feign/core/codec/InputStreamAndReaderDecoder.java
@@ -1,16 +1,15 @@
 package feign.core.codec;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Reader;
-import java.lang.reflect.Type;
-
 import feign.FeignException;
 import feign.Response;
 import feign.Util;
 import feign.codec.DecodeException;
 import feign.codec.Decoder;
 import feign.utils.ContentTypeParser;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.lang.reflect.Type;
 
 public class InputStreamAndReaderDecoder implements Decoder {
   private final Decoder delegateDecoder;
@@ -30,9 +29,8 @@ public class InputStreamAndReaderDecoder implements Decoder {
           .body()
           .asReader(
               ContentTypeParser.parseContentTypeFromHeaders(response.headers())
-              	.map(ctr -> ctr.getCharset().orElse(Util.UTF_8) )
-              	.orElse(Util.UTF_8)
-             );
+                  .map(ctr -> ctr.getCharset().orElse(Util.UTF_8))
+                  .orElse(Util.UTF_8));
 
     if (delegateDecoder == null) return null;
 

--- a/core/src/test/java/feign/core/codec/InputStreamAndReaderDecoderTest.java
+++ b/core/src/test/java/feign/core/codec/InputStreamAndReaderDecoderTest.java
@@ -1,0 +1,143 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package feign.core.codec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import feign.Feign;
+import feign.RequestLine;
+import feign.Util;
+import java.io.InputStream;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import mockwebserver3.internal.BufferMockResponseBody;
+import okio.Buffer;
+import org.junit.jupiter.api.Test;
+
+public class InputStreamAndReaderDecoderTest {
+  public final MockWebServer server = new MockWebServer();
+
+  interface LargeStreamTestInterface {
+
+    @RequestLine("GET /")
+    InputStream getLargeStream();
+
+    @RequestLine("GET /")
+    Reader getLargeReader();
+  }
+
+  @Test
+  void streamingResponse() throws Exception {
+
+    server.start();
+
+    byte[] expectedResponse = new byte[16184];
+    new Random().nextBytes(expectedResponse);
+    server.enqueue(
+        new MockResponse.Builder()
+            .body(new BufferMockResponseBody(new Buffer().write(expectedResponse)))
+            .build());
+
+    LargeStreamTestInterface api =
+        Feign.builder()
+            .decoder(new InputStreamAndReaderDecoder(null))
+            .target(LargeStreamTestInterface.class, "http://localhost:" + server.getPort());
+
+    try (InputStream is = api.getLargeStream()) {
+      byte[] out = is.readAllBytes();
+      assertThat(out.length).isEqualTo(expectedResponse.length);
+      assertThat(out).isEqualTo(expectedResponse);
+    }
+  }
+
+  @Test
+  void streamingReaderResponse() throws Exception {
+
+    server.start();
+
+    String expectedResponse =
+        new Random()
+            .ints(1, 1500 + 1)
+            .limit(16184)
+            .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+            .toString();
+
+    server.enqueue(
+        new MockResponse.Builder()
+            .body(
+                new BufferMockResponseBody(
+                    new Buffer().write(expectedResponse.getBytes(StandardCharsets.UTF_16))))
+            .addHeader("content-type", "text/plan; charset=utf-16")
+            .build());
+
+    LargeStreamTestInterface api =
+        Feign.builder()
+            .decoder(new InputStreamAndReaderDecoder(null))
+            .target(LargeStreamTestInterface.class, "http://localhost:" + server.getPort());
+
+    try (Reader r = api.getLargeReader()) {
+      String out = Util.toString(r);
+      assertThat(out.length()).isEqualTo(expectedResponse.length());
+      assertThat(out).isEqualTo(expectedResponse);
+    }
+  }
+
+  @Test
+  void streamingReaderResponseWithNoCharset() throws Exception {
+
+    server.start();
+
+    String expectedResponse =
+        new Random()
+            .ints(1, 1500 + 1)
+            .limit(16184)
+            .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+            .toString();
+
+    server.enqueue(
+        new MockResponse.Builder()
+            .body(
+                new BufferMockResponseBody(
+                    new Buffer().write(expectedResponse.getBytes(Util.UTF_8))))
+            .addHeader("content-type", "text/plan")
+            .build());
+
+    LargeStreamTestInterface api =
+        Feign.builder()
+            .decoder(new InputStreamAndReaderDecoder(null))
+            .target(LargeStreamTestInterface.class, "http://localhost:" + server.getPort());
+
+    try (Reader r = api.getLargeReader()) {
+      String out = Util.toString(r);
+      assertThat(out.length()).isEqualTo(expectedResponse.length());
+      assertThat(out).isEqualTo(expectedResponse);
+    }
+  }
+}

--- a/core/src/test/java/feign/core/codec/InputStreamAndReaderDecoderTest.java
+++ b/core/src/test/java/feign/core/codec/InputStreamAndReaderDecoderTest.java
@@ -1,28 +1,17 @@
 /*
- * ====================================================================
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- * ====================================================================
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * This software consists of voluntary contributions made by many
- * individuals on behalf of the Apache Software Foundation.  For more
- * information on the Apache Software Foundation, please see
- * <http://www.apache.org/>.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package feign.core.codec;
 

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -30,7 +30,7 @@
   <description>Feign Kotlin</description>
 
   <properties>
-    <kotlin.version>2.4.0</kotlin.version>
+    <kotlin.version>2.4.10</kotlin.version>
     <kotlinx.coroutines.version>1.11.0</kotlinx.coroutines.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
     <maven-toolchains-plugin.version>3.2.0</maven-toolchains-plugin.version>
     <go-offline-maven-plugin.version>1.2.8</go-offline-maven-plugin.version>
     <sortpom-maven-plugin.version>4.0.0</sortpom-maven-plugin.version>
-    <rewrite-maven-plugin.version>6.43.0</rewrite-maven-plugin.version>
+    <rewrite-maven-plugin.version>6.44.0</rewrite-maven-plugin.version>
     <rewrite-testing-frameworks.version>3.41.0</rewrite-testing-frameworks.version>
     <rewrite-migrate-java.version>3.39.0</rewrite-migrate-java.version>
     <japicmp-maven-plugin.version>0.26.1</japicmp-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
 
     <okhttp3.version>5.4.0</okhttp3.version>
     <guava.version>33.6.0-jre</guava.version>
-    <googlehttpclient.version>2.1.0</googlehttpclient.version>
+    <googlehttpclient.version>2.1.1</googlehttpclient.version>
     <gson.version>2.14.0</gson.version>
     <moshi.version>1.15.2</moshi.version>
     <slf4j.version>2.0.18</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
     <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
     <license-maven-plugin.version>5.1.1</license-maven-plugin.version>
-    <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
+    <maven-jar-plugin.version>3.5.1</maven-jar-plugin.version>
     <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
     <maven-bundle-plugin.version>6.0.2</maven-bundle-plugin.version>
     <centralsync-maven-plugin.version>0.1.1</centralsync-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
     <sortpom-maven-plugin.version>4.0.0</sortpom-maven-plugin.version>
     <rewrite-maven-plugin.version>6.43.0</rewrite-maven-plugin.version>
     <rewrite-testing-frameworks.version>3.41.0</rewrite-testing-frameworks.version>
-    <rewrite-migrate-java.version>3.39.0</rewrite-migrate-java.version>
+    <rewrite-migrate-java.version>3.40.0</rewrite-migrate-java.version>
     <japicmp-maven-plugin.version>0.26.1</japicmp-maven-plugin.version>
     <java18-signature.version>1.0</java18-signature.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
     <go-offline-maven-plugin.version>1.2.8</go-offline-maven-plugin.version>
     <sortpom-maven-plugin.version>4.0.0</sortpom-maven-plugin.version>
     <rewrite-maven-plugin.version>6.43.0</rewrite-maven-plugin.version>
-    <rewrite-testing-frameworks.version>3.40.0</rewrite-testing-frameworks.version>
+    <rewrite-testing-frameworks.version>3.41.0</rewrite-testing-frameworks.version>
     <rewrite-migrate-java.version>3.39.0</rewrite-migrate-java.version>
     <japicmp-maven-plugin.version>0.26.1</japicmp-maven-plugin.version>
     <java18-signature.version>1.0</java18-signature.version>

--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
     <sortpom-maven-plugin.version>4.0.0</sortpom-maven-plugin.version>
     <rewrite-maven-plugin.version>6.42.0</rewrite-maven-plugin.version>
     <rewrite-testing-frameworks.version>3.40.0</rewrite-testing-frameworks.version>
-    <rewrite-migrate-java.version>3.38.0</rewrite-migrate-java.version>
+    <rewrite-migrate-java.version>3.39.0</rewrite-migrate-java.version>
     <japicmp-maven-plugin.version>0.26.1</japicmp-maven-plugin.version>
     <java18-signature.version>1.0</java18-signature.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
     <go-offline-maven-plugin.version>1.2.8</go-offline-maven-plugin.version>
     <sortpom-maven-plugin.version>4.0.0</sortpom-maven-plugin.version>
     <rewrite-maven-plugin.version>6.44.0</rewrite-maven-plugin.version>
-    <rewrite-testing-frameworks.version>3.41.0</rewrite-testing-frameworks.version>
+    <rewrite-testing-frameworks.version>3.42.0</rewrite-testing-frameworks.version>
     <rewrite-migrate-java.version>3.40.0</rewrite-migrate-java.version>
     <japicmp-maven-plugin.version>0.26.1</japicmp-maven-plugin.version>
     <java18-signature.version>1.0</java18-signature.version>

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
     <go-offline-maven-plugin.version>1.2.8</go-offline-maven-plugin.version>
     <sortpom-maven-plugin.version>4.0.0</sortpom-maven-plugin.version>
     <rewrite-maven-plugin.version>6.44.0</rewrite-maven-plugin.version>
-    <rewrite-testing-frameworks.version>3.42.0</rewrite-testing-frameworks.version>
+    <rewrite-testing-frameworks.version>3.42.1</rewrite-testing-frameworks.version>
     <rewrite-migrate-java.version>3.40.0</rewrite-migrate-java.version>
     <japicmp-maven-plugin.version>0.26.1</japicmp-maven-plugin.version>
     <java18-signature.version>1.0</java18-signature.version>

--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
     <graphql-java.version>26.0</graphql-java.version>
     <handlebars.version>4.5.2</handlebars.version>
     <httpclient4.version>4.5.14</httpclient4.version>
-    <httpclient5.version>5.6.1</httpclient5.version>
+    <httpclient5.version>5.6.2</httpclient5.version>
     <javapoet.version>1.13.0</javapoet.version>
     <hystrix-core.version>1.5.18</hystrix-core.version>
     <jakarta.ws.rs-api-3.version>3.1.0</jakarta.ws.rs-api-3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
     <springboot.version>4.1.0</springboot.version>
 
     <junit5.version>6.1.1</junit5.version>
-    <jackson.version>2.22.0</jackson.version>
+    <jackson.version>2.22.1</jackson.version>
     <jackson3.version>3.2.0</jackson3.version>
     <assertj.version>3.27.7</assertj.version>
     <mockito.version>5.23.0</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,7 @@
     <spring-cloud-dependencies.version>2025.1.2</spring-cloud-dependencies.version>
     <spring-cloud-starter-openfeign.version>5.0.2</spring-cloud-starter-openfeign.version>
     <spring.version>7.0.8</spring.version>
-    <undertow-core.version>2.4.1.Final</undertow-core.version>
+    <undertow-core.version>2.4.2.Final</undertow-core.version>
     <utils-java.version>1.18.0</utils-java.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
 
     <okhttp3.version>5.4.0</okhttp3.version>
     <guava.version>33.6.0-jre</guava.version>
-    <googlehttpclient.version>2.1.1</googlehttpclient.version>
+    <googlehttpclient.version>2.2.0</googlehttpclient.version>
     <gson.version>2.14.0</gson.version>
     <moshi.version>1.15.2</moshi.version>
     <slf4j.version>2.0.18</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
     <gson.version>2.14.0</gson.version>
     <moshi.version>1.15.2</moshi.version>
     <slf4j.version>2.0.18</slf4j.version>
-    <json.version>20260522</json.version>
+    <json.version>20260719</json.version>
     <springboot.version>4.1.0</springboot.version>
 
     <junit5.version>6.1.2</junit5.version>

--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
     <commons-text.version>1.15.0</commons-text.version>
     <compile-testing.version>0.23.0</compile-testing.version>
     <graphql-java.version>26.0</graphql-java.version>
-    <handlebars.version>4.5.2</handlebars.version>
+    <handlebars.version>4.5.3</handlebars.version>
     <httpclient4.version>4.5.14</httpclient4.version>
     <httpclient5.version>5.6.2</httpclient5.version>
     <javapoet.version>1.13.0</javapoet.version>

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
 
     <junit5.version>6.1.1</junit5.version>
     <jackson.version>2.22.1</jackson.version>
-    <jackson3.version>3.2.0</jackson3.version>
+    <jackson3.version>3.2.1</jackson3.version>
     <assertj.version>3.27.7</assertj.version>
     <mockito.version>5.23.0</mockito.version>
     <fastjson2.version>2.0.61.android8</fastjson2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
     <json.version>20260522</json.version>
     <springboot.version>4.1.0</springboot.version>
 
-    <junit5.version>6.1.0</junit5.version>
+    <junit5.version>6.1.1</junit5.version>
     <jackson.version>2.22.0</jackson.version>
     <jackson3.version>3.2.0</jackson3.version>
     <assertj.version>3.27.7</assertj.version>

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
     <json.version>20260522</json.version>
     <springboot.version>4.1.0</springboot.version>
 
-    <junit5.version>6.1.1</junit5.version>
+    <junit5.version>6.1.2</junit5.version>
     <jackson.version>2.22.1</jackson.version>
     <jackson3.version>3.2.0</jackson3.version>
     <assertj.version>3.27.7</assertj.version>

--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
     <maven-toolchains-plugin.version>3.2.0</maven-toolchains-plugin.version>
     <go-offline-maven-plugin.version>1.2.8</go-offline-maven-plugin.version>
     <sortpom-maven-plugin.version>4.0.0</sortpom-maven-plugin.version>
-    <rewrite-maven-plugin.version>6.42.0</rewrite-maven-plugin.version>
+    <rewrite-maven-plugin.version>6.43.0</rewrite-maven-plugin.version>
     <rewrite-testing-frameworks.version>3.40.0</rewrite-testing-frameworks.version>
     <rewrite-migrate-java.version>3.38.0</rewrite-migrate-java.version>
     <japicmp-maven-plugin.version>0.26.1</japicmp-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
     <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
     <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
-    <license-maven-plugin.version>5.0.0</license-maven-plugin.version>
+    <license-maven-plugin.version>5.1.1</license-maven-plugin.version>
     <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
     <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
     <maven-bundle-plugin.version>6.0.2</maven-bundle-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
     <docker-maven-plugin.version>1.2.2</docker-maven-plugin.version>
     <moditect-maven-plugin.version>1.3.0.Final</moditect-maven-plugin.version>
     <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
-    <maven-toolchains-plugin.version>3.2.0</maven-toolchains-plugin.version>
+    <maven-toolchains-plugin.version>3.3.0</maven-toolchains-plugin.version>
     <go-offline-maven-plugin.version>1.2.8</go-offline-maven-plugin.version>
     <sortpom-maven-plugin.version>4.0.0</sortpom-maven-plugin.version>
     <rewrite-maven-plugin.version>6.44.0</rewrite-maven-plugin.version>

--- a/vertx/feign-vertx/pom.xml
+++ b/vertx/feign-vertx/pom.xml
@@ -31,7 +31,7 @@
 
   <properties>
     <main.java.version>11</main.java.version>
-    <jackson.version>2.22.0</jackson.version>
+    <jackson.version>2.22.1</jackson.version>
   </properties>
 
   <dependencyManagement>

--- a/vertx/feign-vertx4-test/pom.xml
+++ b/vertx/feign-vertx4-test/pom.xml
@@ -30,7 +30,7 @@
   <description>Tests with Vertx 4.x.</description>
 
   <properties>
-    <vertx.version>4.5.30</vertx.version>
+    <vertx.version>4.5.31</vertx.version>
   </properties>
 
   <dependencies>

--- a/vertx/feign-vertx4-test/pom.xml
+++ b/vertx/feign-vertx4-test/pom.xml
@@ -30,7 +30,7 @@
   <description>Tests with Vertx 4.x.</description>
 
   <properties>
-    <vertx.version>4.5.28</vertx.version>
+    <vertx.version>4.5.29</vertx.version>
   </properties>
 
   <dependencies>

--- a/vertx/feign-vertx4-test/pom.xml
+++ b/vertx/feign-vertx4-test/pom.xml
@@ -30,7 +30,7 @@
   <description>Tests with Vertx 4.x.</description>
 
   <properties>
-    <vertx.version>4.5.29</vertx.version>
+    <vertx.version>4.5.30</vertx.version>
   </properties>
 
   <dependencies>

--- a/vertx/feign-vertx5-test/pom.xml
+++ b/vertx/feign-vertx5-test/pom.xml
@@ -30,7 +30,7 @@
   <description>Tests with Vertx 5.x.</description>
 
   <properties>
-    <vertx.version>5.1.3</vertx.version>
+    <vertx.version>5.1.4</vertx.version>
   </properties>
 
   <dependencies>

--- a/vertx/feign-vertx5-test/pom.xml
+++ b/vertx/feign-vertx5-test/pom.xml
@@ -30,7 +30,7 @@
   <description>Tests with Vertx 5.x.</description>
 
   <properties>
-    <vertx.version>5.1.4</vertx.version>
+    <vertx.version>5.1.5</vertx.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Adds support for streaming decode for Feign RequestLine methods that return InputStream or Reader.

To use:

```
  interface LargeStreamTestInterface {

    @RequestLine("GET /")
    InputStream getLargeStream();

    @RequestLine("GET /")
    Reader getLargeReader();
  }
```
```
public void test(){
  try(InputStream is = myLargeStreamTestInterface.getLargeStream()){
     // process the is
  }
}
```

### Changes ###

1. `InvocationContext` now leaves the response stream open if the return type from the decoder implements `Closeable`
2. New `InputStreamAndReaderDecoder` class that can be registered with the Feign `builder.decoder()` method. Supports passing the decode request to a delegate if the method return type is not `InputStream` or `Reader`.  If the return type is `Reader`, the charset of the response Content-Type header is used. If no charset is specified in the header, UTF-8 is assumed.
3. New `ContentTypeParser` utility method for obtaining information from the Content-Type header
