### PR TITLE
Document that Logger reflects Feign's Request, not the wire request

### DIFF
--- a/core/src/main/java/feign/Logger.java
+++ b/core/src/main/java/feign/Logger.java
@@ -32,7 +32,18 @@ import java.util.logging.Handler;
 import java.util.logging.LogRecord;
 import java.util.logging.SimpleFormatter;
 
-/** Simple logging abstraction for debug messages. Adapted from {@code retrofit.RestAdapter.Log}. */
+/**
+ * Simple logging abstraction for debug messages. Adapted from {@code retrofit.RestAdapter.Log}.
+ *
+ * <p>Request logging reflects the {@link Request} that Feign builds from the method invocation,
+ * captured before it is handed to the {@link Client}. Depending on the {@link Client}
+ * implementation, the bytes actually sent over the wire may differ from what is logged here. In
+ * particular the default {@link Client.Default} is backed by {@link java.net.HttpURLConnection},
+ * which silently drops headers the JDK treats as restricted (for example {@code Host}, {@code
+ * Connection} and {@code Content-Length}) unless the {@code sun.net.http.allowRestrictedHeaders}
+ * system property is set, so such a header can appear in the log without being present in the
+ * outgoing request.
+ */
 public abstract class Logger {
 
   protected static String methodTag(String configKey) {


### PR DESCRIPTION
Adds a note to the Logger class javadoc explaining that request logging reflects the Request that Feign builds, which can differ from what the underlying Client actually sends. The default HttpURLConnection based Client drops headers the JDK treats as restricted, so a header can show up in the log without being on the wire. Closes #2682.