### PR TITLE
Avoid default Content-Type on POST/PUT/PATCH with empty body

### DIFF
--- a/core/src/main/java/feign/DefaultClient.java
+++ b/core/src/main/java/feign/DefaultClient.java
@@ -193,11 +193,7 @@ public class DefaultClient implements Client {
 
     byte[] body = request.body();
 
-    if (body != null && (body.length > 0 || request.httpMethod() != Request.HttpMethod.GET)) {
-      /*
-       * Ignore disableRequestBuffering flag if the empty body was set, to ensure that internal
-       * retry logic applies to such requests.
-       */
+    if (body != null && body.length > 0) {
       if (disableRequestBuffering) {
         if (contentLength != null) {
           connection.setFixedLengthStreamingMode(contentLength);
@@ -220,10 +216,15 @@ public class DefaultClient implements Client {
         } catch (IOException suppressed) { // NOPMD
         }
       }
-    }
-
-    if (body == null && request.httpMethod().isWithBody()) {
-      // To use this Header, set 'sun.net.http.allowRestrictedHeaders' property true.
+    } else if (request.httpMethod().isWithBody()) {
+      /*
+       * Avoid calling connection.getOutputStream() for an empty body: HttpURLConnection defaults
+       * the Content-Type to application/x-www-form-urlencoded as soon as an output stream (a
+       * "poster") is created, even when zero bytes are written to it. Setting Content-Length
+       * directly ensures internal retry logic still applies to such requests, without triggering
+       * that default.
+       * To use this Header, set 'sun.net.http.allowRestrictedHeaders' property true.
+       */
       connection.addRequestProperty("Content-Length", "0");
     }
 

--- a/core/src/test/java/feign/client/AbstractClientTest.java
+++ b/core/src/test/java/feign/client/AbstractClientTest.java
@@ -229,6 +229,16 @@ public abstract class AbstractClientTest {
     api.noPutBody();
   }
 
+  @Test
+  void emptyStringBodyForPost() throws Exception {
+    server.enqueue(new MockResponse());
+
+    TestInterface api =
+        newBuilder().target(TestInterface.class, "http://localhost:" + server.getPort());
+
+    api.postEmptyStringBody("");
+  }
+
   /**
    * Some client implementation tests should override this test if the PATCH operation is
    * unsupported.
@@ -611,6 +621,9 @@ public abstract class AbstractClientTest {
 
     @RequestLine("POST")
     String noPostBody();
+
+    @RequestLine("POST /")
+    String postEmptyStringBody(String body);
 
     @RequestLine("PUT")
     String noPutBody();

--- a/core/src/test/java/feign/client/DefaultClientTest.java
+++ b/core/src/test/java/feign/client/DefaultClientTest.java
@@ -167,6 +167,15 @@ public class DefaultClientTest extends AbstractClientTest {
 
   @Test
   @Override
+  void emptyStringBodyForPost() throws Exception {
+    super.emptyStringBodyForPost();
+    MockWebServerAssertions.assertThat(server.takeRequest())
+        .hasMethod("POST")
+        .hasNoHeaderNamed("Content-Type");
+  }
+
+  @Test
+  @Override
   public void noResponseBodyForPut() throws Exception {
     super.noResponseBodyForPut();
     MockWebServerAssertions.assertThat(server.takeRequest())


### PR DESCRIPTION
Fixes #2068

## Problem

`DefaultClient` opens the connection's output stream and writes to it whenever the request body is non-null, even if it is a zero-length array. `HttpURLConnection` creates an internal "poster" as soon as an output stream is requested, and defaults `Content-Type` to `application/x-www-form-urlencoded` if none was explicitly set — regardless of whether any bytes are actually written. This is undocumented JDK behavior (see the JDK's `HttpURLConnection` source referenced in the issue).

This causes POST/PUT/PATCH requests with an empty body (e.g. an empty `String` argument, which encodes to a non-null zero-length `byte[]`) to silently get an incorrect `Content-Type` header, which can make servers reject the request with `415 Unsupported Media Type`.

#2555 partially addressed this by no longer synthesizing a fake empty `byte[]` for a `null` body (avoiding the output stream in that specific case), but it left the output stream path in place for any body that is non-null with `length == 0` — which is exactly what happens whenever a caller explicitly sends an empty body. That's why the issue was left open after #2555 merged.

## Fix

Skip `connection.getOutputStream()` entirely whenever the body is empty (`null` or zero-length) for methods that carry a body (POST/PUT/PATCH), and set `Content-Length: 0` directly instead — mirroring the existing `null`-body path. Non-empty bodies are unaffected.

## Testing

Added `emptyStringBodyForPost()` to `AbstractClientTest`/`DefaultClientTest`, asserting a POST with an explicit empty-string body does not get a `Content-Type` header. Confirmed the test fails on `master` (reproducing the reported header) and passes with this change.

Ran the full test suite for `core`, `java11`, `googlehttpclient`, `okhttp`, `hc5`, `httpclient`, and `jaxrs2` (all modules sharing `AbstractClientTest`) — all green, no regressions in other `Client` implementations.

Verification done:
1. Checked for an in-flight PR/duplicate — none open against #2068 besides the already-merged, partial #2555.
2. No active self-claim on the issue.
3. Change is code + tests only (`.java`), no docs.
4. Confirmed on current `master` (grepped `DefaultClient.convertAndSend`) that the empty-non-null-body path still calls `getOutputStream()`/`write()`, and reproduced the bug with a new test before applying the fix.
5. No parent epic.
6. Not a `spring-projects/*` repo, so the triage gate doesn't apply; issue already carries `bug` + `help wanted` labels.