### PR TITLE
Apply JAXB factory properties when creating unmarshallers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Version 13.14
 
+* `JAXBContextFactory.withProperty` is now applied when creating Unmarshallers, not only
+  Marshallers. Marshaller-only properties are skipped on unmarshal (#3056).
 * Add support for the HTTP QUERY method (RFC 10008) — safe, idempotent, and cacheable with a
   request body. `HttpCacheInterceptor` includes QUERY in its default cacheable set and
   incorporates a body hash into the cache key to reduce cross-body collisions.

--- a/jaxb-jakarta/src/main/java/feign/jaxb/JAXBContextFactory.java
+++ b/jaxb-jakarta/src/main/java/feign/jaxb/JAXBContextFactory.java
@@ -66,6 +66,7 @@ public final class JAXBContextFactory {
   /** Creates a new {@link jakarta.xml.bind.Unmarshaller} that handles the supplied class. */
   public Unmarshaller createUnmarshaller(Class<?> clazz) throws JAXBException {
     Unmarshaller unmarshaller = getContext(clazz).createUnmarshaller();
+    setUnmarshallerProperties(unmarshaller);
     if (unmarshallerEventHandler != null) {
       unmarshaller.setEventHandler(unmarshallerEventHandler);
     }
@@ -87,6 +88,16 @@ public final class JAXBContextFactory {
   private void setMarshallerProperties(Marshaller marshaller) throws PropertyException {
     for (Entry<String, Object> en : properties.entrySet()) {
       marshaller.setProperty(en.getKey(), en.getValue());
+    }
+  }
+
+  private void setUnmarshallerProperties(Unmarshaller unmarshaller) {
+    for (Entry<String, Object> en : properties.entrySet()) {
+      try {
+        unmarshaller.setProperty(en.getKey(), en.getValue());
+      } catch (PropertyException ignored) {
+        // The same map holds marshaller-only properties (for example JAXB_FORMATTED_OUTPUT).
+      }
     }
   }
 
@@ -164,7 +175,8 @@ public final class JAXBContextFactory {
     }
 
     /**
-     * Sets the given property of any Marshaller created by this factory.
+     * Sets the given property of any Marshaller or Unmarshaller created by this factory.
+     * Marshaller-only properties are ignored when creating an Unmarshaller.
      *
      * <p>Example : <br>
      * <br>

--- a/jaxb-jakarta/src/test/java/feign/jaxb/JAXBCodecTest.java
+++ b/jaxb-jakarta/src/test/java/feign/jaxb/JAXBCodecTest.java
@@ -30,6 +30,7 @@ import feign.codec.EncodeException;
 import feign.codec.Encoder;
 import jakarta.xml.bind.MarshalException;
 import jakarta.xml.bind.UnmarshalException;
+import jakarta.xml.bind.ValidationEventHandler;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
@@ -40,10 +41,13 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.xml.XMLConstants;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
+import org.glassfish.jaxb.runtime.IDResolver;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation")
@@ -208,6 +212,54 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\
     JAXBDecoder decoder = new JAXBDecoder(new JAXBContextFactory.Builder().build());
 
     assertThat(decoder.decode(response, MockObject.class)).isEqualTo(mock);
+  }
+
+  @Test
+  void decodesXmlUsingFactoryProperty() throws Exception {
+    MockObject mock = new MockObject();
+    mock.value = "Test";
+
+    String mockXml =
+        """
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?><mockObject>\
+        <value>Test</value></mockObject>\
+        """;
+
+    Response response =
+        Response.builder()
+            .status(200)
+            .reason("OK")
+            .request(
+                Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+            .headers(Collections.emptyMap())
+            .body(mockXml, UTF_8)
+            .build();
+
+    AtomicBoolean started = new AtomicBoolean();
+    IDResolver resolver =
+        new IDResolver() {
+          @Override
+          public void startDocument(ValidationEventHandler eventHandler) {
+            started.set(true);
+          }
+
+          @Override
+          public void bind(String id, Object obj) {}
+
+          @Override
+          public Callable<?> resolve(String id, Class targetType) {
+            return () -> null;
+          }
+        };
+
+    JAXBContextFactory factory =
+        new JAXBContextFactory.Builder()
+            .withMarshallerFormattedOutput(true)
+            .withProperty(IDResolver.class.getName(), resolver)
+            .build();
+
+    assertThat(new JAXBDecoder(factory).decode(response, MockObject.class)).isEqualTo(mock);
+    assertThat(started).isTrue();
   }
 
   @Test

--- a/jaxb-jakarta/src/test/java/feign/jaxb/JAXBContextFactoryTest.java
+++ b/jaxb-jakarta/src/test/java/feign/jaxb/JAXBContextFactoryTest.java
@@ -26,9 +26,11 @@ import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import javax.xml.XMLConstants;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
+import org.glassfish.jaxb.runtime.IDResolver;
 import org.junit.jupiter.api.Test;
 
 class JAXBContextFactoryTest {
@@ -92,6 +94,34 @@ class JAXBContextFactoryTest {
 
     Marshaller marshaller = factory.createMarshaller(Object.class);
     assertThat(marshaller.getSchema()).isSameAs(schema);
+  }
+
+  @Test
+  void buildsUnmarshallerWithProperty() throws Exception {
+    IDResolver resolver =
+        new IDResolver() {
+          @Override
+          public void bind(String id, Object obj) {}
+
+          @Override
+          public Callable<?> resolve(String id, Class targetType) {
+            return () -> null;
+          }
+        };
+    JAXBContextFactory factory =
+        new JAXBContextFactory.Builder().withProperty(IDResolver.class.getName(), resolver).build();
+
+    Unmarshaller unmarshaller = factory.createUnmarshaller(Object.class);
+    assertThat(unmarshaller.getProperty(IDResolver.class.getName())).isSameAs(resolver);
+  }
+
+  @Test
+  void buildsUnmarshallerWhenFactoryHasMarshallerProperties() throws Exception {
+    JAXBContextFactory factory =
+        new JAXBContextFactory.Builder().withMarshallerFormattedOutput(true).build();
+
+    Unmarshaller unmarshaller = factory.createUnmarshaller(Object.class);
+    assertThat(unmarshaller).isNotNull();
   }
 
   @Test

--- a/jaxb/src/main/java/feign/jaxb/JAXBContextFactory.java
+++ b/jaxb/src/main/java/feign/jaxb/JAXBContextFactory.java
@@ -66,6 +66,7 @@ public final class JAXBContextFactory {
   /** Creates a new {@link javax.xml.bind.Unmarshaller} that handles the supplied class. */
   public Unmarshaller createUnmarshaller(Class<?> clazz) throws JAXBException {
     Unmarshaller unmarshaller = getContext(clazz).createUnmarshaller();
+    setUnmarshallerProperties(unmarshaller);
     if (unmarshallerEventHandler != null) {
       unmarshaller.setEventHandler(unmarshallerEventHandler);
     }
@@ -87,6 +88,16 @@ public final class JAXBContextFactory {
   private void setMarshallerProperties(Marshaller marshaller) throws PropertyException {
     for (Entry<String, Object> en : properties.entrySet()) {
       marshaller.setProperty(en.getKey(), en.getValue());
+    }
+  }
+
+  private void setUnmarshallerProperties(Unmarshaller unmarshaller) {
+    for (Entry<String, Object> en : properties.entrySet()) {
+      try {
+        unmarshaller.setProperty(en.getKey(), en.getValue());
+      } catch (PropertyException ignored) {
+        // The same map holds marshaller-only properties (for example JAXB_FORMATTED_OUTPUT).
+      }
     }
   }
 
@@ -164,7 +175,8 @@ public final class JAXBContextFactory {
     }
 
     /**
-     * Sets the given property of any Marshaller created by this factory.
+     * Sets the given property of any Marshaller or Unmarshaller created by this factory.
+     * Marshaller-only properties are ignored when creating an Unmarshaller.
      *
      * <p>Example : <br>
      * <br>

--- a/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
+++ b/jaxb/src/test/java/feign/jaxb/JAXBCodecTest.java
@@ -20,6 +20,7 @@ import static feign.assertj.FeignAssertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.sun.xml.bind.IDResolver;
 import feign.Request;
 import feign.Request.HttpMethod;
 import feign.RequestTemplate;
@@ -34,6 +35,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.xml.XMLConstants;
 import javax.xml.bind.MarshalException;
 import javax.xml.bind.UnmarshalException;
@@ -208,6 +210,54 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\
     JAXBDecoder decoder = new JAXBDecoder(new JAXBContextFactory.Builder().build());
 
     assertThat(decoder.decode(response, MockObject.class)).isEqualTo(mock);
+  }
+
+  @Test
+  void decodesXmlUsingFactoryProperty() throws Exception {
+    MockObject mock = new MockObject();
+    mock.value = "Test";
+
+    String mockXml =
+        """
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?><mockObject>\
+        <value>Test</value></mockObject>\
+        """;
+
+    Response response =
+        Response.builder()
+            .status(200)
+            .reason("OK")
+            .request(
+                Request.create(HttpMethod.GET, "/api", Collections.emptyMap(), null, Util.UTF_8))
+            .headers(Collections.emptyMap())
+            .body(mockXml, UTF_8)
+            .build();
+
+    AtomicBoolean started = new AtomicBoolean();
+    IDResolver resolver =
+        new IDResolver() {
+          @Override
+          public void startDocument(javax.xml.bind.ValidationEventHandler eventHandler) {
+            started.set(true);
+          }
+
+          @Override
+          public void bind(String id, Object obj) {}
+
+          @Override
+          public java.util.concurrent.Callable<?> resolve(String id, Class targetType) {
+            return () -> null;
+          }
+        };
+
+    JAXBContextFactory factory =
+        new JAXBContextFactory.Builder()
+            .withMarshallerFormattedOutput(true)
+            .withProperty(IDResolver.class.getName(), resolver)
+            .build();
+
+    assertThat(new JAXBDecoder(factory).decode(response, MockObject.class)).isEqualTo(mock);
+    assertThat(started).isTrue();
   }
 
   @Test

--- a/jaxb/src/test/java/feign/jaxb/JAXBContextFactoryTest.java
+++ b/jaxb/src/test/java/feign/jaxb/JAXBContextFactoryTest.java
@@ -17,12 +17,14 @@ package feign.jaxb;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.sun.xml.bind.IDResolver;
 import feign.jaxb.mock.onepackage.AnotherMockedJAXBObject;
 import feign.jaxb.mock.onepackage.MockedJAXBObject;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import javax.xml.XMLConstants;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
@@ -92,6 +94,34 @@ class JAXBContextFactoryTest {
 
     Marshaller marshaller = factory.createMarshaller(Object.class);
     assertThat(marshaller.getSchema()).isSameAs(schema);
+  }
+
+  @Test
+  void buildsUnmarshallerWithProperty() throws Exception {
+    IDResolver resolver =
+        new IDResolver() {
+          @Override
+          public void bind(String id, Object obj) {}
+
+          @Override
+          public Callable<?> resolve(String id, Class targetType) {
+            return () -> null;
+          }
+        };
+    JAXBContextFactory factory =
+        new JAXBContextFactory.Builder().withProperty(IDResolver.class.getName(), resolver).build();
+
+    Unmarshaller unmarshaller = factory.createUnmarshaller(Object.class);
+    assertThat(unmarshaller.getProperty(IDResolver.class.getName())).isSameAs(resolver);
+  }
+
+  @Test
+  void buildsUnmarshallerWhenFactoryHasMarshallerProperties() throws Exception {
+    JAXBContextFactory factory =
+        new JAXBContextFactory.Builder().withMarshallerFormattedOutput(true).build();
+
+    Unmarshaller unmarshaller = factory.createUnmarshaller(Object.class);
+    assertThat(unmarshaller).isNotNull();
   }
 
   @Test


### PR DESCRIPTION
## What
`JAXBContextFactory.withProperty` was applied when creating a `Marshaller` (`JAXBEncoder`) but not when creating an `Unmarshaller` (`JAXBDecoder`). Sharing one factory for encode and decode therefore dropped factory properties on unmarshal.

## How
- Apply the same factory property map in `createUnmarshaller` in both `jaxb` and `jaxb-jakarta`.
- Skip properties the unmarshaller rejects (`PropertyException`) so existing `withMarshaller*` helpers (for example `JAXB_FORMATTED_OUTPUT`) still work when the same factory is used to decode.
- Document the behavior on `Builder.withProperty`.

## Testing
```
mvn -pl jaxb -am test -Dsurefire.failIfNoSpecifiedTests=false
mvn -pl jaxb-jakarta -am test -Dtest=JAXBContextFactoryTest,JAXBCodecTest -Dsurefire.failIfNoSpecifiedTests=false
```
- `feign-jaxb`: Tests run: 32, Failures: 0, Errors: 0, Skipped: 0
- `feign-jaxb-jakarta`: Tests run: 32, Failures: 0, Errors: 0, Skipped: 0

Regression coverage:
- `buildsUnmarshallerWithProperty` — `withProperty` is visible on the created unmarshaller
- `decodesXmlUsingFactoryProperty` — the property is used during unmarshal (`IDResolver.startDocument`)
- `buildsUnmarshallerWhenFactoryHasMarshallerProperties` — marshaller-only keys do not break unmarshaller creation

Fixes #3056

Made with [Cursor](https://cursor.com)