### PR TITLE
Encode Gson request bodies using the runtime class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Version 13.15
+
+* `GsonEncoder` serializes request bodies using the runtime type when the declared body type is a
+  raw `Class`, so subclass fields on an abstract `@RequestBody` type are included. Parameterized
+  types (TypeToken / generics) still use the declared type (#2485).
+
 ### Version 13.14
 
 * Add `@Experimental` `MultiEncoder`, `PredicatedEncoder` and `EncoderPredicate`, letting a single

--- a/gson/src/main/java/feign/gson/GsonEncoder.java
+++ b/gson/src/main/java/feign/gson/GsonEncoder.java
@@ -43,7 +43,19 @@ public class GsonEncoder implements Encoder, PredicatedEncoder, JsonEncoder {
 
   @Override
   public void encode(Object object, Type bodyType, RequestTemplate template) {
-    template.body(gson.toJson(object, bodyType));
+    template.body(gson.toJson(object, typeToEncode(object, bodyType)));
+  }
+
+  /**
+   * Gson honors the supplied type, so {@code toJson(subclass, Abstract.class)} drops subclass
+   * fields. Use the runtime class when {@code bodyType} is a raw {@link Class}. Parameterized types
+   * (TypeToken / generics) keep {@code bodyType} so type arguments are not erased.
+   */
+  private static Type typeToEncode(Object object, Type bodyType) {
+    if (object != null && bodyType instanceof Class) {
+      return object.getClass();
+    }
+    return bodyType;
   }
 
   @Override

--- a/gson/src/test/java/feign/gson/GsonCodecTest.java
+++ b/gson/src/test/java/feign/gson/GsonCodecTest.java
@@ -123,6 +123,42 @@ class GsonCodecTest {
             """);
   }
 
+  @Test
+  void encodesSubclassFieldsWhenBodyTypeIsAbstract() {
+    SimpleTextMessage message = new SimpleTextMessage("user", "hello", 1);
+
+    RequestTemplate template = new RequestTemplate();
+    new GsonEncoder().encode(message, Message.class, template);
+
+    assertThat(template)
+        .hasBody(
+            """
+            {
+              "content": "hello",
+              "type": 1,
+              "toUser": "user"
+            }            """);
+  }
+
+  abstract static class Message {
+    final String toUser;
+
+    Message(String toUser) {
+      this.toUser = toUser;
+    }
+  }
+
+  static class SimpleTextMessage extends Message {
+    final String content;
+    final Integer type;
+
+    SimpleTextMessage(String toUser, String content, Integer type) {
+      super(toUser);
+      this.content = content;
+      this.type = type;
+    }
+  }
+
   static class Zone extends LinkedHashMap<String, Object> {
 
     Zone() {


### PR DESCRIPTION
Fixes #2485.

**Problem**
When a Feign method declares an abstract (or superclass) body type, `GsonEncoder` serializes only the fields on that declared type. Fields on the concrete subclass never appear in the JSON.

**Root cause**
`GsonEncoder.encode` called `gson.toJson(object, bodyType)`. Gson treats the second argument as the schema, so a `SimpleTextMessage` passed as `Message` is written as `{"toUser":"..."}`.

**Fix**
If `bodyType` is a raw `Class`, serialize with `object.getClass()`. Parameterized types (`TypeToken` / generics) still use the declared type so type arguments are not erased. Jackson and the other encoders are unchanged.

**Tests**
`GsonCodecTest.encodesSubclassFieldsWhenBodyTypeIsAbstract` encodes a subclass as the abstract type and asserts the JSON includes the subclass fields. Existing TypeToken encoding tests still pass.

`./mvnw test -pl gson -am` (gson: 11 tests, 0 failures).