### PR TITLE
Allow retryable exceptions without a request

### DIFF
--- a/core/src/main/java/feign/RetryableException.java
+++ b/core/src/main/java/feign/RetryableException.java
@@ -71,6 +71,44 @@ public class RetryableException extends FeignException {
   }
 
   /**
+   * Represents a retryable exception without retaining the original request.
+   *
+   * <p>Use this constructor when the request is unavailable or should not be retained by the
+   * exception.
+   *
+   * @param status the HTTP status code
+   * @param message the exception message
+   * @param httpMethod the HTTP method (GET, POST, etc.)
+   * @param retryAfter the retry delay in milliseconds
+   */
+  public RetryableException(int status, String message, HttpMethod httpMethod, Long retryAfter) {
+    super(status, message);
+    this.httpMethod = httpMethod;
+    this.retryAfter = retryAfter;
+    this.methodKey = null;
+  }
+
+  /**
+   * Represents a retryable exception without retaining the original request.
+   *
+   * <p>Use this constructor when the request is unavailable or should not be retained by the
+   * exception.
+   *
+   * @param status the HTTP status code
+   * @param message the exception message
+   * @param httpMethod the HTTP method (GET, POST, etc.)
+   * @param cause the underlying cause of the exception
+   * @param retryAfter the retry delay in milliseconds
+   */
+  public RetryableException(
+      int status, String message, HttpMethod httpMethod, Throwable cause, Long retryAfter) {
+    super(status, message, cause);
+    this.httpMethod = httpMethod;
+    this.retryAfter = retryAfter;
+    this.methodKey = null;
+  }
+
+  /**
    * Represents a retryable exception when Retry-After information is available.
    *
    * <p>Use this constructor when the server response includes a Retry-After header specifying the

--- a/core/src/test/java/feign/RetryableExceptionTest.java
+++ b/core/src/test/java/feign/RetryableExceptionTest.java
@@ -29,6 +29,35 @@ import org.junit.jupiter.api.Test;
 class RetryableExceptionTest {
 
   @Test
+  void createRetryableExceptionWithoutRequest() {
+    Long retryAfter = 5000L;
+
+    RetryableException retryableException =
+        new RetryableException(503, "Service Unavailable", Request.HttpMethod.GET, retryAfter);
+
+    assertThat(retryableException.hasRequest()).isFalse();
+    assertThat(retryableException.request()).isNull();
+    assertThat(retryableException.retryAfter()).isEqualTo(retryAfter);
+    assertThat(retryableException.method()).isEqualTo(Request.HttpMethod.GET);
+  }
+
+  @Test
+  void createRetryableExceptionWithoutRequestAndWithCause() {
+    Long retryAfter = 5000L;
+    Throwable cause = new RuntimeException("test cause");
+
+    RetryableException retryableException =
+        new RetryableException(
+            503, "Service Unavailable", Request.HttpMethod.GET, cause, retryAfter);
+
+    assertThat(retryableException.hasRequest()).isFalse();
+    assertThat(retryableException.request()).isNull();
+    assertThat(retryableException.getCause()).isSameAs(cause);
+    assertThat(retryableException.retryAfter()).isEqualTo(retryAfter);
+    assertThat(retryableException.method()).isEqualTo(Request.HttpMethod.GET);
+  }
+
+  @Test
   void createRetryableExceptionWithResponseAndResponseHeader() {
     // given
     Long retryAfter = 5000L;


### PR DESCRIPTION
## Summary

- add `RetryableException` overloads that do not require or retain a `Request`
- support both cause and no-cause construction using the current millisecond `Long retryAfter` value
- verify request absence and preserved retry metadata with focused tests

## Testing

- `mvn -pl core -Pdev -Dtoolchain.skip=true -Dtest=RetryableExceptionTest test` (5 passed)
- `mvn -pl core -Pdev -Dtoolchain.skip=true verify` (731 passed, 4 skipped)
- `mvn clean install -pl core -Pdev -Dtoolchain.skip=true` (731 passed, 4 skipped)
- current-head CircleCI setup and full PR build after merging `master` (JDK 25)
- `git diff --check`
- publication leak scan (no new findings in changed lines or this PR body)

## AI assistance

OpenAI Codex assisted with code navigation, implementation, and validation. I reviewed and verified the final changes.

Fixes #1296
