### PR TITLE
Decode kotlin.Unit suspend return values to Unit.INSTANCE instead of null

### DIFF
--- a/core/src/main/java/feign/InvocationContext.java
+++ b/core/src/main/java/feign/InvocationContext.java
@@ -82,7 +82,7 @@ public class InvocationContext {
 
       if (isVoidType(returnType) && !decodeVoid) {
         ensureClosed(response.body());
-        return null;
+        return kotlinUnitInstance(returnType);
       }
 
       Class<?> rawType = Types.getRawType(returnType);
@@ -140,5 +140,21 @@ public class InvocationContext {
     return returnType == Void.class
         || returnType == void.class
         || returnType.getTypeName().equals("kotlin.Unit");
+  }
+
+  /**
+   * Kotlin's {@code Unit} is non-nullable, so a suspend function declared to return it must get
+   * back the singleton {@code Unit.INSTANCE} rather than {@code null}. Resolved reflectively since
+   * feign-core has no compile-time dependency on kotlin-stdlib.
+   */
+  private static Object kotlinUnitInstance(Type returnType) {
+    if (!(returnType instanceof Class) || !returnType.getTypeName().equals("kotlin.Unit")) {
+      return null;
+    }
+    try {
+      return ((Class<?>) returnType).getField("INSTANCE").get(null);
+    } catch (ReflectiveOperationException e) {
+      return null;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- \`feign-kotlin\`'s \`CoroutineFeignTest\` never actually ran under surefire 3.5.6 (confirmed on a pristine clone of master: \`Tests run: 0\` for that module). Surefire 3.6.0 (see #3556) fixes JUnit Platform test discovery for this class and in doing so exposed a real bug.
- \`InvocationContext.isVoidType()\` treats \`kotlin.Unit\` the same as Java \`void\`/\`Void\` and returns \`null\` for it. But Kotlin's \`Unit\` is non-nullable, so a suspend function declared to return \`Unit\` needs the singleton \`Unit.INSTANCE\`, not \`null\`.
- Adds a reflective resolution (feign-core has no compile-time dependency on kotlin-stdlib) that returns \`Unit.INSTANCE\` specifically for \`kotlin.Unit\` return types, leaving \`void\`/\`Void\` behavior unchanged.

## Test plan
- [x] \`CoroutineFeignTest\` (6/6) passes with surefire 3.6.0
- [x] \`feign-core\`'s full suite (729 tests) unaffected
- [x] \`mvn verify\` on \`core\`,\`kotlin\` (including japicmp binary-compat check) passes