### PR TITLE
Skip synthetic/bridge methods in BaseContract parsing

### DIFF
--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -60,7 +60,9 @@ public interface Contract {
         if (method.getDeclaringClass() == Object.class
             || (method.getModifiers() & Modifier.STATIC) != 0
             || Util.isDefault(method)
-            || method.isAnnotationPresent(FeignIgnore.class)) {
+            || method.isAnnotationPresent(FeignIgnore.class)
+            || method.isSynthetic()
+            || method.isBridge()) {
           continue;
         }
         final MethodMetadata metadata = parseAndValidateMetadata(targetType, method);


### PR DESCRIPTION
## Summary

`Contract.BaseContract.parseAndValidateMetadata` walks `Class.getMethods()` but did not skip compiler-generated methods. Covariant overrides produce synthetic bridge methods without HTTP annotations, which then fail with `Method … not annotated with HTTP method type`.

This skips `isSynthetic()` / `isBridge()` methods in that loop so inheritance cases like `overrideParameterizedApiSupported` and `multipleInheritanceDoneCorrectly2` parse cleanly.

## Related

Fixes the remaining `DefaultContractInheritanceTest` failures from #2752 (JUL/`MultipleLoggerTest` side is handled separately).

## Test plan

- [x] `mvn test -pl core -Dtest=DefaultContractInheritanceTest` (9 tests, 0 failures)
- [ ] Confirm CI green on this PR