### PR TITLE
Bump mvnd wrapper to 1.0.6 to fix broken 1.0.2 download URL

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 wrapperVersion=3.3.1
-distributionUrl=https://downloads.apache.org/maven/mvnd/1.0.2/maven-mvnd-1.0.2-linux-amd64.zip
+distributionUrl=https://downloads.apache.org/maven/mvnd/1.0.6/maven-mvnd-1.0.6-linux-amd64.zip
 distributionType=mvnd


### PR DESCRIPTION
## Summary
- `.mvn/wrapper/maven-wrapper.properties` pinned mvnd 1.0.2, whose zip has been pruned from `downloads.apache.org` (Apache only retains the latest release there), causing every CI job's `setup-environment` step to fail with a 404 on `wget`
- Bumps to mvnd 1.0.6, currently the version available on `downloads.apache.org`
- This is blocking all open Dependabot PRs, which fail CI at the same step regardless of what they bump

## Test plan
- [x] `./mvnw -version` downloads and runs mvnd 1.0.6 successfully
- [x] CircleCI `setup-environment` on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DL8tzzwKCqASYAZbyPLy9N