### PR TITLE
Generate the flattened feign-bom POM under target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,3 @@ release.properties
 pom.xml.releaseBackup
 .mvn/.develocity/develocity-workspace-id
 .sdkmanrc
-
-# flatten-maven-plugin
-.flattened-pom.xml

--- a/feign-bom/pom.xml
+++ b/feign-bom/pom.xml
@@ -272,6 +272,8 @@
         <version>${flatten-maven-plugin.version}</version>
         <configuration>
           <flattenMode>bom</flattenMode>
+          <!-- keep the generated POM out of the source tree, so `mvn clean` disposes of it -->
+          <outputDirectory>${project.build.directory}</outputDirectory>
           <pomElements>
             <properties>remove</properties>
           </pomElements>


### PR DESCRIPTION
`flatten-maven-plugin` writes `.flattened-pom.xml` into the module directory by default, so `feign-bom/.flattened-pom.xml` showed up as an untracked file after every build and had to be gitignored (`3f0a1f4`-era change).

Point the plugin at `${project.build.directory}` instead: the generated POM is build output, it lands in `target/`, `mvn clean` disposes of it, and the source tree stays clean. The `.gitignore` entry is no longer needed.

Verified: `mvn -pl feign-bom install` installs `feign-bom/target/.flattened-pom.xml` as the artifact POM, still flattened (no `<parent>`, 44 managed dependencies, no inherited `dependencyManagement` imports), and the module directory stays empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKEB9VnpAxLPnSsJtxwoiD