### PR TITLE
Decode every root field of a GraphQL operation

### DIFF
--- a/graphql-apt/README.md
+++ b/graphql-apt/README.md
@@ -56,6 +56,29 @@ public record CharByRegion(String id, Location location) {
 }
 ```
 
+### Multiple root fields
+
+An operation selecting several root fields gets a record with one component per field, mirroring the operation's own selection set rather than a single field's type:
+
+```graphql
+query authorPage($authorId: ID!) {
+  books(authorId: $authorId) { id title }
+  reviews(authorId: $authorId) { id rating }
+}
+```
+
+```java
+public record AuthorPage(Optional<List<Books>> books, Optional<List<Reviews>> reviews) {
+
+  public record Books(String id, String title) {}
+
+  public record Reviews(String id, Integer rating) {}
+
+}
+```
+
+With a single root field the record still mirrors that field's type, so `{ character(id: "1") { id name } }` keeps generating `record CharacterResult(String id, String name)`.
+
 ### Conflicting return type error
 
 If two queries use the same return type name but select different fields, the processor reports compilation errors on both methods showing which fields each selects:

--- a/graphql-apt/src/main/java/feign/graphql/apt/GraphqlSchemaProcessor.java
+++ b/graphql-apt/src/main/java/feign/graphql/apt/GraphqlSchemaProcessor.java
@@ -247,22 +247,7 @@ public class GraphqlSchemaProcessor extends AbstractProcessor {
 
     var returnTypeName = getSimpleTypeName(method.getReturnType());
     if (returnTypeName != null && !isExistingExternalType(method.getReturnType(), targetPackage)) {
-      var rootType = getRootType(operation, registry);
-      if (rootType != null) {
-        var rootField = findRootField(operation.getSelectionSet());
-        if (rootField != null && rootField.getSelectionSet() != null) {
-          var rootFieldDef = GraphqlTypeMapper.findFieldDefinition(rootType, rootField.getName());
-          if (rootFieldDef != null) {
-            var fieldTypeName = GraphqlTypeMapper.unwrapTypeName(rootFieldDef.getType());
-            var fieldObjectType =
-                registry.getType(fieldTypeName, ObjectTypeDefinition.class).orElse(null);
-            if (fieldObjectType != null) {
-              generator.generateResultType(
-                  returnTypeName, rootField.getSelectionSet(), fieldObjectType, method);
-            }
-          }
-        }
-      }
+      generateReturnType(returnTypeName, operation, registry, generator, method);
     }
 
     var params = method.getParameters();
@@ -294,16 +279,58 @@ public class GraphqlSchemaProcessor extends AbstractProcessor {
     return null;
   }
 
-  private Field findRootField(SelectionSet selectionSet) {
+  /**
+   * A single root field is the operation result itself, so the record mirrors that field's type.
+   * Several root fields are all part of the result — the decoder binds the whole {@code data} map —
+   * so the record mirrors the operation's own selection set, one component per root field.
+   */
+  private void generateReturnType(
+      String returnTypeName,
+      OperationDefinition operation,
+      TypeDefinitionRegistry registry,
+      TypeGenerator generator,
+      ExecutableElement method) {
+    var rootType = getRootType(operation, registry);
+    if (rootType == null) {
+      return;
+    }
+
+    var rootFields = rootFields(operation.getSelectionSet());
+    if (rootFields.size() > 1) {
+      generator.generateResultType(returnTypeName, operation.getSelectionSet(), rootType, method);
+      return;
+    }
+
+    if (rootFields.isEmpty()) {
+      return;
+    }
+
+    var rootField = rootFields.get(0);
+    if (rootField.getSelectionSet() == null) {
+      return;
+    }
+
+    var rootFieldDef = GraphqlTypeMapper.findFieldDefinition(rootType, rootField.getName());
+    if (rootFieldDef == null) {
+      return;
+    }
+
+    var fieldTypeName = GraphqlTypeMapper.unwrapTypeName(rootFieldDef.getType());
+    var fieldObjectType = registry.getType(fieldTypeName, ObjectTypeDefinition.class).orElse(null);
+    if (fieldObjectType != null) {
+      generator.generateResultType(
+          returnTypeName, rootField.getSelectionSet(), fieldObjectType, method);
+    }
+  }
+
+  private List<Field> rootFields(SelectionSet selectionSet) {
     if (selectionSet == null) {
-      return null;
+      return List.of();
     }
-    for (var selection : selectionSet.getSelections()) {
-      if (selection instanceof Field field) {
-        return field;
-      }
-    }
-    return null;
+    return selectionSet.getSelections().stream()
+        .filter(Field.class::isInstance)
+        .map(Field.class::cast)
+        .toList();
   }
 
   private ObjectTypeDefinition getRootType(

--- a/graphql-apt/src/test/java/feign/graphql/apt/GraphqlSchemaProcessorTest.java
+++ b/graphql-apt/src/test/java/feign/graphql/apt/GraphqlSchemaProcessorTest.java
@@ -636,6 +636,102 @@ class GraphqlSchemaProcessorTest {
   }
 
   @Test
+  void multipleRootFieldsGenerateOneComponentPerField() {
+    var source =
+        JavaFileObjects.forSourceString(
+            "test.MultiRootApi",
+            """
+            package test;
+
+            import feign.graphql.GraphqlSchema;
+            import feign.graphql.GraphqlQuery;
+
+            @GraphqlSchema("test-schema.graphql")
+            interface MultiRootApi {
+              @GraphqlQuery(\"""
+                  query overview($id: ID!) {
+                    character(id: $id) { id name }
+                    starship(id: $id) { id name }
+                  }\""")
+              Overview overview(String id);
+            }
+            """);
+
+    var compilation = javac().withProcessors(new GraphqlSchemaProcessor()).compile(source);
+
+    assertThat(compilation).succeeded();
+
+    var contents =
+        assertThat(compilation).generatedSourceFile("test.Overview").contentsAsUtf8String();
+
+    contents.contains(
+        "public record Overview(Optional<Character> character, Optional<Starship> starship) {");
+    contents.contains("public record Character(String id, String name) {}");
+    contents.contains("public record Starship(String id, String name) {}");
+  }
+
+  @Test
+  void multipleRootFieldsKeepListAndScalarShapes() {
+    var source =
+        JavaFileObjects.forSourceString(
+            "test.MultiRootListApi",
+            """
+            package test;
+
+            import feign.graphql.GraphqlSchema;
+            import feign.graphql.GraphqlQuery;
+
+            @GraphqlSchema("test-schema.graphql")
+            interface MultiRootListApi {
+              @GraphqlQuery(\"""
+                  query page($id: ID!) {
+                    characters { id name }
+                    starship(id: $id) { id name }
+                  }\""")
+              Page page(String id);
+            }
+            """);
+
+    var compilation = javac().withProcessors(new GraphqlSchemaProcessor()).compile(source);
+
+    assertThat(compilation).succeeded();
+
+    var contents = assertThat(compilation).generatedSourceFile("test.Page").contentsAsUtf8String();
+
+    contents.contains(
+        "public record Page(Optional<List<Characters>> characters, Optional<Starship> starship) {");
+    contents.contains("public record Characters(String id, String name) {}");
+  }
+
+  @Test
+  void singleRootFieldStillMirrorsThatFieldType() {
+    var source =
+        JavaFileObjects.forSourceString(
+            "test.SingleRootApi",
+            """
+            package test;
+
+            import feign.graphql.GraphqlSchema;
+            import feign.graphql.GraphqlQuery;
+
+            @GraphqlSchema("test-schema.graphql")
+            interface SingleRootApi {
+              @GraphqlQuery("query one($id: ID!) { character(id: $id) { id name } }")
+              One one(String id);
+            }
+            """);
+
+    var compilation = javac().withProcessors(new GraphqlSchemaProcessor()).compile(source);
+
+    assertThat(compilation).succeeded();
+
+    assertThat(compilation)
+        .generatedSourceFile("test.One")
+        .contentsAsUtf8String()
+        .contains("public record One(String id, String name) {}");
+  }
+
+  @Test
   void differentQueriesDifferentNestedFields() {
     var source =
         JavaFileObjects.forSourceString(

--- a/graphql/README.md
+++ b/graphql/README.md
@@ -215,6 +215,40 @@ The processor maps `DateTime` fields to `java.time.Instant` in the generated rec
 public record Event(String id, String name, Instant startTime) {}
 ```
 
+## Multiple Root Fields
+
+A single operation can select more than one root field, and all of them are decoded — one round trip instead of one call per field:
+
+```java
+@GraphqlQuery("""
+    query authorPage($authorId: ID!) {
+      books(authorId: $authorId) { id title }
+      reviews(authorId: $authorId) { id rating }
+    }
+    """)
+AuthorPage authorPage(String authorId);
+```
+
+The processor generates a record with one component per root field, each with its own inner record:
+
+```java
+public record AuthorPage(Optional<List<Books>> books, Optional<List<Reviews>> reviews) {
+
+  public record Books(String id, String title) {}
+
+  public record Reviews(String id, Integer rating) {}
+
+}
+```
+
+When the response carries several root fields the whole `data` map binds to the return type, so every field lands on its matching component:
+
+```json
+{"data": {"books": [...], "reviews": [...]}}
+```
+
+Operations with a single root field are unaffected: that field is still unwrapped and decoded into the return type directly.
+
 ## Single Result from Array Queries
 
 When a GraphQL query returns an array type (e.g. `[User!]`) but the Java method declares a single return type, the decoder automatically unwraps the first element:

--- a/graphql/src/main/java/feign/graphql/GraphqlDecoder.java
+++ b/graphql/src/main/java/feign/graphql/GraphqlDecoder.java
@@ -113,13 +113,17 @@ public class GraphqlDecoder implements Decoder {
     }
 
     var dataMap = (Map<String, Object>) data;
-    var fieldNames = dataMap.keySet().iterator();
-    if (!fieldNames.hasNext()) {
+    if (dataMap.isEmpty()) {
       return Util.emptyValueOf(type);
     }
 
-    var firstField = fieldNames.next();
-    var operationData = dataMap.get(firstField);
+    // A single root field is the operation result itself; several root fields are its components,
+    // so the whole data map binds to the return type and no field gets dropped.
+    if (dataMap.size() > 1) {
+      return jsonDecoder.convert(dataMap, type);
+    }
+
+    var operationData = dataMap.values().iterator().next();
     if (operationData == null) {
       return Util.emptyValueOf(type);
     }

--- a/graphql/src/test/java/feign/graphql/GraphqlClientTest.java
+++ b/graphql/src/test/java/feign/graphql/GraphqlClientTest.java
@@ -55,6 +55,12 @@ class GraphqlClientTest {
     public String name;
   }
 
+  public record Book(String id, String title) {}
+
+  public record Review(String id, Integer rating) {}
+
+  public record AuthorPage(List<Book> books, List<Review> reviews) {}
+
   @Headers("Content-Type: application/json")
   interface TestApi {
 
@@ -78,6 +84,12 @@ class GraphqlClientTest {
 
     @GraphqlQuery("query topUser($limit: Int!) {" + " topUsers(limit: $limit) { id name email } }")
     User topUser(int limit);
+
+    @GraphqlQuery(
+        "query authorPage($authorId: ID!) {"
+            + " books(authorId: $authorId) { id title }"
+            + " reviews(authorId: $authorId) { id rating } }")
+    AuthorPage authorPage(String authorId);
   }
 
   @BeforeEach
@@ -213,6 +225,27 @@ class GraphqlClientTest {
     var user = buildClient().findUser("999");
 
     assertThat(user).isEmpty();
+  }
+
+  @Test
+  void multipleRootFieldsDecodedIntoSingleResult() throws Exception {
+    server.enqueue(
+        new MockResponse()
+            .setBody(
+                "{\"data\":{\"books\":[{\"id\":\"1\",\"title\":\"Dune\"}],"
+                    + "\"reviews\":[{\"id\":\"9\",\"rating\":5}]}}")
+            .addHeader("Content-Type", "application/json"));
+
+    var page = buildClient().authorPage("42");
+
+    assertThat(page.books()).hasSize(1);
+    assertThat(page.books().getFirst().title()).isEqualTo("Dune");
+    assertThat(page.reviews()).hasSize(1);
+    assertThat(page.reviews().getFirst().rating()).isEqualTo(5);
+
+    var recorded = server.takeRequest();
+    var body = mapper.readTree(recorded.getBody().readUtf8());
+    assertThat(body.get("variables").get("authorId").asText()).isEqualTo("42");
   }
 
   @Test

--- a/graphql/src/test/java/feign/graphql/GraphqlDecoderTest.java
+++ b/graphql/src/test/java/feign/graphql/GraphqlDecoderTest.java
@@ -53,6 +53,14 @@ class GraphqlDecoderTest {
 
   public record DeeplyNested(String value, Optional<UserWithAddress> nested) {}
 
+  public record Book(String id, String title) {}
+
+  public record Review(String id, Integer rating) {}
+
+  public record AuthorPage(List<Book> books, List<Review> reviews) {}
+
+  public record MixedPage(User getUser, List<Book> books) {}
+
   @Test
   void decodesDataField() throws Exception {
     var json = "{\"data\":{\"getUser\":{\"id\":\"1\",\"name\":\"Alice\"}}}";
@@ -318,6 +326,69 @@ class GraphqlDecoderTest {
     var result = (List<User>) decoder.decode(response, parameterizedType(List.class, User.class));
 
     assertThat(result).isEmpty();
+  }
+
+  @Test
+  void decodesMultipleRootFieldsIntoRecord() throws Exception {
+    var json =
+        "{\"data\":{\"books\":[{\"id\":\"1\",\"title\":\"Dune\"}],"
+            + "\"reviews\":[{\"id\":\"9\",\"rating\":5}]}}";
+    var response = buildResponse(json);
+
+    var page = (AuthorPage) decoder.decode(response, AuthorPage.class);
+
+    assertThat(page.books()).hasSize(1);
+    assertThat(page.books().getFirst().title()).isEqualTo("Dune");
+    assertThat(page.reviews()).hasSize(1);
+    assertThat(page.reviews().getFirst().rating()).isEqualTo(5);
+  }
+
+  @Test
+  void decodesMultipleRootFieldsOfDifferentShapes() throws Exception {
+    var json =
+        "{\"data\":{\"getUser\":{\"id\":\"1\",\"name\":\"Alice\"},"
+            + "\"books\":[{\"id\":\"1\",\"title\":\"Dune\"}]}}";
+    var response = buildResponse(json);
+
+    var page = (MixedPage) decoder.decode(response, MixedPage.class);
+
+    assertThat(page.getUser().name).isEqualTo("Alice");
+    assertThat(page.books()).hasSize(1);
+  }
+
+  @Test
+  void keepsNullRootFieldWhenDecodingMultipleRootFields() throws Exception {
+    var json = "{\"data\":{\"books\":[{\"id\":\"1\",\"title\":\"Dune\"}],\"reviews\":null}}";
+    var response = buildResponse(json);
+
+    var page = (AuthorPage) decoder.decode(response, AuthorPage.class);
+
+    assertThat(page.books()).hasSize(1);
+    assertThat(page.reviews()).isNull();
+  }
+
+  @Test
+  void decodesMultipleRootFieldsIntoOptional() throws Exception {
+    var json =
+        "{\"data\":{\"books\":[{\"id\":\"1\",\"title\":\"Dune\"}],"
+            + "\"reviews\":[{\"id\":\"9\",\"rating\":5}]}}";
+    var response = buildResponse(json);
+
+    @SuppressWarnings("unchecked")
+    var page = (Optional<AuthorPage>) decoder.decode(response, optionalOf(AuthorPage.class));
+
+    assertThat(page).isPresent();
+    assertThat(page.get().reviews()).hasSize(1);
+  }
+
+  @Test
+  void throwsGraphqlErrorExceptionOnErrorsWithMultipleRootFields() {
+    var json = "{\"errors\":[{\"message\":\"Boom\"}],\"data\":{\"books\":null,\"reviews\":null}}";
+    var response = buildResponse(json);
+
+    assertThatThrownBy(() -> decoder.decode(response, AuthorPage.class))
+        .isInstanceOf(GraphqlErrorException.class)
+        .hasMessageContaining("Boom");
   }
 
   private Response buildResponse(String body) {


### PR DESCRIPTION
Fixes #3525

`GraphqlDecoder` unwrapped `data` and decoded only the first root field, so an operation selecting two root fields — legal GraphQL, one round trip — silently dropped everything after the first.

### Decoder

When `data` carries more than one key, the whole `data` map is converted into the return type, so each root field binds to its matching component/property. A single root field keeps unwrapping exactly as before (including array-to-single unwrapping and `Optional`), so existing clients are unaffected.

### Code generation

`feign-graphql-apt` generated the return record from the first root field's type. It now mirrors the operation's own selection set when several root fields are selected — one component per root field, each with its own inner record:

```java
@GraphqlQuery("""
    query authorPage($authorId: ID!) {
      books(authorId: $authorId) { id title }
      reviews(authorId: $authorId) { id rating }
    }
    """)
AuthorPage authorPage(String authorId);
```

```java
public record AuthorPage(Optional<List<Books>> books, Optional<List<Reviews>> reviews) {

  public record Books(String id, String title) {}

  public record Reviews(String id, Integer rating) {}

}
```

Single-root-field queries still generate the record for that field's type.

### Tests

- `GraphqlDecoderTest`: multiple root fields into a record, mixed shapes (object + list), null root field, `Optional` return, errors with multiple root fields
- `GraphqlClientTest`: end-to-end multi-root query over `MockWebServer`
- `GraphqlSchemaProcessorTest`: multi-root generation, list/scalar shapes, single-root regression

`mvn test -pl graphql,graphql-apt -am` is green. READMEs for both modules document the behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
