### PR TITLE
Stop publishing feign-bom twice during release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,46 +101,6 @@ commands:
           command: |
             source "$HOME/.sdkman/bin/sdkman-init.sh"
             ./mvnw -ntp -nsu --serial -s .circleci/settings.xml -P release -pl -:feign-benchmark,-:feign-vertx4-test,-:feign-vertx5-test,-:feign-example-github,-:feign-example-github-with-coroutine,-:feign-example-wikipedia,-:feign-example-wikipedia-with-springboot -DskipTests=true deploy
-      - run:
-          name: 'Publish BOM to Maven Central'
-          when: always
-          command: |
-            BOM_DIR=target/classes/feign-bom
-            BOM_POM=$BOM_DIR/pom.xml
-            if [ ! -f "$BOM_POM" ]; then
-              echo "BOM pom not found, skipping"
-              exit 0
-            fi
-            BOM_VERSION=$(grep '<version>' "$BOM_POM" | head -1 | sed 's/.*<version>\(.*\)<\/version>.*/\1/')
-            if [[ "$BOM_VERSION" == *SNAPSHOT* ]]; then
-              echo "Skipping BOM publish for SNAPSHOT version $BOM_VERSION"
-              exit 0
-            fi
-            DEP_COUNT=$(grep -c '<artifactId>feign-' "$BOM_POM" || true)
-            if [ "$DEP_COUNT" -eq 0 ]; then
-              echo "ERROR: BOM has no feign dependencies, refusing to publish an empty BOM"
-              exit 1
-            fi
-            echo "BOM contains $DEP_COUNT feign dependencies"
-            STAGING_DIR=/tmp/bom-staging/io/github/openfeign/feign-bom/$BOM_VERSION
-            mkdir -p "$STAGING_DIR"
-            cp "$BOM_POM" "$STAGING_DIR/feign-bom-${BOM_VERSION}.pom"
-            gpg --armor --detach-sign "$STAGING_DIR/feign-bom-${BOM_VERSION}.pom"
-            md5sum "$STAGING_DIR/feign-bom-${BOM_VERSION}.pom" | awk '{print $1}' > "$STAGING_DIR/feign-bom-${BOM_VERSION}.pom.md5"
-            sha1sum "$STAGING_DIR/feign-bom-${BOM_VERSION}.pom" | awk '{print $1}' > "$STAGING_DIR/feign-bom-${BOM_VERSION}.pom.sha1"
-            sha256sum "$STAGING_DIR/feign-bom-${BOM_VERSION}.pom" | awk '{print $1}' > "$STAGING_DIR/feign-bom-${BOM_VERSION}.pom.sha256"
-            sha512sum "$STAGING_DIR/feign-bom-${BOM_VERSION}.pom" | awk '{print $1}' > "$STAGING_DIR/feign-bom-${BOM_VERSION}.pom.sha512"
-            (cd /tmp/bom-staging && zip -r /tmp/feign-bom-bundle.zip .)
-            TOKEN=$(echo -n "${CENTRAL_TOKEN_USERNAME}:${CENTRAL_TOKEN_PASSWORD}" | base64)
-            HTTP_CODE=$(curl -s -w "%{http_code}" -o /tmp/bom-upload-response.txt \
-              -X POST "https://central.sonatype.com/api/v1/publisher/upload?name=feign-bom-${BOM_VERSION}&publishingType=AUTOMATIC" \
-              -H "Authorization: Bearer $TOKEN" \
-              -F "bundle=@/tmp/feign-bom-bundle.zip")
-            echo "BOM upload response: $(cat /tmp/bom-upload-response.txt) (HTTP $HTTP_CODE)"
-            if [ "$HTTP_CODE" != "201" ]; then
-              echo "BOM upload failed"
-              exit 1
-            fi
 
 # our job defaults
 defaults: &defaults


### PR DESCRIPTION
Removes the `Publish BOM to Maven Central` step from the release job. `feign-bom` is already published by the regular reactor `deploy`, so this step uploaded a second, competing copy of the same coordinates on every release.

### What went wrong in 13.15

The step's bundle upload was rejected by Central:

```
Component with package url: 'pkg:maven/io.github.openfeign/feign-bom@13.15?type=pom' already exists
```

The CircleCI job still went green, because the step only checks that the upload returns `201`. Central validates asynchronously, so the failure surfaced later in the publisher portal and left a FAILED deployment sitting there to be dropped by hand.

### Why the step is obsolete

It was added in a5518245 (Feb 2026), back when the reactor deploy did not produce a usable BOM. That changed in 44f688ef (#3508, Aug 2026), which put `flatten-maven-plugin` with `flattenMode=bom` on `feign-bom`. Since 13.14 the reactor deploy has been publishing the BOM on its own, and this step has been a duplicate.

The published `feign-bom-13.15.pom` confirms which one won — it has no `<parent>`, `<build>` or `<properties>`, i.e. it is the flattened artifact from the reactor deploy.

### Why it is worth deleting rather than guarding

The step uploads `target/classes/feign-bom/pom.xml`, the raw sundr-generated POM, which still carries `<parent>`, `<build>` and `<properties>`. That is precisely the unflattened shape #3508 removed because it overrides consumer dependency management. Today the duplicate loses the race and is rejected; if it ever won, it would republish the bug.

### Verification

- `circleci config validate` passes.
- `nexus-deploy` now has a single step, `Deploy Core Modules Sonatype`.
- `feign-bom` is not in the deploy's `-pl` exclusion list, so the reactor continues to publish it.
- On Central, 43 of the 45 BOM-listed modules are live at 13.15. The two absent ones, `feign-vertx4-test` and `feign-vertx5-test`, are excluded from the deploy on purpose and are also missing at 13.14 — a pre-existing wart, untouched here.

CI-only change; no Maven or Java sources affected.
