### PR TITLE
Stop Http2ClientTest from calling live nghttp2.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Version 14.0
 
+* `Http2ClientTest` no longer depends on live `nghttp2.org/httpbin` calls; patch/delete use MockWebServer and GET-with-body uses a local socket server so CI does not hang or fail when the external host is down. (https://github.com/OpenFeign/feign/issues/3483)
+
 * `DefaultEncoder` now supports streaming request bodies for `File`, `Path`, `InputStream`, and `Request.Body` types,
   avoiding in-memory buffering. New `Request.PathBody` and `Request.InputStreamBody` implementations are provided for
   these cases. (https://github.com/OpenFeign/feign/pull/3396)

--- a/java11/src/test/java/feign/http2client/test/Http2ClientTest.java
+++ b/java11/src/test/java/feign/http2client/test/Http2ClientTest.java
@@ -19,7 +19,6 @@ import static feign.Util.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.entry;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import feign.*;
 import feign.assertj.MockWebServerAssertions;
@@ -27,31 +26,23 @@ import feign.client.AbstractClientTest;
 import feign.http2client.Http2Client;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
 import java.net.http.HttpTimeoutException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import mockwebserver3.MockResponse;
 import mockwebserver3.RecordedRequest;
 import org.junit.jupiter.api.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
 
 /** Tests client-specific behavior, such as ensuring Content-Length is sent when specified. */
 public class Http2ClientTest extends AbstractClientTest {
-
-  private static final boolean HTTPBIN_REACHABLE;
-
-  static {
-    boolean reachable = false;
-    try {
-      java.net.InetAddress.getByName("nghttp2.org");
-      reachable = true;
-    } catch (java.net.UnknownHostException _) {
-      // ignore
-    }
-    HTTPBIN_REACHABLE = reachable;
-  }
 
   public interface TestInterface {
     @RequestLine("PATCH /patch")
@@ -96,19 +87,39 @@ public class Http2ClientTest extends AbstractClientTest {
   @Override
   @Test
   public void patch() throws Exception {
-    assumeTrue(HTTPBIN_REACHABLE, "nghttp2.org is not reachable");
+    server.enqueue(new MockResponse.Builder().body("foo").build());
+
     final TestInterface api =
-        newBuilder().target(TestInterface.class, "https://nghttp2.org/httpbin/");
-    assertThat(api.patch("")).contains("https://nghttp2.org/httpbin/patch");
+        newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    assertThat(api.patch("some text")).isEqualTo("foo");
+
+    MockWebServerAssertions.assertThat(server.takeRequest())
+        .hasMethod("PATCH")
+        .hasPath("/patch")
+        .hasBody("some text");
   }
 
   @Override
   @Test
   public void noResponseBodyForPatch() {
-    assumeTrue(HTTPBIN_REACHABLE, "nghttp2.org is not reachable");
+    server.enqueue(new MockResponse.Builder().build());
+
     final TestInterface api =
-        newBuilder().target(TestInterface.class, "https://nghttp2.org/httpbin/");
-    assertThat(api.patch()).contains("https://nghttp2.org/httpbin/patch");
+        newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    assertThat(api.patch()).isEmpty();
+
+    MockWebServerAssertions.assertThat(takeRequest()).hasMethod("PATCH").hasPath("/patch");
+  }
+
+  private RecordedRequest takeRequest() {
+    try {
+      return server.takeRequest();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException(e);
+    }
   }
 
   @Override
@@ -169,22 +180,60 @@ public class Http2ClientTest extends AbstractClientTest {
 
   @Test
   void getWithRequestBody() throws Exception {
-    assumeTrue(HTTPBIN_REACHABLE, "nghttp2.org is not reachable");
-    final TestInterface api =
-        newBuilder().target(TestInterface.class, "https://nghttp2.org/httpbin/");
-    String result = api.getWithBody();
-    String expected = "{ \"data\":\"some request body\" }";
-    JSONAssert.assertEquals(expected, result, false);
+    // MockWebServer rejects GET requests carrying a body ("Request must not have a body"),
+    // so this test runs against a minimal local socket server instead.
+    try (ServerSocket httpServer = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
+      final AtomicReference<String> receivedRequest = new AtomicReference<>();
+      final Thread serverThread =
+          new Thread(
+              () -> {
+                try (Socket socket = httpServer.accept()) {
+                  socket.setSoTimeout(5000);
+                  final InputStream in = socket.getInputStream();
+                  final StringBuilder request = new StringBuilder();
+                  final byte[] buffer = new byte[8192];
+                  while (!request.toString().contains("some request body")) {
+                    final int read = in.read(buffer);
+                    if (read == -1) {
+                      break;
+                    }
+                    request.append(new String(buffer, 0, read, UTF_8));
+                  }
+                  receivedRequest.set(request.toString());
+                  socket
+                      .getOutputStream()
+                      .write("HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nfoo".getBytes(UTF_8));
+                } catch (IOException e) {
+                  throw new UncheckedIOException(e);
+                }
+              });
+      serverThread.start();
+
+      final TestInterface api =
+          newBuilder().target(TestInterface.class, "http://localhost:" + httpServer.getLocalPort());
+
+      assertThat(api.getWithBody()).isEqualTo("foo");
+
+      serverThread.join(5000);
+      assertThat(receivedRequest.get())
+          .startsWith("GET /anything HTTP/1.1")
+          .contains("some request body");
+    }
   }
 
   @Test
   void deleteWithRequestBody() throws Exception {
-    assumeTrue(HTTPBIN_REACHABLE, "nghttp2.org is not reachable");
+    server.enqueue(new MockResponse.Builder().body("foo").build());
+
     final TestInterface api =
-        newBuilder().target(TestInterface.class, "https://nghttp2.org/httpbin/");
-    String result = api.deleteWithBody();
-    String expected = "{ \"data\":\"some request body\" }";
-    JSONAssert.assertEquals(expected, result, false);
+        newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    assertThat(api.deleteWithBody()).isEqualTo("foo");
+
+    MockWebServerAssertions.assertThat(server.takeRequest())
+        .hasMethod("DELETE")
+        .hasPath("/anything")
+        .hasBody("some request body");
   }
 
   @Override


### PR DESCRIPTION
## What
`Http2ClientTest` on `14.x` had four tests that hit live `https://nghttp2.org/httpbin/` after a DNS-only reachability check. When DNS resolves but the HTTP service is down or slow, those tests fail or hang the whole build.

## How
- `patch` / `noResponseBodyForPatch` / `deleteWithRequestBody` now use the existing MockWebServer fixture.
- `getWithRequestBody` uses a small local `ServerSocket` server (MockWebServer rejects GET requests that carry a body).
- Removed the `HTTPBIN_REACHABLE` DNS gate and the `JSONAssert` dependency from these tests.
- Approach matches what already landed on `master`.

## Testing
```
./mvnw -Dtoolchain.skip=true -pl java11 -am test -Dtest=Http2ClientTest -Dsurefire.failIfNoSpecifiedTests=false
```
Result: **Tests run: 33, Failures: 0, Errors: 0, Skipped: 0**

Fixes #3483