### PR TITLE
Flatten feign-bom so imports do not override consumer dependency management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ release.properties
 pom.xml.releaseBackup
 .mvn/.develocity/develocity-workspace-id
 .sdkmanrc
+
+# flatten-maven-plugin
+.flattened-pom.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Add support for the HTTP QUERY method (RFC 10008) — safe, idempotent, and cacheable with a
   request body. `HttpCacheInterceptor` includes QUERY in its default cacheable set and
   incorporates a body hash into the cache key to reduce cross-body collisions.
+* Flatten `feign-bom` on install/deploy so importing the BOM does not pull `feign-parent`
+  dependency management (for example Jackson) into consumer projects such as Spring Boot.
 
 ### Version 13.12
 

--- a/feign-bom/pom.xml
+++ b/feign-bom/pom.xml
@@ -269,7 +269,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
-        <version>1.7.3</version>
+        <version>${flatten-maven-plugin.version}</version>
         <configuration>
           <flattenMode>bom</flattenMode>
           <pomElements>
@@ -279,19 +279,28 @@
         <executions>
           <execution>
             <id>flatten</id>
-            <phase>process-resources</phase>
             <goals>
               <goal>flatten</goal>
             </goals>
+            <phase>process-resources</phase>
           </execution>
           <execution>
             <id>flatten.clean</id>
-            <phase>clean</phase>
             <goals>
               <goal>clean</goal>
             </goals>
+            <phase>clean</phase>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.github.ekryd.sortpom</groupId>
+        <artifactId>sortpom-maven-plugin</artifactId>
+        <!-- flatten swaps project.file for .flattened-pom.xml, so point sortpom back at
+             the committed POM to keep it under format enforcement. -->
+        <configuration>
+          <pomFile>${project.basedir}/pom.xml</pomFile>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/feign-bom/pom.xml
+++ b/feign-bom/pom.xml
@@ -262,4 +262,38 @@
     </dependencies>
   </dependencyManagement>
 
+  <!-- Flatten the installed/deployed POM so importing feign-bom does not pull
+       feign-parent dependencyManagement (e.g. jackson-bom) into consumer projects. -->
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.7.3</version>
+        <configuration>
+          <flattenMode>bom</flattenMode>
+          <pomElements>
+            <properties>remove</properties>
+          </pomElements>
+        </configuration>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,7 @@
     <maven-toolchains-plugin.version>3.3.0</maven-toolchains-plugin.version>
     <go-offline-maven-plugin.version>1.2.8</go-offline-maven-plugin.version>
     <sortpom-maven-plugin.version>4.0.0</sortpom-maven-plugin.version>
+    <flatten-maven-plugin.version>1.7.3</flatten-maven-plugin.version>
     <rewrite-maven-plugin.version>6.45.0</rewrite-maven-plugin.version>
     <rewrite-testing-frameworks.version>3.43.0</rewrite-testing-frameworks.version>
     <rewrite-migrate-java.version>3.41.0</rewrite-migrate-java.version>

--- a/src/config/bom.xml
+++ b/src/config/bom.xml
@@ -72,7 +72,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
-        <version>1.7.3</version>
+        <version>${flatten-maven-plugin.version}</version>
         <configuration>
           <flattenMode>bom</flattenMode>
           <pomElements>
@@ -82,19 +82,28 @@
         <executions>
           <execution>
             <id>flatten</id>
-            <phase>process-resources</phase>
             <goals>
               <goal>flatten</goal>
             </goals>
+            <phase>process-resources</phase>
           </execution>
           <execution>
             <id>flatten.clean</id>
-            <phase>clean</phase>
             <goals>
               <goal>clean</goal>
             </goals>
+            <phase>clean</phase>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.github.ekryd.sortpom</groupId>
+        <artifactId>sortpom-maven-plugin</artifactId>
+        <!-- flatten swaps project.file for .flattened-pom.xml, so point sortpom back at
+             the committed POM to keep it under format enforcement. -->
+        <configuration>
+          <pomFile>${project.basedir}/pom.xml</pomFile>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/src/config/bom.xml
+++ b/src/config/bom.xml
@@ -65,4 +65,38 @@
     </dependencies>
   </dependencyManagement>
 
+  <!-- Flatten the installed/deployed POM so importing feign-bom does not pull
+       feign-parent dependencyManagement (e.g. jackson-bom) into consumer projects. -->
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.7.3</version>
+        <configuration>
+          <flattenMode>bom</flattenMode>
+          <pomElements>
+            <properties>remove</properties>
+          </pomElements>
+        </configuration>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>


### PR DESCRIPTION
## Summary
Importing `feign-bom` into a consumer that already manages versions (for example Spring Boot) previously pulled `feign-parent` dependency management through the published BOM parent. That overrode consumer-managed artifacts such as Jackson.

This applies `flatten-maven-plugin` in `bom` mode on the committed `feign-bom` module and the sundr BOM template so the installed/deployed POM only manages Feign modules.

Fixes #3505

## Verification
- `./mvnw -N -Pquickbuild install`
- `./mvnw -pl feign-bom -Pquickbuild install`
- Installed `feign-bom` POM has no `<parent>` and no third-party `dependencyManagement` entries
- Consumer with `spring-boot-starter-parent` 3.5.4:
  - Boot only: `jackson-core` 2.19.2
  - + central `feign-bom` 13.13: `jackson-core` 2.22.0 (override bug)
  - + local flattened `feign-bom` 13.14-SNAPSHOT: `jackson-core` 2.19.2 (Boot version kept)