### PR TITLE
Skip bridge methods in contract parsing and map them for dispatch

### DIFF
--- a/core/src/main/java/feign/Contract.java
+++ b/core/src/main/java/feign/Contract.java
@@ -60,7 +60,9 @@ public interface Contract {
         if (method.getDeclaringClass() == Object.class
             || (method.getModifiers() & Modifier.STATIC) != 0
             || Util.isDefault(method)
-            || method.isAnnotationPresent(FeignIgnore.class)) {
+            || method.isAnnotationPresent(FeignIgnore.class)
+            || method.isSynthetic()
+            || method.isBridge()) {
           continue;
         }
         final MethodMetadata metadata = parseAndValidateMetadata(targetType, method);

--- a/core/src/main/java/feign/ReflectiveFeign.java
+++ b/core/src/main/java/feign/ReflectiveFeign.java
@@ -155,7 +155,65 @@ public class ReflectiveFeign<C> extends Feign {
         }
       }
 
+      for (Method method : target.type().getMethods()) {
+        if (!method.isBridge()) {
+          continue;
+        }
+        Method bridged = resolveBridgedMethod(method);
+        MethodHandler handler = result.get(bridged);
+        if (handler != null) {
+          result.put(method, handler);
+        }
+      }
+
       return result;
+    }
+
+    static Method resolveBridgedMethod(Method bridgeMethod) {
+      Method matched = null;
+      Class<?>[] bridgeParams = bridgeMethod.getParameterTypes();
+      for (Method candidate : bridgeMethod.getDeclaringClass().getDeclaredMethods()) {
+        if (candidate.isBridge()
+            || candidate.isSynthetic()
+            || !candidate.getName().equals(bridgeMethod.getName())
+            || candidate.getParameterCount() != bridgeParams.length) {
+          continue;
+        }
+        Class<?>[] candidateParams = candidate.getParameterTypes();
+        boolean paramsMatch = true;
+        for (int i = 0; i < bridgeParams.length; i++) {
+          if (!bridgeParams[i].isAssignableFrom(candidateParams[i])) {
+            paramsMatch = false;
+            break;
+          }
+        }
+        if (!paramsMatch) {
+          continue;
+        }
+        Class<?> bridgeReturn = bridgeMethod.getReturnType();
+        Class<?> candidateReturn = candidate.getReturnType();
+        if (bridgeReturn != void.class && !bridgeReturn.isAssignableFrom(candidateReturn)) {
+          continue;
+        }
+        if (matched == null || isMoreSpecific(candidate, matched)) {
+          matched = candidate;
+        }
+      }
+      return matched != null ? matched : bridgeMethod;
+    }
+
+    private static boolean isMoreSpecific(Method candidate, Method current) {
+      Class<?>[] candidateParams = candidate.getParameterTypes();
+      Class<?>[] currentParams = current.getParameterTypes();
+      for (int i = 0; i < candidateParams.length; i++) {
+        if (candidateParams[i] != currentParams[i]
+            && currentParams[i].isAssignableFrom(candidateParams[i])) {
+          return true;
+        }
+      }
+      Class<?> candidateReturn = candidate.getReturnType();
+      Class<?> currentReturn = current.getReturnType();
+      return candidateReturn != currentReturn && currentReturn.isAssignableFrom(candidateReturn);
     }
 
     private MethodHandler createMethodHandler(

--- a/core/src/test/java/feign/BridgeMethodTest.java
+++ b/core/src/test/java/feign/BridgeMethodTest.java
@@ -37,8 +37,7 @@ class BridgeMethodTest {
 
   @Test
   void contractSkipsBridgeMethodsFromGenericOverride() {
-    List<MethodMetadata> metadata =
-        new Contract.Default().parseAndValidateMetadata(UserApi.class);
+    List<MethodMetadata> metadata = new Contract.Default().parseAndValidateMetadata(UserApi.class);
 
     assertThat(metadata).hasSize(1);
     assertThat(metadata.get(0).configKey()).isEqualTo("UserApi#get(String)");

--- a/core/src/test/java/feign/BridgeMethodTest.java
+++ b/core/src/test/java/feign/BridgeMethodTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2012 The Feign Authors (feign@commonhaus.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign;
+
+import static feign.assertj.FeignAssertions.assertThat;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class BridgeMethodTest {
+
+  interface CrudApi<T> {
+    @RequestLine("GET /items/{id}")
+    String get(@Param("id") T id);
+  }
+
+  interface UserApi extends CrudApi<String> {
+    @Override
+    @RequestLine("GET /users/{id}")
+    String get(@Param("id") String id);
+  }
+
+  @Test
+  void contractSkipsBridgeMethodsFromGenericOverride() {
+    List<MethodMetadata> metadata =
+        new Contract.Default().parseAndValidateMetadata(UserApi.class);
+
+    assertThat(metadata).hasSize(1);
+    assertThat(metadata.get(0).configKey()).isEqualTo("UserApi#get(String)");
+    assertThat(metadata.get(0).template()).hasMethod("GET").hasUrl("/users/{id}");
+  }
+
+  @Test
+  void callsThroughGenericSuperInterfaceUseBridgedHandler() {
+    AtomicReference<Request> captured = new AtomicReference<>();
+
+    CrudApi<String> api =
+        (CrudApi<String>)
+            Feign.builder()
+                .client(
+                    (request, options) -> {
+                      captured.set(request);
+                      return Response.builder()
+                          .status(200)
+                          .reason("OK")
+                          .request(request)
+                          .headers(Collections.emptyMap())
+                          .body("ok", Util.UTF_8)
+                          .build();
+                    })
+                .target(UserApi.class, "http://localhost:1");
+
+    assertThat(api.get("1")).isEqualTo("ok");
+    assertThat(captured.get().url()).isEqualTo("http://localhost:1/users/1");
+  }
+}


### PR DESCRIPTION
## Summary

`Contract.BaseContract.parseAndValidateMetadata` walks `Class.getMethods()` and previously tried to parse compiler-generated bridge/synthetic methods. This PR skips those during contract parsing.

Skipping bridges alone is not enough: when a call arrives through a generic super-interface (erased signature), the JDK proxy dispatches on the bridge `Method`. `ReflectiveFeign` now maps each bridge method onto the handler of the method it bridges to, so those calls still resolve.

## Changes

- Skip `isSynthetic()` / `isBridge()` methods in `BaseContract.parseAndValidateMetadata`
- In `ReflectiveFeign.ParseHandlersByName`, resolve bridge methods to their bridged targets and reuse that handler in the dispatch map
- Add `BridgeMethodTest` covering:
  - contract metadata excludes the erased bridge (`UserApi#get(Object)`)
  - `CrudApi<String>` calls through a `UserApi` target still dispatch (the regression called out in review)

## Test plan

- [x] `mvn test -pl core -Dtest=BridgeMethodTest,DefaultContractInheritanceTest`
- [ ] Confirm CI green on this PR

Fixes #2752