### PR TITLE
Refactor Logger level checks and encapsulate Response.Builder fields

### DIFF
--- a/core/src/main/java/feign/Logger.java
+++ b/core/src/main/java/feign/Logger.java
@@ -68,7 +68,7 @@ public abstract class Logger {
   protected void logRequest(String configKey, Level logLevel, Request request) {
     String protocolVersion = resolveProtocolVersion(request.protocolVersion());
     log(configKey, "---> %s %s %s", request.httpMethod().name(), request.url(), protocolVersion);
-    if (logLevel.ordinal() >= Level.HEADERS.ordinal()) {
+    if (logLevel.atLeast(Level.HEADERS)) {
 
       for (String field : request.headers().keySet()) {
         if (shouldLogRequestHeader(field)) {
@@ -81,7 +81,7 @@ public abstract class Logger {
       int bodyLength = 0;
       if (request.body() != null) {
         bodyLength = request.length();
-        if (logLevel.ordinal() >= Level.FULL.ordinal()) {
+        if (logLevel.atLeast(Level.FULL)) {
           String bodyText =
               request.charset() != null ? new String(request.body(), request.charset()) : null;
           log(configKey, ""); // CRLF
@@ -105,27 +105,20 @@ public abstract class Logger {
             : "";
     int status = response.status();
     log(configKey, "<--- %s %s%s (%sms)", protocolVersion, status, reason, elapsedTime);
-    if (logLevel.ordinal() >= Level.HEADERS.ordinal()) {
+    if (logLevel.atLeast(Level.HEADERS)) {
 
-      for (String field : response.headers().keySet()) {
-        if (shouldLogResponseHeader(field)) {
-          for (String value : valuesOrEmpty(response.headers(), field)) {
-            log(configKey, "%s: %s", field, value);
-          }
-        }
-      }
+      logResponseHeaders(configKey, logLevel, response);
 
       int bodyLength = 0;
       if (response.body() != null && !(status == 204 || status == 205)) {
         // HTTP 204 No Content "...response MUST NOT include a message-body"
         // HTTP 205 Reset Content "...response MUST NOT include an entity"
-        if (logLevel.ordinal() >= Level.FULL.ordinal()) {
+        if (logLevel.atLeast(Level.FULL)) {
           log(configKey, ""); // CRLF
         }
-        byte[] bodyData = Util.toByteArray(response.body().asInputStream());
-        ensureClosed(response.body());
+        byte[] bodyData = rebufferBody(response);
         bodyLength = bodyData.length;
-        if (logLevel.ordinal() >= Level.FULL.ordinal() && bodyLength > 0) {
+        if (logLevel.atLeast(Level.FULL) && bodyLength > 0) {
           log(configKey, "%s", decodeOrDefault(bodyData, UTF_8, "Binary data"));
         }
         log(configKey, "<--- END HTTP (%s-byte body)", bodyLength);
@@ -137,6 +130,22 @@ public abstract class Logger {
     return response;
   }
 
+  private void logResponseHeaders(String configKey, Level logLevel, Response response) {
+    for (String field : response.headers().keySet()) {
+      if (shouldLogResponseHeader(field)) {
+        for (String value : valuesOrEmpty(response.headers(), field)) {
+          log(configKey, "%s: %s", field, value);
+        }
+      }
+    }
+  }
+
+  private byte[] rebufferBody(Response response) throws IOException {
+    byte[] bodyData = Util.toByteArray(response.body().asInputStream());
+    ensureClosed(response.body());
+    return bodyData;
+  }
+
   protected IOException logIOException(
       String configKey, Level logLevel, IOException ioe, long elapsedTime) {
     log(
@@ -145,7 +154,7 @@ public abstract class Logger {
         ioe.getClass().getSimpleName(),
         ioe.getMessage(),
         elapsedTime);
-    if (logLevel.ordinal() >= Level.FULL.ordinal()) {
+    if (logLevel.atLeast(Level.FULL)) {
       StringWriter sw = new StringWriter();
       ioe.printStackTrace(new PrintWriter(sw));
       log(configKey, "%s", sw.toString());
@@ -170,7 +179,12 @@ public abstract class Logger {
     /** Log the basic information along with request and response headers. */
     HEADERS,
     /** Log the headers, body, and metadata for both requests and responses. */
-    FULL
+    FULL;
+
+    /** Returns {@code true} if this level is at least as verbose as {@code other}. */
+    public boolean atLeast(Level other) {
+      return ordinal() >= other.ordinal();
+    }
   }
 
   /** Logs to System.err. */

--- a/core/src/main/java/feign/Response.java
+++ b/core/src/main/java/feign/Response.java
@@ -36,13 +36,13 @@ public final class Response implements Closeable {
   private final ProtocolVersion protocolVersion;
 
   private Response(Builder builder) {
-    checkState(builder.request != null, "original request is required");
-    this.status = builder.status;
-    this.request = builder.request;
-    this.reason = builder.reason; // nullable
-    this.headers = caseInsensitiveCopyOf(builder.headers);
-    this.body = builder.body; // nullable
-    this.protocolVersion = builder.protocolVersion;
+    checkState(builder.request() != null, "original request is required");
+    this.status = builder.status();
+    this.request = builder.request();
+    this.reason = builder.reason(); // nullable
+    this.headers = caseInsensitiveCopyOf(builder.headers());
+    this.body = builder.body(); // nullable
+    this.protocolVersion = builder.protocolVersion();
   }
 
   public Builder toBuilder() {
@@ -55,11 +55,11 @@ public final class Response implements Closeable {
 
   public static final class Builder {
     private static final ProtocolVersion DEFAULT_PROTOCOL_VERSION = ProtocolVersion.HTTP_1_1;
-    int status;
-    String reason;
-    Map<String, Collection<String>> headers;
-    Body body;
-    Request request;
+    private int status;
+    private String reason;
+    private Map<String, Collection<String>> headers;
+    private Body body;
+    private Request request;
     private RequestTemplate requestTemplate;
     private ProtocolVersion protocolVersion = DEFAULT_PROTOCOL_VERSION;
 
@@ -72,6 +72,30 @@ public final class Response implements Closeable {
       this.body = source.body;
       this.request = source.request;
       this.protocolVersion = source.protocolVersion;
+    }
+
+    int status() {
+      return status;
+    }
+
+    String reason() {
+      return reason;
+    }
+
+    Map<String, Collection<String>> headers() {
+      return headers;
+    }
+
+    Body body() {
+      return body;
+    }
+
+    Request request() {
+      return request;
+    }
+
+    ProtocolVersion protocolVersion() {
+      return protocolVersion;
     }
 
     /**

--- a/core/src/test/java/feign/LoggerMethodsTest.java
+++ b/core/src/test/java/feign/LoggerMethodsTest.java
@@ -54,4 +54,19 @@ public class LoggerMethodsTest {
     verify(spyBody).close();
     assertThat(rebufferedResponse.body()).isNotSameAs(spyBody);
   }
+  
+  @Test
+  void atLeastReturnsTrueForEqualLevel() {
+    assertThat(Level.BASIC.atLeast(Level.BASIC)).isTrue();
+  }
+
+  @Test
+  void atLeastReturnsTrueWhenMoreVerbose() {
+    assertThat(Level.FULL.atLeast(Level.HEADERS)).isTrue();
+  }
+
+  @Test
+  void atLeastReturnsFalseWhenLessVerbose() {
+    assertThat(Level.NONE.atLeast(Level.FULL)).isFalse();
+  }
 }


### PR DESCRIPTION
Refactors logging level comparisons and encapsulates `Response.Builder` fields for better API hygiene.

### Summary of Changes

* **`Logger.Level#atLeast`**: Adds `atLeast(Level other)` helper to `Logger.Level` and replaces `ordinal()` comparisons across `Logger.java`.
* **Logger helper extraction**: Splits `logAndRebufferResponse` into `logResponseHeaders` and `rebufferBody` private helpers.
* **`Response.Builder` encapsulation**: Makes `Builder` fields private (`status`, `reason`, `headers`, `body`, `request`).

### Tests Added

* `LoggerMethodsTest`: Adds tests for `Logger.Level.atLeast()` covering equal, more verbose, and less verbose level comparisons.

$ ./mvnw test -pl core -Dtest=LoggerMethodsTest,LoggerTest,LoggerRebufferTest -Dtoolchain.skip=true
Tests run: 11, Failures: 0, Errors: 0, Skipped: 0
