### PR TITLE
Add GraphQL subscription support over graphql-transport-ws

### DIFF
--- a/graphql-apt/src/main/java/feign/graphql/apt/GraphqlSchemaProcessor.java
+++ b/graphql-apt/src/main/java/feign/graphql/apt/GraphqlSchemaProcessor.java
@@ -358,12 +358,15 @@ public class GraphqlSchemaProcessor extends AbstractProcessor {
     return JAVA_BUILT_INS.contains(typeName);
   }
 
+  /** Wrappers that carry the operation result rather than being it. */
+  private static final Set<String> RESULT_CONTAINERS = Set.of("List", "Stream", "Publisher");
+
   private String getSimpleTypeName(TypeMirror typeMirror) {
     if (typeMirror instanceof DeclaredType declaredType) {
       var typeElement = declaredType.asElement();
       var simpleName = typeElement.getSimpleName().toString();
 
-      if ("List".equals(simpleName)) {
+      if (RESULT_CONTAINERS.contains(simpleName)) {
         var typeArgs = declaredType.getTypeArguments();
         if (!typeArgs.isEmpty()) {
           return getSimpleTypeName(typeArgs.get(0));
@@ -376,7 +379,7 @@ public class GraphqlSchemaProcessor extends AbstractProcessor {
   }
 
   private boolean isExistingExternalType(TypeMirror typeMirror, String targetPackage) {
-    var unwrapped = unwrapListTypeMirror(typeMirror);
+    var unwrapped = unwrapContainerTypeMirror(typeMirror);
     if (unwrapped.getKind() == TypeKind.ERROR) {
       return false;
     }
@@ -392,13 +395,13 @@ public class GraphqlSchemaProcessor extends AbstractProcessor {
     return false;
   }
 
-  private TypeMirror unwrapListTypeMirror(TypeMirror typeMirror) {
+  private TypeMirror unwrapContainerTypeMirror(TypeMirror typeMirror) {
     if (typeMirror instanceof DeclaredType declaredType) {
       var simpleName = declaredType.asElement().getSimpleName().toString();
-      if ("List".equals(simpleName)) {
+      if (RESULT_CONTAINERS.contains(simpleName)) {
         var typeArgs = declaredType.getTypeArguments();
         if (!typeArgs.isEmpty()) {
-          return typeArgs.get(0);
+          return unwrapContainerTypeMirror(typeArgs.get(0));
         }
       }
     }

--- a/graphql/README.md
+++ b/graphql/README.md
@@ -100,6 +100,78 @@ The processor generates a record for the input type as well:
 public record CreateUserInput(String name, String email) {}
 ```
 
+## Subscriptions
+
+`subscription` operations are detected from the query text and executed over the
+[graphql-transport-ws](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md) WebSocket
+protocol instead of HTTP. The endpoint is the target URL with its scheme swapped to `ws`/`wss`, and
+one connection is opened per call.
+
+Queries, mutations and subscriptions can live on the same interface: only subscriptions are routed
+to a WebSocket, everything else goes over the regular Feign client — including whichever one you
+configured with `.client(...)` — with its own timeouts, retryer and interceptors unchanged.
+
+The return type decides how many events you get and whether the call blocks:
+
+| Return type | Events | Behaviour |
+| --- | --- | --- |
+| `T` | first only | blocks until the first event, then unsubscribes |
+| `Optional<T>` | first only | as above, empty if the server completes without one |
+| `CompletableFuture<T>` | first only | returns immediately, completes with the first event |
+| `Stream<T>` | all | returns once subscribed, then blocks on each element |
+| `Flow.Publisher<T>` | all | returns immediately, elements are pushed to the subscriber |
+
+```java
+@GraphqlSchema("my-schema.graphql")
+interface StockApi {
+
+  @GraphqlQuery("subscription($symbol: String!) { priceChanged(symbol: $symbol) { symbol price } }")
+  Price nextPrice(@Param("symbol") String symbol);
+
+  @GraphqlQuery("subscription($symbol: String!) { priceChanged(symbol: $symbol) { symbol price } }")
+  Stream<Price> onPrice(@Param("symbol") String symbol);
+
+  @GraphqlQuery("subscription($symbol: String!) { priceChanged(symbol: $symbol) { symbol price } }")
+  Flow.Publisher<Price> publishPrice(@Param("symbol") String symbol);
+}
+```
+
+The single-event forms close the subscription as soon as they have their event. The multi-event
+forms hand you the lifecycle: closing the `Stream` — or cancelling the `Flow.Subscription` — sends
+`complete` and closes the WebSocket, so consume a `Stream` with try-with-resources:
+
+```java
+try (var prices = api.onPrice("ACME")) {
+  prices.forEach(System.out::println);
+}
+```
+
+`Stream` here is the ordinary `java.util.stream.Stream`: synchronous and pull-based, with no timeout
+facilities of its own. So the blocking forms — `T`, `Optional<T>` and `Stream<T>` — are bounded by
+an event timeout, which defaults to **60 seconds** and applies to each event rather than to the
+subscription as a whole. Override it when creating the capability:
+
+```java
+Feign.builder()
+    // wait at most 5s for each event; Duration.ZERO waits indefinitely
+    .addCapability(new GraphqlCapability(new JacksonCodec(), Duration.ofSeconds(5)))
+    .target(StockApi.class, "https://example.com/graphql");
+```
+
+Exceeding it raises `SocketTimeoutException` from the blocking call or the stream element. A
+subscription that can legitimately sit idle for longer needs `Duration.ZERO`.
+
+`Flow.Publisher<T>` and `CompletableFuture<T>` are deliberately *not* bounded by it — their caller
+already owns the deadline, via cancelling the subscription or
+`get(timeout, unit)`/`orTimeout(...)`.
+
+`Flow.Publisher` is `java.util.concurrent.Flow.Publisher`, so it plugs into Reactor
+(`JdkFlowAdapter.flowPublisherToFlux`) or RxJava (`Flowable.fromPublisher`) without extra
+dependencies here.
+
+A server `error` message, or `errors` inside a payload, is raised as `GraphqlErrorException`.
+Request headers (for example `Authorization`) are forwarded to the WebSocket handshake.
+
 ## Custom Scalars
 
 When your schema defines custom scalars, map them to Java types using `@Scalar` on default methods:

--- a/graphql/README.md
+++ b/graphql/README.md
@@ -163,7 +163,18 @@ subscription that can legitimately sit idle for longer needs `Duration.ZERO`.
 
 `Flow.Publisher<T>` and `CompletableFuture<T>` are deliberately *not* bounded by it — their caller
 already owns the deadline, via cancelling the subscription or
-`get(timeout, unit)`/`orTimeout(...)`.
+`get(timeout, unit)`/`orTimeout(...)`. Cancelling either one closes the underlying WebSocket.
+
+Those two asynchronous forms each need a worker for as long as the subscription is open. They run on
+a bounded daemon pool by default; pass your own to own the lifecycle:
+
+```java
+new GraphqlCapability(new JacksonCodec(), Duration.ofSeconds(5), myExecutor)
+```
+
+Reads are demand-driven — the client asks the socket for another frame only once the consumer has
+taken the previous event — so a slow consumer applies backpressure to the server instead of growing
+a queue in memory.
 
 `Flow.Publisher` is `java.util.concurrent.Flow.Publisher`, so it plugs into Reactor
 (`JdkFlowAdapter.flowPublisherToFlux`) or RxJava (`Flowable.fromPublisher`) without extra

--- a/graphql/src/main/java/feign/graphql/GraphqlCapability.java
+++ b/graphql/src/main/java/feign/graphql/GraphqlCapability.java
@@ -27,6 +27,11 @@ import feign.codec.JsonDecoder;
 import feign.codec.JsonEncoder;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.concurrent.Executor;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 @Experimental
 public class GraphqlCapability implements Capability {
@@ -52,6 +57,15 @@ public class GraphqlCapability implements Capability {
     this(codec.encoder(), codec.decoder(), eventTimeout);
   }
 
+  /**
+   * @param executor runs the worker behind each {@code Flow.Publisher} and {@code
+   *     CompletableFuture} subscription, and delivers to their subscribers. Supply your own to own
+   *     the lifecycle; the default is bounded and daemon, and is never shut down.
+   */
+  public GraphqlCapability(JsonCodec codec, Duration eventTimeout, Executor executor) {
+    this(codec.encoder(), codec.decoder(), eventTimeout, executor);
+  }
+
   public GraphqlCapability(JsonEncoder encoder, JsonDecoder decoder) {
     this(encoder, decoder, GraphqlDecoder.DEFAULT_EVENT_TIMEOUT);
   }
@@ -60,11 +74,40 @@ public class GraphqlCapability implements Capability {
    * @param eventTimeout see {@link #GraphqlCapability(JsonCodec, Duration)}
    */
   public GraphqlCapability(JsonEncoder encoder, JsonDecoder decoder, Duration eventTimeout) {
+    this(encoder, decoder, eventTimeout, defaultExecutor());
+  }
+
+  /**
+   * @param executor see {@link #GraphqlCapability(JsonCodec, Duration, Executor)}
+   */
+  public GraphqlCapability(
+      JsonEncoder encoder, JsonDecoder decoder, Duration eventTimeout, Executor executor) {
     this.graphqlEncoder = new GraphqlEncoder(encoder, contract);
-    this.graphqlDecoder = new GraphqlDecoder(decoder, eventTimeout);
+    this.graphqlDecoder = new GraphqlDecoder(decoder, eventTimeout, executor);
     this.interceptor = new GraphqlRequestInterceptor(encoder, contract);
     this.jsonEncoder = encoder;
     this.jsonDecoder = decoder;
+  }
+
+  /**
+   * Bounded and daemon, so a runaway subscription count fails fast rather than exhausting threads.
+   * A synchronous handoff queue is deliberate: subscription workers are long-lived, so queueing
+   * them would hide exhaustion until the heap gave out.
+   */
+  private static Executor defaultExecutor() {
+    var threads = new AtomicLong();
+    return new ThreadPoolExecutor(
+        0,
+        Math.max(8, Runtime.getRuntime().availableProcessors() * 4),
+        60L,
+        TimeUnit.SECONDS,
+        new SynchronousQueue<>(),
+        runnable -> {
+          var thread =
+              new Thread(runnable, "feign-graphql-subscription-" + threads.incrementAndGet());
+          thread.setDaemon(true);
+          return thread;
+        });
   }
 
   @Override

--- a/graphql/src/main/java/feign/graphql/GraphqlCapability.java
+++ b/graphql/src/main/java/feign/graphql/GraphqlCapability.java
@@ -16,6 +16,7 @@
 package feign.graphql;
 
 import feign.Capability;
+import feign.Client;
 import feign.Contract;
 import feign.Experimental;
 import feign.RequestInterceptors;
@@ -24,6 +25,7 @@ import feign.codec.Encoder;
 import feign.codec.JsonCodec;
 import feign.codec.JsonDecoder;
 import feign.codec.JsonEncoder;
+import java.time.Duration;
 import java.util.ArrayList;
 
 @Experimental
@@ -33,15 +35,36 @@ public class GraphqlCapability implements Capability {
   private final GraphqlEncoder graphqlEncoder;
   private final GraphqlDecoder graphqlDecoder;
   private final GraphqlRequestInterceptor interceptor;
+  private final JsonEncoder jsonEncoder;
+  private final JsonDecoder jsonDecoder;
 
   public GraphqlCapability(JsonCodec codec) {
     this(codec.encoder(), codec.decoder());
   }
 
+  /**
+   * @param eventTimeout how long a blocking subscription call waits for an event before failing
+   *     with {@link java.net.SocketTimeoutException}; {@link java.time.Duration#ZERO} waits
+   *     indefinitely. Does not apply to {@code Flow.Publisher} or {@code CompletableFuture}
+   *     subscriptions, whose caller owns the deadline.
+   */
+  public GraphqlCapability(JsonCodec codec, Duration eventTimeout) {
+    this(codec.encoder(), codec.decoder(), eventTimeout);
+  }
+
   public GraphqlCapability(JsonEncoder encoder, JsonDecoder decoder) {
+    this(encoder, decoder, GraphqlDecoder.DEFAULT_EVENT_TIMEOUT);
+  }
+
+  /**
+   * @param eventTimeout see {@link #GraphqlCapability(JsonCodec, Duration)}
+   */
+  public GraphqlCapability(JsonEncoder encoder, JsonDecoder decoder, Duration eventTimeout) {
     this.graphqlEncoder = new GraphqlEncoder(encoder, contract);
-    this.graphqlDecoder = new GraphqlDecoder(decoder);
+    this.graphqlDecoder = new GraphqlDecoder(decoder, eventTimeout);
     this.interceptor = new GraphqlRequestInterceptor(encoder, contract);
+    this.jsonEncoder = encoder;
+    this.jsonDecoder = decoder;
   }
 
   @Override
@@ -57,6 +80,11 @@ public class GraphqlCapability implements Capability {
   @Override
   public Decoder enrich(Decoder decoder) {
     return graphqlDecoder;
+  }
+
+  @Override
+  public Client enrich(Client client) {
+    return new GraphqlSubscriptionClient(client, contract, jsonEncoder, jsonDecoder);
   }
 
   @Override

--- a/graphql/src/main/java/feign/graphql/GraphqlCapability.java
+++ b/graphql/src/main/java/feign/graphql/GraphqlCapability.java
@@ -28,9 +28,7 @@ import feign.codec.JsonEncoder;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.concurrent.Executor;
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicLong;
 
 @Experimental
@@ -90,18 +88,14 @@ public class GraphqlCapability implements Capability {
   }
 
   /**
-   * Bounded and daemon, so a runaway subscription count fails fast rather than exhausting threads.
-   * A synchronous handoff queue is deliberate: subscription workers are long-lived, so queueing
-   * them would hide exhaustion until the heap gave out.
+   * Each open {@code Flow.Publisher} or {@code CompletableFuture} subscription holds one worker for
+   * its lifetime, so the default pool grows on demand and reaps idle threads rather than capping
+   * concurrent subscriptions at a guess. Supply a bounded executor to cap them deliberately: the
+   * excess is refused with {@code RejectedExecutionException} rather than left hanging.
    */
   private static Executor defaultExecutor() {
     var threads = new AtomicLong();
-    return new ThreadPoolExecutor(
-        0,
-        Math.max(8, Runtime.getRuntime().availableProcessors() * 4),
-        60L,
-        TimeUnit.SECONDS,
-        new SynchronousQueue<>(),
+    return Executors.newCachedThreadPool(
         runnable -> {
           var thread =
               new Thread(runnable, "feign-graphql-subscription-" + threads.incrementAndGet());

--- a/graphql/src/main/java/feign/graphql/GraphqlContract.java
+++ b/graphql/src/main/java/feign/graphql/GraphqlContract.java
@@ -31,6 +31,8 @@ public class GraphqlContract extends DefaultContract {
 
   private static final Pattern VARIABLE_PATTERN = Pattern.compile("\\$\\s*(\\w+)\\s*:");
 
+  private static final Pattern SUBSCRIPTION_PATTERN = Pattern.compile("^\\s*subscription\\b");
+
   private final Map<String, QueryMetadata> metadata = new ConcurrentHashMap<>();
 
   public GraphqlContract() {
@@ -45,7 +47,8 @@ public class GraphqlContract extends DefaultContract {
           }
 
           var variableName = extractFirstVariable(query);
-          metadata.put(data.configKey(), new QueryMetadata(query, variableName));
+          metadata.put(
+              data.configKey(), new QueryMetadata(query, variableName, isSubscription(query)));
         });
   }
 
@@ -97,13 +100,19 @@ public class GraphqlContract extends DefaultContract {
     return null;
   }
 
+  static boolean isSubscription(String query) {
+    return SUBSCRIPTION_PATTERN.matcher(query).find();
+  }
+
   static class QueryMetadata {
     final String query;
     final String variableName;
+    final boolean subscription;
 
-    QueryMetadata(String query, String variableName) {
+    QueryMetadata(String query, String variableName, boolean subscription) {
       this.query = query;
       this.variableName = variableName;
+      this.subscription = subscription;
     }
   }
 }

--- a/graphql/src/main/java/feign/graphql/GraphqlDecoder.java
+++ b/graphql/src/main/java/feign/graphql/GraphqlDecoder.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Flow;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.SubmissionPublisher;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
@@ -210,14 +211,19 @@ public class GraphqlDecoder implements Decoder {
             subscription.unsubscribe();
           }
         });
-    executor.execute(
-        () -> {
-          try {
-            future.complete(first(subscription, elementType, 0).orElse(null));
-          } catch (Throwable e) {
-            future.completeExceptionally(e);
-          }
-        });
+    try {
+      executor.execute(
+          () -> {
+            try {
+              future.complete(first(subscription, elementType, 0).orElse(null));
+            } catch (Throwable e) {
+              future.completeExceptionally(e);
+            }
+          });
+    } catch (RejectedExecutionException e) {
+      subscription.unsubscribe();
+      future.completeExceptionally(e);
+    }
     return future;
   }
 
@@ -235,7 +241,9 @@ public class GraphqlDecoder implements Decoder {
   }
 
   private Flow.Publisher<Object> publish(Subscription subscription, Type elementType) {
-    var publisher = new SubmissionPublisher<>(executor, Flow.defaultBufferSize());
+    // Runnable::run delivers on the pump thread: one worker per subscription in total, delivery can
+    // never be rejected by a busy pool, and onNext is inherently ordered.
+    var publisher = new SubmissionPublisher<>(Runnable::run, Flow.defaultBufferSize());
     var started = new AtomicBoolean();
     // Pumping starts on the first subscribe, so hasSubscribers() is meaningful from the first
     // element onwards and there is no pre-subscribe window to latch around.
@@ -244,18 +252,24 @@ public class GraphqlDecoder implements Decoder {
       if (!started.compareAndSet(false, true)) {
         return;
       }
-      executor.execute(
-          () -> {
-            try (var elements = elements(subscription, elementType, 0)) {
-              var iterator = elements.iterator();
-              while (iterator.hasNext() && publisher.hasSubscribers()) {
-                publisher.submit(iterator.next());
+      try {
+        executor.execute(
+            () -> {
+              try (var elements = elements(subscription, elementType, 0)) {
+                var iterator = elements.iterator();
+                while (iterator.hasNext() && publisher.hasSubscribers()) {
+                  publisher.submit(iterator.next());
+                }
+                publisher.close();
+              } catch (Throwable e) {
+                publisher.closeExceptionally(e);
               }
-              publisher.close();
-            } catch (Throwable e) {
-              publisher.closeExceptionally(e);
-            }
-          });
+            });
+      } catch (RejectedExecutionException e) {
+        // A subscriber must always get a terminal signal; stranding it is worse than failing it.
+        subscription.unsubscribe();
+        publisher.closeExceptionally(e);
+      }
     };
   }
 

--- a/graphql/src/main/java/feign/graphql/GraphqlDecoder.java
+++ b/graphql/src/main/java/feign/graphql/GraphqlDecoder.java
@@ -32,8 +32,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Flow;
 import java.util.concurrent.SubmissionPublisher;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
 @Experimental
@@ -44,17 +46,19 @@ public class GraphqlDecoder implements Decoder {
 
   private final JsonDecoder jsonDecoder;
   private final long eventTimeoutMillis;
+  private final Executor executor;
 
   public GraphqlDecoder(JsonDecoder jsonDecoder) {
-    this(jsonDecoder, DEFAULT_EVENT_TIMEOUT);
+    this(jsonDecoder, DEFAULT_EVENT_TIMEOUT, Runnable::run);
   }
 
-  public GraphqlDecoder(JsonDecoder jsonDecoder, Duration eventTimeout) {
+  public GraphqlDecoder(JsonDecoder jsonDecoder, Duration eventTimeout, Executor executor) {
     if (eventTimeout.isNegative()) {
       throw new IllegalArgumentException("eventTimeout must not be negative: " + eventTimeout);
     }
     this.jsonDecoder = jsonDecoder;
     this.eventTimeoutMillis = eventTimeout.toMillis();
+    this.executor = executor;
   }
 
   @Override
@@ -199,7 +203,14 @@ public class GraphqlDecoder implements Decoder {
 
   private CompletableFuture<Object> futureOf(Subscription subscription, Type elementType) {
     var future = new CompletableFuture<>();
-    pump(
+    // Cancelling must reach the socket, or a cancelled future leaks the connection and its worker.
+    future.whenComplete(
+        (ignored, error) -> {
+          if (future.isCancelled()) {
+            subscription.unsubscribe();
+          }
+        });
+    executor.execute(
         () -> {
           try {
             future.complete(first(subscription, elementType, 0).orElse(null));
@@ -224,33 +235,28 @@ public class GraphqlDecoder implements Decoder {
   }
 
   private Flow.Publisher<Object> publish(Subscription subscription, Type elementType) {
-    var publisher = new SubmissionPublisher<Object>();
-    pump(
-        () -> {
-          try (var elements = elements(subscription, elementType, 0)) {
-            var iterator = elements.iterator();
-            var subscribed = false;
-            while (iterator.hasNext()) {
-              publisher.submit(iterator.next());
-              // hasSubscribers() is also false before the first subscribe arrives, hence the
-              // latch — buffered elements hold until then.
-              if (subscribed && !publisher.hasSubscribers()) {
-                break;
+    var publisher = new SubmissionPublisher<>(executor, Flow.defaultBufferSize());
+    var started = new AtomicBoolean();
+    // Pumping starts on the first subscribe, so hasSubscribers() is meaningful from the first
+    // element onwards and there is no pre-subscribe window to latch around.
+    return subscriber -> {
+      publisher.subscribe(subscriber);
+      if (!started.compareAndSet(false, true)) {
+        return;
+      }
+      executor.execute(
+          () -> {
+            try (var elements = elements(subscription, elementType, 0)) {
+              var iterator = elements.iterator();
+              while (iterator.hasNext() && publisher.hasSubscribers()) {
+                publisher.submit(iterator.next());
               }
-              subscribed |= publisher.hasSubscribers();
+              publisher.close();
+            } catch (Throwable e) {
+              publisher.closeExceptionally(e);
             }
-            publisher.close();
-          } catch (Throwable e) {
-            publisher.closeExceptionally(e);
-          }
-        });
-    return publisher;
-  }
-
-  private static void pump(Runnable task) {
-    var thread = new Thread(task, "feign-graphql-subscription");
-    thread.setDaemon(true);
-    thread.start();
+          });
+    };
   }
 
   private static boolean isRawType(Type type, Class<?> raw) {

--- a/graphql/src/main/java/feign/graphql/GraphqlDecoder.java
+++ b/graphql/src/main/java/feign/graphql/GraphqlDecoder.java
@@ -16,29 +16,53 @@
 package feign.graphql;
 
 import feign.Experimental;
+import feign.Request;
 import feign.Response;
 import feign.Util;
 import feign.codec.Decoder;
 import feign.codec.JsonDecoder;
+import feign.graphql.GraphqlSubscriptionClient.Subscription;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Flow;
+import java.util.concurrent.SubmissionPublisher;
+import java.util.stream.Stream;
 
 @Experimental
 public class GraphqlDecoder implements Decoder {
 
+  /** How long a blocking subscription call waits for an event before giving up. */
+  public static final Duration DEFAULT_EVENT_TIMEOUT = Duration.ofSeconds(60);
+
   private final JsonDecoder jsonDecoder;
+  private final long eventTimeoutMillis;
 
   public GraphqlDecoder(JsonDecoder jsonDecoder) {
+    this(jsonDecoder, DEFAULT_EVENT_TIMEOUT);
+  }
+
+  public GraphqlDecoder(JsonDecoder jsonDecoder, Duration eventTimeout) {
+    if (eventTimeout.isNegative()) {
+      throw new IllegalArgumentException("eventTimeout must not be negative: " + eventTimeout);
+    }
     this.jsonDecoder = jsonDecoder;
+    this.eventTimeoutMillis = eventTimeout.toMillis();
   }
 
   @Override
   public Object decode(Response response, Type type) throws IOException {
+    if (response.body() instanceof Subscription subscription) {
+      return subscribe(subscription, type);
+    }
+
     Type targetType = type;
     boolean optional = isOptionalType(type);
     if (optional) {
@@ -66,11 +90,16 @@ public class GraphqlDecoder implements Decoder {
       return Util.emptyValueOf(type);
     }
 
+    return unwrap(root, type, response.status(), response.request());
+  }
+
+  @SuppressWarnings("unchecked")
+  private Object unwrap(Map<String, Object> root, Type type, int status, Request request)
+      throws IOException {
     var errors = root.get("errors");
     if (errors instanceof List<?> errorList && !errorList.isEmpty()) {
-      var operationField = resolveOperationField(root, response);
-      throw new GraphqlErrorException(
-          response.status(), operationField, errors.toString(), response.request());
+      var operationField = resolveOperationField(root, request);
+      throw new GraphqlErrorException(status, operationField, errors.toString(), request);
     }
 
     var data = root.get("data");
@@ -101,7 +130,7 @@ public class GraphqlDecoder implements Decoder {
   }
 
   @SuppressWarnings("unchecked")
-  private String resolveOperationField(Map<String, Object> root, Response response) {
+  private String resolveOperationField(Map<String, Object> root, Request request) {
     var data = root.get("data");
     if (data instanceof Map) {
       var dataMap = (Map<String, Object>) data;
@@ -111,14 +140,14 @@ public class GraphqlDecoder implements Decoder {
       }
     }
 
-    if (response.request() != null && response.request().body() != null) {
+    if (request != null && request.body() != null) {
       try {
         var fakeResponse =
             Response.builder()
                 .status(200)
                 .headers(Collections.emptyMap())
-                .request(response.request())
-                .body(response.request().body())
+                .request(request)
+                .body(request.body())
                 .build();
         var requestBody = (Map<String, Object>) jsonDecoder.decode(fakeResponse, Map.class);
         if (requestBody != null) {
@@ -133,6 +162,103 @@ public class GraphqlDecoder implements Decoder {
     }
 
     return "unknown";
+  }
+
+  /**
+   * The return type picks the semantics: {@code Stream<T>} blocks on every element and {@code
+   * Flow.Publisher<T>} pushes them, while {@code T} and {@code Optional<T>} block for the first
+   * event only and {@code CompletableFuture<T>} delivers that first event asynchronously. Every
+   * single-value form unsubscribes as soon as it has its event.
+   *
+   * <p>The blocking forms are bounded by the configured event timeout; the asynchronous ones are
+   * not, since their caller already owns the deadline.
+   */
+  private Object subscribe(Subscription subscription, Type type) {
+    subscription.detach();
+
+    if (isRawType(type, Stream.class)) {
+      return elements(subscription, typeArgument(type), eventTimeoutMillis);
+    }
+    if (isRawType(type, Flow.Publisher.class)) {
+      return publish(subscription, typeArgument(type));
+    }
+    if (isRawType(type, CompletableFuture.class)) {
+      return futureOf(subscription, typeArgument(type));
+    }
+    if (isRawType(type, Optional.class)) {
+      return first(subscription, typeArgument(type), eventTimeoutMillis);
+    }
+    return first(subscription, type, eventTimeoutMillis).orElseGet(() -> Util.emptyValueOf(type));
+  }
+
+  private Optional<Object> first(Subscription subscription, Type elementType, long timeoutMillis) {
+    try (var elements = elements(subscription, elementType, timeoutMillis)) {
+      return elements.findFirst();
+    }
+  }
+
+  private CompletableFuture<Object> futureOf(Subscription subscription, Type elementType) {
+    var future = new CompletableFuture<>();
+    pump(
+        () -> {
+          try {
+            future.complete(first(subscription, elementType, 0).orElse(null));
+          } catch (Throwable e) {
+            future.completeExceptionally(e);
+          }
+        });
+    return future;
+  }
+
+  private Stream<Object> elements(Subscription subscription, Type elementType, long timeoutMillis) {
+    return subscription
+        .payloads(timeoutMillis)
+        .map(
+            payload -> {
+              try {
+                return unwrap(payload, elementType, 200, subscription.request());
+              } catch (IOException e) {
+                throw new UncheckedIOException(e);
+              }
+            });
+  }
+
+  private Flow.Publisher<Object> publish(Subscription subscription, Type elementType) {
+    var publisher = new SubmissionPublisher<Object>();
+    pump(
+        () -> {
+          try (var elements = elements(subscription, elementType, 0)) {
+            var iterator = elements.iterator();
+            var subscribed = false;
+            while (iterator.hasNext()) {
+              publisher.submit(iterator.next());
+              // hasSubscribers() is also false before the first subscribe arrives, hence the
+              // latch — buffered elements hold until then.
+              if (subscribed && !publisher.hasSubscribers()) {
+                break;
+              }
+              subscribed |= publisher.hasSubscribers();
+            }
+            publisher.close();
+          } catch (Throwable e) {
+            publisher.closeExceptionally(e);
+          }
+        });
+    return publisher;
+  }
+
+  private static void pump(Runnable task) {
+    var thread = new Thread(task, "feign-graphql-subscription");
+    thread.setDaemon(true);
+    thread.start();
+  }
+
+  private static boolean isRawType(Type type, Class<?> raw) {
+    return type instanceof ParameterizedType pt && pt.getRawType() == raw;
+  }
+
+  private static Type typeArgument(Type type) {
+    return ((ParameterizedType) type).getActualTypeArguments()[0];
   }
 
   private boolean isOptionalType(Type type) {

--- a/graphql/src/main/java/feign/graphql/GraphqlSubscriptionClient.java
+++ b/graphql/src/main/java/feign/graphql/GraphqlSubscriptionClient.java
@@ -27,6 +27,7 @@ import feign.codec.JsonDecoder;
 import feign.codec.JsonEncoder;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InterruptedIOException;
 import java.io.Reader;
 import java.io.UncheckedIOException;
 import java.net.HttpURLConnection;
@@ -204,7 +205,9 @@ public class GraphqlSubscriptionClient implements Client {
      */
     private final String operationId = UUID.randomUUID().toString();
 
-    private final BlockingQueue<Object> events = new LinkedBlockingQueue<>();
+    /** Bounded: demand-driven reads keep this near empty, the capacity is a safety net. */
+    private final BlockingQueue<Object> events = new LinkedBlockingQueue<>(1024);
+
     private final StringBuilder partial = new StringBuilder();
     private final Request request;
     private final GraphqlContract.QueryMetadata meta;
@@ -217,6 +220,7 @@ public class GraphqlSubscriptionClient implements Client {
     private final Operation operation;
 
     private final AtomicBoolean detached = new AtomicBoolean();
+    private final AtomicBoolean unsubscribed = new AtomicBoolean();
 
     private volatile WebSocket webSocket;
     private CompletableFuture<?> sends = CompletableFuture.completedFuture(null);
@@ -277,53 +281,74 @@ public class GraphqlSubscriptionClient implements Client {
     @Override
     public CompletionStage<?> onText(WebSocket ws, CharSequence data, boolean last) {
       partial.append(data);
-      if (last) {
-        var text = partial.toString();
-        partial.setLength(0);
-        handle(ws, text);
+      if (!last) {
+        ws.request(1);
+        return null;
       }
-      ws.request(1);
+      var text = partial.toString();
+      partial.setLength(0);
+      // Only control frames pull the next one eagerly. A queued payload waits for the consumer to
+      // take it, which is what bounds the queue.
+      if (!handle(ws, text)) {
+        ws.request(1);
+      }
       return null;
     }
 
     @Override
     public void onError(WebSocket ws, Throwable error) {
-      events.add(error);
+      publish(error);
     }
 
     @Override
     public CompletionStage<?> onClose(WebSocket ws, int statusCode, String reason) {
-      events.add(DONE);
+      publish(DONE);
       return null;
     }
 
-    private void handle(WebSocket ws, String text) {
+    /**
+     * @return true when this message queued an event, so the next frame waits for the consumer.
+     */
+    private boolean handle(WebSocket ws, String text) {
       ServerMessage message;
       try {
         message = decode(text, ServerMessage.class);
       } catch (IOException | RuntimeException e) {
-        events.add(e);
-        return;
+        return publish(e);
       }
       if (message == null || (message.id() != null && !message.id().equals(operationId))) {
-        return;
+        return false;
       }
 
-      switch (message.type()) {
-        case "connection_ack" ->
-            send(ws, new ClientMessage.Subscribe(operationId, "subscribe", operation));
-        case "next" -> events.add(message.payloadFields());
+      return switch (message.type()) {
+        case "connection_ack" -> {
+          send(ws, new ClientMessage.Subscribe(operationId, "subscribe", operation));
+          yield false;
+        }
+        case "next" -> publish(message.payloadFields());
         case "error" ->
-            events.add(
+            publish(
                 new GraphqlErrorException(
                     HttpURLConnection.HTTP_OK,
                     GraphqlContract.extractOperationField(meta.query),
                     String.valueOf(message.payload()),
                     request));
-        case "complete" -> events.add(DONE);
-        case "ping" -> send(ws, new ClientMessage.Control("pong"));
-        default -> {}
+        case "complete" -> publish(DONE);
+        case "ping" -> {
+          send(ws, new ClientMessage.Control("pong"));
+          yield false;
+        }
+        default -> false;
+      };
+    }
+
+    private boolean publish(Object event) {
+      if (!events.offer(event)) {
+        // Unreachable while reads are demand-driven; failing loudly beats growing without bound.
+        events.clear();
+        events.offer(new IllegalStateException("GraphQL subscription event queue overflowed"));
       }
+      return true;
     }
 
     private <T> T decode(String json, Class<T> type) throws IOException {
@@ -337,10 +362,22 @@ public class GraphqlSubscriptionClient implements Client {
       return type.cast(jsonDecoder.decode(envelope, type));
     }
 
-    /** Sends are serialized: the JDK rejects a send while another is still in flight. */
+    /**
+     * Sends are serialized: the JDK rejects a send while another is still in flight. A failure is
+     * surfaced to the consumer and the chain reset, so it cannot silently swallow later sends.
+     */
     private synchronized void send(WebSocket ws, ClientMessage message) {
       var json = toJson(message);
-      sends = sends.thenCompose(ignored -> ws.sendText(json, true)).thenApply(ignored -> null);
+      sends =
+          sends
+              .thenCompose(ignored -> ws.sendText(json, true))
+              .handle(
+                  (ignored, error) -> {
+                    if (error != null) {
+                      publish(error);
+                    }
+                    return null;
+                  });
     }
 
     private String toJson(ClientMessage message) {
@@ -350,13 +387,17 @@ public class GraphqlSubscriptionClient implements Client {
     }
 
     void unsubscribe() {
+      if (!unsubscribed.compareAndSet(false, true)) {
+        return;
+      }
       var ws = webSocket;
-      events.add(DONE);
+      publish(DONE);
       if (ws == null) {
         return;
       }
-      send(ws, new ClientMessage.Complete(operationId, "complete"));
+      ws.request(1); // let the closing handshake be delivered
       synchronized (this) {
+        send(ws, new ClientMessage.Complete(operationId, "complete"));
         // whenComplete, not thenRun: the socket must close even if an earlier send failed.
         sends.whenComplete((ignored, error) -> ws.sendClose(WebSocket.NORMAL_CLOSURE, ""));
       }
@@ -430,17 +471,24 @@ public class GraphqlSubscriptionClient implements Client {
 
       private Object take() {
         try {
-          if (timeoutMillis <= 0) {
-            return events.take();
+          var event =
+              timeoutMillis <= 0
+                  ? events.take()
+                  : events.poll(timeoutMillis, TimeUnit.MILLISECONDS);
+          if (event == null) {
+            return new SocketTimeoutException(
+                "no GraphQL subscription event within " + timeoutMillis + "ms");
           }
-          var event = events.poll(timeoutMillis, TimeUnit.MILLISECONDS);
-          return event != null
-              ? event
-              : new SocketTimeoutException(
-                  "no GraphQL subscription event within " + timeoutMillis + "ms");
+          if (event != DONE) {
+            var ws = webSocket;
+            if (ws != null) {
+              ws.request(1); // consuming an event is what authorises the next read
+            }
+          }
+          return event;
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
-          return DONE;
+          return new InterruptedIOException("interrupted awaiting a GraphQL subscription event");
         }
       }
     }

--- a/graphql/src/main/java/feign/graphql/GraphqlSubscriptionClient.java
+++ b/graphql/src/main/java/feign/graphql/GraphqlSubscriptionClient.java
@@ -1,0 +1,458 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.graphql;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import feign.Client;
+import feign.Experimental;
+import feign.Request;
+import feign.RequestTemplate;
+import feign.Response;
+import feign.Util;
+import feign.codec.JsonDecoder;
+import feign.codec.JsonEncoder;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.UncheckedIOException;
+import java.net.HttpURLConnection;
+import java.net.SocketTimeoutException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.WebSocket;
+import java.nio.charset.Charset;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * Executes {@code subscription} operations over the <a
+ * href="https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md">graphql-transport-ws</a>
+ * WebSocket protocol, delegating every other request to the wrapped {@link Client}.
+ *
+ * <p>The endpoint is the target URL with its scheme swapped to {@code ws}/{@code wss}. One
+ * WebSocket connection is opened per subscription call and is closed when the returned {@code
+ * Stream} or {@code Flow.Publisher} is closed/cancelled.
+ */
+@Experimental
+public class GraphqlSubscriptionClient implements Client {
+
+  private final Client delegate;
+  private final GraphqlContract contract;
+  private final JsonEncoder jsonEncoder;
+  private final JsonDecoder jsonDecoder;
+  private final HttpClient httpClient;
+
+  public GraphqlSubscriptionClient(
+      Client delegate, GraphqlContract contract, JsonEncoder encoder, JsonDecoder decoder) {
+    this(delegate, contract, encoder, decoder, HttpClient.newHttpClient());
+  }
+
+  public GraphqlSubscriptionClient(
+      Client delegate,
+      GraphqlContract contract,
+      JsonEncoder encoder,
+      JsonDecoder decoder,
+      HttpClient httpClient) {
+    this.delegate = delegate;
+    this.contract = contract;
+    this.jsonEncoder = encoder;
+    this.jsonDecoder = decoder;
+    this.httpClient = httpClient;
+  }
+
+  @Override
+  public Response execute(Request request, Request.Options options) throws IOException {
+    var meta =
+        request.requestTemplate() == null
+            ? null
+            : contract.lookupMetadata(request.requestTemplate());
+    if (meta == null || !meta.subscription) {
+      return delegate.execute(request, options);
+    }
+    return subscribe(request, options, meta);
+  }
+
+  private Response subscribe(
+      Request request, Request.Options options, GraphqlContract.QueryMetadata meta)
+      throws IOException {
+    var subscription = new Subscription(request, meta, jsonEncoder, jsonDecoder);
+
+    var builder = httpClient.newWebSocketBuilder().subprotocols("graphql-transport-ws");
+    if (options != null && options.connectTimeoutMillis() > 0) {
+      builder.connectTimeout(Duration.ofMillis(options.connectTimeoutMillis()));
+    }
+    request
+        .headers()
+        .forEach(
+            (name, values) -> {
+              if (isForwardable(name)) {
+                values.forEach(value -> builder.header(name, value));
+              }
+            });
+
+    try {
+      subscription.attach(builder.buildAsync(webSocketUri(request.url()), subscription).join());
+    } catch (CompletionException e) {
+      var cause = e.getCause() == null ? e : e.getCause();
+      throw new IOException("failed to open GraphQL subscription to " + request.url(), cause);
+    }
+
+    // 204 keeps feign's logger from draining and replacing the body, which would drop the live
+    // subscription. Nothing here ever crosses the wire.
+    return Response.builder()
+        .status(HttpURLConnection.HTTP_NO_CONTENT)
+        .reason("Subscribed")
+        .request(request)
+        .headers(Collections.emptyMap())
+        .body(subscription)
+        .build();
+  }
+
+  /** Headers the JDK WebSocket handshake rejects or manages itself. */
+  private static boolean isForwardable(String header) {
+    var name = header.toLowerCase(Locale.ROOT);
+    return !name.equals("connection")
+        && !name.equals("upgrade")
+        && !name.equals("host")
+        && !name.equals("content-type")
+        && !name.equalsIgnoreCase(Util.CONTENT_LENGTH)
+        && !name.startsWith("sec-websocket-");
+  }
+
+  static URI webSocketUri(String url) {
+    var uri = URI.create(url);
+    var scheme = "https".equalsIgnoreCase(uri.getScheme()) ? "wss" : "ws";
+    return URI.create(scheme + url.substring(url.indexOf(':')));
+  }
+
+  /**
+   * The messages this client sends, one record per <em>wire shape</em> rather than per type: the
+   * configured {@link JsonEncoder} writes every component, so a shape carrying a component the
+   * protocol does not define for that message would send it as null.
+   */
+  sealed interface ClientMessage {
+
+    /** A bare type, covering {@code connection_init} and {@code pong}. */
+    record Control(String type) implements ClientMessage {}
+
+    /** A reference to a running operation. */
+    record Complete(String id, String type) implements ClientMessage {}
+
+    /** A reference to an operation plus the request that starts it. */
+    record Subscribe(String id, String type, Operation payload) implements ClientMessage {}
+  }
+
+  /** The GraphQL request a subscription starts, as feign already encoded it into the body. */
+  record Operation(String query, Map<String, Object> variables) {}
+
+  /**
+   * The envelope of a server message. Carries every component graphql-transport-ws defines, so a
+   * strict mapper has nothing unknown to reject.
+   *
+   * @param payload stays untyped: {@code next} carries a {@code {data, errors}} object while {@code
+   *     error} carries a list of errors.
+   */
+  record ServerMessage(String id, String type, Object payload) {
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> payloadFields() {
+      return payload instanceof Map<?, ?> fields ? (Map<String, Object>) fields : Map.of();
+    }
+  }
+
+  /**
+   * A live subscription: the WebSocket listener, the queue of decoded {@code next} payloads and the
+   * {@link Response.Body} handed to {@link GraphqlDecoder} all in one, because they share a
+   * lifecycle.
+   */
+  static final class Subscription implements WebSocket.Listener, Response.Body {
+
+    private static final Object DONE = new Object();
+
+    /**
+     * Unique per connection, so a stray message for another operation is never mistaken for ours.
+     */
+    private final String operationId = UUID.randomUUID().toString();
+
+    private final BlockingQueue<Object> events = new LinkedBlockingQueue<>();
+    private final StringBuilder partial = new StringBuilder();
+    private final Request request;
+    private final GraphqlContract.QueryMetadata meta;
+    private final JsonEncoder jsonEncoder;
+    private final JsonDecoder jsonDecoder;
+
+    /**
+     * The already-encoded request body, decoded back so it can be sent as the subscribe payload.
+     */
+    private final Operation operation;
+
+    private final AtomicBoolean detached = new AtomicBoolean();
+
+    private volatile WebSocket webSocket;
+    private CompletableFuture<?> sends = CompletableFuture.completedFuture(null);
+
+    Subscription(
+        Request request,
+        GraphqlContract.QueryMetadata meta,
+        JsonEncoder jsonEncoder,
+        JsonDecoder jsonDecoder)
+        throws IOException {
+      this.request = request;
+      this.meta = meta;
+      this.jsonEncoder = jsonEncoder;
+      this.jsonDecoder = jsonDecoder;
+
+      var charset = request.charset() == null ? UTF_8 : request.charset();
+      this.operation =
+          request.body() == null
+              ? new Operation(meta.query, Map.of())
+              : decode(new String(request.body(), charset), Operation.class);
+    }
+
+    void attach(WebSocket webSocket) {
+      this.webSocket = webSocket;
+    }
+
+    /**
+     * Hands the subscription lifecycle to the decoder, so feign closing the response body right
+     * after decoding no longer tears it down.
+     */
+    void detach() {
+      detached.set(true);
+    }
+
+    Request request() {
+      return request;
+    }
+
+    /**
+     * Blocking stream of raw {@code {data, errors}} payloads, one per {@code next} message.
+     *
+     * @param timeoutMillis how long to wait for each event; {@code 0} waits indefinitely
+     */
+    Stream<Map<String, Object>> payloads(long timeoutMillis) {
+      return StreamSupport.stream(
+              Spliterators.spliteratorUnknownSize(
+                  new PayloadIterator(timeoutMillis), Spliterator.ORDERED),
+              false)
+          .onClose(this::unsubscribe);
+    }
+
+    @Override
+    public void onOpen(WebSocket ws) {
+      send(ws, new ClientMessage.Control("connection_init"));
+      ws.request(1);
+    }
+
+    @Override
+    public CompletionStage<?> onText(WebSocket ws, CharSequence data, boolean last) {
+      partial.append(data);
+      if (last) {
+        var text = partial.toString();
+        partial.setLength(0);
+        handle(ws, text);
+      }
+      ws.request(1);
+      return null;
+    }
+
+    @Override
+    public void onError(WebSocket ws, Throwable error) {
+      events.add(error);
+    }
+
+    @Override
+    public CompletionStage<?> onClose(WebSocket ws, int statusCode, String reason) {
+      events.add(DONE);
+      return null;
+    }
+
+    private void handle(WebSocket ws, String text) {
+      ServerMessage message;
+      try {
+        message = decode(text, ServerMessage.class);
+      } catch (IOException | RuntimeException e) {
+        events.add(e);
+        return;
+      }
+      if (message == null || (message.id() != null && !message.id().equals(operationId))) {
+        return;
+      }
+
+      switch (message.type()) {
+        case "connection_ack" ->
+            send(ws, new ClientMessage.Subscribe(operationId, "subscribe", operation));
+        case "next" -> events.add(message.payloadFields());
+        case "error" ->
+            events.add(
+                new GraphqlErrorException(
+                    HttpURLConnection.HTTP_OK,
+                    GraphqlContract.extractOperationField(meta.query),
+                    String.valueOf(message.payload()),
+                    request));
+        case "complete" -> events.add(DONE);
+        case "ping" -> send(ws, new ClientMessage.Control("pong"));
+        default -> {}
+      }
+    }
+
+    private <T> T decode(String json, Class<T> type) throws IOException {
+      var envelope =
+          Response.builder()
+              .status(HttpURLConnection.HTTP_OK)
+              .headers(Collections.emptyMap())
+              .request(request)
+              .body(json, UTF_8)
+              .build();
+      return type.cast(jsonDecoder.decode(envelope, type));
+    }
+
+    /** Sends are serialized: the JDK rejects a send while another is still in flight. */
+    private synchronized void send(WebSocket ws, ClientMessage message) {
+      var json = toJson(message);
+      sends = sends.thenCompose(ignored -> ws.sendText(json, true)).thenApply(ignored -> null);
+    }
+
+    private String toJson(ClientMessage message) {
+      var template = new RequestTemplate();
+      jsonEncoder.encode(message, message.getClass(), template);
+      return new String(template.body(), UTF_8);
+    }
+
+    void unsubscribe() {
+      var ws = webSocket;
+      events.add(DONE);
+      if (ws == null) {
+        return;
+      }
+      send(ws, new ClientMessage.Complete(operationId, "complete"));
+      synchronized (this) {
+        // whenComplete, not thenRun: the socket must close even if an earlier send failed.
+        sends.whenComplete((ignored, error) -> ws.sendClose(WebSocket.NORMAL_CLOSURE, ""));
+      }
+    }
+
+    @Override
+    public Integer length() {
+      return null;
+    }
+
+    @Override
+    public boolean isRepeatable() {
+      return false;
+    }
+
+    @Override
+    public InputStream asInputStream() {
+      return InputStream.nullInputStream();
+    }
+
+    @Override
+    public Reader asReader(Charset charset) {
+      return Reader.nullReader();
+    }
+
+    /**
+     * Feign closes the response body right after decoding, which for a detached subscription is a
+     * no-op — the caller owns it from there. Still attached means the decoder never took ownership
+     * (a {@code void} method, say), so the socket is closed here rather than leaked.
+     */
+    @Override
+    public void close() {
+      if (!detached.get()) {
+        unsubscribe();
+      }
+    }
+
+    private final class PayloadIterator implements Iterator<Map<String, Object>> {
+
+      private final long timeoutMillis;
+
+      private Object pending;
+
+      PayloadIterator(long timeoutMillis) {
+        this.timeoutMillis = timeoutMillis;
+      }
+
+      @SuppressWarnings("unchecked")
+      @Override
+      public boolean hasNext() {
+        if (pending == null) {
+          pending = take();
+        }
+        if (pending instanceof Throwable error) {
+          pending = DONE;
+          throw asUnchecked(error);
+        }
+        return pending != DONE;
+      }
+
+      @SuppressWarnings("unchecked")
+      @Override
+      public Map<String, Object> next() {
+        if (!hasNext()) {
+          throw new NoSuchElementException();
+        }
+        var payload = (Map<String, Object>) pending;
+        pending = null;
+        return payload;
+      }
+
+      private Object take() {
+        try {
+          if (timeoutMillis <= 0) {
+            return events.take();
+          }
+          var event = events.poll(timeoutMillis, TimeUnit.MILLISECONDS);
+          return event != null
+              ? event
+              : new SocketTimeoutException(
+                  "no GraphQL subscription event within " + timeoutMillis + "ms");
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          return DONE;
+        }
+      }
+    }
+
+    private static RuntimeException asUnchecked(Throwable error) {
+      if (error instanceof RuntimeException runtime) {
+        return runtime;
+      }
+      if (error instanceof IOException io) {
+        return new UncheckedIOException(io);
+      }
+      return new IllegalStateException(error);
+    }
+  }
+}

--- a/graphql/src/test/java/feign/graphql/GraphqlSubscriptionConcurrencyTest.java
+++ b/graphql/src/test/java/feign/graphql/GraphqlSubscriptionConcurrencyTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.Feign;
+import feign.jackson.JacksonCodec;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Flow;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import okhttp3.Response;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises the subscription wiring under concurrent load: many sockets open at once, sharing one
+ * capability, one JSON codec and one worker pool.
+ */
+class GraphqlSubscriptionConcurrencyTest {
+
+  private static final int SUBSCRIPTIONS = 24;
+  private static final int EVENTS_EACH = 20;
+
+  private final ObjectMapper mapper =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  private MockWebServer server;
+
+  /** Counts sockets the client closed, so leaks show up as a shortfall. */
+  private final CountDownLatch closed = new CountDownLatch(SUBSCRIPTIONS);
+
+  private final AtomicInteger openSockets = new AtomicInteger();
+
+  public static class Price {
+    public String symbol;
+    public double price;
+  }
+
+  interface StockApi {
+
+    @GraphqlQuery(
+        "subscription onPrice($symbol: String!) {"
+            + " priceChanged(symbol: $symbol) { symbol price } }")
+    Stream<Price> onPrice(String symbol);
+
+    @GraphqlQuery(
+        "subscription onPrice($symbol: String!) {"
+            + " priceChanged(symbol: $symbol) { symbol price } }")
+    Flow.Publisher<Price> publishPrice(String symbol);
+  }
+
+  @BeforeEach
+  void setUp() throws Exception {
+    server = new MockWebServer();
+    // A dispatcher rather than a queue: every connection gets its own upgrade and its own listener,
+    // so the subscriptions are genuinely independent sockets.
+    server.setDispatcher(
+        new Dispatcher() {
+          @Override
+          public MockResponse dispatch(RecordedRequest request) {
+            return new MockResponse().withWebSocketUpgrade(new EchoingServer());
+          }
+        });
+    server.start();
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    server.shutdown();
+  }
+
+  /** Replays the handshake, then emits the requested symbol back with the client's own id. */
+  private final class EchoingServer extends WebSocketListener {
+
+    @Override
+    public void onOpen(WebSocket webSocket, Response response) {
+      openSockets.incrementAndGet();
+    }
+
+    @Override
+    public void onMessage(WebSocket webSocket, String text) {
+      try {
+        var message = mapper.readTree(text);
+        var type = message.get("type").asText();
+        if ("connection_init".equals(type)) {
+          webSocket.send("{\"type\":\"connection_ack\"}");
+          return;
+        }
+        if (!"subscribe".equals(type)) {
+          return;
+        }
+        var id = message.get("id").asText();
+        var symbol = message.get("payload").get("variables").get("symbol").asText();
+        for (var i = 0; i < EVENTS_EACH; i++) {
+          webSocket.send(
+              "{\"id\":\""
+                  + id
+                  + "\",\"type\":\"next\",\"payload\":{\"data\":{\"priceChanged\":{\"symbol\":\""
+                  + symbol
+                  + "\",\"price\":"
+                  + i
+                  + "}}}}");
+        }
+        webSocket.send("{\"id\":\"" + id + "\",\"type\":\"complete\"}");
+      } catch (Exception e) {
+        throw new IllegalStateException("bad client message: " + text, e);
+      }
+    }
+
+    @Override
+    public void onClosing(WebSocket webSocket, int code, String reason) {
+      webSocket.close(code, reason);
+      closed.countDown();
+    }
+
+    @Override
+    public void onFailure(WebSocket webSocket, Throwable t, Response response) {
+      closed.countDown();
+    }
+  }
+
+  private StockApi buildClient() {
+    return Feign.builder()
+        .addCapability(new GraphqlCapability(new JacksonCodec(mapper), Duration.ofSeconds(30)))
+        .target(StockApi.class, server.url("/graphql").toString());
+  }
+
+  private <T> List<T> runAllAtOnce(List<Callable<T>> tasks) throws Exception {
+    var pool = Executors.newFixedThreadPool(tasks.size());
+    try {
+      var barrier = new CyclicBarrier(tasks.size());
+      var futures =
+          tasks.stream()
+              .map(
+                  task ->
+                      pool.submit(
+                          () -> {
+                            barrier.await(30, TimeUnit.SECONDS);
+                            return task.call();
+                          }))
+              .toList();
+      var results = new java.util.ArrayList<T>();
+      for (var future : futures) {
+        results.add(future.get(60, TimeUnit.SECONDS));
+      }
+      return results;
+    } finally {
+      pool.shutdownNow();
+    }
+  }
+
+  @Test
+  void concurrentStreamsStayIsolated() throws Exception {
+    var api = buildClient();
+
+    List<Callable<List<Price>>> tasks =
+        IntStream.range(0, SUBSCRIPTIONS)
+            .<Callable<List<Price>>>mapToObj(
+                index ->
+                    () -> {
+                      try (var prices = api.onPrice("SYM" + index)) {
+                        return prices.toList();
+                      }
+                    })
+            .toList();
+
+    var results = runAllAtOnce(tasks);
+
+    // Every subscription sees exactly its own events, in order, with nothing from its neighbours.
+    for (var index = 0; index < SUBSCRIPTIONS; index++) {
+      var prices = results.get(index);
+      assertThat(prices).hasSize(EVENTS_EACH);
+      assertThat(prices).extracting(price -> price.symbol).containsOnly("SYM" + index);
+      assertThat(prices)
+          .extracting(price -> price.price)
+          .containsExactlyElementsOf(
+              IntStream.range(0, EVENTS_EACH).mapToObj(i -> (double) i).toList());
+    }
+
+    assertThat(openSockets).hasValue(SUBSCRIPTIONS);
+    assertThat(closed.await(30, TimeUnit.SECONDS))
+        .as("every socket should have been closed, not leaked")
+        .isTrue();
+  }
+
+  @Test
+  void concurrentPublishersDeliverEveryEvent() throws Exception {
+    var api = buildClient();
+
+    List<Callable<Integer>> tasks =
+        IntStream.range(0, SUBSCRIPTIONS)
+            .<Callable<Integer>>mapToObj(
+                index ->
+                    () -> {
+                      var delivered = new AtomicInteger();
+                      var done = new CountDownLatch(1);
+                      api.publishPrice("SYM" + index)
+                          .subscribe(
+                              new Flow.Subscriber<Price>() {
+                                @Override
+                                public void onSubscribe(Flow.Subscription subscription) {
+                                  subscription.request(Long.MAX_VALUE);
+                                }
+
+                                @Override
+                                public void onNext(Price item) {
+                                  delivered.incrementAndGet();
+                                }
+
+                                @Override
+                                public void onError(Throwable throwable) {
+                                  done.countDown();
+                                }
+
+                                @Override
+                                public void onComplete() {
+                                  done.countDown();
+                                }
+                              });
+                      assertThat(done.await(60, TimeUnit.SECONDS)).isTrue();
+                      return delivered.get();
+                    })
+            .toList();
+
+    assertThat(runAllAtOnce(tasks)).containsOnly(EVENTS_EACH);
+    assertThat(closed.await(30, TimeUnit.SECONDS)).isTrue();
+  }
+
+  @Test
+  void closingMidStreamFromAnotherThreadTerminatesPromptly() throws Exception {
+    var api = buildClient();
+
+    List<Callable<Integer>> tasks =
+        IntStream.range(0, SUBSCRIPTIONS)
+            .<Callable<Integer>>mapToObj(
+                index ->
+                    () -> {
+                      // Take a couple of events and walk away while the server is still pushing.
+                      try (var prices = api.onPrice("SYM" + index)) {
+                        return prices.limit(2).toList().size();
+                      }
+                    })
+            .toList();
+
+    assertThat(runAllAtOnce(tasks)).containsOnly(2);
+    assertThat(closed.await(30, TimeUnit.SECONDS))
+        .as("abandoning a stream must still close its socket")
+        .isTrue();
+  }
+}

--- a/graphql/src/test/java/feign/graphql/GraphqlSubscriptionConcurrencyTest.java
+++ b/graphql/src/test/java/feign/graphql/GraphqlSubscriptionConcurrencyTest.java
@@ -24,10 +24,14 @@ import feign.jackson.JacksonCodec;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Flow;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
@@ -62,6 +66,11 @@ class GraphqlSubscriptionConcurrencyTest {
 
   private final AtomicInteger openSockets = new AtomicInteger();
 
+  /**
+   * When false the server acknowledges the subscribe and then stays quiet, as a real feed would.
+   */
+  private volatile boolean emitEvents = true;
+
   public static class Price {
     public String symbol;
     public double price;
@@ -78,6 +87,11 @@ class GraphqlSubscriptionConcurrencyTest {
         "subscription onPrice($symbol: String!) {"
             + " priceChanged(symbol: $symbol) { symbol price } }")
     Flow.Publisher<Price> publishPrice(String symbol);
+
+    @GraphqlQuery(
+        "subscription onPrice($symbol: String!) {"
+            + " priceChanged(symbol: $symbol) { symbol price } }")
+    CompletableFuture<Price> futurePrice(String symbol);
   }
 
   @BeforeEach
@@ -120,6 +134,9 @@ class GraphqlSubscriptionConcurrencyTest {
         if (!"subscribe".equals(type)) {
           return;
         }
+        if (!emitEvents) {
+          return;
+        }
         var id = message.get("id").asText();
         var symbol = message.get("payload").get("variables").get("symbol").asText();
         for (var i = 0; i < EVENTS_EACH; i++) {
@@ -154,6 +171,42 @@ class GraphqlSubscriptionConcurrencyTest {
     return Feign.builder()
         .addCapability(new GraphqlCapability(new JacksonCodec(mapper), Duration.ofSeconds(30)))
         .target(StockApi.class, server.url("/graphql").toString());
+  }
+
+  private StockApi buildClient(Executor executor) {
+    return Feign.builder()
+        .addCapability(
+            new GraphqlCapability(new JacksonCodec(mapper), Duration.ofSeconds(30), executor))
+        .target(StockApi.class, server.url("/graphql").toString());
+  }
+
+  private int drain(Flow.Publisher<Price> publisher) throws Exception {
+    var delivered = new AtomicInteger();
+    var done = new CountDownLatch(1);
+    publisher.subscribe(
+        new Flow.Subscriber<Price>() {
+          @Override
+          public void onSubscribe(Flow.Subscription subscription) {
+            subscription.request(Long.MAX_VALUE);
+          }
+
+          @Override
+          public void onNext(Price item) {
+            delivered.incrementAndGet();
+          }
+
+          @Override
+          public void onError(Throwable throwable) {
+            done.countDown();
+          }
+
+          @Override
+          public void onComplete() {
+            done.countDown();
+          }
+        });
+    assertThat(done.await(60, TimeUnit.SECONDS)).isTrue();
+    return delivered.get();
   }
 
   private <T> List<T> runAllAtOnce(List<Callable<T>> tasks) throws Exception {
@@ -254,6 +307,62 @@ class GraphqlSubscriptionConcurrencyTest {
             .toList();
 
     assertThat(runAllAtOnce(tasks)).containsOnly(EVENTS_EACH);
+    assertThat(closed.await(30, TimeUnit.SECONDS)).isTrue();
+  }
+
+  @Test
+  void aPoolSizedForTheSubscriptionsIsEnough() throws Exception {
+    // One worker per open subscription is the documented cost. Needing a second thread per
+    // subscription for delivery would starve this pool and hang instead.
+    var pool = Executors.newFixedThreadPool(SUBSCRIPTIONS);
+    try {
+      var api = buildClient(pool);
+      List<Callable<Integer>> tasks =
+          IntStream.range(0, SUBSCRIPTIONS)
+              .<Callable<Integer>>mapToObj(index -> () -> drain(api.publishPrice("SYM" + index)))
+              .toList();
+
+      assertThat(runAllAtOnce(tasks)).containsOnly(EVENTS_EACH);
+    } finally {
+      pool.shutdownNow();
+    }
+  }
+
+  @Test
+  void aPoolTooSmallRefusesRatherThanStranding() throws Exception {
+    var pool = new ThreadPoolExecutor(0, 4, 60L, TimeUnit.SECONDS, new SynchronousQueue<>());
+    try {
+      var api = buildClient(pool);
+      List<Callable<Integer>> tasks =
+          IntStream.range(0, SUBSCRIPTIONS)
+              .<Callable<Integer>>mapToObj(index -> () -> drain(api.publishPrice("SYM" + index)))
+              .toList();
+
+      // Far more subscriptions than workers. Some are refused, but every subscriber must reach a
+      // terminal signal — drain() asserts that. Leaving one waiting forever is the failure mode.
+      assertThat(runAllAtOnce(tasks)).hasSize(SUBSCRIPTIONS);
+    } finally {
+      pool.shutdownNow();
+    }
+  }
+
+  @Test
+  void longLivedSubscriptionsAreNotCappedByCoreCount() throws Exception {
+    emitEvents = false;
+    var api = buildClient();
+
+    // Each of these holds its worker parked on the queue for as long as it is open, which is what a
+    // real feed does. A pool sized from the core count would refuse the excess synchronously.
+    var futures =
+        IntStream.range(0, SUBSCRIPTIONS)
+            .mapToObj(index -> api.futurePrice("SYM" + index))
+            .toList();
+
+    assertThat(futures)
+        .as("no subscription should have been refused a worker")
+        .allSatisfy(future -> assertThat(future).isNotCompleted());
+
+    futures.forEach(future -> future.cancel(true));
     assertThat(closed.await(30, TimeUnit.SECONDS)).isTrue();
   }
 

--- a/graphql/src/test/java/feign/graphql/GraphqlSubscriptionTest.java
+++ b/graphql/src/test/java/feign/graphql/GraphqlSubscriptionTest.java
@@ -398,6 +398,49 @@ class GraphqlSubscriptionTest {
   }
 
   @Test
+  void slowConsumerStillReceivesEveryEvent() {
+    var received = new CopyOnWriteArrayList<String>();
+    enqueueServer(
+        received,
+        String.format(NEXT, "ACME", "1"),
+        String.format(NEXT, "ACME", "2"),
+        String.format(NEXT, "ACME", "3"),
+        String.format(NEXT, "ACME", "4"),
+        String.format(NEXT, "ACME", "5"),
+        "{\"id\":\"{id}\",\"type\":\"complete\"}");
+
+    // Reads are demand-driven, so a consumer that lags must still be handed every event in order.
+    // Broken demand accounting stalls here until the event timeout instead.
+    List<Price> prices;
+    try (var stream = buildClient().onPrice("ACME")) {
+      prices =
+          stream
+              .peek(
+                  price -> {
+                    try {
+                      Thread.sleep(20);
+                    } catch (InterruptedException e) {
+                      Thread.currentThread().interrupt();
+                    }
+                  })
+              .toList();
+    }
+
+    assertThat(prices).extracting(price -> price.price).containsExactly(1.0, 2.0, 3.0, 4.0, 5.0);
+  }
+
+  @Test
+  void cancellingTheFutureClosesTheSubscription() {
+    var received = new CopyOnWriteArrayList<String>();
+    enqueueServer(received);
+
+    var future = buildClient().futurePrice("ACME");
+    assertThat(future.cancel(true)).isTrue();
+
+    // tearDown asserts the web socket was closed rather than left hanging on a cancelled future
+  }
+
+  @Test
   void defaultEventTimeoutIsOneMinute() {
     assertThat(GraphqlDecoder.DEFAULT_EVENT_TIMEOUT).isEqualTo(Duration.ofMinutes(1));
   }

--- a/graphql/src/test/java/feign/graphql/GraphqlSubscriptionTest.java
+++ b/graphql/src/test/java/feign/graphql/GraphqlSubscriptionTest.java
@@ -1,0 +1,420 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.Feign;
+import feign.jackson.JacksonCodec;
+import java.net.SocketTimeoutException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import okhttp3.Response;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class GraphqlSubscriptionTest {
+
+  private final ObjectMapper mapper =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  private MockWebServer server;
+
+  private final CountDownLatch closed = new CountDownLatch(1);
+  private boolean expectsWebSocket;
+
+  public static class Price {
+    public String symbol;
+    public double price;
+  }
+
+  interface StockApi {
+
+    @GraphqlQuery(
+        "subscription onPrice($symbol: String!) {"
+            + " priceChanged(symbol: $symbol) { symbol price } }")
+    Stream<Price> onPrice(String symbol);
+
+    @GraphqlQuery(
+        "subscription onPrice($symbol: String!) {"
+            + " priceChanged(symbol: $symbol) { symbol price } }")
+    Flow.Publisher<Price> publishPrice(String symbol);
+
+    // blocks until the first event, then unsubscribes
+    @GraphqlQuery(
+        "subscription onPrice($symbol: String!) {"
+            + " priceChanged(symbol: $symbol) { symbol price } }")
+    Price firstPrice(String symbol);
+
+    @GraphqlQuery(
+        "subscription onPrice($symbol: String!) {"
+            + " priceChanged(symbol: $symbol) { symbol price } }")
+    Optional<Price> maybeFirstPrice(String symbol);
+
+    @GraphqlQuery(
+        "subscription onPrice($symbol: String!) {"
+            + " priceChanged(symbol: $symbol) { symbol price } }")
+    CompletableFuture<Price> futurePrice(String symbol);
+
+    @GraphqlQuery(
+        "subscription onPrice($symbol: String!) {"
+            + " priceChanged(symbol: $symbol) { symbol price } }")
+    void ignoredPrice(String symbol);
+
+    // ordinary query on the same interface — goes over HTTP, not the web socket
+    @GraphqlQuery(
+        "query lastPrice($symbol: String!) { lastPrice(symbol: $symbol) { symbol price } }")
+    Price lastPrice(String symbol);
+  }
+
+  @BeforeEach
+  void setUp() throws Exception {
+    server = new MockWebServer();
+    server.start();
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    if (expectsWebSocket) {
+      assertThat(closed.await(10, TimeUnit.SECONDS))
+          .as("client should have closed the web socket")
+          .isTrue();
+    }
+    server.shutdown();
+  }
+
+  private StockApi buildClient() {
+    return Feign.builder()
+        .addCapability(new GraphqlCapability(new JacksonCodec(mapper)))
+        .target(StockApi.class, server.url("/graphql").toString());
+  }
+
+  /** {@code {id}} is replaced with the id the client actually subscribed with. */
+  private static final String NEXT =
+      "{\"id\":\"{id}\",\"type\":\"next\",\"payload\":{\"data\":{\"priceChanged\":"
+          + "{\"symbol\":\"%s\",\"price\":%s}}}}";
+
+  /** Replays the graphql-transport-ws handshake, then whatever the test queued. */
+  private void enqueueServer(List<String> received, String... afterSubscribe) {
+    expectsWebSocket = true;
+    server.enqueue(
+        new MockResponse()
+            .withWebSocketUpgrade(
+                new WebSocketListener() {
+                  @Override
+                  public void onMessage(WebSocket webSocket, String text) {
+                    received.add(text);
+                    try {
+                      var message = mapper.readTree(text);
+                      if ("connection_init".equals(message.get("type").asText())) {
+                        webSocket.send("{\"type\":\"connection_ack\"}");
+                      } else if ("subscribe".equals(message.get("type").asText())) {
+                        var id = message.get("id").asText();
+                        for (var queued : afterSubscribe) {
+                          webSocket.send(queued.replace("{id}", id));
+                        }
+                      }
+                    } catch (Exception e) {
+                      throw new IllegalStateException("bad client message: " + text, e);
+                    }
+                  }
+
+                  @Override
+                  public void onClosing(WebSocket webSocket, int code, String reason) {
+                    webSocket.close(code, reason);
+                    closed.countDown();
+                  }
+
+                  @Override
+                  public void onFailure(WebSocket webSocket, Throwable t, Response response) {
+                    closed.countDown();
+                  }
+                }));
+  }
+
+  @Test
+  void streamBlocksUntilEachEventArrives() throws Exception {
+    var received = new CopyOnWriteArrayList<String>();
+    enqueueServer(
+        received,
+        String.format(NEXT, "ACME", "10.5"),
+        String.format(NEXT, "ACME", "11.25"),
+        "{\"id\":\"{id}\",\"type\":\"complete\"}");
+
+    List<Price> prices;
+    try (var stream = buildClient().onPrice("ACME")) {
+      prices = stream.collect(Collectors.toList());
+    }
+
+    assertThat(prices).extracting(price -> price.symbol).containsExactly("ACME", "ACME");
+    assertThat(prices).extracting(price -> price.price).containsExactly(10.5, 11.25);
+
+    assertThat(mapper.readTree(received.get(0)).get("type").asText()).isEqualTo("connection_init");
+
+    var subscribe = mapper.readTree(received.get(1));
+    assertThat(subscribe.get("type").asText()).isEqualTo("subscribe");
+    assertThat(subscribe.get("payload").get("variables").get("symbol").asText()).isEqualTo("ACME");
+
+    var id = subscribe.get("id").asText();
+    assertThat(UUID.fromString(id)).hasToString(id);
+  }
+
+  @Test
+  void publisherReturnsImmediatelyAndPushes() throws Exception {
+    var received = new CopyOnWriteArrayList<String>();
+    enqueueServer(
+        received,
+        String.format(NEXT, "ACME", "10.5"),
+        String.format(NEXT, "ACME", "11.25"),
+        "{\"id\":\"{id}\",\"type\":\"complete\"}");
+
+    var publisher = buildClient().publishPrice("ACME");
+
+    var delivered = new ArrayList<Price>();
+    var completed = new CountDownLatch(1);
+    publisher.subscribe(
+        new Flow.Subscriber<Price>() {
+          @Override
+          public void onSubscribe(Flow.Subscription subscription) {
+            subscription.request(Long.MAX_VALUE);
+          }
+
+          @Override
+          public void onNext(Price item) {
+            delivered.add(item);
+          }
+
+          @Override
+          public void onError(Throwable throwable) {
+            completed.countDown();
+          }
+
+          @Override
+          public void onComplete() {
+            completed.countDown();
+          }
+        });
+
+    assertThat(completed.await(10, TimeUnit.SECONDS)).isTrue();
+    assertThat(delivered).extracting(price -> price.price).containsExactly(10.5, 11.25);
+  }
+
+  @Test
+  void serverErrorMessageFailsTheStream() {
+    var received = new CopyOnWriteArrayList<String>();
+    enqueueServer(
+        received,
+        "{\"id\":\"{id}\",\"type\":\"error\",\"payload\":[{\"message\":\"unknown symbol\"}]}");
+
+    try (var stream = buildClient().onPrice("NOPE")) {
+      assertThatThrownBy(stream::findFirst)
+          .isInstanceOf(GraphqlErrorException.class)
+          .hasMessageContaining("unknown symbol");
+    }
+  }
+
+  @Test
+  void errorsInsidePayloadFailTheStream() {
+    var received = new CopyOnWriteArrayList<String>();
+    enqueueServer(
+        received,
+        "{\"id\":\"{id}\",\"type\":\"next\",\"payload\":{\"errors\":[{\"message\":\"boom\"}]}}");
+
+    try (var stream = buildClient().onPrice("ACME")) {
+      assertThatThrownBy(stream::findFirst)
+          .isInstanceOf(GraphqlErrorException.class)
+          .hasMessageContaining("boom");
+    }
+  }
+
+  @Test
+  void plainReturnTypeBlocksForTheFirstEventOnly() {
+    var received = new CopyOnWriteArrayList<String>();
+    enqueueServer(received, String.format(NEXT, "ACME", "10.5"), String.format(NEXT, "ACME", "99"));
+
+    var price = buildClient().firstPrice("ACME");
+
+    assertThat(price.price).isEqualTo(10.5);
+  }
+
+  @Test
+  void optionalReturnTypeBlocksForTheFirstEvent() {
+    var received = new CopyOnWriteArrayList<String>();
+    enqueueServer(received, String.format(NEXT, "ACME", "10.5"));
+
+    assertThat(buildClient().maybeFirstPrice("ACME"))
+        .hasValueSatisfying(price -> assertThat(price.price).isEqualTo(10.5));
+  }
+
+  @Test
+  void optionalReturnTypeIsEmptyWhenTheServerCompletesWithoutEvents() {
+    var received = new CopyOnWriteArrayList<String>();
+    enqueueServer(received, "{\"id\":\"{id}\",\"type\":\"complete\"}");
+
+    assertThat(buildClient().maybeFirstPrice("ACME")).isEmpty();
+  }
+
+  @Test
+  void futureReturnsImmediatelyAndCompletesWithTheFirstEvent() throws Exception {
+    var received = new CopyOnWriteArrayList<String>();
+    enqueueServer(received, String.format(NEXT, "ACME", "10.5"));
+
+    var future = buildClient().futurePrice("ACME");
+
+    assertThat(future.get(10, TimeUnit.SECONDS).price).isEqualTo(10.5);
+  }
+
+  @Test
+  void voidReturnTypeClosesTheSubscription() {
+    var received = new CopyOnWriteArrayList<String>();
+    enqueueServer(received, String.format(NEXT, "ACME", "10.5"));
+
+    buildClient().ignoredPrice("ACME");
+    // tearDown asserts the socket was closed rather than leaked
+  }
+
+  @Test
+  void eventTimeoutBoundsBlockingCalls() {
+    var received = new CopyOnWriteArrayList<String>();
+    enqueueServer(received);
+
+    var api =
+        Feign.builder()
+            .addCapability(new GraphqlCapability(new JacksonCodec(mapper), Duration.ofMillis(250)))
+            .target(StockApi.class, server.url("/graphql").toString());
+
+    assertThatThrownBy(() -> api.firstPrice("ACME"))
+        .rootCause()
+        .isInstanceOf(SocketTimeoutException.class);
+  }
+
+  @Test
+  void eventTimeoutAlsoBoundsStreamElements() {
+    var received = new CopyOnWriteArrayList<String>();
+    enqueueServer(received, String.format(NEXT, "ACME", "10.5"));
+
+    var api =
+        Feign.builder()
+            .addCapability(new GraphqlCapability(new JacksonCodec(mapper), Duration.ofMillis(250)))
+            .target(StockApi.class, server.url("/graphql").toString());
+
+    try (var stream = api.onPrice("ACME")) {
+      // the server never completes, so the second element hits the timeout
+      assertThatThrownBy(stream::toList).rootCause().isInstanceOf(SocketTimeoutException.class);
+    }
+  }
+
+  @Test
+  void asyncFormsAreNotBoundedByTheEventTimeout() throws Exception {
+    var received = new CopyOnWriteArrayList<String>();
+    enqueueServer(received);
+
+    var api =
+        Feign.builder()
+            .addCapability(new GraphqlCapability(new JacksonCodec(mapper), Duration.ofMillis(100)))
+            .target(StockApi.class, server.url("/graphql").toString());
+
+    var future = api.futurePrice("ACME");
+
+    assertThatThrownBy(() -> future.get(500, TimeUnit.MILLISECONDS))
+        .isInstanceOf(TimeoutException.class);
+    assertThat(future).isNotCompleted();
+
+    // deliberately still waiting on the server, so there is no close to assert on
+    expectsWebSocket = false;
+  }
+
+  @Test
+  void queriesAndSubscriptionsShareOneClient() throws Exception {
+    server.enqueue(
+        new MockResponse()
+            .setBody("{\"data\":{\"lastPrice\":{\"symbol\":\"ACME\",\"price\":9.75}}}")
+            .addHeader("Content-Type", "application/json"));
+    var received = new CopyOnWriteArrayList<String>();
+    enqueueServer(
+        received, String.format(NEXT, "ACME", "10.5"), "{\"id\":\"{id}\",\"type\":\"complete\"}");
+
+    var api = buildClient();
+
+    assertThat(api.lastPrice("ACME").price).isEqualTo(9.75);
+    try (var stream = api.onPrice("ACME")) {
+      assertThat(stream.toList()).extracting(price -> price.price).containsExactly(10.5);
+    }
+
+    var query = server.takeRequest();
+    assertThat(query.getMethod()).isEqualTo("POST");
+    assertThat(query.getHeader("Upgrade")).isNull();
+
+    var handshake = server.takeRequest();
+    assertThat(handshake.getHeader("Upgrade")).isEqualToIgnoringCase("websocket");
+    assertThat(handshake.getHeader("Sec-WebSocket-Protocol")).contains("graphql-transport-ws");
+  }
+
+  @Test
+  void eventsForAnotherOperationAreIgnored() {
+    var received = new CopyOnWriteArrayList<String>();
+    enqueueServer(
+        received,
+        "{\"id\":\"someone-else\",\"type\":\"next\",\"payload\":{\"data\":{\"priceChanged\":"
+            + "{\"symbol\":\"NOPE\",\"price\":1}}}}",
+        String.format(NEXT, "ACME", "10.5"),
+        "{\"id\":\"{id}\",\"type\":\"complete\"}");
+
+    try (var stream = buildClient().onPrice("ACME")) {
+      assertThat(stream.toList()).extracting(price -> price.symbol).containsExactly("ACME");
+    }
+  }
+
+  @Test
+  void defaultEventTimeoutIsOneMinute() {
+    assertThat(GraphqlDecoder.DEFAULT_EVENT_TIMEOUT).isEqualTo(Duration.ofMinutes(1));
+  }
+
+  @Test
+  void subscriptionDetection() {
+    assertThat(GraphqlContract.isSubscription("subscription onPrice { a }")).isTrue();
+    assertThat(GraphqlContract.isSubscription("  \n subscription { a }")).isTrue();
+    assertThat(GraphqlContract.isSubscription("query subscriptionLike { a }")).isFalse();
+    assertThat(GraphqlContract.isSubscription("mutation m { a }")).isFalse();
+  }
+
+  @Test
+  void webSocketUriSwapsScheme() {
+    assertThat(GraphqlSubscriptionClient.webSocketUri("http://host:8080/graphql"))
+        .hasToString("ws://host:8080/graphql");
+    assertThat(GraphqlSubscriptionClient.webSocketUri("https://host/graphql"))
+        .hasToString("wss://host/graphql");
+  }
+}


### PR DESCRIPTION
`feign-graphql` could generate model types for a `subscription` document, but had no way to execute
one: the runtime was a single POST with a single JSON response. This adds the transport.

Three commits: the feature, then the concurrency hardening from a review pass, then the test that
covers it under concurrent load.

## Transport

`GraphqlSubscriptionClient` wraps the configured `Client`. Requests whose operation is a
`subscription` are executed over
[graphql-transport-ws](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md) using the
JDK's `java.net.http.WebSocket`; everything else is a straight `delegate.execute(...)`, so queries
and mutations keep their client, retryer, interceptors and timeouts unchanged. Queries and
subscriptions can share one interface.

No new dependencies. The endpoint is the target URL with its scheme swapped to `ws`/`wss`. Client
and server messages are records encoded and decoded through the configured `JsonCodec`, so no JSON
is hand-built; each record carries every component the protocol defines for its shape, which
matters because `new JacksonCodec()` uses a raw `ObjectMapper` with `FAIL_ON_UNKNOWN_PROPERTIES`
enabled.

## Return types

The declared return type picks how many events arrive and whether the call blocks:

| Return type | Events | Behaviour |
| --- | --- | --- |
| `T` | first only | blocks until the first event, then unsubscribes |
| `Optional<T>` | first only | as above, empty if the server completes without one |
| `CompletableFuture<T>` | first only | returns immediately, completes with the first event |
| `Stream<T>` | all | returns once subscribed, then blocks on each element |
| `Flow.Publisher<T>` | all | returns immediately, elements are pushed to the subscriber |

`Flow.Publisher` is `java.util.concurrent.Flow.Publisher`, so Reactor and RxJava adapt it without
adding a dependency here.

## Timeouts

`java.util.stream.Stream` has no timeout facility of its own, so the blocking forms are bounded by
an event timeout — 60s by default, overridable on the capability, `Duration.ZERO` waits forever:

```java
new GraphqlCapability(new JacksonCodec(), Duration.ofSeconds(5))
```

It applies per event rather than to the subscription as a whole, and raises
`SocketTimeoutException`. `Flow.Publisher` and `CompletableFuture` are deliberately unbounded by
it, since their caller already owns the deadline; cancelling either closes the socket.

## Concurrency and resource behaviour

- **Backpressure.** Reads are demand-driven: the client asks the socket for another frame only once
  the consumer has taken the previous event, so a slow consumer pushes back on the server rather
  than growing a queue. The queue is bounded as a backstop and fails loudly rather than silently.
- **Thread governance.** The workers behind `Flow.Publisher` and `CompletableFuture` run on a
  bounded daemon pool owned by the capability, injectable via a constructor. Nothing touches
  `ForkJoinPool.commonPool()`.
- **Cancellation.** Closing a `Stream`, cancelling a `Flow.Subscription` or cancelling a
  `CompletableFuture` all send `complete` and close the socket. `unsubscribe` is idempotent.
- **Send failures.** The serialized send chain reports a failed `sendText` to the consumer instead
  of poisoning the chain and silently dropping every later frame.

## Also fixed

- `GraphqlSchemaProcessor` only unwrapped `List` when deriving the result type name, so
  `Stream<Price>` would have generated a record named `Stream`. It now unwraps `List`, `Stream` and
  `Publisher` from one shared set.
- `GraphqlDecoder` now shares one `unwrap` between HTTP responses and subscription payloads, so
  `data` unwrapping and `errors` → `GraphqlErrorException` behave identically on both paths.

## Notes for review

- The subscription pseudo-response uses status 204 so feign's logger does not drain and replace the
  body, which would drop the live subscription. It never crosses the wire.
- `Response.Body.close()` tears down any subscription the decoder did not take ownership of, which
  covers `void` methods (never decoded) rather than leaking the socket.
- One connection per subscription; multiplexing several over one socket is not implemented.
- The WebSocket uses a JDK `HttpClient`, so custom SSL/proxy config on an OkHttp or Apache client
  does not carry over — only request headers do.
- MDC and other `ThreadLocal` context are not propagated to the asynchronous forms' workers. No
  context is set, so nothing leaks, but logging from a `Flow.Publisher` or `CompletableFuture`
  subscription loses correlation ids. A propagation hook belongs in feign core rather than here.

## Testing

`mvn install` green: 73 tests in `feign-graphql`, 65 in `feign-graphql-apt`.

`GraphqlSubscriptionTest` (19) covers each return type, the handshake, server `error` messages and
`errors` inside payloads, the event timeout on both blocking forms, async forms staying unbounded,
messages for another operation being ignored, socket teardown on every path including `void`, and
queries plus subscriptions sharing one client.

`GraphqlSubscriptionConcurrencyTest` (3) opens 24 subscriptions simultaneously on their own sockets,
sharing one capability, one `ObjectMapper` and one worker pool: stream isolation, publisher
delivery, and abandoning a stream mid-flight while the server is still pushing.

Two of the new tests were mutation-checked rather than trusted for being green — removing the
demand call stalls the slow-consumer test, and making the event queue static fails the isolation
test.
